### PR TITLE
Biot rhs

### DIFF
--- a/examples/example5/test_upwind_examples.py
+++ b/examples/example5/test_upwind_examples.py
@@ -39,6 +39,8 @@ class BasicsTest(unittest.TestCase):
         data[pp.PARAMETERS]["transport"]["time_step"] = time_step
 
         U, rhs = advect.assemble_matrix_rhs(g, data)
+        rhs = time_step * rhs
+        U = time_step * U
         OF = advect.outflow(g, data)
         M, _ = pp.MassMatrix("transport").assemble_matrix_rhs(g, data)
 
@@ -91,6 +93,8 @@ class BasicsTest(unittest.TestCase):
         data[pp.PARAMETERS]["transport"]["time_step"] = time_step
 
         U, rhs = advect.assemble_matrix_rhs(g, data)
+        rhs = time_step * rhs
+        U = time_step * U
         M, _ = pp.MassMatrix("transport").assemble_matrix_rhs(g, data)
 
         conc = np.zeros(g.num_cells)
@@ -192,8 +196,10 @@ class BasicsTest(unittest.TestCase):
         advect = pp.Upwind("transport")
 
         U, rhs = advect.assemble_matrix_rhs(g, data)
-
         time_step = advect.cfl(g, data)
+        rhs = time_step * rhs
+        U = time_step * U
+
         data[pp.PARAMETERS]["transport"]["time_step"] = time_step
         M, _ = pp.MassMatrix("transport").assemble_matrix_rhs(g, data)
 

--- a/src/porepy/numerics/fv/biot.py
+++ b/src/porepy/numerics/fv/biot.py
@@ -202,7 +202,7 @@ class Biot:
                 [A_mech, matrices_m["grad_p"] * biot_alpha],
                 [
                     matrices_m["div_d"] * biot_alpha * d_scaling,
-                    matrices_f["mass"] + dt * A_flow + matrices_f["biot_stabilization"],
+                    matrices_f["mass"] + dt * A_flow + biot_alpha * matrices_f["biot_stabilization"],
                 ],
             ]
         ).tocsr()
