### PR TITLE
if variable not found in grid, skip!

### DIFF
--- a/src/porepy/viz/exporter.py
+++ b/src/porepy/viz/exporter.py
@@ -302,6 +302,8 @@ class Exporter():
 
         if data is not None:
             for name_field, values_field in data.items():
+                if values_field is None:
+                    continue
                 dataVTK = ns.numpy_to_vtk(values_field.ravel(order='F'),
                                           deep=True, array_type=vtk.VTK_DOUBLE)
                 dataVTK.SetName(str(name_field))


### PR DESCRIPTION
I sometimes have variables that only live on some grids (e.g. mechanical displacement only exist in 3D).
  
I'm not sure if we want to do this change. What do you think? 