### PR TITLE
Bugfix in coarsening, wrong type of argument for single grids.

### DIFF
--- a/src/porepy/grids/coarsening.py
+++ b/src/porepy/grids/coarsening.py
@@ -82,6 +82,10 @@ def generate_coarse_grid(g, subdiv):
 
     """
     if isinstance(g, grid.Grid):
+        if isinstance(subdiv, dict):
+            # If the subdiv is a dictionary with g as a key (this can happen if we are
+            # forwarded here from coarsen), the input must be simplified.
+            subdiv = subdiv[g][1]
         _generate_coarse_grid_single(g, subdiv, False)
 
     if isinstance(g, grid_bucket.GridBucket):

--- a/src/porepy/grids/coarsening.py
+++ b/src/porepy/grids/coarsening.py
@@ -1,9 +1,10 @@
-# -*- coding: utf-8 -*-
+""" Module with methods to coarsen a grid. The main method is coarsen(), see this for more information.
 
+"""
 import numpy as np
 import scipy.sparse as sps
-import scipy.stats as stats
 import porepy as pp
+from typing import Union, Tuple, Any, Dict
 
 from porepy.grids import grid, grid_bucket
 
@@ -15,7 +16,9 @@ from porepy.utils import half_space, tags
 # ------------------------------------------------------------------------------#
 
 
-def coarsen(g, method, **method_kwargs):
+def coarsen(
+    g: Union[pp.Grid, pp.GridBucket], method: str, **method_kwargs
+) -> Union[None, sps.spmatrix]:
     """ Create a coarse grid from a given grid. If a grid bucket is passed the
     procedure is applied to the higher in dimension.
     Note: the grid is modified in place.
@@ -37,7 +40,7 @@ def coarsen(g, method, **method_kwargs):
         seeds = np.empty(0, dtype=np.int)
         if method_kwargs.get("if_seeds", False):
             seeds = generate_seeds(g)
-        matrix = tpfa_matrix(g)
+        matrix = _tpfa_matrix(g)
         partition = create_partition(matrix, g, seeds=seeds, **method_kwargs)
 
     else:
@@ -79,20 +82,24 @@ def generate_coarse_grid(g, subdiv):
 
     """
     if isinstance(g, grid.Grid):
-        generate_coarse_grid_single(g, subdiv, False)
+        _generate_coarse_grid_single(g, subdiv, False)
 
     if isinstance(g, grid_bucket.GridBucket):
-        generate_coarse_grid_gb(g, subdiv)
+        _generate_coarse_grid_gb(g, subdiv)
 
 
 # ------------------------------------------------------------------------------#
 
 
-def reorder_partition(subdiv):
+def reorder_partition(
+    subdiv: Union[Dict[Any, Tuple[Any, np.ndarray]], np.ndarray]
+) -> Union[Dict[Any, Tuple[Any, np.ndarray]], np.ndarray]:
     """
     Re-order the partition id in case to obtain contiguous numbers.
+
     Parameters:
         subdiv: array where for each cell one id
+
     Return:
         the subdivision written in a contiguous way
     """
@@ -112,7 +119,7 @@ def reorder_partition(subdiv):
 # ------------------------------------------------------------------------------#
 
 
-def generate_coarse_grid_single(g, subdiv, face_map):
+def _generate_coarse_grid_single(g, subdiv, face_map):
     """
     Specific function for a single grid. Use the common interface instead.
     """
@@ -230,7 +237,7 @@ def generate_coarse_grid_single(g, subdiv, face_map):
 # ------------------------------------------------------------------------------#
 
 
-def generate_coarse_grid_gb(gb, subdiv):
+def _generate_coarse_grid_gb(gb, subdiv):
     """
     Specific function for a grid bucket. Use the common interface instead.
     """
@@ -242,7 +249,7 @@ def generate_coarse_grid_gb(gb, subdiv):
     for g, (_, partition) in subdiv.items():
 
         # Construct the coarse grids
-        face_map = generate_coarse_grid_single(g, partition, True)
+        face_map = _generate_coarse_grid_single(g, partition, True)
 
         # Update all the master_to_mortar_int for all the 'edges' connected to the grid
         # We update also all the face_cells
@@ -278,7 +285,7 @@ def generate_coarse_grid_gb(gb, subdiv):
 # ------------------------------------------------------------------------------#
 
 
-def tpfa_matrix(g, perm=None):
+def _tpfa_matrix(g, perm=None):
     """
     Compute a two-point flux approximation matrix useful related to a call of
     create_partition.

--- a/test/integration/test_coarsening.py
+++ b/test/integration/test_coarsening.py
@@ -537,7 +537,7 @@ class BasicsTest(unittest.TestCase):
     def test_create_partition_2d_cart(self):
         g = pp.CartGrid([5, 5])
         g.compute_geometry()
-        part = co.create_partition(co.tpfa_matrix(g), g)
+        part = co.create_partition(co._tpfa_matrix(g), g)
         known = np.array(
             [0, 0, 0, 1, 1, 0, 0, 2, 1, 1, 3, 2, 2, 2, 1, 3, 3, 2, 4, 4, 3, 3, 4, 4, 4]
         )
@@ -549,7 +549,7 @@ class BasicsTest(unittest.TestCase):
     def test_create_partition_2d_tri(self):
         g = pp.StructuredTriangleGrid([3, 2])
         g.compute_geometry()