@@ -390,7 +390,7 @@ class Biot:
         num_dir_subface = (
             bound_exclusion_mech.exclude_neu.shape[1]
             - bound_exclusion_mech.exclude_neu.shape[0]
-        ) * nd
+        )
         # No right hand side for cell displacement equations.
         rhs_normals_displ_var = sps.coo_matrix(
             (
@@ -964,8 +964,8 @@ class BiotStabilization(
                 """BiotStabilization class requires a pre-computed
                              discretization to be stored in the matrix dictionary."""
             )
-
-        return matrix_dictionary["biot_stabilization"]
+        alpha = data[pp.PARAMETERS][self.keyword]['biot_alpha']
+        return alpha * matrix_dictionary["biot_stabilization"]
 
     def assemble_rhs(self, g, data):
         """ Return the zero right-hand side for a discretization of the displacement

--- a/src/porepy/numerics/fv/biot.py
+++ b/src/porepy/numerics/fv/biot.py
@@ -110,12 +110,12 @@ class Biot:
         d_scaling = parameter_dictionary.get("displacement_scaling", 1)
         div_d = matrix_dictionaries[self.mechanics_keyword]["div_d"]
 
-        div_d = np.squeeze(parameter_dictionary["biot_alpha"] * div_d * d * d_scaling)
+        div_d_rhs = np.squeeze(parameter_dictionary["biot_alpha"] * div_d * d * d_scaling)
         p_cmpr = matrix_dictionaries[self.flow_keyword]["mass"] * p
 
         mech_rhs = np.zeros(g.dim * g.num_cells)
 
-        return np.hstack((mech_rhs, div_d + p_cmpr))
+        return np.hstack((mech_rhs, div_d_rhs + p_cmpr))
 
     def discretize(self, g, data):
         """ Discretize flow and mechanics equations using FV methods.

--- a/src/porepy/numerics/fv/biot.py
+++ b/src/porepy/numerics/fv/biot.py
@@ -76,9 +76,7 @@ class Biot:
         matrices_f = data[pp.DISCRETIZATION_MATRICES][self.flow_keyword]
 
         dt = data[pp.PARAMETERS][self.flow_keyword]["time_step"]
-        p_bound = (
-            -div_flow * matrices_f["bound_flux"] * p * dt
-        )
+        p_bound = -div_flow * matrices_f["bound_flux"] * p * dt
         s_bound = -div_mech * matrices_m["bound_stress"] * d
         return np.hstack((s_bound, p_bound))
 
@@ -114,7 +112,9 @@ class Biot:
         d_scaling = parameter_dictionary.get("displacement_scaling", 1)
         div_d = matrix_dictionaries[self.mechanics_keyword]["div_d"]
 
-        div_d_rhs = np.squeeze(parameter_dictionary["biot_alpha"] * div_d * d * d_scaling)
+        div_d_rhs = np.squeeze(
+            parameter_dictionary["biot_alpha"] * div_d * d * d_scaling
+        )
         p_cmpr = matrix_dictionaries[self.flow_keyword]["mass"] * p
 
         mech_rhs = np.zeros(g.dim * g.num_cells)
@@ -857,7 +857,9 @@ class DivD(
         d_bound_1 = parameter_dictionary["bc_values"]
         d_bound_0 = parameter_dictionary["bc_values"]
         biot_alpha = parameter_dictionary["biot_alpha"]
-        rhs_bound =  - matrix_dictionary["bound_div_d"] * (d_bound_1-d_bound_0) * biot_alpha
+        rhs_bound = (
+            -matrix_dictionary["bound_div_d"] * (d_bound_1 - d_bound_0) * biot_alpha
+        )
 
         # Time part
         d_cell = parameter_dictionary["state"]

--- a/src/porepy/numerics/fv/biot.py
+++ b/src/porepy/numerics/fv/biot.py
@@ -202,7 +202,9 @@ class Biot:
                 [A_mech, matrices_m["grad_p"] * biot_alpha],
                 [
                     matrices_m["div_d"] * biot_alpha * d_scaling,
-                    matrices_f["mass"] + dt * A_flow + biot_alpha * matrices_f["biot_stabilization"],
+                    matrices_f["mass"]
+                    + dt * A_flow
+                    + biot_alpha * matrices_f["biot_stabilization"],
                 ],
             ]
         ).tocsr()
@@ -964,7 +966,7 @@ class BiotStabilization(
                 """BiotStabilization class requires a pre-computed
                              discretization to be stored in the matrix dictionary."""
             )
-        alpha = data[pp.PARAMETERS][self.keyword]['biot_alpha']
+        alpha = data[pp.PARAMETERS][self.keyword]["biot_alpha"]
         return alpha * matrix_dictionary["biot_stabilization"]
 
     def assemble_rhs(self, g, data):

--- a/src/porepy/numerics/fv/mass_matrix.py
+++ b/src/porepy/numerics/fv/mass_matrix.py
@@ -155,7 +155,6 @@ class MassMatrix:
                 represent the porosity or heat capacity.
             apertures (ndarray, g.num_cells): Apertures of the cells for scaling of
                 the face normals.
-            time_step: Time step for a possible temporal discretization scheme.
 
         matrix_dictionary will be updated with the following entries:
             mass: sps.dia_matrix (sparse dia, self.ndof x self.ndof): Mass matrix
@@ -174,7 +173,7 @@ class MassMatrix:
         w = parameter_dictionary["mass_weight"]
         aperture = parameter_dictionary["aperture"]
         volumes = g.cell_volumes * aperture
-        coeff = volumes * w / parameter_dictionary["time_step"]
+        coeff = volumes * w
 
         matrix_dictionary["mass"] = sps.dia_matrix((coeff, 0), shape=(ndof, ndof))
         matrix_dictionary["bound_mass"] = np.zeros(ndof)

--- a/src/porepy/numerics/fv/mass_matrix.py
+++ b/src/porepy/numerics/fv/mass_matrix.py
@@ -251,8 +251,6 @@ class InvMassMatrix:
                 porosity. If not given assumed unitary.
             apertures (ndarray, g.num_cells): Apertures of the cells for scaling of
                 the face normals. If not given assumed unitary.
-        deltaT: Time step for a possible temporal discretization scheme. If not given
-            assumed unitary.
         """
         return self.assemble_matrix(g, data), self.assemble_rhs(g, data)
 
@@ -325,8 +323,6 @@ class InvMassMatrix:
                 porosity. If not given assumed unitary.
             apertures (ndarray, g.num_cells): Apertures of the cells for scaling of
                 the face normals. If not given assumed unitary.
-        deltaT: Time step for a possible temporal discretization scheme. If not given
-            assumed unitary.
         """
         matrix_dictionary = data[pp.DISCRETIZATION_MATRICES][self.keyword]
         M, rhs = MassMatrix(keyword=self.keyword).assemble_matrix_rhs(g, data)

--- a/src/porepy/params/parameter_dictionaries.py
+++ b/src/porepy/params/parameter_dictionaries.py
@@ -32,7 +32,6 @@ def flow_dictionary(g, in_data=None):
         "second_order_tensor": pp.SecondOrderTensor(g.dim, np.ones(g.num_cells)),
         "bc": pp.BoundaryCondition(g),
         "bc_values": np.zeros(g.num_faces),
-        "fluid_compressibility": np.ones(g.num_cells),
         "time_step": 1,
     }
 

