### PR TITLE
Mixed dim assembler filters

### DIFF
--- a/src/porepy/numerics/mixed_dim/assembler.py
+++ b/src/porepy/numerics/mixed_dim/assembler.py
@@ -281,11 +281,19 @@ class Assembler:
 
         """
         def make_filter(var_term_list: List[str] = None) -> Callable[[str], bool]:
-            """ Construct a filter for variable and terms
+            """ Construct a filter for variables and terms
 
-            The result is a callable which takes one argument (a string).
-            I
-            filter is a list of strings.
+            The input should be either
+            a) a list of variables (terms) that are to be discretized.
+                Then, only the variables (terms) in that list will be
+                discretized on any node.
+            b) a list of variables (terms), each prefixed by "!", that
+                are to be excluded from discretization.
+                Then, every term will be discretized, except those
+                associated with the given list of variables (terms).
+
+            The result is a callable which takes one argument (a string),
+            and returns a boolean.
             """
             def return_true(s):
                 return True

--- a/src/porepy/numerics/mixed_dim/assembler.py
+++ b/src/porepy/numerics/mixed_dim/assembler.py
@@ -8,8 +8,6 @@ import porepy as pp
 
 from typing import Set, List, Tuple, Union, Dict, Any, Callable, Type, Optional
 
-from porepy.numerics.interface_laws.abstract_interface_law import AbstractInterfaceLaw
-
 csc_or_csr_matrix = Union[sps.csc_matrix, sps.csr_matrix]
 
 

--- a/src/porepy/numerics/mixed_dim/assembler.py
+++ b/src/porepy/numerics/mixed_dim/assembler.py
@@ -601,6 +601,7 @@ class Assembler:
                 if master_vals is None:
                     # An empty identifying string will create no problems below.
                     master_var_key = ""
+                    master_term_key = ""
                     # If the master variable index is None, this signifies that
                     # the master variable index is not active
                     mi = None
@@ -628,6 +629,7 @@ class Assembler:
                 slave_vals: Tuple[str, str] = coupling_term.get(g_slave, None)
                 if slave_vals is None:
                     slave_var_key = ""
+                    slave_term_key = ""
                     si = None
 
                     # If operation is 'assemble', set mat_key_slave to None here
@@ -663,6 +665,8 @@ class Assembler:
                             variable_filter(master_var_key)
                             and variable_filter(slave_var_key)
                             and variable_filter(edge_var_key)
