### PR TITLE
Bugfix in mesh splitting, new discretization class

### DIFF
--- a/src/porepy/__init__.py
+++ b/src/porepy/__init__.py
@@ -83,7 +83,10 @@ from porepy.numerics.interface_laws.elliptic_discretization import (
 # Control volume, elliptic
 from porepy.numerics.fv import fvutils
 from porepy.numerics.fv.mpsa import Mpsa
-from porepy.numerics.fv.fv_elliptic import FVElliptic
+from porepy.numerics.fv.fv_elliptic import (
+    FVElliptic,
+    EllipticDiscretizationZeroPermeability,
+)
 from porepy.numerics.fv.tpfa import Tpfa
 from porepy.numerics.fv.mpfa import Mpfa
 from porepy.numerics.fv.biot import Biot, GradP, DivU, BiotStabilization

--- a/src/porepy/fracs/meshing.py
+++ b/src/porepy/fracs/meshing.py
@@ -169,7 +169,10 @@ def _tag_faces(grids, check_highest_dim=True):
         domain_boundary_tags[bnd_faces] = True
         g_h.tags["domain_boundary_faces"] = domain_boundary_tags
         bnd_nodes, _, _ = sps.find(g_h.face_nodes[:, bnd_faces])
-        bnd_nodes = np.unique(bnd_nodes)
+
+        # Boundary nodes of g_h in terms of global indices
+        bnd_nodes_glb = g_h.global_point_ind[np.unique(bnd_nodes)]
+
         for g_dim in grids[1:-1]:
             for g in g_dim:
                 # We find the global nodes of all boundary faces
@@ -181,7 +184,7 @@ def _tag_faces(grids, check_highest_dim=True):
                 nodes_glb = g.global_point_ind[nodes_loc]
                 # We then tag each node as a tip node if it is not a global
                 # boundary node
-                is_tip = np.in1d(nodes_glb, bnd_nodes, invert=True)
+                is_tip = np.in1d(nodes_glb, bnd_nodes_glb, invert=True)
                 # We reshape the nodes such that each column equals the nodes of
                 # one face. If a face only contains global boundary nodes, the
                 # local face is also a boundary face. Otherwise, we add a TIP tag.

--- a/src/porepy/numerics/fv/fv_elliptic.py
+++ b/src/porepy/numerics/fv/fv_elliptic.py
@@ -450,6 +450,7 @@ class FVElliptic(pp.EllipticDiscretization):
         # Operation is void for finite volume methods
         pass
 
+
 class EllipticDiscretizationZeroPermeability(FVElliptic):
     """ Specialized discretization for domains with zero tangential permeability.
 
@@ -537,8 +538,10 @@ class EllipticDiscretizationZeroPermeability(FVElliptic):
                 used. Needed for periodic boundary conditions.
 
         """
-        raise NotImplementedError("""This class should not be used as a
-                                  higher-dimensional discretization""")
+        raise NotImplementedError(
+            """This class should not be used as a
+                                  higher-dimensional discretization"""
+        )
 
     def assemble_int_bound_pressure_trace(
         self, g, data, data_edge, cc, matrix, rhs, self_ind, use_slave_proj=False
@@ -570,5 +573,7 @@ class EllipticDiscretizationZeroPermeability(FVElliptic):
                 used. Needed for periodic boundary conditions.
 
         """
-        raise NotImplementedError("""This class should not be used as a
-                                  higher-dimensional discretization""")
+        raise NotImplementedError(
+            """This class should not be used as a
+                                  higher-dimensional discretization"""
+        )


### PR DESCRIPTION
## Overview
Two contributions:
1. When tagging faces during splitting of meshes, there was a reference to local point indices instead of global once.
2. A specialized EllipticDiscretization class for the case of zero tangential permeability is introduced. This is intended used for imposing full continuity conditions between two meshes of higher dimension (e.g. two fractures in a DFN setting) in cases where one does not want to eliminate the intermediate lower-dimensional domain.