### PR TITLE
Biot

### DIFF
--- a/src/porepy/__init__.py
+++ b/src/porepy/__init__.py
@@ -30,7 +30,7 @@ __all__ = []
 from porepy.numerics.fv.mpsa import Mpsa, FracturedMpsa
 from porepy.numerics.fv.tpfa import Tpfa
 from porepy.numerics.fv.mpfa import Mpfa
-from porepy.numerics.fv.biot import Biot
+from porepy.numerics.fv.biot import Biot, GradP, DivD, BiotStabilization
 from porepy.numerics.fv.source import Integral
 
 # Virtual elements, elliptic

--- a/src/porepy/fracs/meshing.py
+++ b/src/porepy/fracs/meshing.py
@@ -259,7 +259,9 @@ def dfn(fracs, conforming, intersections=None, keep_geo=False, tol=1e-4, **kwarg
             grid_list.append(grids)
             neigh_list.append(other_frac)
 
-        logger.warning("Finished creating grids. Elapsed time " + str(time.time() - tic))
+        logger.warning(
+            "Finished creating grids. Elapsed time " + str(time.time() - tic)
+        )
         logger.warning("Merge grids")
         tic = time.time()
         grids = non_conforming.merge_grids(grid_list, neigh_list)

--- a/src/porepy/numerics/fv/biot.py
+++ b/src/porepy/numerics/fv/biot.py
@@ -8,12 +8,14 @@ from porepy.numerics.mixed_dim.solver import Solver
 
 
 class Biot(Solver):
-    def __init__(self, eta=None):
-        """ Set default values for some parameters used in discretization.
+    def __init__(self, mechanics_keyword="mechanics", flow_keyword="flow"):
+        """ Set the two keywords.
 
+        The keywords are used to access and store parameters and discretization
+        matrices.
         """
-        defaults = {"fluid_compr": 0, "fluid_viscosity": 1, "biot_alpha": 1}
-        self.defaults = defaults
+        self.mechanics_keyword = mechanics_keyword
+        self.flow_keyword = flow_keyword
 
     def ndof(self, g):
         """ Return the number of degrees of freedom associated wiht the method.
@@ -62,18 +64,18 @@ class Biot(Solver):
             state.
 
         """
-        d = data[pp.PARAMETERS]["mechanics"]["bc_values"]
-        p = data[pp.PARAMETERS]["flow"]["bc_values"]
+        d = data[pp.PARAMETERS][self.mechanics_keyword]["bc_values"]
+        p = data[pp.PARAMETERS][self.flow_keyword]["bc_values"]
 
         div_flow = fvutils.scalar_divergence(g)
         div_mech = fvutils.vector_divergence(g)
 
-        m_matrices = data[pp.DISCRETIZATION_MATRICES]["mechanics"]
-        f_matrices = data[pp.DISCRETIZATION_MATRICES]["flow"]
+        matrices_m = data[pp.DISCRETIZATION_MATRICES][self.mechanics_keyword]
+        matrices_f = data[pp.DISCRETIZATION_MATRICES][self.flow_keyword]
         p_bound = (
-            -div_flow * f_matrices["bound_flux"] * p - m_matrices["bound_div_d"] * d
+            -div_flow * matrices_f["bound_flux"] * p - matrices_m["bound_div_d"] * d
         )
-        s_bound = -div_mech * m_matrices["bound_stress"] * d
+        s_bound = -div_mech * matrices_m["bound_stress"] * d
         return np.hstack((s_bound, p_bound))
 
     def rhs_time(self, g, data):
@@ -102,14 +104,14 @@ class Biot(Solver):
         d = self.extractD(g, state, as_vector=True)
         p = self.extractP(g, state)
 
-        parameter_dictionary = data[pp.PARAMETERS]["mechanics"]
+        parameter_dictionary = data[pp.PARAMETERS][self.mechanics_keyword]
         matrix_dictionaries = data[pp.DISCRETIZATION_MATRICES]
 
         d_scaling = parameter_dictionary.get("displacement_scaling", 1)
-        div_d = matrix_dictionaries["mechanics"]["div_d"]
+        div_d = matrix_dictionaries[self.mechanics_keyword]["div_d"]
 
         div_d = np.squeeze(parameter_dictionary["biot_alpha"] * div_d * d * d_scaling)
-        p_cmpr = matrix_dictionaries["flow"]["mass"] * p
+        p_cmpr = matrix_dictionaries[self.flow_keyword]["mass"] * p
 
         mech_rhs = np.zeros(g.dim * g.num_cells)
 
@@ -121,21 +123,17 @@ class Biot(Solver):
         The parameters needed for the discretization are stored in the
         dictionary data, which should contain the following mandatory keywords:
 
-            Related to flow equation:
-                perm: Second order tensor representing permeability
-                bound_flow: BoundaryCondition object for flow equation. Used in
-                    mpfa.
+            Related to flow equation (in data[pp.PARAMETERS][self.flow_keyword]):
+                second_order_tensor: Second order tensor representing hydraulic
+                    conductivity, i.e. permeability / fluid viscosity
+                bc: BoundaryCondition object for flow equation. Used in mpfa.
 
-            Related to mechanics equation:
-                stiffness: Fourth order tensor representing elastic moduli.
-                bound_mech: BoundaryCondition object for mechanics equation.
+            Related to mechanics equation (in data[pp.PARAMETERS][self.mechanids_keyword]):
+                fourt_order_tensor: Fourth order tensor representing elastic moduli.
+                bc: BoundaryCondition object for mechanics equation.
                     Used in mpsa.
 
         In addition, the following parameters are optional:
-
-            Related to flow equation:
-                fluid_viscosity (double). Defaults to 1.
-                fluid_compr (double): Fluid compressibility. Defaults to 0.
 
             Related to coupling terms:
                 biot_alpha (double between 0 and 1): Biot's coefficient.
@@ -145,7 +143,7 @@ class Biot(Solver):
                 inverter (str): Which method to use for block inversion. See
                     fvutils.invert_diagonal_blocks for detail, and for default
                     options.
-                eta (double): Location of continuity point in MPSA and MPFA.
+                mpsa_eta, mpfa_eta (double): Location of continuity point in MPSA and MPFA.
                     Defaults to 1/3 for simplex grids, 0 otherwise.
 
         The discretization is stored in the data dictionary, in the form of
@@ -182,28 +180,25 @@ class Biot(Solver):
         div_mech = fvutils.vector_divergence(g)
         param = data[pp.PARAMETERS]
 
-        fluid_viscosity = param["flow"]["fluid_viscosity"]
-        biot_alpha = param["flow"]["biot_alpha"]
+        biot_alpha = param[self.flow_keyword]["biot_alpha"]
 
-        m_matrices = data[pp.DISCRETIZATION_MATRICES]["mechanics"]
-        f_matrices = data[pp.DISCRETIZATION_MATRICES]["flow"]
+        matrices_m = data[pp.DISCRETIZATION_MATRICES][self.mechanics_keyword]
+        matrices_f = data[pp.DISCRETIZATION_MATRICES][self.flow_keyword]
         # Put together linear system
-        A_flow = div_flow * f_matrices["flux"] / fluid_viscosity
-        A_mech = div_mech * m_matrices["stress"]
+        A_flow = div_flow * matrices_f["flux"]
+        A_mech = div_mech * matrices_m["stress"]
 
         # Time step size
-        dt = data["time_step"]
+        dt = param[self.flow_keyword]["time_step"]
 
-        d_scaling = param["mechanics"].get("displacement_scaling", 1)
+        d_scaling = param[self.mechanics_keyword].get("displacement_scaling", 1)
         # Matrix for left hand side
         A_biot = sps.bmat(
             [
-                [A_mech, m_matrices["grad_p"] * biot_alpha],
+                [A_mech, matrices_m["grad_p"] * biot_alpha],
                 [
-                    m_matrices["div_d"] * biot_alpha * d_scaling,
-                    f_matrices["mass"]
-                    + dt * A_flow
-                    + m_matrices["stabilization"],
+                    matrices_m["div_d"] * biot_alpha * d_scaling,
+                    matrices_f["mass"] + dt * A_flow + matrices_f["biot_stabilization"],
                 ],
             ]
         ).tocsr()
@@ -213,20 +208,22 @@ class Biot(Solver):
     def _discretize_flow(self, g, data):
 
         # Discretiztaion using MPFA
-        key = "flow"
+        key = self.flow_keyword
         md = pp.Mpfa(key)
 
         md.discretize(g, data)
 
     def _discretize_compr(self, g, data):
-        parameter_dictionary = data[pp.PARAMETERS]["flow"]
-        matrix_dictionary = data[pp.DISCRETIZATION_MATRICES]["flow"]
-        compr = parameter_dictionary["fluid_compressibility"]
-        poro = parameter_dictionary["porosity"]
+        """
+        TODO: Sort out time step (inconsistent with MassMatrix).
+        """
+        parameter_dictionary = data[pp.PARAMETERS][self.flow_keyword]
+        matrix_dictionary = data[pp.DISCRETIZATION_MATRICES][self.flow_keyword]
+        w = parameter_dictionary["mass_weight"]
         apertures = parameter_dictionary["aperture"]
-        volumes = poro * g.cell_volumes * apertures
+        volumes = g.cell_volumes * apertures
         matrix_dictionary["mass"] = sps.dia_matrix(
-            (volumes * compr, 0), shape=(g.num_cells, g.num_cells)
+            (volumes * w, 0), shape=(g.num_cells, g.num_cells)
         )
 
     def _discretize_mech(self, g, data):
@@ -246,9 +243,10 @@ class Biot(Solver):
             constit (porepy.bc.bc.BoundaryCondition) class for boundary values
             faces (np.ndarray) faces to be considered. Intended for partial
                 discretization, may change in the future
-            eta Location of pressure continuity point. Should be 1/3 for simplex
+            mpsa_eta Location of pressure continuity point. Should be 1/3 for simplex
                 grids, 0 otherwise. On boundary faces with Dirichlet conditions,
-                eta=0 will be enforced.
+                eta=0 will be enforced. Defaults to the values computed by
+                fvutils.determine_eta(g).
             inverter (string) Block inverter to be used, either numba (default),
                 cython or python. See fvutils.invert_diagonal_blocks for details.
 
@@ -313,14 +311,16 @@ class Biot(Solver):
             p = x[g.num_cells * gdim:]
 
         """
-        parameters = data[pp.PARAMETERS]
-        m_matrices = data[pp.DISCRETIZATION_MATRICES]["mechanics"]
-        bound_mech = parameters["mechanics"]["bc"]
-        bound_flow = parameters["flow"]["bc"]
-        constit = parameters["mechanics"]["fourth_order_tensor"]
+        parameters_m = data[pp.PARAMETERS][self.mechanics_keyword]
+        parameters_f = data[pp.PARAMETERS][self.flow_keyword]
+        matrices_m = data[pp.DISCRETIZATION_MATRICES][self.mechanics_keyword]
+        matrices_f = data[pp.DISCRETIZATION_MATRICES][self.flow_keyword]
+        bound_mech = parameters_m["bc"]
+        bound_flow = parameters_f["bc"]
+        constit = parameters_m["fourth_order_tensor"]
 
-        eta = data.get("eta", 0)
-        inverter = data.get("inverter", None)
+        eta = parameters_m.get("mpsa_eta", fvutils.determine_eta(g))
+        inverter = parameters_m.get("inverter", None)
 
         # The grid coordinates are always three-dimensional, even if the grid
         # is really 2D. This means that there is not a 1-1 relation between the
@@ -338,6 +338,7 @@ class Biot(Solver):
             g.face_normals = np.delete(g.face_normals, (2), axis=0)
             g.nodes = np.delete(g.nodes, (2), axis=0)
 
+            constit = constit.copy()
             constit.values = np.delete(constit.values, (2, 5, 6, 7, 8), axis=0)
             constit.values = np.delete(constit.values, (2, 5, 6, 7, 8), axis=1)
         nd = g.dim
@@ -448,17 +449,17 @@ class Biot(Solver):
 
         stabilization = div * igrad * rhs_normals
 
-        m_matrices["stress"] = stress
-        m_matrices["bound_stress"] = bound_stress
-        m_matrices["grad_p"] = grad_p
-        m_matrices["div_d"] = div_d
-        m_matrices["stabilization"] = stabilization
-        m_matrices["bound_div_d"] = bound_div_d
+        matrices_m["stress"] = stress
+        matrices_m["bound_stress"] = bound_stress
+        matrices_m["grad_p"] = grad_p
+        matrices_m["div_d"] = div_d
+        matrices_f["biot_stabilization"] = stabilization
+        matrices_m["bound_div_d"] = bound_div_d
 
     def _face_vector_to_scalar(self, nf, nd):
-        """ Create a mapping from vector quantities on faces (stresses) to
-        scalar quantities. The mapping is intended for the boundary
-        discretization of the term div(u) (coupling term in the flow equation).
+        """ Create a mapping from vector quantities on faces (stresses) to scalar
+        quantities. The mapping is intended for the boundary discretization of the
+        displacement divergence term  (coupling term in the flow equation).
 
         Parameters:
             nf (int): Number of faces in the grid
@@ -470,9 +471,9 @@ class Biot(Solver):
         return sps.coo_matrix((vals, (rows, cols))).tocsr()
 
     def _subcell_gradient_to_cell_scalar(self, g, cell_node_blocks):
-        """ Create a mapping from sub-cell gradients to cell-wise traces of the
-        gradient operator. The mapping is intended for the discretization of
-        the term div(u) (coupling term in flow equation).
+        """ Create a mapping from sub-cell gradients to cell-wise traces of the gradient
+        operator. The mapping is intended for the discretization of the term div(u)
+        (coupling term in flow equation).
         """
         # To pick out the trace of the strain tensor, we access elements
         #   (2d): 0 (u_x) and 3 (u_y)
@@ -587,9 +588,9 @@ class Biot(Solver):
             np.ndarray: Flux over all faces
 
         """
-        flux_discr = data[pp.DISCRETIZATION_MATRICES]["flow"]["flux"]
-        bound_flux = data[pp.DISCRETIZATION_MATRICES]["flow"]["bound_flux"]
-        bound_val = data[pp.PARAMETERS]["flow"]["bc_values"]
+        flux_discr = data[pp.DISCRETIZATION_MATRICES][self.flow_keyword]["flux"]
+        bound_flux = data[pp.DISCRETIZATION_MATRICES][self.flow_keyword]["bound_flux"]
+        bound_val = data[pp.PARAMETERS][self.flow_keyword]["bc_values"]
         p = self.extractP(g, u)
         flux = flux_discr * p + bound_flux * bound_val
         return flux
@@ -610,18 +611,19 @@ class Biot(Solver):
                 all stress values on the first face, then the second etc.
 
         """
-        matrix_dictionary = data[pp.DISCRETIZATION_MATRICES]["mechanics"]
+        matrix_dictionary = data[pp.DISCRETIZATION_MATRICES][self.mechanics_keyword]
         stress_discr = matrix_dictionary["stress"]
         bound_stress = matrix_dictionary["bound_stress"]
-        bound_val = data[pp.PARAMETERS]["mechanics"]["bc_values"]
+        bound_val = data[pp.PARAMETERS][self.mechanics_keyword]["bc_values"]
         d = self.extractD(g, u, as_vector=True)
         stress = np.squeeze(stress_discr * d) + (bound_stress * bound_val)
         return stress
 
 
 class GradP(pp.numerics.mixed_dim.VectorEllipticDiscretization):
-    """ Class for the grad p term of the Biot equation.
+    """ Class for the pressure gradientdivergence term of the Biot equation.
     """
+
     def ndof(self, g):
         """ Return the number of degrees of freedom associated to the method.
 
@@ -656,7 +658,7 @@ class GradP(pp.numerics.mixed_dim.VectorEllipticDiscretization):
         return solution_array
 
     def discretize(self, g, data):
-        """ Discretize the grad p term of the Biot equation.
+        """ Discretize the pressure gradient term of the Biot equation.
 
         Parameters:
             g (pp.Grid): grid, or a subclass, with geometry fields computed.
@@ -666,12 +668,14 @@ class GradP(pp.numerics.mixed_dim.VectorEllipticDiscretization):
             NotImplementedError, the discretization should be performed using the
             discretize method of the Biot class.
         """
-        raise NotImplementedError("""No discretize method implemented for the GradP
-                                  class. See the Biot class.""")
+        raise NotImplementedError(
+            """No discretize method implemented for the GradP
+                                  class. See the Biot class."""
+        )
 
     def assemble_matrix_rhs(self, g, data):
-        """ Return the matrix and right-hand side for a discretization of the grad p
-        term of the Biot equation.
+        """ Return the matrix and right-hand side for a discretization of the pressure
+        gradient term of the Biot equation.
 
         Parameters:
             g : grid, or a subclass, with geometry fields computed.
@@ -686,8 +690,8 @@ class GradP(pp.numerics.mixed_dim.VectorEllipticDiscretization):
         return self.assemble_matrix(g, data), self.assemble_rhs(g, data)
 
     def assemble_matrix(self, g, data):
-        """ Return the matrix and right-hand side for a discretization of the grad p
-        term of the Biot equation.
+        """ Return the matrix and right-hand side for a discretization of the pressure
+        gradient term of the Biot equation.
 
         Parameters:
             g (Grid): Computational grid, with geometry fields computed.
@@ -698,17 +702,20 @@ class GradP(pp.numerics.mixed_dim.VectorEllipticDiscretization):
                 size of the matrix will depend on the specific discretization.
 
         Raises:
-            ValueError if the grad p term has not already been discretized.
+            ValueError if the pressure gradient term has not already been discretized.
         """
         matrix_dictionary = data[pp.DISCRETIZATION_MATRICES][self.keyword]
         if not "grad_p" in matrix_dictionary:
-            raise ValueError("""GradP class requires a pre-computed discretization to be
-                             stored in the matrix dictionary.""")
-
-        return matrix_dictionary["grad_p"]
+            raise ValueError(
+                """GradP class requires a pre-computed discretization to be
+                             stored in the matrix dictionary."""
+            )
+        biot_alpha = data[pp.PARAMETERS][self.keyword]["biot_alpha"]
+        return matrix_dictionary["grad_p"] * biot_alpha
 
     def assemble_rhs(self, g, data):
-        """ Return the zero right-hand side for a discretization of the grad p term.
+        """ Return the zero right-hand side for a discretization of the pressure
+        gradient term.
 
         @Runar: Is it correct that this is zero.
 
@@ -720,6 +727,228 @@ class GradP(pp.numerics.mixed_dim.VectorEllipticDiscretization):
             np.ndarray: Zero right hand side vector with representation of boundary
                 conditions.
         """
-        return np.zeros(self.ndof)
+        return np.zeros(self.ndof(g))
 
 
+class DivD(pp.numerics.mixed_dim.VectorEllipticDiscretization):
+    """ Class for the displacement divergence term of the Biot equation.
+    """
+
+    def ndof(self, g):
+        """ Return the number of degrees of freedom associated to the method.
+
+        In this case number of cells times dimension (stress dof).
+
+        Parameter
+        ---------
+        g: grid, or a subclass.
+
+        Return
+        ------
+        dof: the number of degrees of freedom.
+
+        """
+        return g.num_cells
+
+    def extract_displacement(self, g, solution_array, d):
+        """ Extract the displacement part of a solution.
+
+        The method is trivial for finite volume methods, with the displacement being
+        the only primary variable.
+
+        Parameters:
+            g (grid): To which the solution array belongs.
+            solution_array (np.array): Solution for this grid obtained from
+                either a mono-dimensional or a mixed-dimensional problem.
+            d (dictionary): Data dictionary associated with the grid. Not used,
+                but included for consistency reasons.
+        Returns:
+            np.array (g.num_cells): Displacement solution vector. Will be identical
+                to solution_array.
+        """
+        return solution_array
+
+    def discretize(self, g, data):
+        """ Discretize the displacement divergence term of the Biot equation.
+
+        Parameters:
+            g (pp.Grid): grid, or a subclass, with geometry fields computed.
+            data (dict): For entries, see above.
+
+        Raises:
+            NotImplementedError, the discretization should be performed using the
+            discretize method of the Biot class.
+        """
+        raise NotImplementedError(
+            """No discretize method implemented for the GradP
+                                  class. See the Biot class."""
+        )
+
+    def assemble_matrix_rhs(self, g, data):
+        """ Return the matrix and right-hand side for a discretization of the
+        displacement divergence term of the Biot equation.
+
+        Parameters:
+            g : grid, or a subclass, with geometry fields computed.
+            data: dictionary to store the data. For details on necessary keywords,
+                see method discretize()
+
+        Returns:
+            matrix: sparse csr (g.dim * g_num_cells, g.dim * g_num_cells) Discretization
+            matrix.
+            rhs: array (g.dim * g_num_cells) Right-hand side.
+        """
+        return self.assemble_matrix(g, data), self.assemble_rhs(g, data)
+
+    def assemble_matrix(self, g, data):
+        """ Return the matrix and right-hand side for a discretization of the
+        displacement divergence term of the Biot equation.
+
+        Parameters:
+            g (Grid): Computational grid, with geometry fields computed.
+            data (dictionary): With data stored.
+
+        Returns:
+            scipy.sparse.csr_matrix: System matrix of this discretization. The
+                size of the matrix will depend on the specific discretization.
+
+        Raises:
+            ValueError if the displacement divergence term has not already been
+            discretized.
+        """
+        matrix_dictionary = data[pp.DISCRETIZATION_MATRICES][self.keyword]
+        if not "div_d" in matrix_dictionary:
+            raise ValueError(
+                """DivD class requires a pre-computed discretization to be
+                             stored in the matrix dictionary."""
+            )
+        biot_alpha = data[pp.PARAMETERS][self.keyword]["biot_alpha"]
+        return matrix_dictionary["div_d"] * biot_alpha
+
+    def assemble_rhs(self, g, data):
+        """ Return the zero right-hand side for a discretization of the displacement
+        divergence term.
+
+        @Runar: Is it correct that this is zero.
+
+        Parameters:
+            g (Grid): Computational grid.
+            data (dictionary): With data stored.
+
+        Returns:
+            np.ndarray: Zero right hand side vector with representation of boundary
+                conditions.
+        """
+        return np.zeros(self.ndof(g))
+
+
+class BiotStabilization(pp.numerics.mixed_dim.VectorEllipticDiscretization):
+    """ Class for the stabilization term of the Biot equation.
+    """
+
+    def ndof(self, g):
+        """ Return the number of degrees of freedom associated to the method.
+
+        In this case number of cells times dimension (stress dof).
+
+        Parameter
+        ---------
+        g: grid, or a subclass.
+
+        Return
+        ------
+        dof: the number of degrees of freedom.
+
+        """
+        return g.num_cells
+
+    def extract_displacement(self, g, solution_array, d):
+        """ Extract the displacement part of a solution.
+
+        The method is trivial for finite volume methods, with the displacement being
+        the only primary variable.
+
+        Parameters:
+            g (grid): To which the solution array belongs.
+            solution_array (np.array): Solution for this grid obtained from
+                either a mono-dimensional or a mixed-dimensional problem.
+            d (dictionary): Data dictionary associated with the grid. Not used,
+                but included for consistency reasons.
+        Returns:
+            np.array (g.num_cells): Displacement solution vector. Will be identical
+                to solution_array.
+        """
+        return solution_array
+
+    def discretize(self, g, data):
+        """ Discretize the stabilization term of the Biot equation.
+
+        Parameters:
+            g (pp.Grid): grid, or a subclass, with geometry fields computed.
+            data (dict): For entries, see above.
+
+        Raises:
+            NotImplementedError, the discretization should be performed using the
+            discretize method of the Biot class.
+        """
+        raise NotImplementedError(
+            """No discretize method implemented for the DivD
+                                  class. See the Biot class."""
+        )
+
+    def assemble_matrix_rhs(self, g, data):
+        """ Return the matrix and right-hand side for a discretization of the
+        stabilization term of the Biot equation.
+
+        Parameters:
+            g : grid, or a subclass, with geometry fields computed.
+            data: dictionary to store the data. For details on necessary keywords,
+                see method discretize()
+
+        Returns:
+            matrix: sparse csr (g.dim * g_num_cells, g.dim * g_num_cells) Discretization
+            matrix.
+            rhs: array (g.dim * g_num_cells) Right-hand side.
+        """
+        return self.assemble_matrix(g, data), self.assemble_rhs(g, data)
+
+    def assemble_matrix(self, g, data):
+        """ Return the matrix and right-hand side for a discretization of the
+        stabilization term of the Biot equation.
+
+        Parameters:
+            g (Grid): Computational grid, with geometry fields computed.
+            data (dictionary): With data stored.
+
+        Returns:
+            scipy.sparse.csr_matrix: System matrix of this discretization. The
+                size of the matrix will depend on the specific discretization.
+
+        Raises:
+            ValueError if the stabilization term has not already been
+            discretized.
+        """
+        matrix_dictionary = data[pp.DISCRETIZATION_MATRICES][self.keyword]
+        if not "biot_stabilization" in matrix_dictionary:
+            raise ValueError(
+                """BiotStabilization class requires a pre-computed
+                             discretization to be stored in the matrix dictionary."""
+            )
+
+        return matrix_dictionary["biot_stabilization"]
+
+    def assemble_rhs(self, g, data):
+        """ Return the zero right-hand side for a discretization of the displacement
+        divergence term.
+
+        @Runar: Is it correct that this is zero.
+
+        Parameters:
+            g (Grid): Computational grid.
+            data (dictionary): With data stored.
+
+        Returns:
+            np.ndarray: Zero right hand side vector with representation of boundary
+                conditions.
+        """
+        return np.zeros(self.ndof(g))

--- a/src/porepy/numerics/fv/mpsa.py
+++ b/src/porepy/numerics/fv/mpsa.py
@@ -17,7 +17,7 @@ import porepy as pp
 logger = logging.getLogger(__name__)
 
 
-class Mpsa(pp.numerics.mixed_dim.EllipticDiscretization):
+class Mpsa(pp.numerics.mixed_dim.VectorEllipticDiscretization):
     def ndof(self, g):
         """
         Return the number of degrees of freedom associated to the method.
@@ -35,8 +35,9 @@ class Mpsa(pp.numerics.mixed_dim.EllipticDiscretization):
         return g.dim * g.num_cells
 
     def extract_displacement(self, g, solution_array, d):
-        """ Extract the pressure part of a solution.
-        The method is trivial for finite volume methods, with the pressure
+        """ Extract the displacement part of a solution.
+
+        The method is trivial for finite volume methods, with the displacement
         being the only primary variable.
 
         Parameters:
@@ -66,8 +67,8 @@ class Mpsa(pp.numerics.mixed_dim.EllipticDiscretization):
                 Stored in data[pp.DISCRETIZATION_MATRICES][self.keyword]
 
         parameter_dictionary contains the entries:
-            fourth_order_tensor : (pp.FourthOrderTensor) Stiffness tensor defined cell-wise.
-            bc : (BoundaryConditionVectorial) boundary conditions
+            fourth_order_tensor: (pp.FourthOrderTensor) Stiffness tensor defined cell-wise.
+            bc: (BoundaryConditionVectorial) boundary conditions
             mpsa_eta: (float/np.ndarray) Optional. Range [0, 1). Location of
                 displacement continuity point: eta. eta = 0 gives cont. pt. at face midpoint,
                 eta = 1 at the vertex. If not given, porepy tries to set an optimal
@@ -80,22 +81,23 @@ class Mpsa(pp.numerics.mixed_dim.EllipticDiscretization):
                 stress discretization, cell center contribution
             bound_flux: sps.csc_matrix (g.dim * g.num_faces, g.dim * g.num_faces)
                 stress discretization, face contribution
-            bound_displacement_cell: sps.csc_matrix (g.dim * g.num_faces, g.dim * g.num_cells)
-                Operator for reconstructing the displacement trace. Cell center contribution
-            bound_displacement_face: sps.csc_matrix (g.dim * g.num_faces, g.dim * g.num_faces)
-                Operator for reconstructing the displacement trace. Face contribution
-
-        Hidden option (intended as "advanced" option that one should normally not
-        care about):
-            Half transmissibility calculation according to Ivar Aavatsmark, see
-            folk.uib.no/fciia/elliptisk.pdf. Activated by adding the entry
-            Aavatsmark_transmissibilities: True   to the data dictionary.
+            bound_displacement_cell: sps.csc_matrix (g.dim * g.num_faces,
+                                                     g.dim * g.num_cells)
+                Operator for reconstructing the displacement trace. Cell center
+                contribution.
+            bound_displacement_face: sps.csc_matrix (g.dim * g.num_faces,
+                                                     g.dim * g.num_faces)
+                Operator for reconstructing the displacement trace. Face contribution.
 
         Parameters
         ----------
         g (pp.Grid): grid, or a subclass, with geometry fields computed.
         data (dict): For entries, see above.
         faces (np.ndarray): optional. Defines active faces.
+
+        Raises
+        ------
+        NotImplementedError for partial discretization
         """
         parameter_dictionary = data[pp.PARAMETERS][self.keyword]
         matrix_dictionary = data[pp.DISCRETIZATION_MATRICES][self.keyword]
@@ -148,17 +150,13 @@ class Mpsa(pp.numerics.mixed_dim.EllipticDiscretization):
 
     def assemble_matrix(self, g, data):
         """
-        Return the matrix for a discretization of a second order elliptic equation
-        using a FV method.
+        Return the matrix for a discretization of a second order elliptic vector
+        equation using a FV method.
 
         The name of data in the input dictionary (data) are:
-        k : FourthOrderTensor
-            stiffness tensor defined cell-wise.
-        bc : boundary conditions (optional)
-        bc_val : dictionary (optional)
-            Values of the boundary conditions. The dictionary has at most the
-            following keys: 'dir', 'neu' 'rob', for Dirichlet, Neumann and Robin
-            boundary conditions, respectively.
+        fourth_order_tensor: FourthOrderTensor stiffness tensor defined cell-wise.
+        bc: boundary conditions, pp.BoundaryConditionVectorial.
+        bc_values: (g.dim * g.num_faces) Values of the boundary conditions.
 
         Parameters:
             g (Grid): Computational grid, with geometry fields computed.

--- a/src/porepy/numerics/mixed_dim/__init__.py
+++ b/src/porepy/numerics/mixed_dim/__init__.py
@@ -2,4 +2,7 @@ from .abstract_coupling import AbstractCoupling
 from .coupler import Coupler
 from .solver import Solver
 from .abstract_assembler import AbstractAssembler
-from .elliptic_discretization import EllipticDiscretization
+from .elliptic_discretization import (
+    EllipticDiscretization,
+    VectorEllipticDiscretization,
+)

--- a/src/porepy/params/data.py
+++ b/src/porepy/params/data.py
@@ -231,7 +231,8 @@ def initialize_data(g, data, keyword, specified_parameters=None):
     """ Initialize a data dictionary for a single keyword.
 
     The initialization consists of adding a parameter dictionary and initializing a
-    matrix dictionary in the proper fields of data.
+    matrix dictionary in the proper fields of data. If there is a Parameters object
+    in data, the new keyword is added using the update_dictionaries method.
 
     Args:
         data: Outer data dictionary, to which the parameters will be added.
@@ -246,8 +247,10 @@ def initialize_data(g, data, keyword, specified_parameters=None):
     if not specified_parameters:
         specified_parameters = {}
     add_discretization_matrix_keyword(data, keyword)
-    parameters = pp.Parameters(g, [keyword], [specified_parameters])
-    data[pp.PARAMETERS] = parameters
+    if pp.PARAMETERS in data:
+        data[pp.PARAMETERS].update_dictionaries([keyword], [specified_parameters])
+    else:
+        data[pp.PARAMETERS] = pp.Parameters(g, [keyword], [specified_parameters])
     return data
 
 

--- a/test/integration/test_upwind_coupling.py
+++ b/test/integration/test_upwind_coupling.py
@@ -1,11 +1,11 @@
 from __future__ import division
 import numpy as np
 import unittest
-import scipy.sparse as sps
 
 import porepy as pp
 from porepy.utils.grid_util import sign_of_boundary_faces
 from test.integration import _helper_test_upwind_coupling
+from test.test_utils import permute_matrix_vector
 
 # ------------------------------------------------------------------------------#
 
@@ -24,7 +24,8 @@ class BasicsTest(unittest.TestCase):
         key = "transport"
         upwind = pp.Upwind(key)
         upwind_coupling = pp.UpwindCoupling(key)
-        assign_discretization(gb, upwind, upwind_coupling, key)
+        variable = "T"
+        assign_discretization(gb, upwind, upwind_coupling, variable)
 
         # assign parameters
         gb.add_node_props(["param"])
@@ -58,15 +59,17 @@ class BasicsTest(unittest.TestCase):
         U_tmp, rhs, block_dof, full_dof = assembler.assemble_matrix_rhs(gb)
 
         grids = np.empty(gb.num_graph_nodes() + gb.num_graph_edges(), dtype=np.object)
-        keys = np.empty_like(grids)
+        variables = np.empty_like(grids)
         for g, d in gb:
             grids[d["node_number"]] = g
-            keys[d["node_number"]] = key
+            variables[d["node_number"]] = variable
         for e, d in gb.edges():
             grids[d["edge_number"] + gb.num_graph_nodes()] = e
-            keys[d["edge_number"] + gb.num_graph_nodes()] = "lambda_u"
+            variables[d["edge_number"] + gb.num_graph_nodes()] = "lambda_u"
 
-        U, rhs = permute_matrix_vector(U_tmp, rhs, block_dof, full_dof, grids, keys)
+        U, rhs = permute_matrix_vector(
+            U_tmp, rhs, block_dof, full_dof, grids, variables
+        )
 
         theta = np.linalg.solve(U.A, rhs)
         #        deltaT = solver.cfl(gb)
@@ -105,7 +108,8 @@ class BasicsTest(unittest.TestCase):
         key = "transport"
         upwind = pp.Upwind(key)
         upwind_coupling = pp.UpwindCoupling(key)
-        assign_discretization(gb, upwind, upwind_coupling, key)
+        variable = "T"
+        assign_discretization(gb, upwind, upwind_coupling, variable)
 
         # assign parameters
 
@@ -142,15 +146,17 @@ class BasicsTest(unittest.TestCase):
         U_tmp, rhs, block_dof, full_dof = assembler.assemble_matrix_rhs(gb)
 
         grids = np.empty(gb.num_graph_nodes() + gb.num_graph_edges(), dtype=np.object)
-        keys = np.empty_like(grids)
+        variables = np.empty_like(grids)
         for g, d in gb:
             grids[d["node_number"]] = g
-            keys[d["node_number"]] = key
+            variables[d["node_number"]] = variable
         for e, d in gb.edges():
             grids[d["edge_number"] + gb.num_graph_nodes()] = e
-            keys[d["edge_number"] + gb.num_graph_nodes()] = "lambda_u"
+            variables[d["edge_number"] + gb.num_graph_nodes()] = "lambda_u"
 
-        U, rhs = permute_matrix_vector(U_tmp, rhs, block_dof, full_dof, grids, keys)
+        U, rhs = permute_matrix_vector(
+            U_tmp, rhs, block_dof, full_dof, grids, variables
+        )
         theta = np.linalg.solve(U.A, rhs)
         #        deltaT = solver.cfl(gb)
 
@@ -237,7 +243,8 @@ class BasicsTest(unittest.TestCase):
         key = "transport"
         upwind = pp.Upwind(key)
         upwind_coupling = pp.UpwindCoupling(key)
-        assign_discretization(gb, upwind, upwind_coupling, key)
+        variable = "T"
+        assign_discretization(gb, upwind, upwind_coupling, variable)
 
         # define parameters
         tol = 1e-3
@@ -275,14 +282,16 @@ class BasicsTest(unittest.TestCase):
         U_tmp, rhs, block_dof, full_dof = assembler.assemble_matrix_rhs(gb)
 
         grids = np.empty(gb.num_graph_nodes() + gb.num_graph_edges(), dtype=np.object)
-        keys = np.empty_like(grids)
+        variables = np.empty_like(grids)
         for g, d in gb:
             grids[d["node_number"]] = g
-            keys[d["node_number"]] = key
+            variables[d["node_number"]] = variable
         for e, d in gb.edges():
             grids[d["edge_number"] + gb.num_graph_nodes()] = e
-            keys[d["edge_number"] + gb.num_graph_nodes()] = "lambda_u"
-        U, rhs = permute_matrix_vector(U_tmp, rhs, block_dof, full_dof, grids, keys)
+            variables[d["edge_number"] + gb.num_graph_nodes()] = "lambda_u"
+        U, rhs = permute_matrix_vector(
+            U_tmp, rhs, block_dof, full_dof, grids, variables
+        )
         theta = np.linalg.solve(U.A, rhs)
         #        deltaT = solver.cfl(gb)
         U_known = np.array(
@@ -826,7 +835,8 @@ class BasicsTest(unittest.TestCase):
         key = "transport"
         upwind = pp.Upwind(key)
         upwind_coupling = pp.UpwindCoupling(key)
-        assign_discretization(gb, upwind, upwind_coupling, key)
+        variable = "T"
+        assign_discretization(gb, upwind, upwind_coupling, variable)
 
         # add parameters
         tol = 1e-3
@@ -861,15 +871,17 @@ class BasicsTest(unittest.TestCase):
         U_tmp, rhs, block_dof, full_dof = assembler.assemble_matrix_rhs(gb)
 
         grids = np.empty(gb.num_graph_nodes() + gb.num_graph_edges(), dtype=np.object)
-        keys = np.empty_like(grids)
+        variables = np.empty_like(grids)
         for g, d in gb:
             grids[d["node_number"]] = g
-            keys[d["node_number"]] = key
+            variables[d["node_number"]] = variable
         for e, d in gb.edges():
             grids[d["edge_number"] + gb.num_graph_nodes()] = e
-            keys[d["edge_number"] + gb.num_graph_nodes()] = "lambda_u"
+            variables[d["edge_number"] + gb.num_graph_nodes()] = "lambda_u"
 
-        U, rhs = permute_matrix_vector(U_tmp, rhs, block_dof, full_dof, grids, keys)
+        U, rhs = permute_matrix_vector(
+            U_tmp, rhs, block_dof, full_dof, grids, variables
+        )
         theta = np.linalg.solve(U.A, rhs)
         #        deltaT = solver.cfl(gb)
 
@@ -885,8 +897,6 @@ class BasicsTest(unittest.TestCase):
         rhs_known = np.array([1, 0, 0, 0, 0])
 
         theta_known = np.array([1, 1, 1, -1, 1])
-
-        deltaT_known = 5 * 1e-3
 
         rtol = 1e-15
         atol = rtol
@@ -908,7 +918,8 @@ class BasicsTest(unittest.TestCase):
         key = "transport"
         upwind = pp.Upwind(key)
         upwind_coupling = pp.UpwindCoupling(key)
-        assign_discretization(gb, upwind, upwind_coupling, key)
+        variable = "T"
+        assign_discretization(gb, upwind, upwind_coupling, variable)
 
         # assign parameters
         tol = 1e-3
@@ -943,15 +954,17 @@ class BasicsTest(unittest.TestCase):
         U_tmp, rhs, block_dof, full_dof = assembler.assemble_matrix_rhs(gb)
 
         grids = np.empty(gb.num_graph_nodes() + gb.num_graph_edges(), dtype=np.object)
-        keys = np.empty_like(grids)
+        variables = np.empty_like(grids)
         for g, d in gb:
             grids[d["node_number"]] = g
-            keys[d["node_number"]] = key
+            variables[d["node_number"]] = variable
         for e, d in gb.edges():
             grids[d["edge_number"] + gb.num_graph_nodes()] = e
-            keys[d["edge_number"] + gb.num_graph_nodes()] = "lambda_u"
+            variables[d["edge_number"] + gb.num_graph_nodes()] = "lambda_u"
 
-        U, rhs = permute_matrix_vector(U_tmp, rhs, block_dof, full_dof, grids, keys)
+        U, rhs = permute_matrix_vector(
+            U_tmp, rhs, block_dof, full_dof, grids, variables
+        )
 
         theta = np.linalg.solve(U.A, rhs)
         #        deltaT = solver.cfl(gb)
@@ -1080,7 +1093,8 @@ class BasicsTest(unittest.TestCase):
         key = "transport"
         upwind = pp.Upwind(key)
         upwind_coupling = pp.UpwindCoupling(key)
-        assign_discretization(gb, upwind, upwind_coupling, key)
+        variable = "T"
+        assign_discretization(gb, upwind, upwind_coupling, variable)
 
         # assign parameters
         tol = 1e-3
@@ -1115,14 +1129,16 @@ class BasicsTest(unittest.TestCase):
         U_tmp, rhs, block_dof, full_dof = assembler.assemble_matrix_rhs(gb)
 
         grids = np.empty(gb.num_graph_nodes() + gb.num_graph_edges(), dtype=np.object)
-        keys = np.empty_like(grids)
+        variables = np.empty_like(grids)
         for g, d in gb:
             grids[d["node_number"]] = g
-            keys[d["node_number"]] = key
+            variables[d["node_number"]] = variable
         for e, d in gb.edges():
             grids[d["edge_number"] + gb.num_graph_nodes()] = e
-            keys[d["edge_number"] + gb.num_graph_nodes()] = "lambda_u"
-        U, rhs = permute_matrix_vector(U_tmp, rhs, block_dof, full_dof, grids, keys)
+            variables[d["edge_number"] + gb.num_graph_nodes()] = "lambda_u"
+        U, rhs = permute_matrix_vector(
+            U_tmp, rhs, block_dof, full_dof, grids, variables
+        )
 
         theta = np.linalg.solve(U.A, rhs)
         #        deltaT = solver.cfl(gb)
@@ -1216,8 +1232,6 @@ class BasicsTest(unittest.TestCase):
             ]
         )
 