--- a/test/unit/test_biot.py
+++ b/test/unit/test_biot.py
@@ -181,7 +181,8 @@ class BiotTest(unittest.TestCase):
         g = gb.grids_of_dimension(2)[0]
         d = gb.node_props(g)
 
-        # Parameters identified by two keywords
+        # Parameters identified by two keywords. Non-default parameters of somewhat
+        # arbitrary values are assigned to make the test more revealing.
         kw_m = "mechanics"
         kw_f = "flow"
         bound_mech, bound_flow = self.make_boundary_conditions(g)
@@ -279,10 +280,9 @@ class BiotTest(unittest.TestCase):
 class ImplicitMassMatrix(pp.MassMatrix):
     def assemble_rhs(self, g, data):
         """ Overwrite MassMatrix method to
-        1) Be consistent with the Biot dt convention.
-        2) Return the correct rhs for an IE time discretization of the Biot problem.
+        Return the correct rhs for an IE time discretization of the Biot problem.
 
-        TODO: Implement more general solutions.
+        TODO: Implement a more general solution.
         """
 
         parameter_dictionary = data[pp.PARAMETERS][self.keyword]
@@ -294,11 +294,10 @@ class ImplicitMassMatrix(pp.MassMatrix):
 
 class ImplicitMpfa(pp.Mpfa):
     def assemble_matrix_rhs(self, g, data):
-        """ Overwrite MassMatrix method to
+        """ Overwrite MPSA method to
         1) Be consistent with the Biot dt convention.
-        2) Return the correct rhs for an IE time discretization of the Biot problem.
 
