### PR TITLE
Do not specify numba version in requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ before_script:
   - cd $TRAVIS_BUILD_DIR 
   - echo $TRAVIS_BUILD_DIR
   - export PYTHONPATH=${TRAVIS_BUILD_DIR}:${PYTHONPATH}
+  - export NUMBA_CACHE_DIR=${HOME}
   
   # Download file for point-in-polyhedron test
   - wget https://raw.githubusercontent.com/keileg/polyhedron/master/polyhedron.py

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,6 +12,6 @@ shapely[vectorized] == 1.6.4.post2
 pytest == 4.5.0
 pytest-cov == 2.6.1
 pytest-runner == 4.4
-numba == 0.47
+numba
 vtk == 8.1.2
 gmsh-sdk

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,6 @@ future == 0.17.1
 six == 1.12.0
 shapely == 1.6.4.post2
 shapely[vectorized] == 1.6.4.post2
-numba == 0.47
+numba
 vtk == 8.1.2
 gmsh-sdk


### PR DESCRIPTION
Travis failed when LLVMlite changed the backend llvm to v9 - this broke numba compilation. Change to newer version of numba to free this.