-        part = co.create_partition(co.tpfa_matrix(g), g)
+        part = co.create_partition(co._tpfa_matrix(g), g)
         known = np.array([1, 1, 1, 0, 0, 1, 0, 2, 2, 0, 2, 2])
         known_map = np.array([4, 3, 7, 5, 11, 8, 1, 2, 10, 6, 12, 9]) - 1
         part = next(iter(part.values()))[1]
@@ -560,7 +560,7 @@ class BasicsTest(unittest.TestCase):
     def test_create_partition_2d_cart_cdepth4(self):
         g = pp.CartGrid([10, 10])
         g.compute_geometry()
-        part = co.create_partition(co.tpfa_matrix(g), g, cdepth=4)
+        part = co.create_partition(co._tpfa_matrix(g), g, cdepth=4)
         known = (
             np.array(
                 [
@@ -676,7 +676,7 @@ class BasicsTest(unittest.TestCase):
     def test_create_partition_3d_cart(self):
         g = pp.CartGrid([4, 4, 4])
         g.compute_geometry()
-        part = co.create_partition(co.tpfa_matrix(g), g)
+        part = co.create_partition(co._tpfa_matrix(g), g)
         known = (
             np.array(
                 [
@@ -756,7 +756,7 @@ class BasicsTest(unittest.TestCase):
     def test_create_partition_2d_1d_test0(self):
         gb, _ = pp.grid_buckets_2d.single_horizontal([2, 2], simplex=False)
 
-        part = co.create_partition(co.tpfa_matrix(gb), gb)
+        part = co.create_partition(co._tpfa_matrix(gb), gb)
         co.generate_coarse_grid(gb, part)
 
         # Test
@@ -775,7 +775,7 @@ class BasicsTest(unittest.TestCase):
         gb, _ = pp.grid_buckets_2d.single_horizontal(
             [2, 2], x_endpoints=[0.5, 0], simplex=False
         )
-        part = co.create_partition(co.tpfa_matrix(gb), gb)
+        part = co.create_partition(co._tpfa_matrix(gb), gb)
         co.generate_coarse_grid(gb, part)
 
         # Test
@@ -798,7 +798,7 @@ class BasicsTest(unittest.TestCase):
         known_seeds = np.array([0, 2])
         self.assertTrue(np.array_equal(seeds, known_seeds))
 
-        part = co.create_partition(co.tpfa_matrix(gb), gb, seeds=seeds)
+        part = co.create_partition(co._tpfa_matrix(gb), gb, seeds=seeds)
         co.generate_coarse_grid(gb, part)
 
         # Test
@@ -817,7 +817,7 @@ class BasicsTest(unittest.TestCase):
             [2, 2], x_endpoints=[0.5, 1], simplex=False
         )
 
-        part = co.create_partition(co.tpfa_matrix(gb), gb)
+        part = co.create_partition(co._tpfa_matrix(gb), gb)
         co.generate_coarse_grid(gb, part)
 
         # Test
@@ -840,7 +840,7 @@ class BasicsTest(unittest.TestCase):
         known_seeds = np.array([1, 3])
         self.assertTrue(np.array_equal(seeds, known_seeds))
 
-        part = co.create_partition(co.tpfa_matrix(gb), gb, seeds=seeds)
+        part = co.create_partition(co._tpfa_matrix(gb), gb, seeds=seeds)
         co.generate_coarse_grid(gb, part)
 
         # Test
@@ -863,7 +863,7 @@ class BasicsTest(unittest.TestCase):
             gb = pp.meshing.cart_grid([f1, f2], [6, 6])
             gb.compute_geometry()
 
-            part = co.create_partition(co.tpfa_matrix(gb), gb, cdepth=3)
+            part = co.create_partition(co._tpfa_matrix(gb), gb, cdepth=3)
             co.generate_coarse_grid(gb, part)
 
             cell_centers_1 = np.array(
@@ -926,7 +926,7 @@ class BasicsTest(unittest.TestCase):
             known_seeds = np.array([8, 9, 26, 27, 13, 16, 19, 22])
             self.assertTrue(np.array_equal(np.sort(seeds), np.sort(known_seeds)))
 
-            part = co.create_partition(co.tpfa_matrix(gb), gb, cdepth=3, seeds=seeds)
+            part = co.create_partition(co._tpfa_matrix(gb), gb, cdepth=3, seeds=seeds)
             co.generate_coarse_grid(gb, part)
 
             cell_centers_1 = np.array(
@@ -990,7 +990,7 @@ class BasicsTest(unittest.TestCase):
             known_seeds = np.array([29, 30, 369, 370, 181, 198, 201, 218])
             self.assertTrue(np.array_equal(np.sort(seeds), np.sort(known_seeds)))
 
-            part = co.create_partition(co.tpfa_matrix(gb), gb, cdepth=3, seeds=seeds)
+            part = co.create_partition(co._tpfa_matrix(gb), gb, cdepth=3, seeds=seeds)
             co.generate_coarse_grid(gb, part)
 
             cell_centers_1 = np.array(


### PR DESCRIPTION
# Main contribution
When the method coarsen() was called with a single grid, and the call forwarded to generate_coarse_grid(), the argument type of subdiv should be changed from Dict[pp.Grid, Dict[pp.Grid, np.ndarray]] to simply Dict[pp.Grid, np.ndarray]. 

# Other changes
Some work on documentation, in particular on module level. Also changed a few function names to indicate they are private.

# Other possible changes 
More documentation, typing etc. I have no idea whether the method I accessed was the one intended as a the front.