-        deltaT_known = 5 * 1e-3
-
         rtol = 1e-15
         atol = rtol
         self.assertTrue(np.allclose(U.todense(), U_known, rtol, atol))
@@ -1239,7 +1253,8 @@ class BasicsTest(unittest.TestCase):
         key = "transport"
         upwind = pp.Upwind(key)
         upwind_coupling = pp.UpwindCoupling(key)
-        assign_discretization(gb, upwind, upwind_coupling, key)
+        variable = "T"
+        assign_discretization(gb, upwind, upwind_coupling, variable)
 
         gb.add_node_props(["param"])
         a = 1e-2
@@ -1256,15 +1271,17 @@ class BasicsTest(unittest.TestCase):
         U_tmp, rhs, block_dof, full_dof = assembler.assemble_matrix_rhs(gb)
 
         grids = np.empty(gb.num_graph_nodes() + gb.num_graph_edges(), dtype=np.object)
-        keys = np.empty_like(grids)
+        variables = np.empty_like(grids)
         for g, d in gb:
             grids[d["node_number"]] = g
-            keys[d["node_number"]] = key
+            variables[d["node_number"]] = variable
         for e, d in gb.edges():
             grids[d["edge_number"] + gb.num_graph_nodes()] = e
-            keys[d["edge_number"] + gb.num_graph_nodes()] = "lambda_u"
+            variables[d["edge_number"] + gb.num_graph_nodes()] = "lambda_u"
 
