### PR TITLE
The Exporter init now always compute the initial VTK.

### DIFF
--- a/src/porepy/viz/exporter.py
+++ b/src/porepy/viz/exporter.py
@@ -239,8 +239,7 @@ class Exporter:
 
         self.has_numba = "numba" in sys.modules
 
-        if self.fixed_grid:
-            self._update_gb_VTK()
+        self._update_gb_VTK()
 
         # Counter for time step. Will be used to identify files of individual time step,
         # unless this is overridden by optional parameters in write_vtk


### PR DESCRIPTION
The Exporter only updates the grid if a new grid is given for a time step:
https://github.com/pmgbergen/porepy/blob/7d6b67b69efdc4dcb484a027064e8fd7bd712a02/src/porepy/viz/exporter.py#L301-L305

We should therefore always update the VTK in the init to handle the cases
where the grid is not updated in the first time step.

