### PR TITLE
fix: gmsh interface path error and bug in log handling

### DIFF
--- a/src/porepy/grids/gmsh/gmsh_interface.py
+++ b/src/porepy/grids/gmsh/gmsh_interface.py
@@ -742,7 +742,7 @@ def run_gmsh(in_file: Union[str, Path], out_file: Union[str, Path], dim: int) ->
     # Look for errors
     log = gmsh.logger.get()
     for line in log:
-        if "Error" in line:
+        if "Error:" in line:
             fn = _dump_gmsh_log(log, in_file)
             raise ValueError(
                 f"""Error when reading gmsh file {in_file}.
@@ -755,7 +755,7 @@ def run_gmsh(in_file: Union[str, Path], out_file: Union[str, Path], dim: int) ->
     # Look for errors
     log = gmsh.logger.get()
     for line in log:
-        if "Error" in line:
+        if "Error:" in line:
             fn = _dump_gmsh_log(log, in_file)
             raise ValueError(
                 f"Error in gmsh when generating mesh for {in_file}\n"


### PR DESCRIPTION
# Overview
This PR has two main contributions. Both are fixes to the `run_gmsh` method in `gmsh_interface.py`.

### Commit 9190c18 
This commit fixes an issue where if an absolute path is passed to `in_file`, the helper method `_dump_gmsh_log` would determine a non-valid path to `debug_file_name`. Consider especially the line
```
debug_file_name = "gmsh_log_" + fn + ".dbg"
```
for the case where `fn` is a full path. Clearly, this will result in an invalid path.

Otherwise, I have also exclusively used the `pathlib.Path` library to perform all operations, and only converted to string where required.

### Commit 5f2358f 
This commit **tries** to fix an issue for how errors are located in the gmsh logger.
In particular, a typical `Info` message that will be included in the log is:
```
Info: Reading '/home/path/to/folder/with/name/TestGridError/gmsh_frac_file.geo
```
Notice how `Error` is included in the path. This will raise an error in the current implementation. My suggestion is to instead search for `Error:`. However, this is possibly not viable either as I am not certain as to whether the gmsh log messages are of the format `<log level>: <log message>` irrespective of what local changes I make to log handling. This needs to be investigated at some point.