### PR TITLE
Workaround for cell-face mapping issue related to gmsh.

### DIFF
--- a/src/porepy/fracs/meshing.py
+++ b/src/porepy/fracs/meshing.py
@@ -329,7 +329,7 @@ def assemble_in_bucket(grids, **kwargs):
 
 
 def obtain_interdim_mappings(lg, fn, n_per_face,
-                             ensure_matching_face_cell=True):
+                             ensure_matching_face_cell=True, **kwargs):
     """
     Find mappings between faces in higher dimension and cells in the lower
     dimension


### PR DESCRIPTION
Allow for a keyword to be passed to the simplex meshing algorithm so
that an assertion that cells in lower dimension corresponds to a face
in higher dimension is *not* made.

This is a workaround, but not a solution, to #43.