### PR TITLE
fix: do not change input array

### DIFF
--- a/src/porepy/geometry/map_geometry.py
+++ b/src/porepy/geometry/map_geometry.py
@@ -145,7 +145,7 @@ def project_points_to_line(p, tol=1e-4):
 
     """
     center = np.mean(p, axis=1).reshape((-1, 1))
-    p -= center
+    p = p - center
 
     if p.shape[0] == 2:
         p = np.vstack((p, np.zeros(p.shape[1])))


### PR DESCRIPTION
# Overview
The input array in the old code is changed inplace, with no way to recreate it unless I pass a copy of p to the method.
See e.g. https://stackoverflow.com/a/25463222 

As a side note, the output `sorted_coord` has not been scaled "back" to the original coordinates.

# Reproduce
Try e.g.
```
p = np.array([[2.,4.,6.]]).T.dot(np.atleast_2d(np.arange(10)))
print(p)
sorted_coord, rot, active_dimension, sort_ind = pp.map_geometry.project_points_to_line(p)
print(p)
print(sorted_coord)
```
to reproduce. Notice that both `p` and `sorted_coord` are centered around zero.

If this is intended behaviour, I think we should add a warning in the documentation, as this could cause very confusing errors if e.g. `g.nodes` is passed directly to this method.