+                            and term_filter(master_term_key)
+                            and term_filter(slave_term_key)
                         ):
                             edge_discr.discretize(
                                 g_master, g_slave, data_master, data_slave, data_edge

--- a/src/porepy/numerics/mixed_dim/assembler.py
+++ b/src/porepy/numerics/mixed_dim/assembler.py
@@ -53,9 +53,7 @@ class Assembler:
             return row + "_" + col
 
     @staticmethod
-    def _variable_term_key(
-        term: str, key_1: str, key_2: str, key_3: str = None
-    ) -> str:
+    def _variable_term_key(term: str, key_1: str, key_2: str, key_3: str = None) -> str:
         """ Get the key-variable combination used to identify a specific term in the equation.
 
         For nodes and internally to edges in the GridBucket (i.e. fixed-dimensional grids),
@@ -100,7 +98,7 @@ class Assembler:
         self, matrix_format: str = "csr", add_matrices: bool = True
     ) -> Union[
         Tuple[Union[csc_or_csr_matrix, np.ndarray], np.ndarray],
-        Tuple[Dict[str, sps.spmatrix], Dict[str, np.ndarray]]
+        Tuple[Dict[str, sps.spmatrix], Dict[str, np.ndarray]],
     ]:
         """ Assemble the system matrix and right hand side for a general linear
         multi-physics problem, and return a block matrix and right hand side.
@@ -252,9 +250,13 @@ class Assembler:
             Variable filter works as internal to nodes / edges.
             The term filter acts on the identifier of a coupling, so
 
-            d[pp.COUPLING_DISCRETIZATION] = {'coupling_id' : {g1: {'temp': 'diffusion'},
-                                                              g2:  {'pressure': 'diffusion'},
-                                                              (g1, g2): {'coupling_variable': FooBar()}}}
+            d[pp.COUPLING_DISCRETIZATION] = {
+                'coupling_id' : {
+                    g1: {'temp': 'diffusion'},
+                    g2:  {'pressure': 'diffusion'},
+                    (g1, g2): {'coupling_variable': FooBar()}
+                }
+            }
 
             will survive term_filter = ['coupling_id']
 
@@ -280,6 +282,7 @@ class Assembler:
         Implemented actions are discretization and assembly.
 
         """
+
         def make_filter(var_term_list: List[str] = None) -> Callable[[str], bool]:
             """ Construct a filter for variables and terms
 
@@ -295,6 +298,7 @@ class Assembler:
             The result is a callable which takes one argument (a string),
             and returns a boolean.
             """
+
             def return_true(s):
                 return True
 
@@ -414,12 +418,12 @@ class Assembler:
             )
 
     def _operate_on_edge(
-            self,
-            operation: str,
-            matrix: Union[Dict[str, np.ndarray], None],
-            rhs: Union[Dict[str, np.ndarray], None],
-            variable_filter: Callable[[str], bool],
-            term_filter: Callable[[str], bool],
+        self,
+        operation: str,
+        matrix: Union[Dict[str, np.ndarray], None],
+        rhs: Union[Dict[str, np.ndarray], None],
+        variable_filter: Callable[[str], bool],
+        term_filter: Callable[[str], bool],
     ):
         """ Perform operation on all edges in self.GridBucket.
 
@@ -450,14 +454,14 @@ class Assembler:
             )
 
     def __operate_on_node_or_edge(
-            self,
-            node_or_edge: Union[pp.Grid, Tuple[pp.Grid, pp.Grid]],
-            data: Dict,
-            operation: str,
-            matrix: Union[Dict[str, np.ndarray], None],
-            rhs: Union[Dict[str, np.ndarray], None],
-            variable_filter: Callable[[str], bool],
-            term_filter: Callable[[str], bool],
+        self,
+        node_or_edge: Union[pp.Grid, Tuple[pp.Grid, pp.Grid]],
+        data: Dict,
+        operation: str,
+        matrix: Union[Dict[str, np.ndarray], None],
+        rhs: Union[Dict[str, np.ndarray], None],
+        variable_filter: Callable[[str], bool],
+        term_filter: Callable[[str], bool],
     ):
         # Extract the active local variables
         loc_var = self._local_variables(data)
@@ -483,9 +487,9 @@ class Assembler:
 
                         if operation == "discretize":
                             if (
-                                    variable_filter(row)
-                                    and variable_filter(col)
-                                    and term_filter(term_key)
+                                variable_filter(row)
+                                and variable_filter(col)
+                                and term_filter(term_key)
                             ):
                                 # Call appropriate discretization method for
                                 # nodes and edges, respectively.
@@ -498,7 +502,9 @@ class Assembler:
                             # discretize if not done before.
                             # Call appropriate assembler for nodes and edges, respectively.
                             if isinstance(node_or_edge, pp.Grid):
-                                loc_A, loc_b = term_discr.assemble_matrix_rhs(node_or_edge, data)
+                                loc_A, loc_b = term_discr.assemble_matrix_rhs(
+                                    node_or_edge, data
+                                )
                             else:
                                 loc_A, loc_b = term_discr.assemble_matrix_rhs(data)
 
@@ -581,7 +587,10 @@ class Assembler:
             if discr is None:
                 continue
 
-            for coupling_key, coupling_term in discr.items():  # coupling_key: str, coupling_term: Dict
+            for (
+                coupling_key,
+                coupling_term,
+            ) in discr.items():  # coupling_key: str, coupling_term: Dict
                 # Get edge coupling discretization
                 edge_vals: Tuple[str, Any] = coupling_term.get(e)
                 edge_var_key, edge_discr = edge_vals
