### PR TITLE
mcolon should return empty array instead of None

### DIFF
--- a/src/porepy/utils/mcolon.py
+++ b/src/porepy/utils/mcolon.py
@@ -47,7 +47,7 @@ def mcolon(lo, hi):
 
     i = hi >= lo + 1
     if not any(i):
-        return None
+        return np.array([], dtype=np.int32)
 
     lo = lo[i]
     hi = hi[i] - 1

--- a/test/unit/test_mcolon.py
+++ b/test/unit/test_mcolon.py
@@ -17,27 +17,35 @@ def test_mcolon_simple():
     assert np.all((c - np.array([1, 2, 2, 3])) == 0)
 
 
+def test_mcolon_zero_output():
+    a = np.array([1, 2])
+    b = np.array([1, 2])
+    c = mcolon.mcolon(a, b)
+    assert c.size == 0
+
+
 def test_mcolon_one_missing():
     a = np.array([1, 2])
     b = np.array([3, 1])
     c = mcolon.mcolon(a, b)
     assert np.all((c - np.array([1, 2])) == 0)
 
+
 def test_mcolon_middle_equal():
     # Motivated by Github issue #11
-    indPtr = np.array([1,5,5,6])
-    select = np.array([0,1,2])
+    indPtr = np.array([1, 5, 5, 6])
+    select = np.array([0, 1, 2])
 
-    c = mcolon.mcolon(indPtr[select], indPtr[select+1])
+    c = mcolon.mcolon(indPtr[select], indPtr[select + 1])
     c_known = np.array([1, 2, 3, 4, 5])
     assert np.allclose(c, c_known)
 
 
 def test_mcolon_last_equal():
     # Motivated by Github issue #11
-    indPtr = np.array([1,5,5,6])
-    select = np.array([0,1])
+    indPtr = np.array([1, 5, 5, 6])
+    select = np.array([0, 1])
 
-    c = mcolon.mcolon(indPtr[select], indPtr[select+1])
+    c = mcolon.mcolon(indPtr[select], indPtr[select + 1])
     c_known = np.array([1, 2, 3, 4])
     assert np.allclose(c, c_known)


### PR DESCRIPTION
Previously:
```python
a = np.array([1, 2])
b = np.array([1, 2])
c = mcolon.mcolon(a, b)
assert c is None
```

Now: 
```python
a = np.array([1, 2])
b = np.array([1, 2])
c = mcolon.mcolon(a, b)
assert c.size==0
```

Any objections?