### PR TITLE
fix: shape of input array

### DIFF
--- a/src/porepy/utils/sort_points.py
+++ b/src/porepy/utils/sort_points.py
@@ -109,6 +109,8 @@ def sort_point_plane(pts, centre, normal=None, tol=1e-5):
     map_pts: np.array, 1xn, sorted point ids.
 
     """
+    _c = np.atleast_2d(centre)
+    centre = _c if _c.shape[0] > _c.shape[1] else _c.T
     R = pp.map_geometry.project_plane_matrix(pts, normal)
     # project points and center,  project to plane
     delta = np.dot(R, pts - centre)

--- a/src/porepy/utils/sort_points.py
+++ b/src/porepy/utils/sort_points.py
@@ -109,8 +109,7 @@ def sort_point_plane(pts, centre, normal=None, tol=1e-5):
     map_pts: np.array, 1xn, sorted point ids.
 
     """
-    _c = np.atleast_2d(centre)
-    centre = _c if _c.shape[0] > _c.shape[1] else _c.T
+    centre = centre.reshape((-1, 1))
     R = pp.map_geometry.project_plane_matrix(pts, normal)
     # project points and center,  project to plane
     delta = np.dot(R, pts - centre)


### PR DESCRIPTION
# Overview
A bug in the method `porepy.utils.sort_points.sort_point_plane` is triggered by `pp.plot_grid(g)`. The following code reproduces the bug.

# Reproduce the bug
```
n_cells = np.array([2, 2, 2])
physdims = np.array([10, 10, 10])

gb = pp.meshing.cart_grid(
            fracs=[],
            nx=n_cells,
            physdims=physdims,
        )
g = gb.grids_of_dimension(3)[0]
pp.plot_grid(g)
```

# Explanation
The function `sort_point_plane` expects the argument `centre` to be a `3x1` numpy array. However, the method `porepy.viz.plot_grid.plot_grid_3d` passes a `1d`-array of length `3`.

# Proposed fix
The function `sort_point_plane` needs to following modification:
* `_c = np.atleast_2d(centre)`
* `centre = _c if _c.shape[0]>_c.shape[1] else _c.T`

# Supplement
I examined the bug and tested the proposed fix [on my personal github](https://github.com/haakon-e/mastersproject/blob/develop/PorePy%20development/bug%20-%20sort_point_plane%20-%20argument%20shape.ipynb)