@@ -692,15 +701,19 @@ class Assembler:
                         if mat_key_master:
                             loc_mat[0, 0] = matrix[mat_key_master][mi, mi]
                         else:
-                            raise ValueError(f"No discretization found on the master grid "
-                                             f"of dimension {g_master.dim}, for the "
-                                             f"coupling term {coupling_term}.")
+                            raise ValueError(
+                                f"No discretization found on the master grid "
+                                f"of dimension {g_master.dim}, for the "
+                                f"coupling term {coupling_term}."
+                            )
                         if mat_key_slave:
                             loc_mat[1, 1] = matrix[mat_key_slave][si, si]
                         else:
-                            raise ValueError(f"No discretization found on the slave grid "
-                                             f"of dimension {g_slave.dim}, for the "
-                                             f"coupling term {coupling_term}.")
+                            raise ValueError(
+                                f"No discretization found on the slave grid "
+                                f"of dimension {g_slave.dim}, for the "
+                                f"coupling term {coupling_term}."
+                            )
 
                         # Run the discretization, and assign the resulting matrix
                         # to a temporary construct
@@ -728,7 +741,9 @@ class Assembler:
                     # si is None
                     # The operation is a simplified version of the full option above.
                     if operation == "discretize":
-                        if variable_filter(master_var_key) and variable_filter(edge_var_key):
+                        if variable_filter(master_var_key) and variable_filter(
+                            edge_var_key
+                        ):
                             edge_discr.discretize(g_master, data_master, data_edge)
                     elif operation == "assemble":
 
@@ -753,7 +768,9 @@ class Assembler:
                     # mi is None
                     # The operation is a simplified version of the full option above.
                     if operation == "discretize":
-                        if variable_filter(slave_var_key) and variable_filter(edge_var_key):
+                        if variable_filter(slave_var_key) and variable_filter(
+                            edge_var_key
+                        ):
                             edge_discr.discretize(g_slave, data_slave, data_edge)
                     elif operation == "assemble":
 
@@ -824,7 +841,10 @@ class Assembler:
                         loc_mat, _ = self._assign_matrix_vector(
                             self.full_dof[[mi, ei, oi]], sps_matrix
                         )
