### PR TITLE
Reworked import statements to reduce porepy import time

### DIFF
--- a/src/porepy/fracs/fractures_3d.py
+++ b/src/porepy/fracs/fractures_3d.py
@@ -10,7 +10,7 @@ import time
 import logging
 import numpy as np
 import csv
-from sympy.geometry import Point, Polygon
+
 
 # Imports of external packages that may not be present at the system. The
 # module will work without any of these, but with limited functionalbility.
@@ -337,6 +337,7 @@ class Fracture(object):
             sympy.geometry.Polygon: Representation of the polygon formed by p.
 
         """
+        from sympy.geometry import Point, Polygon
         if p is None:
             p = self.p
 

--- a/src/porepy/geometry/constrain_geometry.py
+++ b/src/porepy/geometry/constrain_geometry.py
@@ -3,18 +3,7 @@
 Examples are to cut objects to lie within other objects, etc.
 """
 import numpy as np
-import networkx as nx
-
-import shapely.geometry as shapely_geometry
-import shapely.speedups as shapely_speedups
-
 import porepy as pp
-
-
-try:
-    shapely_speedups.enable()
-except AttributeError:
-    pass
 
 
 def lines_by_polygon(poly_pts, pts, edges):
@@ -37,6 +26,14 @@ def lines_by_polygon(poly_pts, pts, edges):
         values if an edge is cut by a non-convex domain.
 
     """
+    import shapely.geometry as shapely_geometry
+    import shapely.speedups as shapely_speedups
+    try:
+        shapely_speedups.enable()
+    except AttributeError:
+        pass
+
+    
     # it stores the points after the intersection
     int_pts = np.empty((2, 0))
     # define the polygon
@@ -102,7 +99,8 @@ def polygons_by_polyhedron(polygons, polyhedron, tol=1e-8):
             polygon
 
     """
-
+    import networkx as nx
+    
     if isinstance(polygons, np.ndarray):
         polygons = [polygons]
 

--- a/src/porepy/geometry/constrain_geometry.py
+++ b/src/porepy/geometry/constrain_geometry.py
@@ -28,12 +28,12 @@ def lines_by_polygon(poly_pts, pts, edges):
     """
     import shapely.geometry as shapely_geometry
     import shapely.speedups as shapely_speedups
+
     try:
         shapely_speedups.enable()
     except AttributeError:
         pass
 
-    
     # it stores the points after the intersection
     int_pts = np.empty((2, 0))
     # define the polygon
@@ -100,7 +100,7 @@ def polygons_by_polyhedron(polygons, polyhedron, tol=1e-8):
 
     """
     import networkx as nx
-    
+
     if isinstance(polygons, np.ndarray):
         polygons = [polygons]
 

--- a/src/porepy/geometry/intersections.py
+++ b/src/porepy/geometry/intersections.py
@@ -1167,12 +1167,12 @@ def triangulations(p_1, p_2, t_1, t_2):
     """
     import shapely.geometry as shapely_geometry
     import shapely.speedups as shapely_speedups
-    
+
     try:
         shapely_speedups.enable()
     except AttributeError:
         pass
-    
+
     n_1 = t_1.shape[1]
     n_2 = t_2.shape[1]
     t_1 = t_1.T

--- a/src/porepy/geometry/intersections.py
+++ b/src/porepy/geometry/intersections.py
@@ -2,22 +2,13 @@
 Module with functions for computing intersections between geometric objects.
 
 """
-
 import numpy as np
 import logging
-
-import shapely.geometry as shapely_geometry
-import shapely.speedups as shapely_speedups
 
 import porepy as pp
 
 # Module level logger
 logger = logging.getLogger(__name__)
-
-try:
-    shapely_speedups.enable()
-except AttributeError:
-    pass
 
 
 def segments_2d(start_1, end_1, start_2, end_2, tol=1e-8):
