### PR TITLE
fix: bug in replace_grids while updating mortar grid

### DIFF
--- a/src/porepy/grids/grid_bucket.py
+++ b/src/porepy/grids/grid_bucket.py
@@ -917,18 +917,16 @@ class GridBucket(Generic[T]):
     def replace_grids(
         self,
         g_map: Dict[pp.Grid, pp.Grid] = None,
-        mg_map: [pp.MortarGrid, pp.MortarGrid] = None,
+        mg_map: Dict[pp.MortarGrid, pp.MortarGrid] = None,
         tol: float = 1e-6,
     ) -> None:
-        """ Replace grids and / or mortar grids in the mixed-dimensional grid.
+        """ Replace grids and / or mortar grids in a mixed-dimensional grid.
 
         Parameters:
-            gb (GridBucket): To be updated.
             g_map (dictionary): Grids to replace. Keys are grids in the old bucket,
                 values are their replacements.
-            mg_map (dictionary): Mortar grids to replace. Keys are EITHER related
-                to mortar grids, or to edges. Probably, mg is most relevant, the we
-                need to identify the right edge shielded from user.
+            mg_map (dictionary): Mortar grids to replace. Keys are mortar grids in 
+                the old bucket, values are their replacements.
 
         """
         if mg_map is None:
@@ -936,7 +934,8 @@ class GridBucket(Generic[T]):
 
         # refine the mortar grids when specified
         for mg_old, mg_new in mg_map.items():
-            mg_old.update_mortar(mg_new, tol)
+            side_grids_new = mg_new.side_grids
+            mg_old.update_mortar(side_grids_new, tol)
 
         # update the grid bucket considering the new grids instead of the old one
         # valid only for physical grids and not for mortar grids

--- a/src/porepy/numerics/fem/rt0.py
+++ b/src/porepy/numerics/fem/rt0.py
@@ -58,9 +58,12 @@ class RT0(pp.numerics.vem.dual_elliptic.DualElliptic):
         matrix_dictionary = data[pp.DISCRETIZATION_MATRICES][self.keyword]
         # If a 0-d grid is given then we return an identity matrix
         if g.dim == 0:
-            matrix_dictionary[self.mass_matrix_key] = sps.dia_matrix(([1], 0), (1, 1))
-            matrix_dictionary[self.div_matrix_key] = sps.csr_matrix((1, 1))
-            matrix_dictionary[self.vector_proj_key] = sps.csr_matrix((3, 1))
+            mass = sps.dia_matrix(([1], 0), (g.num_faces, g.num_faces))                                                
+            matrix_dictionary[self.mass_matrix_key] = mass                                                             
+            matrix_dictionary[self.div_matrix_key] = sps.csr_matrix(                                                   
+                (g.num_faces, g.num_cells)                                                                             
+            )                                                                                                          
+            matrix_dictionary[self.vector_proj_key] = sps.csr_matrix((3, g.num_cells))  
             return
 
         # Get dictionary for parameter storage

--- a/src/porepy/numerics/fem/rt0.py
+++ b/src/porepy/numerics/fem/rt0.py
@@ -58,12 +58,12 @@ class RT0(pp.numerics.vem.dual_elliptic.DualElliptic):
         matrix_dictionary = data[pp.DISCRETIZATION_MATRICES][self.keyword]
         # If a 0-d grid is given then we return an identity matrix
         if g.dim == 0:
-            mass = sps.dia_matrix(([1], 0), (g.num_faces, g.num_faces))                                                
-            matrix_dictionary[self.mass_matrix_key] = mass                                                             
-            matrix_dictionary[self.div_matrix_key] = sps.csr_matrix(                                                   
-                (g.num_faces, g.num_cells)                                                                             
-            )                                                                                                          
-            matrix_dictionary[self.vector_proj_key] = sps.csr_matrix((3, g.num_cells))  
+            mass = sps.dia_matrix(([1], 0), (g.num_faces, g.num_faces))
+            matrix_dictionary[self.mass_matrix_key] = mass
+            matrix_dictionary[self.div_matrix_key] = sps.csr_matrix(
+                (g.num_faces, g.num_cells)
+            )
+            matrix_dictionary[self.vector_proj_key] = sps.csr_matrix((3, g.num_cells))
             return
 
         # Get dictionary for parameter storage

--- a/src/porepy/numerics/vem/mvem.py
+++ b/src/porepy/numerics/vem/mvem.py
@@ -65,7 +65,7 @@ class MVEM(pp.numerics.vem.dual_elliptic.DualElliptic):
             matrix_dictionary[self.div_matrix_key] = sps.csr_matrix(
                 (g.num_faces, g.num_cells)
             )
-            matrix_dictionary[self.vector_proj_key] = sps.csr_matrix((3, g.num_cells))  
+            matrix_dictionary[self.vector_proj_key] = sps.csr_matrix((3, g.num_cells))
             return
 
         # Get dictionary for parameter storage

--- a/src/porepy/numerics/vem/mvem.py
+++ b/src/porepy/numerics/vem/mvem.py
@@ -65,7 +65,7 @@ class MVEM(pp.numerics.vem.dual_elliptic.DualElliptic):
             matrix_dictionary[self.div_matrix_key] = sps.csr_matrix(
                 (g.num_faces, g.num_cells)
             )
-            matrix_dictionary[self.vector_proj_key] = sps.csr_matrix((3, 1))
+            matrix_dictionary[self.vector_proj_key] = sps.csr_matrix((3, g.num_cells))  
             return
 
         # Get dictionary for parameter storage


### PR DESCRIPTION
The `update_mortar` method expects the new side grids dictionary, not the full new mortar grid.

In addition, documentation of the method was improved.