### PR TITLE
Introduce formal abstract classes for discretizations

### DIFF
--- a/src/porepy/models/abstract_model.py
+++ b/src/porepy/models/abstract_model.py
@@ -1,19 +1,18 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 """
-Created on Fri Sep  6 11:29:05 2019
 
-@author: eke001
+
 """
+import abc
 import numpy as np
 
 
-class AbstractModel:
+class AbstractModel(abc.ABC):
     """ This is an abstract class that specifies methods that a model must implement to
     be compatible with the Newton and time stepping methods.
 
     """
 
+    @abc.abstractmethod
     def get_state_vector(self):
         """ Get a vector of the current state of the variables; with the same ordering
             as in the assembler.
@@ -22,8 +21,9 @@ class AbstractModel:
             np.array: The current state of the system.
 
         """
-        raise NotImplementedError("This must be implemented for any new Model")
+        pass
 
+    @abc.abstractmethod
     def prepare_simulation(self):
         """ Method called prior to the start of time stepping, or prior to entering the
         non-linear solver for stationary problems.
@@ -32,8 +32,9 @@ class AbstractModel:
         and time-independent terms, and generally prepare for the simulation.
 
         """
-        raise NotImplementedError("This must be implemented for any new Model")
+        pass
 
+    @abc.abstractmethod
     def before_newton_loop(self):
         """ Method to be called before entering the non-linear solver, thus at the start
         of a new time step.
@@ -41,16 +42,18 @@ class AbstractModel:
         Possible usage is to update time-dependent parameters, discertizations etc.
 
         """
-        raise NotImplementedError("This must be implemented for any new Model")
+        pass
 
+    @abc.abstractmethod
     def before_newton_iteration(self):
         """ Method to be called at the start of every non-linear iteration.
 
         Possible usage is to update non-linear parameters, discertizations etc.
 
         """
-        raise NotImplementedError("This must be implemented for any new Model")
+        pass
 
+    @abc.abstractmethod
     def after_newton_iteration(self, solution_vector):
         """ Method to be called after every non-linear iteration.
 
@@ -61,8 +64,9 @@ class AbstractModel:
             np.array: The new solution state, as computed by the non-linear solver.
 
         """
-        raise NotImplementedError("This must be implemented for any new Model")
+        pass
 
+    @abc.abstractmethod
     def after_newton_convergence(self, solution, errors, iteration_counter):
         """ Method to be called after every non-linear iteration.
 
@@ -72,8 +76,9 @@ class AbstractModel:
             np.array: The new solution state, as computed by the non-linear solver.
 
         """
-        raise NotImplementedError("This must be implemented for any new Model")
+        pass
 
+    @abc.abstractmethod
     def after_newton_failure(self, solution, errors, iteration_counter):
         """ Method called after a non-linear solver has failed.
 
@@ -83,8 +88,9 @@ class AbstractModel:
         The actual implementation depends on the model at hand.
 
         """
-        raise ValueError("Newton iterations did not converge")
+        pass
 
+    @abc.abstractmethod
     def check_convergence(self, solution, prev_solution, init_solution, nl_params):
         """ Implements a convergence check, to be called by a non-linear solver.
 
@@ -105,8 +111,9 @@ class AbstractModel:
                 implemented by this method.
 
         """
-        raise NotImplementedError("This must be implemented for any new Model")
+        pass
 
+    @abc.abstractmethod
     def assemble_and_solve_linear_system(self, tol):
         """ Assemble the linearized system, described by the current state of the model,
         solve and return the new solution vector.
@@ -119,7 +126,7 @@ class AbstractModel:
             np.array: Solution vector.
 
         """
-        raise NotImplementedError("This must be implemented for any new Model")
+        pass
 
     def l2_norm_cell(self, g, u):
         """

--- a/src/porepy/numerics/discretization.py
+++ b/src/porepy/numerics/discretization.py
@@ -1,15 +1,58 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-""" Module with a do-nothing discretization class.
-
+""" Module contains two classes:
+    1) The abstract superclass for all discretizations
+    2) A do-nothing discretization
 
 """
-
+import abc
 import numpy as np
 import scipy.sparse as sps