-        TODO: Implement more general solutions.
+        TODO: Implement more general solution?.
         """
         a, b = super().assemble_matrix_rhs(g, data)
         dt = data[pp.PARAMETERS][self.keyword]["time_step"]
@@ -306,5 +305,4 @@ class ImplicitMpfa(pp.Mpfa):
 
 
 if __name__ == "__main__":
-    #    BiotTest().test_assemble_biot_rhs()
     unittest.main()

--- a/test/unit/test_biot.py
+++ b/test/unit/test_biot.py
@@ -1,6 +1,5 @@
 import scipy.sparse as sps
 import numpy as np
-import numpy.linalg
 import unittest
 import porepy as pp
 from test.integration import setup_grids_mpfa_mpsa_tests as setup_grids
@@ -17,6 +16,16 @@ class BiotTest(unittest.TestCase):
             g, bound_faces.ravel("F"), ["dir"] * bound_faces.size
         )
         return bound_mech, bound_flow
+
+    def make_initial_conditions(self, g, x0, y0, p0):
+        """ Make uniform initial condition vectors.
+        """
+        initial_displacement = x0 * np.ones((g.dim, g.num_cells))
+        initial_displacement[1] = y0
+        initial_displacement = initial_displacement.ravel("F")
+        initial_pressure = p0 * np.ones(g.num_cells)
+        initial_state = np.concatenate((initial_displacement, initial_pressure))
+        return initial_displacement, initial_pressure, initial_state
 
     def test_no_dynamics_2d(self):
         g_list = setup_grids.setup_2d()
@@ -111,9 +120,16 @@ class BiotTest(unittest.TestCase):
         kw_m = "mechanics"
         kw_f = "flow"
         bound_mech, bound_flow = self.make_boundary_conditions(g)
-        pp.initialize_default_data(g, d, kw_m, {"bc": bound_mech, "biot_alpha": 1})
-        pp.initialize_default_data(g, d, kw_f, {"bc": bound_flow, "biot_alpha": 1})
+        initial_disp, initial_pressure, initial_state = self.make_initial_conditions(
+            g, x0=0, y0=0, p0=0
+        )
+        parameters_m = {"bc": bound_mech, "biot_alpha": 1, "state": initial_disp}
+
+        parameters_f = {"bc": bound_flow, "biot_alpha": 1, "state": initial_pressure}
+        pp.initialize_default_data(g, d, kw_m, parameters_m)
+        pp.initialize_default_data(g, d, kw_f, parameters_f)
         # Discretize the mechanics related terms using the Biot class
+        d["state"] = initial_state
         biot_discretizer = pp.Biot()
         biot_discretizer._discretize_mech(g, d)
 
@@ -155,6 +171,140 @@ class BiotTest(unittest.TestCase):
         self.assertTrue(np.all(np.isclose(A.A, A_class.A)))
         self.assertTrue(np.all(np.isclose(b, b_class)))
 
+    def test_assemble_biot_rhs_transient(self):
+        """ Test the assembly of a Biot problem with a non-zero rhs using the assembler.
+
+        The test checks whether the discretization matches that of the Biot class and
+        that the solution reaches the expected steady state.
+        """
+        gb = pp.meshing.cart_grid([], [3, 3], physdims=[1, 1])
+        g = gb.grids_of_dimension(2)[0]
+        d = gb.node_props(g)
+
+        # Parameters identified by two keywords
+        kw_m = "mechanics"
+        kw_f = "flow"
+        bound_mech, bound_flow = self.make_boundary_conditions(g)
+        val_mech = np.ones(g.dim * g.num_faces)
+        val_flow = np.ones(g.num_faces)
+        initial_displacement, initial_pressure, initial_state = self.make_initial_conditions(
+            g, x0=1, y0=2, p0=0
+        )
+        dt = 1e0
+        biot_alpha = 0.6
+
+        parameters_m = {
+            "bc": bound_mech,
+            "bc_values": val_mech,
+            "time_step": dt,
+            "biot_alpha": biot_alpha,
+            "state": initial_displacement,
+        }
+        parameters_f = {
+            "bc": bound_flow,
+            "bc_values": val_flow,
+            "time_step": dt,
+            "biot_alpha": biot_alpha,
+            "state": initial_pressure,
+            "mass_weight": 0.1 * np.ones(g.num_cells),
+        }
+        pp.initialize_default_data(g, d, kw_m, parameters_m)
+        pp.initialize_default_data(g, d, kw_f, parameters_f)
+
+        # Initial condition fot the Biot class
+        d["state"] = initial_state
+
+        # Discretize the mechanics related terms using the Biot class
+        biot_discretizer = pp.Biot()
+        biot_discretizer._discretize_mech(g, d)
+
+        # Set up the structure for the assembler. First define variables and equation
+        # term names.
+        v_0 = "displacement"
+        v_1 = "pressure"
+        term_00 = "stress_divergence"
+        term_01 = "pressure_gradient"
+        term_10 = "displacement_divergence"
+        term_11_0 = "fluid_mass"
+        term_11_1 = "fluid_flux"
+        term_11_2 = "stabilization"
+        d[pp.PRIMARY_VARIABLES] = {v_0: {"cells": g.dim}, v_1: {"cells": 1}}
+        d[pp.DISCRETIZATION] = {
+            v_0: {term_00: pp.Mpsa(kw_m)},
+            v_1: {
+                term_11_0: ImplicitMassMatrix(kw_f),
+                term_11_1: ImplicitMpfa(kw_f),
+                term_11_2: pp.BiotStabilization(kw_f),
+            },
+            v_0 + "_" + v_1: {term_01: pp.GradP(kw_m)},
+            v_1 + "_" + v_0: {term_10: pp.DivD(kw_m)},
+        }
+
+        times = np.arange(5)
+        for t in times:
+            # Assemble. Also discretizes the flow terms (fluid_mass and fluid_flux)
+            general_assembler = pp.Assembler()
+            A, b, block_dof, full_dof = general_assembler.assemble_matrix_rhs(gb)
+
+            # Assemble using the Biot class
+            A_class, b_class = biot_discretizer.matrix_rhs(g, d, discretize=False)
+
+            # Make sure the variable ordering of the matrix assembled by the assembler
+            # matches that of the Biot class.
+            grids = [g, g]
+            variables = [v_0, v_1]
+            A, b = permute_matrix_vector(A, b, block_dof, full_dof, grids, variables)
+
+            # Compare the matrices and rhs vectors
+            self.assertTrue(np.all(np.isclose(A.A, A_class.A)))
+            self.assertTrue(np.all(np.isclose(b, b_class)))
+
+            # Store the current solution for the next time step.
+            # First for the assembler version
+            x_i = sps.linalg.spsolve(A_class, b_class)
+            u_i = x_i[: (g.dim * g.num_cells)]
+            p_i = x_i[(g.dim * g.num_cells) :]
+            d[pp.PARAMETERS][kw_m]["state"] = u_i
+            d[pp.PARAMETERS][kw_f]["state"] = p_i
+            # ... and then for the Biot class
+            d["state"] = x_i
+
+        # Check that the solution has converged to the expected, uniform steady state
+        # dictated by the BCs.
+        assert np.all(np.isclose(x_i, np.ones((g.dim + 1) * g.num_cells)))
+
+        return
+
+
+class ImplicitMassMatrix(pp.MassMatrix):
+    def assemble_rhs(self, g, data):
+        """ Overwrite MassMatrix method to
+        1) Be consistent with the Biot dt convention.
+        2) Return the correct rhs for an IE time discretization of the Biot problem.
+
+        TODO: Implement more general solutions.
+        """
+
+        parameter_dictionary = data[pp.PARAMETERS][self.keyword]
+        matrix_dictionary = data[pp.DISCRETIZATION_MATRICES][self.keyword]
+        previous_pressure = parameter_dictionary["state"]
+
+        return matrix_dictionary["mass"] * previous_pressure
+
+
+class ImplicitMpfa(pp.Mpfa):
+    def assemble_matrix_rhs(self, g, data):
+        """ Overwrite MassMatrix method to
+        1) Be consistent with the Biot dt convention.
+        2) Return the correct rhs for an IE time discretization of the Biot problem.
+
+        TODO: Implement more general solutions.
+        """
+        a, b = super().assemble_matrix_rhs(g, data)
+        dt = data[pp.PARAMETERS][self.keyword]["time_step"]
+        return a * dt, b * dt
+
 
 if __name__ == "__main__":
+    #    BiotTest().test_assemble_biot_rhs()
     unittest.main()

--- a/test/unit/test_mass_matrix.py
+++ b/test/unit/test_mass_matrix.py
@@ -16,7 +16,7 @@ class MassMatrixTest(unittest.TestCase):
         time_discr = pp.MassMatrix()
         lhs, rhs = time_discr.assemble_matrix_rhs(g, data)
         self.assertTrue(np.allclose(rhs, 0))
-        self.assertTrue(np.allclose(lhs.diagonal(), g.cell_volumes * phi / dt))
+        self.assertTrue(np.allclose(lhs.diagonal(), g.cell_volumes * phi))
         off_diag = np.where(~np.eye(lhs.shape[0], dtype=bool))
         self.assertTrue(np.allclose(lhs.A[off_diag], 0))
 
@@ -30,7 +30,7 @@ class MassMatrixTest(unittest.TestCase):
         time_discr = pp.InvMassMatrix()
         lhs, rhs = time_discr.assemble_matrix_rhs(g, data)
         self.assertTrue(np.allclose(rhs, 0))
-        self.assertTrue(np.allclose(lhs.diagonal(), dt / (g.cell_volumes * phi)))
+        self.assertTrue(np.allclose(lhs.diagonal(), 1 / (g.cell_volumes * phi)))
         off_diag = np.where(~np.eye(lhs.shape[0], dtype=bool))
         self.assertTrue(np.allclose(lhs.A[off_diag], 0))
 

--- a/test/unit/test_parameter_dictionaries.py
+++ b/test/unit/test_parameter_dictionaries.py
@@ -160,7 +160,6 @@ class TestParameterDictionaries(unittest.TestCase):
         p_list = [
             "aperture",
             "porosity",
-            "fluid_compressibility",
             "mass_weight",
             "source",
             "time_step",
@@ -170,12 +169,7 @@ class TestParameterDictionaries(unittest.TestCase):
         ]
         [self.assertIn(parameter, dictionary) for parameter in p_list]
         # Check some of the values:
-        unitary_parameters = [
-            "aperture",
-            "porosity",
-            "fluid_compressibility",
-            "mass_weight",
-        ]
+        unitary_parameters = ["aperture", "porosity", "mass_weight"]
         ones = np.ones(self.g.num_cells)
         for parameter in unitary_parameters:
             self.assertTrue(np.all(np.isclose(dictionary[parameter], ones)))


### PR DESCRIPTION
Important note:
The time step was removed from MassMatrix.

Otherwise, there are few updates in fv/biot.py:
DivD class returns the rhs
Fixed two bugs in the Biot rhs

utils/test_biot.py was extended with a test of the rhs. See that file for how to assemble Biot with a non-zero rhs. In particular, the assemble_rhs functions of the classes Mpfa and MassMatrix must be adjusted to account for the time step and the rhs, respectively.