@@ -1174,6 +1165,14 @@ def triangulations(p_1, p_2, t_1, t_2):
             and their common area.
 
     """
+    import shapely.geometry as shapely_geometry
+    import shapely.speedups as shapely_speedups
+    
+    try:
+        shapely_speedups.enable()
+    except AttributeError:
+        pass
+    
     n_1 = t_1.shape[1]
     n_2 = t_2.shape[1]
     t_1 = t_1.T

--- a/src/porepy/grids/grid.py
+++ b/src/porepy/grids/grid.py
@@ -10,7 +10,6 @@ Acknowledgements:
     of the corresponding functions in MRST.
 
 """
-from __future__ import division
 import numpy as np
 import itertools
 from scipy import sparse as sps

--- a/src/porepy/grids/mortar_grid.py
+++ b/src/porepy/grids/mortar_grid.py
@@ -1,6 +1,5 @@
 """ Module containing the class for the mortar grid.
 """
-from __future__ import division
 import warnings
 import numpy as np
 from scipy import sparse as sps

--- a/src/porepy/grids/partition.py
+++ b/src/porepy/grids/partition.py
@@ -4,9 +4,7 @@ Module for partitioning of grids based on various methods.
 Intended support is by Cartesian indexing, and METIS-based.
 
 """
-from __future__ import division
 import warnings
-import networkx
 import numpy as np
 import scipy.sparse as sps
 from typing import List, Tuple
@@ -786,6 +784,7 @@ def grid_is_connected(
         False
 
     """
+    import networkx
 
     # If no cell indices are specified, we use them all.
     if cell_ind is None:

--- a/src/porepy/numerics/fv/fvutils.py
+++ b/src/porepy/numerics/fv/fvutils.py
@@ -1,7 +1,6 @@
 """
 Various FV specific utility functions.
 """
-from __future__ import division
 import numpy as np
 import scipy.sparse as sps
 from typing import Tuple

--- a/src/porepy/numerics/fv/mpfa.py
+++ b/src/porepy/numerics/fv/mpfa.py
@@ -2,7 +2,6 @@
 Implementation of the multi-point flux approximation O-method.
 
 """
-from __future__ import division
 import warnings
 import numpy as np
 import scipy.sparse as sps

--- a/src/porepy/numerics/fv/upwind.py
+++ b/src/porepy/numerics/fv/upwind.py
@@ -1,4 +1,3 @@
-from __future__ import division
 import numpy as np
 import scipy.sparse as sps
 

--- a/src/porepy/numerics/fv/upwind.py
+++ b/src/porepy/numerics/fv/upwind.py
@@ -4,33 +4,6 @@ import scipy.sparse as sps
 
 import porepy as pp
 
-# ------------------------------------------------------------------------------#
-
-# class _UpwindMixedDim(pp.numerics.mixed_dim.solver.SolverMixedDim):
-#    def __init__(self, keyword="transport"):
-#        self.keyword = keyword
-#
-#        self.discr = Upwind(self.keyword)
-#        self.discr_ndof = self.discr.ndof
-#        self.coupling_conditions = UpwindCoupling(self.discr)
-#
-#        self.solver = pp.numerics.mixed_dim.coupler.Coupler(
-#            self.discr, self.coupling_conditions
-#        )
-#
-#    def cfl(self, gb):
-#        deltaT = gb.apply_function(self.discr.cfl, self.coupling_conditions.cfl).data
-#        return np.amin(deltaT)
-#
-#    def outflow(self, gb):
-#        def bind(g, d):
-#            return self.discr.outflow(g, d), np.zeros(g.num_cells)
-#
-#        return pp.Coupler(self.discr, solver_fct=bind).matrix_rhs(gb)[0]
-
-
-# ------------------------------------------------------------------------------#
-
 
 class Upwind:
     """