+from typing import Dict, Union
+
+import porepy as pp
 
 
-class VoidDiscretization:
+class Discretization(abc.ABC):
+    """ Interface for all discretizations. Specifies methods that must be implemented
+    for a discretization class to be compatible with the assembler.
+
+    """
+
+    def __init__(self, keyword):
+        self.keyword = keyword
+
+    @abc.abstractmethod
+    def discretize(self, g: pp.Grid, data: Dict) -> None:
+        """ Construct discretization matrices.
+
+        The discretization matrices should be added to 
+            data[pp.DISCRETIZATION_MATRICES][self.keyword]
+
+        Parameters:
+            g (pp.Grid): Grid to be discretized.
+            data (dictionary): With discretization parameters.
+
+        """
+        pass
+
+    @abc.abstractmethod
+    def assemble_matrix_rhs(
+        self, g: pp.Grid, data: Dict
+    ) -> Union[sps.spmatrix, np.ndarray]:
+        """ Assemble discretization matrix and rhs vector.
+
+        Parameters:
+            g (pp.Grid): Grid to be discretized.
+            data (dictionary): With discretization parameters.
+
+        Returns:
+            sps.csc_matrix: Discretization matrix.
+            np.array: Right hand side term.
+
+        """
+        pass
+
+
+class VoidDiscretization(Discretization):
     """ Do-nothing discretization object. Used if a discretizaiton object
     is needed for technical reasons, but not really necessary.
 

--- a/src/porepy/numerics/fv/biot.py
+++ b/src/porepy/numerics/fv/biot.py
@@ -1645,7 +1645,6 @@ class DivU(Discretization):
 
 
 class BiotStabilization(Discretization):
-
     """ Class for the stabilization term of the Biot equation.
     """
 
@@ -1655,7 +1654,7 @@ class BiotStabilization(Discretization):
         The keywords are used to access and store parameters and discretization
         matrices.
         """
-        super().__init__(keyword)
+        self.keyword = keyword
         # Set variable name for the scalar variable (pressure)
         self.variable = variable
 

--- a/src/porepy/numerics/fv/biot.py
+++ b/src/porepy/numerics/fv/biot.py
@@ -29,6 +29,7 @@ from time import time
 import logging
 
 import porepy as pp
+from porepy.numerics.discretization import Discretization
 
 
 # Module-wide logger
@@ -1145,7 +1146,7 @@ class Biot(pp.Mpsa):
         return stress
 
 
-class GradP:
+class GradP(Discretization):
     """ Class for the pressure gradient term of the Biot equation.
     """
 
@@ -1345,7 +1346,7 @@ class GradP:
         pass
 
 
-class DivU:
+class DivU(Discretization):
     """ Class for the displacement divergence term of the Biot equation.
     """
 
@@ -1643,9 +1644,8 @@ class DivU:
         pass
 
 
-class BiotStabilization(
-    pp.numerics.interface_laws.elliptic_discretization.EllipticDiscretization
-):
+class BiotStabilization(Discretization):
+
     """ Class for the stabilization term of the Biot equation.
     """
 

--- a/src/porepy/numerics/fv/mass_matrix.py
+++ b/src/porepy/numerics/fv/mass_matrix.py
@@ -23,7 +23,7 @@ import scipy.sparse as sps
 import porepy as pp
 
 
-class MassMatrix:
+class MassMatrix(pp.numerics.discretization.Discretization):
     """ Class that provides the discretization of a L2-mass bilinear form with constant
     test and trial functions.
     """

--- a/src/porepy/numerics/fv/mpfa.py
+++ b/src/porepy/numerics/fv/mpfa.py
@@ -673,7 +673,9 @@ class Mpfa(pp.FVElliptic):
         #    interior subfaces, and on faces on the boundary.
         # NOTE: The second operation is reversed for Robin boundary conditions,
         #       see below.
-        pr_cont_grad_paired = pp.fvutils.compute_dist_face_cell(g, subcell_topology, eta)
+        pr_cont_grad_paired = pp.fvutils.compute_dist_face_cell(
+            g, subcell_topology, eta
+        )
 
         # Discretized Darcy's law: The flux over a subface is given by the
         # area weighted normal vector, multiplied with the subcell permeability,

--- a/src/porepy/numerics/fv/mpsa.py
+++ b/src/porepy/numerics/fv/mpsa.py
@@ -15,12 +15,13 @@ import porepy as pp
 from time import time
 from typing import Dict, Tuple, Any, Generator
 
+from porepy.numerics.discretization import Discretization
 
 # Module-wide logger
 logger = logging.getLogger(__name__)
 
 
-class Mpsa:
+class Mpsa(Discretization):
     """ Implementation of the Multi-point stress approximation.
 
     Attributes:

--- a/src/porepy/numerics/fv/source.py
+++ b/src/porepy/numerics/fv/source.py
@@ -6,7 +6,7 @@ import scipy.sparse as sps
 import porepy as pp
 
 
-class ScalarSource(object):
+class ScalarSource(pp.numerics.discretization.Discretization):
     """
     Discretization of the integrated source term
     int q * dx