-                        tmp_mat, loc_rhs = edge_discr.assemble_edge_coupling_via_high_dim(
+                        (
+                            tmp_mat,
+                            loc_rhs,
+                        ) = edge_discr.assemble_edge_coupling_via_high_dim(
                             g_master,
                             data_master,
                             e,
@@ -873,7 +893,10 @@ class Assembler:
                         loc_mat, _ = self._assign_matrix_vector(
                             self.full_dof[[si, ei, oi]], sps_matrix
                         )
-                        tmp_mat, loc_rhs = edge_discr.assemble_edge_coupling_via_high_dim(
+                        (
+                            tmp_mat,
+                            loc_rhs,
+                        ) = edge_discr.assemble_edge_coupling_via_high_dim(
                             g_slave, data_slave, data_edge, data_other, loc_mat
                         )
                         matrix[mat_key][ei, oi] = tmp_mat[1, 2]
@@ -893,7 +916,7 @@ class Assembler:
             block_dof: Is a dictionary with keys that are either
                 Tuple[pp.Grid, variable_name: str] for nodes in the GridBucket, or
                 Tuple[Tuple[pp.Grid, pp.Grid], str] for edges in the GridBucket.
-                
+
                 The values in block_dof are integers 0, 1, ..., that identify the block
                 index of this specific grid (or edge) - variable combination.
 
@@ -918,10 +941,7 @@ class Assembler:
         block_dof_counter = 0
 
         # Dictionary that maps node/edge + variable combination to an index.
-        block_dof: Dict[
-            Tuple[Union[pp.Grid, Tuple[pp.Grid, pp.Grid]], str],
-            int
-        ] = {}
+        block_dof: Dict[Tuple[Union[pp.Grid, Tuple[pp.Grid, pp.Grid]], str], int] = {}
 
         # Storage for number of dofs per variable per node/edge, with respect
         # to the ordering specified in block_dof
@@ -1042,11 +1062,10 @@ class Assembler:
                 # on the edge, the variable names of the slave and master grid
                 # in that order, and finally the term name.
                 # There is a tacit assumption here that self.gb.nodes_of_edge return the
-                # grids in the same order here and in the assembly. This should be
-                # okay. The consequences for the methods if this is no longer the case is unclear.
+                # grids in the same order here and in the assembly. This should be okay.
+                # The consequences for the methods if this is no longer the case is unclear.
 
-                # Get the name of the edge variable (it is the first item in
-                # a tuple)
+                # Get the name of the edge variable (it is the first item in a tuple)
                 key_edge: str = val.get(e)[0]
                 if not self._is_active_variable(key_edge):
                     continue
@@ -1090,9 +1109,8 @@ class Assembler:
         # Array version of the number of dofs per node/edge and variable
         self.full_dof: np.ndarray = np.array(full_dof)
         self.block_dof: Dict[
-            Tuple[
-                Union[pp.Grid, Tuple[pp.Grid, pp.Grid]], str
-            ], int] = block_dof
+            Tuple[Union[pp.Grid, Tuple[pp.Grid, pp.Grid]], str], int
+        ] = block_dof
         self.variable_combinations: List[str] = variable_combinations
 
     def _initialize_matrix_rhs(
@@ -1286,9 +1304,7 @@ class Assembler:
             return key in self.active_variables
 
     def distribute_variable(
-        self,
-        values: np.ndarray,
-        variable_names: List[str] = None,
+        self, values: np.ndarray, variable_names: List[str] = None,
     ) -> None:
         """ Distribute a vector to the nodes and edges in the GridBucket.
 
@@ -1324,9 +1340,9 @@ class Assembler:
                     data = self.gb.node_props(g)
 
                 if pp.STATE in data.keys():
-                    data[pp.STATE][var_name] = values[dof[bi]: dof[bi + 1]]
+                    data[pp.STATE][var_name] = values[dof[bi] : dof[bi + 1]]
                 else:
-                    data[pp.STATE] = {var_name: values[dof[bi]: dof[bi + 1]]}
+                    data[pp.STATE] = {var_name: values[dof[bi] : dof[bi + 1]]}
 
     def dof_ind(
         self, g: Union[pp.Grid, Tuple[pp.Grid, pp.Grid]], name: str

--- a/test/integration/test_biot.py
+++ b/test/integration/test_biot.py
@@ -160,6 +160,88 @@ class BiotTest(unittest.TestCase):
         self.assertTrue(np.all(np.isclose(A.A, A_class.A)))
         self.assertTrue(np.all(np.isclose(b, b_class)))
 
+    def test_assemble_biot_exclude_filter(self):
+        """ Test the assembly of the Biot problem using the assembler.
+
+        The test checks whether the discretization matches that of the Biot class.
+        """
+        gb = pp.meshing.cart_grid([], [2, 1])
+        g = gb.grids_of_dimension(2)[0]
+        d = gb.node_props(g)
+        # Parameters identified by two keywords
+        kw_m = "mechanics"
+        kw_f = "flow"
+        variable_m = "displacement"
+        variable_f = "pressure"
+        bound_mech, bound_flow = self.make_boundary_conditions(g)
+        initial_disp, initial_pressure, initial_state = self.make_initial_conditions(
+            g, x0=0, y0=0, p0=0
+        )
+        state = {
+            variable_f: initial_pressure,
+            variable_m: initial_disp,
+            kw_m: {"bc_values": np.zeros(g.num_faces * g.dim)},
+        }
+        parameters_m = {"bc": bound_mech, "biot_alpha": 1}
+
+        parameters_f = {"bc": bound_flow, "biot_alpha": 1}
+        pp.initialize_default_data(g, d, kw_m, parameters_m)
+        pp.initialize_default_data(g, d, kw_f, parameters_f)
+        pp.set_state(d, state)
+        # Discretize the mechanics related terms using the Biot class
+        biot_discretizer = pp.Biot()
+        biot_discretizer._discretize_mech(g, d)
+
+        # Set up the structure for the assembler. First define variables and equation
+        # term names.
+        v_0 = variable_m
+        v_1 = variable_f
+        term_00 = "stress_divergence"
+        term_01 = "pressure_gradient"
+        term_10 = "displacement_divergence"
+        term_11_0 = "fluid_mass"
+        term_11_1 = "fluid_flux"
+        term_11_2 = "stabilization"
+        d[pp.PRIMARY_VARIABLES] = {v_0: {"cells": g.dim}, v_1: {"cells": 1}}
+        d[pp.DISCRETIZATION] = {
+            v_0: {term_00: pp.Mpsa(kw_m)},
+            v_1: {
+                term_11_0: pp.MassMatrix(kw_f),
+                term_11_1: pp.Mpfa(kw_f),
+                term_11_2: pp.BiotStabilization(kw_f),
+            },
+            v_0 + "_" + v_1: {term_01: pp.GradP(kw_m)},
+            v_1 + "_" + v_0: {term_10: pp.DivU(kw_m)},
+        }
+        # Assemble. Also discretizes the flow terms (fluid_mass and fluid_flux)
+        general_assembler = pp.Assembler(gb)
+        general_assembler.discretize(
+            term_filter=[
+                "!stress_divergence", "!pressure_gradient", "!displacement_divergence", "!stabilization"
+            ]
+        )
+        A, b = general_assembler.assemble_matrix_rhs()
+
+        # Re-discretize and assemble using the Biot class
+        A_class, b_class = biot_discretizer.assemble_matrix_rhs(g, d)
+
+        # Make sure the variable ordering of the matrix assembled by the assembler
+        # matches that of the Biot class.
+        grids = [g, g]
+        variables = [v_0, v_1]
+        A, b = permute_matrix_vector(
+            A,
+            b,
+            general_assembler.block_dof,
+            general_assembler.full_dof,
+            grids,
+            variables,
+        )
+
+        # Compare the matrices and rhs vectors
+        self.assertTrue(np.all(np.isclose(A.A, A_class.A)))
+        self.assertTrue(np.all(np.isclose(b, b_class)))
+
     def test_assemble_biot_rhs_transient(self):
         """ Test the assembly of a Biot problem with a non-zero rhs using the assembler.
 


### PR DESCRIPTION
# Overview
This PR implements additional logic to assembler filters.
In addition, general improvements to variable naming, documentation and typing is done.

## Extend `variable_filter` and `term_filter`
Previously, variable and term filters are constructed by passing a list of variables and terms, respectively, which restricts which operators will be discretized. The filters are "strict" in the sense that only terms contained in the respective filters will pass.

This PR extends this functionality such that you can pass a negative filter. That is: "discretize everything except variables/terms in the respective lists". In this proposal, the negative filters are indicated by prefixing each list item by "!" (means 'not'). 
For example:
`variable_filter = ["!temp"]`.
See also the documentation of `Assembler.discretize`, where I added a few examples.

## Filter by list of grids
Previously, you could restrict `Assembler.discretize()` to a single grid.

### Nodes
This PR extends the functionality to accept a list of grids on discretization of nodes.

### Edges and edge couplings
Edge discretizations and edge coupling discretizations have all previously been discretized, irrespective of whether any grid is passed to the grid filter.

This PR intends to allow grid filters to limit which edges/edge couplings are discretized.
Two options are possible. Either,
1) either the slave or master grid has to pass the grid filter, or
2) both the slave and master grid have to pass the grid filter.