--- a/src/porepy/utils/half_space.py
+++ b/src/porepy/utils/half_space.py
@@ -92,7 +92,7 @@ def half_space_pt(n, x0, pts, recompute=True):
 
     """
     import scipy.optimize as opt
-    
+
     dim = (1, n.shape[1])
     c = np.array([0, 0, 0, 0, -1])
     A_ub = np.concatenate((n, [np.sum(-n * x0, axis=0)], np.ones(dim))).T

--- a/src/porepy/utils/half_space.py
+++ b/src/porepy/utils/half_space.py
@@ -1,7 +1,5 @@
-from __future__ import division, print_function
 import numpy as np
 import scipy.sparse as sps
-import scipy.optimize as opt
 
 
 def half_space_int(n, x0, pts):
@@ -93,6 +91,8 @@ def half_space_pt(n, x0, pts, recompute=True):
     http://www.qhull.org/html/qhalf.htm#notes
 
     """
+    import scipy.optimize as opt
+    
     dim = (1, n.shape[1])
     c = np.array([0, 0, 0, 0, -1])
     A_ub = np.concatenate((n, [np.sum(-n * x0, axis=0)], np.ones(dim))).T

--- a/src/porepy/viz/exporter.py
+++ b/src/porepy/viz/exporter.py
@@ -20,10 +20,6 @@ try:
     import vtk.util.numpy_support as ns
 except ImportError:
     warnings.warn("No vtk module loaded. Export with pp.Exporter will not work.")
-try:
-    import numba
-except ImportError:
-    warnings.warn("Numba not available. Export may be slow for large grids")
 
 # Module-wide logger
 logger = logging.getLogger(__name__)
@@ -232,6 +228,11 @@ class Exporter:
             self.m_gb_VTK = dict(zip(self.m_dims, [None] * num_m_dims))
         else:
             self.gb_VTK = None
+
+        try:
+            import numba
+        except ImportError:
+            warnings.warn("Numba not available. Export may be slow for large grids")
 
         self.has_numba = "numba" in sys.modules
 
@@ -784,7 +785,7 @@ class Exporter:
             # The number 1000 here is somewhat random.
             if self.has_numba and g.num_cells > 1000:
                 logger.info("Construct 3d grid information using numba")