@@ -109,7 +109,7 @@ class ScalarSource(object):
         ), "There should be one source value for each cell"
         return matrix_dictionary["bound_source"] * sources
 
-    def discretize(self, g, data, faces=None):
+    def discretize(self, g, data):
         """ Discretize an integrated source term.
 
         Parameters:

--- a/src/porepy/numerics/fv/upwind.py
+++ b/src/porepy/numerics/fv/upwind.py
@@ -4,7 +4,7 @@ import scipy.sparse as sps
 import porepy as pp
 
 
-class Upwind:
+class Upwind(pp.numerics.discretization.Discretization):
     """
     Discretize a hyperbolic transport equation using a single point upstream
     weighting scheme.

--- a/src/porepy/numerics/interface_laws/elliptic_discretization.py
+++ b/src/porepy/numerics/interface_laws/elliptic_discretization.py
@@ -7,9 +7,16 @@ The classes may be interpreted as a "contract" which elliptic discretization met
 must honor. This is particularly useful to ensure uniformity when coupling
 discretizations between dimensions by interface laws.
 """
+from abc import abstractmethod
+from typing import Dict
+import numpy as np
+import scipy.sparse as sps
+
+import porepy as pp
+from porepy.numerics.discretization import Discretization
 
 
-class EllipticDiscretization:
+class EllipticDiscretization(Discretization):
     """ This is the parent class of all discretizations for second order elliptic
     problems. The class cannot be used itself, but should rather be seen as a
     declaration of which methods are assumed implemented for all specific
@@ -41,7 +48,7 @@ class EllipticDiscretization:
 
     """
 
-    def __init__(self, keyword):
+    def __init__(self, keyword: str) -> None:
         """ Set the discretization, with the keyword used for storing various
         information associated with the discretization.
 
@@ -51,7 +58,7 @@ class EllipticDiscretization:
         """
         self.keyword = keyword
 
-    def _key(self):
+    def _key(self) -> str:
         """ Get the keyword of this object, on a format friendly to access relevant
         fields in the data dictionary
 
@@ -61,7 +68,8 @@ class EllipticDiscretization:
         """
         return self.keyword + "_"
 
-    def ndof(self, g):
+    @abstractmethod
+    def ndof(self, g: pp.Grid) -> int:
         """ Abstract method. Return the number of degrees of freedom associated to the
         method.
 
@@ -72,7 +80,7 @@ class EllipticDiscretization:
             int: the number of degrees of freedom.
 
         """
-        raise NotImplementedError("Method not implemented")
+        pass
 
     def extract_pressure(self, g, solution_array, data):
         """ Abstract method. Extract the pressure part of a solution.
@@ -114,71 +122,17 @@ class EllipticDiscretization:
         """
         raise NotImplementedError("Method not implemented")
 
-    def assemble_matrix_rhs(self, g, data):
-        """ Return the matrix and right-hand side for a discretization of a second
-        order elliptic equation.
-
-        Also discretize the necessary operators if the data dictionary does not
-        contain the necessary fields. The decision on whether to discretize
-        will depend on the specific numerical method.
-
-        Parameters:
-            g (Grid): Computational grid, with geometry fields computed.
-            data (dictionary): With data stored.
-
-        Returns:
-            scipy.sparse.csr_matrix: System matrix of this discretization. The
-                size of the matrix will depend on the specific discretization.
-            np.ndarray: Right hand side vector with representation of boundary
-                conditions. The size of the vector will depend on the
-                discretization.
-
-        """
-        raise NotImplementedError("Method not implemented")
-
-    def assemble_matrix(self, g, data):
-        """ Return the matrix for a discretization of a second order elliptic equation.
-
-        Also discretize the necessary operators if the data dictionary does not
-        contain the necessary fields. The decision on whether to discretize
-        will depend on the specific numerical method.
-
-        Parameters:
-            g (Grid): Computational grid, with geometry fields computed.
-            data (dictionary): With data stored.
-
-        Returns:
-            scipy.sparse.csr_matrix: System matrix of this discretization. The
-                size of the matrix will depend on the specific discretization.
-
-        """
-        raise NotImplementedError("Method not implemented")
-
-    # ------------------------------------------------------------------------------#
-
-    def assemble_rhs(self, g, data):
-        """ Return the right-hand side for a discretization of a second
-        order elliptic equation.
-
-        Also discretize the necessary operators if the data dictionary does not
-        contain the necessary fields. The decision on whether to discretize
-        will depend on the specific numerical method.
-
-        Parameters:
-            g (Grid): Computational grid, with geometry fields computed.
-            data (dictionary): With data stored.
-
-        Returns:
-            np.ndarray: Right hand side vector with representation of boundary
-                conditions. The size of the vector will depend on the
-                discretization.
-
-        """
-        raise NotImplementedError("Method not implemented")
-
+    @abstractmethod
     def assemble_int_bound_flux(
-        self, g, data, data_edge, cc, matrix, self_ind, use_slave_proj
-    ):
+        self,
+        g: pp.Grid,
+        data: Dict,
+        data_edge: Dict,
+        cc: np.ndarray,
+        matrix: np.ndarray,
+        self_ind: int,
+        use_slave_proj: bool,
+    ) -> None:
         """ Abstract method. Assemble the contribution from an internal
         boundary, manifested as a flux boundary condition.
 
