### PR TITLE
remove pymetis from requirements and requirements_dev

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,6 @@ numpy >= 1.13
 scipy >= 0.17,<1.0
 sympy >= 1.0
 matplotlib >= 1.0
-pymetis >= 2016.2;platform_system=="Linux"
 cython >= 0.23;platform_system=="Linux"
 pytest >= 3.0.0
 pytest-cov == 2.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ scipy >= 0.17,<1.0
 sympy >= 1.0
 matplotlib >= 1.0
 future
-pymetis >= 2016.2;platform_system=="Linux"
 cython >= 0.23;platform_system=="Linux"
 six
 shapely


### PR DESCRIPTION
attempt to fix Travis by removing the (not essential) pymetis library