### PR TITLE
fix: attr MortarGrid.sides not set properly

### DIFF
--- a/src/porepy/grids/mortar_grid.py
+++ b/src/porepy/grids/mortar_grid.py
@@ -77,7 +77,7 @@ class MortarGrid(object):
 
         self.dim = dim
         self.side_grids = side_grids.copy()
-        self.sides = np.array(self.side_grids.keys)
+        self.sides = np.array(list(self.side_grids.keys()))
 
         if not (self.num_sides() == 1 or self.num_sides() == 2):
             raise ValueError("The number of sides have to be 1 or 2")
@@ -630,7 +630,7 @@ class BoundaryMortar(MortarGrid):
 
         self.dim = dim
         self.side_grids = {0: mortar_grid}
-        self.sides = np.array(self.side_grids.keys)
+        self.sides = np.array(list(self.side_grids.keys()))
 
         if not (self.num_sides() == 1 or self.num_sides() == 2):
             raise ValueError("The number of sides have to be 1 or 2")


### PR DESCRIPTION
# Overview
There seems to be lacking some parantheses to make `self.side_grids.keys` `()` be called properly.

## Additional
This bug seems to have been introduced ~2 years ago (Commit: https://github.com/pmgbergen/porepy/commit/b5cacbc9cd3fa381533c085cb6f720abe00bd2f5), so it is perhaps safe to say that the attribute isn't used anywhere ([suggested by a quick search](https://github.com/pmgbergen/porepy/search?q=sides&unscoped_q=sides)). 

_A perhaps related question:_
In the same commit (https://github.com/pmgbergen/porepy/commit/b5cacbc9cd3fa381533c085cb6f720abe00bd2f5) a tiny class called `SideTag` is introduced, which is referenced to throughout the current documentation (See: [this porepy search](https://github.com/pmgbergen/porepy/search?q=SideTag&unscoped_q=SideTag)), and is also referenced in the documentation of the attribute I fixed above. However, this class seems to have been removed in a more recent update of the codebase, with no updates to the docs. Some insight is gladly appreciated.


