### PR TITLE
build: Use dependabot to bump dependencies

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,11 @@
+# Documentation: https://dependabot.com/docs/config-file/
+version: 1
+update_configs:
+  # Update requirements.txt weekly
+  - package_manager: "python"
+    directory: "/"
+    update_schedule: "daily"
+    
+  # Apply default reviewers
+    default_reviewers:
+      - "keileg"


### PR DESCRIPTION
Add dependabot to automatically bump dependencies
For first-time activation, see: https://dependabot.com/docs/config-file/
