### PR TITLE
when using the plot_grid with a grid bucket handle the case when the …

### DIFF
--- a/src/porepy/viz/plot_grid.py
+++ b/src/porepy/viz/plot_grid.py
@@ -284,8 +284,8 @@ def plot_gb(gb, cell_value, vector_value, info, **kwargs):
         )
         plot_grid_xd(
             g,
-            d[pp.STATE].get(cell_value, None),
-            d[pp.STATE].get(vector_value, None),
+            d.get(pp.STATE, {}).get(cell_value, None),
+            d.get(pp.STATE, {}).get(vector_value, None),
             ax,
             **kwargs
         )


### PR DESCRIPTION
…dictionary pp.STATE is empty

Not really much to say.. It's really a small fix, normally the gb are without the pp.STATE field when are not used yet in a discretization. BTW, I would fix this issue as well.. But it will be for another branch with some extra discussions