### PR TITLE
updated dockerfile and readme to include vtk from conda-forge

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -63,7 +63,7 @@ For the moment, Docker support should be considered experimental.
 To function optimally, PorePy should have access to the pypi packages:
 *  `pymetis` (for mesh partitioning). Will be installed on Linux (not so on Windows, to avoid installation issues for the core package in the case where no C compiler is available).
 * Some computationally expensive methods can be accelerated with `Cython` or `Numba`. Cython is automatically installed on many Linux systems, if not, use pip or conda. Numba can be installed using `conda`.
-* Visualization by either matplotlib or (preferrable for larger problems) vtk/paraview. To dump data to paraview, a vtk filter must be available; the only solution we have found is from the 'conda' repositories, e.g. 'conda install -c clinicalgraphics vtk=7.1.0' (note that vtk should be version 7.0.0 or later, hence not the official channel)
+* Visualization by either matplotlib or (preferrable for larger problems) vtk/paraview. To dump data to paraview, a vtk filter must be available; the only solution we have found is from the 'conda' repositories, e.g. 'RUN conda install -c conda-forge vtk'
 * We use `shapely` for certain geometry-operations.
 * Meshing: currently by [gmsh](http://gmsh.info/doc/texinfo/gmsh.html). For its configuration see [Install](https://github.com/pmgbergen/porepy/blob/develop/Install.md).
 

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -72,7 +72,9 @@ RUN git clone https://github.com/pmgbergen/porepy.git pp
 #    python setup.py install 
 
 WORKDIR /home/porepy/pp
-RUN conda install numpy=1.16.3 scipy=1.2.1 networkx=2.3 sympy=1.4 cython=0.29.7 numba=0.43.1 matplotlib=3.0.3 pytest=4.5.0 pytest-cov=2.6.1 pytest-runner=4.4 vtk=8.2.0 jupyter=1.0.0
+RUN conda install numpy=1.16.3 scipy=1.2.1 networkx=2.3 sympy=1.4 cython=0.29.7 numba=0.43.1 matplotlib=3.0.3 pytest=4.5.0 pytest-cov=2.6.1 pytest-runner=4.4 jupyter=1.0.0
+# Vtk should be install from conda-forged (not all dependencies are installed otherwise):
+RUN conda install -c conda-forge vtk
 RUN pip install meshio==2.3.8 shapely==1.6.4.post2 shapely[vectorized]==1.6.4.post2
 
 RUN python setup.py install


### PR DESCRIPTION
Changed library for vtk to conda-forge.

When installing vtk in docker, this seems to be necessary to get all dependent packages (specifically some packaged assumed to be included in ubuntu).

(clinicalgraphics seems to be down)