### PR TITLE
Freeze version of pytest-cov

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@ matplotlib >= 1.0
 pymetis >= 2016.2;platform_system=="Linux"
 cython >= 0.23;platform_system=="Linux"
 pytest >= 3.0.0
-pytest-cov
+pytest-cov == 2.6.0
 pytest-runner >= 2.0
 coverage
 coveralls


### PR DESCRIPTION
Somehow, pytest 2.6.1 broke the build. For the moment, fix it to 2.6.0