-        M, rhs = permute_matrix_vector(U_tmp, rhs, block_dof, full_dof, grids, keys)
+        M, rhs = permute_matrix_vector(
+            U_tmp, rhs, block_dof, full_dof, grids, variables
+        )
 
         # add generic mass matrix to solve system
         I_diag = np.zeros(M.shape[0])
@@ -1387,11 +1404,11 @@ class BasicsTest(unittest.TestCase):
 
         # define discretization
         key = "transport"
+        variable = "T"
         upwind = pp.Upwind(key)
         upwind_coupling = pp.UpwindCoupling(key)
-        assign_discretization(gb, upwind, upwind_coupling, key)
+        assign_discretization(gb, upwind, upwind_coupling, variable)
 
-        gb.add_node_props(["param"])
         a = 1e-1
         for g, d in gb:
             aperture = np.ones(g.num_cells) * np.power(a, gb.dim_max() - g.dim)
@@ -1413,15 +1430,17 @@ class BasicsTest(unittest.TestCase):
         U_tmp, rhs, block_dof, full_dof = assembler.assemble_matrix_rhs(gb)
 
         grids = np.empty(gb.num_graph_nodes() + gb.num_graph_edges(), dtype=np.object)
-        keys = np.empty_like(grids)
+        variables = np.empty_like(grids)
         for g, d in gb:
             grids[d["node_number"]] = g