@@ -210,9 +164,19 @@ class EllipticDiscretization:
                 used. Needed for periodic boundary conditions.
 
         """
-        raise NotImplementedError("Method not implemented")
+        pass
 
-    def assemble_int_bound_source(self, g, data, data_edge, cc, matrix, rhs, self_ind):
+    @abstractmethod
+    def assemble_int_bound_source(
+        self,
+        g: pp.Grid,
+        data: Dict,
+        data_edge: Dict,
+        cc: np.ndarray,
+        matrix: np.ndarray,
+        rhs: np.ndarray,
+        self_ind: int,
+    ) -> None:
         """ Abstract method. Assemble the contribution from an internal
         boundary, manifested as a source term.
 
@@ -242,11 +206,20 @@ class EllipticDiscretization:
                 Should be either 1 or 2.
 
         """
-        raise NotImplementedError("Method not implemented")
+        pass
 
+    @abstractmethod
     def assemble_int_bound_pressure_trace(
-        self, g, data, data_edge, cc, matrix, rhs, self_ind, use_slave_proj
-    ):
+        self,
+        g: pp.Grid,
+        data: Dict,
+        data_edge: Dict,
+        cc: np.ndarray,
+        matrix: np.ndarray,
+        rhs: np.ndarray,
+        self_ind: int,
+        use_slave_proj: bool,
+    ) -> None:
         """ Abstract method. Assemble the contribution from an internal
         boundary, manifested as a condition on the boundary pressure.
 
@@ -280,11 +253,19 @@ class EllipticDiscretization:
                 used. Needed for periodic boundary conditions.
 
         """
-        raise NotImplementedError("Method not implemented")
+        pass
 
+    @abstractmethod
     def assemble_int_bound_pressure_trace_between_interfaces(
-        self, g, data_grid, proj_primary, proj_secondary, cc, matrix, rhs
-    ):
+        self,
+        g: pp.Grid,
+        data_grid: Dict,
+        proj_primary: sps.spmatrix,
+        proj_secondary: sps.spmatrix,
+        cc: np.ndarray,
+        matrix: np.ndarray,
+        rhs: np.ndarray,
+    ) -> None:
         """ Assemble the contribution from an internal
         boundary, manifested as a condition on the boundary pressure.
 
@@ -294,24 +275,32 @@ class EllipticDiscretization:
                 mixed-dimensional grid.
            proj_primary (sparse matrix): Pressure projection from the higher-dim
                 grid to the primary mortar grid.
-            proj_secondary (sparse matrix): Flux projection from the secondary mortar
+           proj_secondary (sparse matrix): Flux projection from the secondary mortar
                 grid to the main grid.
-            cc (block matrix, 3x3): Block matrix of size 3 x 3, whwere each block represents
-                coupling between variables on this interface. Index 0, 1 and 2
-                represent the master grid, the primary and secondary interface,
+           cc (block matrix, 3x3): Block matrix of size 3 x 3, whwere each block
+                represents coupling between variables on this interface. Index 0, 1 and
+                2 represent the master grid, the primary and secondary interface,
                 respectively.
-            matrix (block matrix 3x3): Discretization matrix for the edge and
+           matrix (block matrix 3x3): Discretization matrix for the edge and
                 the two adjacent nodes.