-                cell_nodes = _point_ind_numba(
+                cell_nodes = self._point_ind_numba(
                     cptr,
                     fptr,
                     faces_cells,
@@ -796,7 +797,7 @@ class Exporter:
                 )
             else:
                 logger.info("Construct 3d grid information using pure python")
-                cell_nodes = _point_ind(
+                cell_nodes = self._point_ind(
                     cptr,
                     fptr,
                     faces_cells,
@@ -849,142 +850,147 @@ class Exporter:
         return gVTK
 
 
-def _point_ind(
-    cell_ptr, face_ptr, face_cells, nodes_faces, nodes, fc, normals, num_cell_nodes
-):
-    cell_nodes = np.zeros(num_cell_nodes.sum(), dtype=np.int)
-    counter = 0
-    for ci in range(cell_ptr.size - 1):
-        loc_c = slice(cell_ptr[ci], cell_ptr[ci + 1])
-
-        for fi in face_cells[loc_c]:
-            loc_f = slice(face_ptr[fi], face_ptr[fi + 1])
-            ptsId = nodes_faces[loc_f]
-            num_p_loc = ptsId.size
-            nodes_loc = nodes[:, ptsId]
-            # Sort points. Cut-down version of
-            # sort_points.sort_points_plane() and subfunctions
-            reference = np.array([0.0, 0.0, 1])
-            angle = np.arccos(np.dot(normals[:, fi], reference))
-            vect = np.cross(normals[:, fi], reference)
-            # Cut-down version of cg.rot()
-            W = np.array(
-                [
-                    [0.0, -vect[2], vect[1]],
-                    [vect[2], 0.0, -vect[0]],
-                    [-vect[1], vect[0], 0.0],
-                ]
-            )
-            R = (
-                np.identity(3)
-                + np.sin(angle) * W
-                + (1.0 - np.cos(angle)) * np.linalg.matrix_power(W, 2)
-            )
-            # pts is now a npt x 3 matrix
-            pts = np.array([R.dot(nodes_loc[:, i]) for i in range(nodes_loc.shape[1])])
-            center = R.dot(fc[:, fi])
-            # Distance from projected points to center
-            delta = np.array([pts[i] - center for i in range(pts.shape[0])])[:, :2]
-            nrm = np.sqrt(delta[:, 0] ** 2 + delta[:, 1] ** 2)
-            delta = delta / nrm[:, np.newaxis]
-
-            argsort = np.argsort(np.arctan2(delta[:, 0], delta[:, 1]))
-            cell_nodes[counter : (counter + num_p_loc)] = ptsId[argsort]
-            counter += num_p_loc
-
-    return cell_nodes
-
-
-if "numba" in sys.modules:
-
-    @numba.jit(
-        "i4[:](i4[:],i4[:],i4[:],i4[:],f8[:,:],f8[:,:],f8[:,:],i4[:])",
-        nopython=True,
-        nogil=False,
-    )
-    def _point_ind_numba(
-        cell_ptr, face_ptr, faces_cells, nodes_faces, nodes, fc, normals, num_cell_nodes
+    def _point_ind(
+        self, cell_ptr, face_ptr, face_cells, nodes_faces, nodes, fc, normals, num_cell_nodes
     ):
-        """ Implementation note: This turned out to be less than pretty, and quite
-        a bit more explicit than the corresponding pure python implementation.
-        The process was basically to circumvent whatever statements numba did not
-        like. Not sure about why this ended so, but there you go.
-        """
-        cell_nodes = np.zeros(num_cell_nodes.sum(), dtype=np.int32)
+        cell_nodes = np.zeros(num_cell_nodes.sum(), dtype=np.int)
         counter = 0
-        fc.astype(np.float64)
         for ci in range(cell_ptr.size - 1):
             loc_c = slice(cell_ptr[ci], cell_ptr[ci + 1])
-            for fi in faces_cells[loc_c]:
-                loc_f = np.arange(face_ptr[fi], face_ptr[fi + 1])
+    
+            for fi in face_cells[loc_c]:
+                loc_f = slice(face_ptr[fi], face_ptr[fi + 1])
                 ptsId = nodes_faces[loc_f]
                 num_p_loc = ptsId.size
-                nodes_loc = np.zeros((3, num_p_loc))
-                for iter1 in range(num_p_loc):
-                    nodes_loc[:, iter1] = nodes[:, ptsId[iter1]]
-                #            # Sort points. Cut-down version of
-                #            # sort_points.sort_points_plane() and subfunctions
+                nodes_loc = nodes[:, ptsId]
+                # Sort points. Cut-down version of
+                # sort_points.sort_points_plane() and subfunctions
                 reference = np.array([0.0, 0.0, 1])
                 angle = np.arccos(np.dot(normals[:, fi], reference))
-                # Hand code cross product, not supported by current numba version
-                vect = np.array(
-                    [
-                        normals[1, fi] * reference[2] - normals[2, fi] * reference[1],
-                        normals[2, fi] * reference[0] - normals[0, fi] * reference[2],
-                        normals[0, fi] * reference[1] - normals[1, fi] * reference[0],
-                    ],
-                    dtype=np.float64,
-                )
-                ##            # Cut-down version of cg.rot()
+                vect = np.cross(normals[:, fi], reference)
+                # Cut-down version of cg.rot()
                 W = np.array(
                     [
-                        0.0,
-                        -vect[2],
-                        vect[1],
-                        vect[2],
-                        0.0,
-                        -vect[0],
-                        -vect[1],
-                        vect[0],
-                        0.0,
+                        [0.0, -vect[2], vect[1]],
+                        [vect[2], 0.0, -vect[0]],
+                        [-vect[1], vect[0], 0.0],
                     ]
-                ).reshape((3, 3))
+                )
                 R = (
                     np.identity(3)
-                    + np.sin(angle) * W.reshape((3, 3))
-                    + (
-                        (1.0 - np.cos(angle)) * np.linalg.matrix_power(W, 2).ravel()
-                    ).reshape((3, 3))
+                    + np.sin(angle) * W
+                    + (1.0 - np.cos(angle)) * np.linalg.matrix_power(W, 2)
                 )
-                ##            # pts is now a npt x 3 matrix
-                num_p = nodes_loc.shape[1]
-                pts = np.zeros((3, num_p))
-                fc_loc = fc[:, fi]
-                center = np.zeros(3)
-                for i in range(3):
-                    center[i] = (
-                        R[i, 0] * fc_loc[0] + R[i, 1] * fc_loc[1] + R[i, 2] * fc_loc[2]
-                    )
-                for i in range(num_p):
-                    for j in range(3):
-                        pts[j, i] = (
-                            R[j, 0] * nodes_loc[0, i]
-                            + R[j, 1] * nodes_loc[1, i]
-                            + +R[j, 2] * nodes_loc[2, i]
-                        )
-                ##            # Distance from projected points to center
-                delta = 0 * pts
-                for i in range(num_p):
-                    delta[:, i] = pts[:, i] - center
-                nrm = np.sqrt(delta[0] ** 2 + delta[1] ** 2)
-                for i in range(num_p):
-                    delta[:, i] = delta[:, i] / nrm[i]
-                ##
-                argsort = np.argsort(np.arctan2(delta[0], delta[1]))
+                # pts is now a npt x 3 matrix
+                pts = np.array([R.dot(nodes_loc[:, i]) for i in range(nodes_loc.shape[1])])
+                center = R.dot(fc[:, fi])
+                # Distance from projected points to center
+                delta = np.array([pts[i] - center for i in range(pts.shape[0])])[:, :2]
+                nrm = np.sqrt(delta[:, 0] ** 2 + delta[:, 1] ** 2)
+                delta = delta / nrm[:, np.newaxis]
+    
+                argsort = np.argsort(np.arctan2(delta[:, 0], delta[:, 1]))
                 cell_nodes[counter : (counter + num_p_loc)] = ptsId[argsort]
                 counter += num_p_loc
-
+    
         return cell_nodes
-
+    
+    
+    
+    def _point_ind_numba(
+        self, cell_ptr, face_ptr, faces_cells, nodes_faces, nodes, fc, normals, num_cell_nodes
+    ):
+        import numba
+        @numba.jit(
+            "i4[:](i4[:],i4[:],i4[:],i4[:],f8[:,:],f8[:,:],f8[:,:],i4[:])",
+            nopython=True,
+            nogil=False,
+        )
+        def _function_to_compile(
+            cell_ptr, face_ptr, faces_cells, nodes_faces, nodes, fc, normals, num_cell_nodes
+        ):
+            """ Implementation note: This turned out to be less than pretty, and quite
+            a bit more explicit than the corresponding pure python implementation.
+            The process was basically to circumvent whatever statements numba did not
+            like. Not sure about why this ended so, but there you go.
+            """
+            cell_nodes = np.zeros(num_cell_nodes.sum(), dtype=np.int32)
+            counter = 0
+            fc.astype(np.float64)
+            for ci in range(cell_ptr.size - 1):
+                loc_c = slice(cell_ptr[ci], cell_ptr[ci + 1])
+                for fi in faces_cells[loc_c]:
+                    loc_f = np.arange(face_ptr[fi], face_ptr[fi + 1])
+                    ptsId = nodes_faces[loc_f]
+                    num_p_loc = ptsId.size
+                    nodes_loc = np.zeros((3, num_p_loc))
+                    for iter1 in range(num_p_loc):
+                        nodes_loc[:, iter1] = nodes[:, ptsId[iter1]]
+                    #            # Sort points. Cut-down version of
+                    #            # sort_points.sort_points_plane() and subfunctions
+                    reference = np.array([0.0, 0.0, 1])
+                    angle = np.arccos(np.dot(normals[:, fi], reference))
+                    # Hand code cross product, not supported by current numba version
+                    vect = np.array(
+                        [
+                            normals[1, fi] * reference[2] - normals[2, fi] * reference[1],
+                            normals[2, fi] * reference[0] - normals[0, fi] * reference[2],
+                            normals[0, fi] * reference[1] - normals[1, fi] * reference[0],
+                        ],
+                        dtype=np.float64,
+                    )
+                    ##            # Cut-down version of cg.rot()
+                    W = np.array(
+                        [
+                            0.0,
+                            -vect[2],
+                            vect[1],
+                            vect[2],
+                            0.0,
+                            -vect[0],
+                            -vect[1],
+                            vect[0],
+                            0.0,
+                        ]
+                    ).reshape((3, 3))
+                    R = (
+                        np.identity(3)
+                        + np.sin(angle) * W.reshape((3, 3))
+                        + (
+                            (1.0 - np.cos(angle)) * np.linalg.matrix_power(W, 2).ravel()
+                        ).reshape((3, 3))
+                    )
+                    ##            # pts is now a npt x 3 matrix
+                    num_p = nodes_loc.shape[1]
+                    pts = np.zeros((3, num_p))
+                    fc_loc = fc[:, fi]
+                    center = np.zeros(3)
+                    for i in range(3):
+                        center[i] = (
+                            R[i, 0] * fc_loc[0] + R[i, 1] * fc_loc[1] + R[i, 2] * fc_loc[2]
+                        )
+                    for i in range(num_p):
+                        for j in range(3):
+                            pts[j, i] = (
+                                R[j, 0] * nodes_loc[0, i]
+                                + R[j, 1] * nodes_loc[1, i]
+                                + +R[j, 2] * nodes_loc[2, i]
+                            )
+                    ##            # Distance from projected points to center
+                    delta = 0 * pts
+                    for i in range(num_p):
+                        delta[:, i] = pts[:, i] - center
+                    nrm = np.sqrt(delta[0] ** 2 + delta[1] ** 2)
+                    for i in range(num_p):
+                        delta[:, i] = delta[:, i] / nrm[i]
+                    ##
+                    argsort = np.argsort(np.arctan2(delta[0], delta[1]))
+                    cell_nodes[counter : (counter + num_p_loc)] = ptsId[argsort]
+                    counter += num_p_loc
+    
+            return cell_nodes
+        
+        return _function_to_compile(cell_ptr, face_ptr, faces_cells, nodes_faces,
+                                   nodes, fc, normals, num_cell_nodes)
 
 # ------------------------------------------------------------------------------#

--- a/src/porepy/viz/exporter.py
+++ b/src/porepy/viz/exporter.py
@@ -974,7 +974,7 @@ class Exporter:
                             pts[j, i] = (
                                 R[j, 0] * nodes_loc[0, i]
                                 + R[j, 1] * nodes_loc[1, i]
-                                + +R[j, 2] * nodes_loc[2, i]
+                                + R[j, 2] * nodes_loc[2, i]
                             )
                     ##            # Distance from projected points to center
                     delta = 0 * pts
@@ -989,8 +989,6 @@ class Exporter:
                     counter += num_p_loc
     
             return cell_nodes
-        
+
         return _function_to_compile(cell_ptr, face_ptr, faces_cells, nodes_faces,
                                    nodes, fc, normals, num_cell_nodes)
-
-# ------------------------------------------------------------------------------#


### PR DESCRIPTION
Moved import statements for little used imports from module- to function level throughout the package. This seems to have reduced time for 'import porepy' with almost a factor of 10.

The main culprit was import of numba, but also of sympy, networkx and other packages.