### PR TITLE
Zero-dimensional grid should not have faces or nodes

### DIFF
--- a/src/porepy/grids/grid_extrusion.py
+++ b/src/porepy/grids/grid_extrusion.py
@@ -656,8 +656,8 @@ def _extrude_0d(
     num_pt = z.size
 
     # x and y coordinates of the right size
-    x = g.nodes[0, 0] * np.ones(num_pt)
-    y = g.nodes[1, 0] * np.ones(num_pt)
+    x = g.cell_centers[0, 0] * np.ones(num_pt)
+    y = g.cell_centers[1, 0] * np.ones(num_pt)
 
     # Initial 1d grid. Coordinates are wrong, but this we will fix later
     # There is no need to do anything special with tags here; the tags of a 0d grid are

--- a/src/porepy/grids/partition.py
+++ b/src/porepy/grids/partition.py
@@ -484,7 +484,13 @@ def __extract_submatrix(mat, ind):
     cols = sub_mat.indptr
     data = sub_mat.data
     unique_rows, rows_sub = np.unique(sub_mat.indices, return_inverse=True)
-    return sps.csc_matrix((data, rows_sub, cols)), unique_rows
+    shape = (unique_rows.size, cols.size - 1)
+    if shape[0]!=0:
+        A = sps.csc_matrix((data, rows_sub, cols))
+        if np.any(A.shape != shape):
+            import pdb; pdb.set_trace()
+    
+    return sps.csc_matrix((data, rows_sub, cols), shape), unique_rows
 
 
 def __extract_cells_from_faces(g, f, is_planar):

--- a/src/porepy/grids/partition.py
+++ b/src/porepy/grids/partition.py
@@ -485,11 +485,6 @@ def __extract_submatrix(mat, ind):
     data = sub_mat.data
     unique_rows, rows_sub = np.unique(sub_mat.indices, return_inverse=True)
     shape = (unique_rows.size, cols.size - 1)
-    if shape[0]!=0:
-        A = sps.csc_matrix((data, rows_sub, cols))
-        if np.any(A.shape != shape):
-            import pdb; pdb.set_trace()
-    
     return sps.csc_matrix((data, rows_sub, cols), shape), unique_rows
 
 

--- a/src/porepy/grids/point_grid.py
+++ b/src/porepy/grids/point_grid.py
@@ -15,10 +15,22 @@ class PointGrid(Grid):
 
         """
 
+        # check input
+        if np.asarray(pt).shape[0] != 3:
+            raise ValueError("PointGrid: points must be given in 3 dimensions")
+
+        pt = np.atleast_2d(pt)
+        if pt.shape[0] == 1: # point is given as 1d array
+            if pt.shape[1] != 3:
+                raise ValueError("PointGrid: 1d point arrays only allowed for single points")
+            pt = pt.T
+
         name = "PointGrid" if name is None else name
 
-        face_nodes = sps.identity(1, np.int, "csr")
-        cell_faces = sps.identity(1, np.int, "csr")
-        pt = np.asarray(pt).reshape((3, 1))
+        face_nodes = sps.identity(0, np.int, "csr")
+        cell_faces = sps.csr_matrix((0, pt.shape[1]), dtype=np.int)
 
-        super(PointGrid, self).__init__(0, pt, face_nodes, cell_faces, name)
+        nodes = np.zeros((3, 0))
+        self.cell_centers = pt
+
+        super(PointGrid, self).__init__(0, nodes, face_nodes, cell_faces, name)

--- a/src/porepy/numerics/fv/fvutils.py
+++ b/src/porepy/numerics/fv/fvutils.py
@@ -299,6 +299,14 @@ def subproblems(
 ) -> Generator[Any, None, None]:
     num_part: int = np.ceil(peak_memory_estimate / max_memory).astype(np.int)
 
+    if active_grid.dim ==0:
+        # nothing realy to do here
+        loc_faces = np.ones(active_grid.num_faces, dtype=bool)
+        loc_cells = np.ones(active_grid.num_cells, dtype=bool)
+        loc2g_cells = sps.eye(active_grid.num_cells, dtype=bool)
+        loc2g_face = sps.eye(active_grid.num_faces, dtype=bool)
+        return active_grid, loc_faces, loc_cells, loc2g_cells, loc2g_face
+
     # Let partitioning module apply the best available method
     part: np.ndarray = pp.partition.partition(active_grid, num_part)
 

--- a/src/porepy/numerics/fv/mpfa.py
+++ b/src/porepy/numerics/fv/mpfa.py
@@ -408,11 +408,11 @@ class Mpfa(pp.FVElliptic):
 
         elif g.dim == 0:
             return (
-                sps.csr_matrix([0]),
-                sps.csr_matrix([0]),
-                sps.csr_matrix([0]),
-                sps.csr_matrix([0]),
-                sps.csr_matrix([0]),
+                sps.csr_matrix((0, g.num_cells)),
+                sps.csr_matrix((0, 0)),
+                sps.csr_matrix((0, g.num_cells)),
+                sps.csr_matrix((0, 0)),
+                sps.csr_matrix((0, g.num_cells)),
             )
 
         # The grid coordinates are always three-dimensional, even if the grid is

--- a/src/porepy/numerics/fv/tpfa.py
+++ b/src/porepy/numerics/fv/tpfa.py
@@ -79,11 +79,11 @@ class Tpfa(pp.FVElliptic):
 
         if g.dim == 0:
             # Short cut for 0d grids
-            matrix_dictionary[self.flux_matrix_key] = sps.csr_matrix([0])
-            matrix_dictionary[self.bound_flux_matrix_key] = sps.csr_matrix([0])
-            matrix_dictionary[self.bound_pressure_cell_matrix_key] = sps.csr_matrix([1])
-            matrix_dictionary[self.bound_pressure_face_matrix_key] = sps.csr_matrix([0])
-            matrix_dictionary[self.vector_source_key] = sps.csr_matrix([0])
+            matrix_dictionary[self.flux_matrix_key] = sps.csr_matrix((0, g.num_cells))
+            matrix_dictionary[self.bound_flux_matrix_key] = sps.csr_matrix((0, 0))
+            matrix_dictionary[self.bound_pressure_cell_matrix_key] = sps.csr_matrix((0, g.num_cells))
+            matrix_dictionary[self.bound_pressure_face_matrix_key] = sps.csr_matrix((0, 0))
+            matrix_dictionary[self.vector_source_key] = sps.csr_matrix((0, g.num_cells))
             return None
 
         # Extract parameters

--- a/src/porepy/numerics/fv/upwind.py
+++ b/src/porepy/numerics/fv/upwind.py
@@ -295,7 +295,10 @@ class Upwind(pp.numerics.discretization.Discretization):
         assert beta.size == 3
 
         if g.dim == 0:
-            dot_prod = np.dot(g.face_normals.ravel("F"), face_apertures * beta)
+            if g.num_faces==0:
+                dot_prod = np.zeros(0)
+            else:
+                dot_prod = np.dot(g.face_normals.ravel("F"), face_apertures * beta)
             return np.atleast_1d(dot_prod)
 
         return np.array(

--- a/src/porepy/numerics/vem/dual_elliptic.py
+++ b/src/porepy/numerics/vem/dual_elliptic.py
@@ -153,7 +153,10 @@ class DualElliptic(
         matrix_dictionary = data[pp.DISCRETIZATION_MATRICES][self.keyword]
 
         mass = matrix_dictionary[self.mass_matrix_key]
-        norm = sps.linalg.norm(mass, np.inf) if bc_weight else 1
+        if mass.shape[0]==0:
+            norm = 1
+        else:
+            norm = sps.linalg.norm(mass, np.inf) if bc_weight else 1
 
         bc = data[pp.PARAMETERS][self.keyword]["bc"]
 

--- a/test/integration/test_fracture_mesh_generation.py
+++ b/test/integration/test_fracture_mesh_generation.py
@@ -125,7 +125,7 @@ class TestDFMMeshGeneration(unittest.TestCase):
         for g in gb.grids_of_dimension(0):
             found = False
             for p in isect_pt:
-                if test_utils.compare_arrays(p, g.nodes):
+                if test_utils.compare_arrays(p, g.cell_centers):
                     found = True
                     break
             self.assertTrue(found)
@@ -133,7 +133,7 @@ class TestDFMMeshGeneration(unittest.TestCase):
         for p in isect_pt:
             found = False
             for g in gb.grids_of_dimension(0):
-                if test_utils.compare_arrays(p, g.nodes):
+                if test_utils.compare_arrays(p, g.cell_centers):
                     found = True
                     break
             self.assertTrue(found)
@@ -1137,9 +1137,12 @@ class TestStructuredGrids(unittest.TestCase):
         self.assertTrue(np.all([g.num_cells == 1 for g in g_1]))
         self.assertTrue(np.all([g.num_faces == 2 for g in g_1]))
 
-        g_all = np.hstack([g_3, g_2, g_1, g_0])
-        for g in g_all:
+        g_321 = np.hstack([g_3, g_2, g_1])
+        for g in g_321:
             d = np.all(np.abs(g.nodes - np.array([[0.5], [0.5], [0.5]])) < 1e-6, axis=0)
+            self.assertTrue(any(d))
+        for g in g_0:
+            d = np.all(np.abs(g.cell_centers - np.array([[0.5], [0.5], [0.5]])) < 1e-6, axis=0)
             self.assertTrue(any(d))
 
     def test_T_intersection_2d(self):

--- a/test/integration/test_split_grid.py
+++ b/test/integration/test_split_grid.py
@@ -107,7 +107,7 @@ class TestMeshing(unittest.TestCase):
                 np.allclose(g.face_centers[:, f_p[0]], g.face_centers[:, f_p[1]])
             )
 
-        self.assertTrue(np.allclose(g_0[0].nodes, np.array([1, 1, 1])))
+        self.assertTrue(np.allclose(g_0[0].cell_centers, np.array([1, 1, 1])))
 
 
 if __name__ == "__main__":

--- a/test/unit/test_grid_extrusion.py
+++ b/test/unit/test_grid_extrusion.py
@@ -57,7 +57,7 @@ class TestGridExtrusion0d(unittest.TestCase):
 
     def test_ignore_original_z(self):
         # Assign non-zero z-coordinate of the point grid. This should be ignored
-        self.g.nodes[2, 0] = 3
+        self.g.cell_centers[2, 0] = 3
         z = np.array([0, 1])
         gn, cell_map, face_map = pp.grid_extrusion._extrude_0d(self.g, z)
         coord_known = self.known_array(z)


### PR DESCRIPTION
This pull-request set  the number of faces and nodes from the PointGrid to zero as nodes and faces does not make sense in a 0d grid. Previously ,they where just given the identity mapping to the cell-center. However, this does not work when we have a 0d grid with several (disconnected) cells. 

This is a more conceptual choice, so you @keileg  gets to voice your opinion.

@alessiofumagalli : can you check the lines:
https://github.com/pmgbergen/porepy/blob/4b41d1dca984837b833a68705b4598c0c44ad2b2/src/porepy/numerics/vem/dual_elliptic.py#L155-L160

The 0d grids gives a mass matrix of dimension 0x0 which makes sps.linalg.norm crash. Have I made reasonable choice in setting the norm to 1? 