-            rhs (block_array 3x1): Block matrix of size 3 x 1, representing the right hand
-                side of this coupling. Index 0, 1 and 2 represent the master grid,
+           rhs (block_array 3x1): Block matrix of size 3 x 1, representing the right
+                hand side of this coupling. Index 0, 1 and 2 represent the master grid,
                 the primary and secondary interface, respectively.
 
         """
-        raise NotImplementedError("Method not implemented")
+        pass
 
+    @abstractmethod
     def assemble_int_bound_pressure_cell(
-        self, g, data, data_edge, cc, matrix, rhs, self_ind
-    ):
+        self,
+        g: pp.Grid,
+        data: Dict,
+        data_edge: Dict,
+        cc: np.ndarray,
+        matrix: np.ndarray,
+        rhs: np.ndarray,
+        self_ind: int,
+    ) -> None:
         """ Abstract method. Assemble the contribution from an internal
         boundary, manifested as a condition on the cell pressure.
 
@@ -341,9 +330,12 @@ class EllipticDiscretization:
                 Should be either 1 or 2.
 
         """
-        raise NotImplementedError("Method not implemented")
+        pass
 
-    def enforce_neumann_int_bound(self, g, data_edge, matrix, self_ind):
+    @abstractmethod
+    def enforce_neumann_int_bound(
+        self, g: pp.Grid, data_edge: Dict, matrix: np.ndarray, self_ind: int
+    ) -> None:
         """ Enforce Neumann boundary conditions on a given system matrix.
 
         Methods based on a mixed variational form will need this function to
@@ -357,4 +349,4 @@ class EllipticDiscretization:
             matrix (scipy.sparse.matrix): Discretization matrix to be modified.
 
         """
-        raise NotImplementedError("Method not implemented")
+        pass

--- a/src/porepy/numerics/vem/vem_source.py
+++ b/src/porepy/numerics/vem/vem_source.py
@@ -12,7 +12,7 @@ import scipy.sparse as sps
 import porepy as pp
 
 
-class DualScalarSource:
+class DualScalarSource(pp.numerics.discretization.Discretization):
     """
     Discretization of the integrated source term
     int q * dx
@@ -96,7 +96,7 @@ class DualScalarSource:
         rhs[is_p] = -sources
         return rhs
 
-    def discretize(self, g, data, faces=None):
+    def discretize(self, g, data):
         """ Discretize an integrated source term.
 
         Parameters:

--- a/test/unit/test_assembler.py
+++ b/test/unit/test_assembler.py
@@ -1602,6 +1602,12 @@ class MockEdgeDiscretization(
         cc[1, 2] = sps.coo_matrix(self.off_diag_val)
 
         return cc + local_matrix, np.empty(3)
+ 
+    def ndof(self, mg):
+        pass   
+ 
+    def discretize(self, g_h, g_l, data_h, data_l, data_edge):
+        pass
 
 
 class MockEdgeDiscretizationModifiesNode(
@@ -1635,6 +1641,12 @@ class MockEdgeDiscretizationModifiesNode(
 
         return cc + local_matrix, np.empty(3)
 
+    def ndof(self, mg):
+        pass
+    
+    def discretize(self, g_h, g_l, data_h, data_l, data_edge):
+        pass
+
 
 class MockEdgeDiscretizationOneSided(
     porepy.numerics.interface_laws.abstract_interface_law.AbstractInterfaceLaw
@@ -1655,7 +1667,12 @@ class MockEdgeDiscretizationOneSided(
         cc[0, 1] = sps.coo_matrix(self.off_diag_val)
 
         return cc + local_matrix, np.empty(2)
-
+    
+    def ndof(self, mg):
+        pass
+    
+    def discretize(self, g_h, g_l, data_h, data_l, data_edge):
+        pass
 
 class MockEdgeDiscretizationOneSidedModifiesNode(
     porepy.numerics.interface_laws.abstract_interface_law.AbstractInterfaceLaw
@@ -1681,6 +1698,11 @@ class MockEdgeDiscretizationOneSidedModifiesNode(
 
         return cc + local_matrix, np.empty(2)
 
+    def discretize(self, g_h, g_l, data_h, data_l, data_edge):
+        pass
+    
+    def ndof(self, mg):
+        pass
 
 class MockEdgeDiscretizationEdgeCouplings(
     porepy.numerics.interface_laws.abstract_interface_law.AbstractInterfaceLaw
@@ -1729,7 +1751,9 @@ class MockEdgeDiscretizationEdgeCouplings(
 
         return cc + matrix, rhs
 
+    def discretize(self, g_h, g_l, data_h, data_l, data_edge):
+        pass
 
 if __name__ == "__main__":
-    # TestAssembler().test_two_variables_coupling_between_node_and_edge_mixed_dependencies()
+    TestAssembler().test_direct_edge_coupling()
     unittest.main()


### PR DESCRIPTION
Use python's abc class to enforce expected function names for discretization classes.