-            keys[d["node_number"]] = key
+            variables[d["node_number"]] = variable
         for e, d in gb.edges():
             grids[d["edge_number"] + gb.num_graph_nodes()] = e
-            keys[d["edge_number"] + gb.num_graph_nodes()] = "lambda_u"
+            variables[d["edge_number"] + gb.num_graph_nodes()] = "lambda_u"
 
-        M, rhs = permute_matrix_vector(U_tmp, rhs, block_dof, full_dof, grids, keys)
+        M, rhs = permute_matrix_vector(
+            U_tmp, rhs, block_dof, full_dof, grids, variables
+        )
         theta = np.linalg.solve(M.A, rhs)
         M_known = np.array(
             [
@@ -1550,18 +1569,22 @@ class BasicsTest(unittest.TestCase):
 # ------------------------------------------------------------------------------#
 
 
-def assign_discretization(gb, disc, coupling_disc, key):
+def assign_discretization(gb, disc, coupling_disc, variable):
     # Identifier of the advection term
     term = "advection"
     for _, d in gb:
-        d[pp.PRIMARY_VARIABLES] = {key: {"cells": 1}}
-        d[pp.DISCRETIZATION] = {key: {term: disc}}
+        d[pp.PRIMARY_VARIABLES] = {variable: {"cells": 1}}
+        d[pp.DISCRETIZATION] = {variable: {term: disc}}
 
     for e, d in gb.edges():
         g1, g2 = gb.nodes_of_edge(e)
         d[pp.PRIMARY_VARIABLES] = {"lambda_u": {"cells": 1}}
         d[pp.COUPLING_DISCRETIZATION] = {
-            key: {g1: (key, term), g2: (key, term), e: ("lambda_u", coupling_disc)}
+            variable: {
+                g1: (variable, term),
+                g2: (variable, term),
+                e: ("lambda_u", coupling_disc),
+            }
         }
 
 
@@ -1595,24 +1618,6 @@ def add_constant_darcy_flux(gb, upwind, flux, a):
             )
         else:
             d[pp.PARAMETERS]["transport"]["darcy_flux"] = darcy_flux_e
-
-
-def permute_matrix_vector(A, rhs, block_dof, full_dof, grids, keys):
-    sz = len(block_dof)
-    mat = np.empty((sz, sz), dtype=np.object)
-    b = np.empty(sz, dtype=np.object)
-    dof = np.empty(sz, dtype=np.object)
-    dof[0] = np.arange(full_dof[0])
-    for i in range(1, sz):
-        dof[i] = dof[i - 1][-1] + 1 + np.arange(full_dof[i])
-    for row in range(sz):
-        i = block_dof[(grids[row], keys[row])]
-        b[row] = rhs[dof[i]]
-        for col in range(sz):
-            j = block_dof[(grids[col], keys[col])]
-            mat[row, col] = A[dof[i]][:, dof[j]]
-
-    return sps.bmat(mat, format="csr"), np.concatenate(tuple(b))
 
 
 # #------------------------------------------------------------------------------#

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,0 +1,44 @@
+""" Utility functions for the tests.
+
+Access: from test import test_utils.
+"""
+
+import numpy as np
+import scipy.sparse as sps
+
+
+def permute_matrix_vector(A, rhs, block_dof, full_dof, grids, variables):
+    """ Permute the matrix and rhs from assembler order to a specified order.
+
+    Args:
+        A: global solution matrix as returned by Assembler.assemble_matrix_rhs.
+        rhs: global rhs vector as returned by Assembler.assemble_matrix_rhs.
+        block_dof: Map coupling a (grid, variable) pair to an block index of A, as
+            returned by Assembler.assemble_matrix_rhs.
+        full_dof: Number of DOFs for each pair in block_dof, as returned by
+            Assembler.assemble_matrix_rhs.
+
+    Returns:
+        sps.bmat(A.size): Permuted matrix.
+        np.ndarray(b.size): Permuted rhs vector.
+    """
+    sz = len(block_dof)
+    mat = np.empty((sz, sz), dtype=np.object)
+    b = np.empty(sz, dtype=np.object)
+    dof = np.empty(sz, dtype=np.object)
+    # Initialize dof vector
+    dof[0] = np.arange(full_dof[0])
+    for i in range(1, sz):
+        dof[i] = dof[i - 1][-1] + 1 + np.arange(full_dof[i])
+
+    for row in range(sz):
+        # Assembler index 0
+        i = block_dof[(grids[row], variables[row])]
+        b[row] = rhs[dof[i]]
+        for col in range(sz):
+            # Assembler index 1
+            j = block_dof[(grids[col], variables[col])]
+            # Put the A block indexed by i and j in mat of running indexes row and col
+            mat[row, col] = A[dof[i]][:, dof[j]]
+
+    return sps.bmat(mat, format="csr"), np.concatenate(tuple(b))

--- a/test/unit/test_biot.py
+++ b/test/unit/test_biot.py
@@ -3,54 +3,53 @@ import numpy as np
 import numpy.linalg
 import unittest
 import porepy as pp
-from porepy.numerics.fv import mpfa, mpsa, fvutils, biot
-from porepy.params import tensor, bc
-from porepy.params.data import Parameters
 from test.integration import setup_grids_mpfa_mpsa_tests as setup_grids
+from porepy.params import parameter_dictionaries as dictionaries
 
 
 class BiotTest(unittest.TestCase):
+    def make_boundary_conditions(self, g):
+        bound_faces = g.get_all_boundary_faces()
+        bound_flow = pp.BoundaryCondition(
+            g, bound_faces.ravel("F"), ["dir"] * bound_faces.size
+        )
+        bound_mech = pp.BoundaryConditionVectorial(
+            g, bound_faces.ravel("F"), ["dir"] * bound_faces.size
+        )
+        return bound_mech, bound_flow
+
     def test_no_dynamics_2d(self):
         g_list = setup_grids.setup_2d()
         kw_f = "flow"
         kw_m = "mechanics"
+        discr = pp.Biot()
         for g in g_list:
-            discr = biot.Biot()
 
-            bound_faces = g.get_all_boundary_faces()
-            bound = bc.BoundaryCondition(
-                g, bound_faces.ravel("F"), ["dir"] * bound_faces.size
-            )
-            bound_mech = bc.BoundaryConditionVectorial(
-                g, bound_faces.ravel("F"), ["dir"] * bound_faces.size
-            )
+            bound_mech, bound_flow = self.make_boundary_conditions(g)
 
             mu = np.ones(g.num_cells)
-            c = tensor.FourthOrderTensor(g.dim, mu, mu)
-            k = tensor.SecondOrderTensor(g.dim, np.ones(g.num_cells))
+            c = pp.FourthOrderTensor(g.dim, mu, mu)
+            k = pp.SecondOrderTensor(g.dim, np.ones(g.num_cells))
 
             bound_val = np.zeros(g.num_faces)
-            porosity = np.ones(g.num_cells)
             aperture = np.ones(g.num_cells)
 
-            param = Parameters(g, [kw_f, kw_m], [{}, {}])
+            param = pp.Parameters(g, [kw_f, kw_m], [{}, {}])
 
-            param[kw_f]["bc"] = bound
+            param[kw_f]["bc"] = bound_flow
             param[kw_m]["bc"] = bound_mech
             param[kw_f]["aperture"] = aperture
             param[kw_m]["aperture"] = aperture
-            param[kw_f]["second_order_tensor"] = k
+            param[kw_f]["second_order_tensor"] = k  # permeability / viscosity
             param[kw_m]["fourth_order_tensor"] = c
             param[kw_f]["bc_values"] = bound_val
             param[kw_m]["bc_values"] = np.tile(bound_val, g.dim)
-            param[kw_f]["porosity"] = porosity
-            param[kw_m]["porosity"] = porosity
             param[kw_f]["biot_alpha"] = 1
             param[kw_m]["biot_alpha"] = 1
-            param[kw_f]["fluid_compressibility"] = 0
-            param[kw_f]["fluid_viscosity"] = 1
-            data = {"inverter": "python", "time_step": 1}
-            data[pp.PARAMETERS] = param
+            param[kw_f]["time_step"] = 1
+            param[kw_f]["mass_weight"] = 0  # fluid compressibility * porosity
+            param[kw_m]["inverter"] = "python"
+            data = {pp.PARAMETERS: param}
             data[pp.DISCRETIZATION_MATRICES] = {kw_f: {}, kw_m: {}}
             A, b = discr.matrix_rhs(g, data)
             sol = np.linalg.solve(A.todense(), b)
@@ -97,9 +96,52 @@ class BiotTest(unittest.TestCase):
         cols = np.arange(6)
         vals = np.ones(6)
         known_matrix = sps.coo_matrix((vals, (rows, cols))).tocsr().toarray()
-        a = biot.Biot()._face_vector_to_scalar(3, 2).toarray()
+        a = pp.Biot()._face_vector_to_scalar(nf, nd).toarray()
         self.assertTrue(np.allclose(known_matrix, a))
+
+    def test_assemble_biot(self):
+        gb = pp.meshing.cart_grid([], [2, 1])
+        g = gb.grids_of_dimension(2)[0]
+        d = gb.node_props(g)
+        kw_m = "mechanics"
+        kw_f = "flow"
+        bound_mech, bound_flow = self.make_boundary_conditions(g)
+        pp.initialize_default_data(g, d, kw_m, {"bc": bound_mech, "biot_alpha": 1})
+        pp.initialize_default_data(g, d, kw_f, {"bc": bound_flow, "biot_alpha": 1})
+        # Discretize the mechanics related terms using the Biot class
+        biot_discretizer = pp.Biot()
+        biot_discretizer._discretize_mech(g, d)
+
+        v_0 = "displacement"
+        v_1 = "pressure"
+        term_00 = "stress_divergence"
+        term_01 = "pressure_gradient"
+        term_10 = "displacement_divergence"
+        term_11_0 = "fluid_mass"
+        term_11_1 = "fluid_flux"
+        term_11_2 = "stabilization"
+        d[pp.PRIMARY_VARIABLES] = {v_0: {"cells": g.dim}, v_1: {"cells": 1}}
+        d[pp.DISCRETIZATION] = {
+            v_0: {term_00: pp.Mpsa(kw_m)},
+            v_1: {
+                term_11_0: pp.MassMatrix(kw_f),
+                term_11_1: pp.Mpfa(kw_f),
+                term_11_2: pp.BiotStabilization(kw_f),
+            },
+            v_0 + "_" + v_1: {term_01: pp.GradP(kw_m)},
+            v_1 + "_" + v_0: {term_10: pp.DivD(kw_m)},
+        }
+        # Assemble. Also discretizes the flow terms (fluid_mass and fluid_flux)
+        general_assembler = pp.Assembler()
+        A, b, block_dof, _ = general_assembler.assemble_matrix_rhs(gb)
+
+        # Re-discretize and assemble using the Biot class
+        A_class, b_class = biot_discretizer.matrix_rhs(g, d)  # , discretize=False)
+        # Compare matrices
+        self.assertTrue(np.all(np.isclose(A.A, A_class.A)))
+        self.assertTrue(np.all(np.isclose(b, b_class)))
 
 
 if __name__ == "__main__":
+    #    BiotTest().test_assemble_biot()
     unittest.main()


### PR DESCRIPTION
Splitting of Biot class into DivD, GradP and BiotStabilization. Thus, the assembler can assemble the individual terms using the assemble_matrix_rhs methods of three new classes and Mpsa, Mpfa and MassMatrix. The idea is to discretize all mechanics terms (the three new + Mpsa) by a call to the _discretize_mech method of the old Biot class.
Testing could be improved, documentation should be fairly good.

Added test_utils.py to the test folder.
Note the inconsistency in source term treatment between mpsa and other discretizations, see slack channel #biot.