### PR TITLE
Cellwise parameters

### DIFF
--- a/src/porepy/numerics/contact_mechanics/contact_conditions.py
+++ b/src/porepy/numerics/contact_mechanics/contact_conditions.py
@@ -115,27 +115,34 @@ class ColoumbContact:
         # Process input
         parameters_l = data_l[pp.PARAMETERS]
 
-        # Mandatory cellwise friction coefficient relates normal and tangential forces.
-        friction_coefficient = parameters_l[self.keyword]["friction_coefficient"]
-        if np.asarray(friction_coefficient).size == 1:
-            friction_coefficient = friction_coefficient * np.ones(g_l.num_cells)
         # Numerical parameter, value and sensitivity is currently unknown.
         # The thesis of Hueeber is probably a good place to look for information.
         c_num = parameters_l[self.keyword].get(
             "contact_mechanics_numerical_parameter", 100
         )
-
+        # Obtain the four cellwise parameters:
+        # Mandatory friction coefficient relates normal and tangential forces.
         # The initial gap will usually be zero.
         # The gap value may be a function of tangential displacement.
         # We assume g(u_t) = - tan(dilation_angle) * || u_t ||
         # The cohesion represents a minimal force, independent of the normal force,
         # that must be overcome before the onset of sliding.
-        cellwise_parameters = ["initial_gap", "dilation_angle", "cohesion"]
-        defaults = [0, 0, 0]
+        cellwise_parameters = [
+            "friction_coefficient",
+            "initial_gap",
+            "dilation_angle",
+            "cohesion",
+        ]
+        defaults = [None, 0, 0, 0]
         vals = parameters_l.expand_scalars(
             g_l.num_cells, self.keyword, cellwise_parameters, defaults
         )
-        initial_gap, dilation_angle, cohesion = vals[0], vals[1], vals[2]
+        friction_coefficient, initial_gap, dilation_angle, cohesion = (
+            vals[0],
+            vals[1],
+            vals[2],
+            vals[3],
+        )
 
         mg = data_edge["mortar_grid"]
 

--- a/src/porepy/numerics/contact_mechanics/contact_conditions.py
+++ b/src/porepy/numerics/contact_mechanics/contact_conditions.py
@@ -108,34 +108,34 @@ class ColoumbContact:
             etc.
 
         """
-
         # CLARIFICATIONS NEEDED:
         #   1) Do projection and rotation commute on non-matching grids? The
         #   gut feel says yes, but I'm not sure.
 
         # Process input
-        parameters_l = data_l[pp.PARAMETERS][self.keyword]
+        parameters_l = data_l[pp.PARAMETERS]
 
         # Mandatory cellwise friction coefficient relates normal and tangential forces.
-        friction_coefficient = parameters_l["friction_coefficient"]
+        friction_coefficient = parameters_l[self.keyword]["friction_coefficient"]
         if np.asarray(friction_coefficient).size == 1:
             friction_coefficient = friction_coefficient * np.ones(g_l.num_cells)
         # Numerical parameter, value and sensitivity is currently unknown.
         # The thesis of Hueeber is probably a good place to look for information.
-        c_num = parameters_l.get("contact_mechanics_numerical_parameter", 100)
+        c_num = parameters_l[self.keyword].get(
+            "contact_mechanics_numerical_parameter", 100
+        )
+
         # The initial gap will usually be zero.
         # The gap value may be a function of tangential displacement.
         # We assume g(u_t) = - tan(dilation_angle) * || u_t ||
         # The cohesion represents a minimal force, independent of the normal force,
         # that must be overcome before the onset of sliding.
         cellwise_parameters = ["initial_gap", "dilation_angle", "cohesion"]
-        vals = []
-        for pa in cellwise_parameters:
-            val = parameters_l.get(pa, 0)
-            if np.asarray(val).size == 1:
-                val *= np.ones(g_l.num_cells)
-            vals.append(val)
-        initial_gap, dilation_angle, cohesion = vals
+        defaults = [0, 0, 0]
+        vals = parameters_l.expand_scalars(
+            g_l.num_cells, self.keyword, cellwise_parameters, defaults
+        )
+        initial_gap, dilation_angle, cohesion = vals[0], vals[1], vals[2]
 
         mg = data_edge["mortar_grid"]
 
@@ -539,7 +539,6 @@ class ColoumbContact:
         # Regularization during the iterations requires computations of parameters
         # alpha, beta, delta
         alpha = -Tt.T.dot(-Tt + cut) / (self._l2(-Tt) * self._l2(-Tt + cut))
-
         # Parameter delta.
         # NOTE: The denominator bf is correct. The definition given in Berge is wrong.
         delta = min(self._l2(-Tt) / bf, 1)

--- a/src/porepy/params/data.py
+++ b/src/porepy/params/data.py
@@ -69,6 +69,7 @@ import warnings
 import porepy.params.parameter_dictionaries as dicts
 from typing import List
 
+
 class Parameters(dict):
     """ Class to store all physical parameters used by solvers.
 
@@ -185,7 +186,9 @@ class Parameters(dict):
         for (p, v) in zip(parameters, values):
             modify_variable(self[keyword][p], v)
 
-    def expand_scalars(self, n_vals: int, keyword: str, parameters: List[str], defaults=None) -> List:
+    def expand_scalars(
+        self, n_vals: int, keyword: str, parameters: List[str], defaults=None
+    ) -> List:
         """ Expand parameters assigned as a single scalar to n_vals arrays. 
         Used e.g. for parameters which may be heterogeneous in space (cellwise),
         but are often homogeneous and assigned as a scalar.
@@ -201,16 +204,17 @@ class Parameters(dict):
         """
         values = []
         if defaults is None:
-            defaults = [None]*len(parameters)
+            defaults = [None] * len(parameters)
         for p, d in zip(parameters, defaults):
             if d is None:
                 val = self[keyword].get(p)
-            else:              
+            else:
                 val = self[keyword].get(p, d)
             if np.asarray(val).size == 1:
                 val *= np.ones(n_vals)
             values.append(val)
         return values
+
 
 """
 Utility methods for handling of dictionaries.

--- a/src/porepy/params/data.py
+++ b/src/porepy/params/data.py
@@ -67,7 +67,7 @@ import porepy as pp
 import numbers
 import warnings
 import porepy.params.parameter_dictionaries as dicts
-
+from typing import List
 
 class Parameters(dict):
     """ Class to store all physical parameters used by solvers.
@@ -185,6 +185,32 @@ class Parameters(dict):
         for (p, v) in zip(parameters, values):
             modify_variable(self[keyword][p], v)
 
+    def expand_scalars(self, n_vals: int, keyword: str, parameters: List[str], defaults=None) -> List:
+        """ Expand parameters assigned as a single scalar to n_vals arrays. 
+        Used e.g. for parameters which may be heterogeneous in space (cellwise),
+        but are often homogeneous and assigned as a scalar.
+        Parameters:
+            n_vals: Size of the expanded arrays. E.g. g.num_cells
+            keyword: The parameter keyword.
+            parameters: List of parameters.
+            defaults (optional): List of default values, one for each parameter.
+                If not set, no default values will be provided and an error
+                will ensue if one of the listed parameters is not present in
+                the dictionary. This avoids assigning None to unset mandatory
+                parameters.
+        """
+        values = []
+        if defaults is None:
+            defaults = [None]*len(parameters)
+        for p, d in zip(parameters, defaults):
+            if d is None:
+                val = self[keyword].get(p)
+            else:              
+                val = self[keyword].get(p, d)
+            if np.asarray(val).size == 1:
+                val *= np.ones(n_vals)
+            values.append(val)
+        return values
 
 """
 Utility methods for handling of dictionaries.

--- a/src/porepy/utils/derived_discretizations/implicit_euler.py
+++ b/src/porepy/utils/derived_discretizations/implicit_euler.py
@@ -225,7 +225,7 @@ class ImplicitUpwind(pp.Upwind):
         dt = parameter_dictionary[self.keyword]["time_step"]
         # Obtain the cellwise advection weights
         w = parameter_dictionary.expand_scalars(
-            g.num_cells, self.keyword, "advection_weight"
+            g.num_cells, self.keyword, ["advection_weight"]
         )[0] * dt
         a, b = super().assemble_matrix_rhs(g, data)
         a = a * sps.diags(w)
@@ -270,10 +270,10 @@ class ImplicitUpwindCoupling(pp.UpwindCoupling):
         lam_flux = data_edge[pp.PARAMETERS][self.keyword]["darcy_flux"]
         dt = parameter_dictionary_master[self.keyword]["time_step"]
         w_master = parameter_dictionary_master.expand_scalars(
-            g_master.num_cells, self.keyword, "advection_weight"
+            g_master.num_cells, self.keyword, ["advection_weight"]
         )[0] * dt
         w_slave = parameter_dictionary_slave.expand_scalars(
-            g_slave.num_cells, self.keyword, "advection_weight"
+            g_slave.num_cells, self.keyword, ["advection_weight"]
         )[0] * dt
         # Retrieve the number of degrees of both grids
         # Create the block matrix for the contributions

--- a/src/porepy/utils/derived_discretizations/implicit_euler.py
+++ b/src/porepy/utils/derived_discretizations/implicit_euler.py
@@ -224,9 +224,12 @@ class ImplicitUpwind(pp.Upwind):
         parameter_dictionary = data[pp.PARAMETERS]
         dt = parameter_dictionary[self.keyword]["time_step"]
         # Obtain the cellwise advection weights
-        w = parameter_dictionary.expand_scalars(
-            g.num_cells, self.keyword, ["advection_weight"]
-        )[0] * dt
+        w = (
+            parameter_dictionary.expand_scalars(
+                g.num_cells, self.keyword, ["advection_weight"]
+            )[0]
+            * dt
+        )
         a, b = super().assemble_matrix_rhs(g, data)
         a = a * sps.diags(w)
         b = b * sps.diags(w)
@@ -269,12 +272,18 @@ class ImplicitUpwindCoupling(pp.UpwindCoupling):
         parameter_dictionary_slave = data_slave[pp.PARAMETERS]
         lam_flux = data_edge[pp.PARAMETERS][self.keyword]["darcy_flux"]
         dt = parameter_dictionary_master[self.keyword]["time_step"]
-        w_master = parameter_dictionary_master.expand_scalars(
-            g_master.num_cells, self.keyword, ["advection_weight"]
-        )[0] * dt
-        w_slave = parameter_dictionary_slave.expand_scalars(
-            g_slave.num_cells, self.keyword, ["advection_weight"]
-        )[0] * dt
+        w_master = (
+            parameter_dictionary_master.expand_scalars(
+                g_master.num_cells, self.keyword, ["advection_weight"]
+            )[0]
+            * dt
+        )
+        w_slave = (
+            parameter_dictionary_slave.expand_scalars(
+                g_slave.num_cells, self.keyword, ["advection_weight"]
+            )[0]
+            * dt
+        )
         # Retrieve the number of degrees of both grids
         # Create the block matrix for the contributions
         g_m = data_edge["mortar_grid"]

--- a/src/porepy/utils/derived_discretizations/implicit_euler.py
+++ b/src/porepy/utils/derived_discretizations/implicit_euler.py
@@ -226,8 +226,7 @@ class ImplicitUpwind(pp.Upwind):
         # Obtain the cellwise advection weights
         w = parameter_dictionary.expand_scalars(
             g.num_cells, self.keyword, "advection_weight"
-        )[0]
-        *dt
+        )[0] * dt
         a, b = super().assemble_matrix_rhs(g, data)
         a = a * sps.diags(w)
         b = b * sps.diags(w)
@@ -272,12 +271,10 @@ class ImplicitUpwindCoupling(pp.UpwindCoupling):
         dt = parameter_dictionary_master[self.keyword]["time_step"]
         w_master = parameter_dictionary_master.expand_scalars(
             g_master.num_cells, self.keyword, "advection_weight"
-        )[0]
-        *dt
+        )[0] * dt
         w_slave = parameter_dictionary_slave.expand_scalars(
             g_slave.num_cells, self.keyword, "advection_weight"
-        )[0]
-        *dt
+        )[0] * dt
         # Retrieve the number of degrees of both grids
         # Create the block matrix for the contributions
         g_m = data_edge["mortar_grid"]

--- a/src/porepy/utils/derived_discretizations/implicit_euler.py
+++ b/src/porepy/utils/derived_discretizations/implicit_euler.py
@@ -133,6 +133,7 @@ class ImplicitTpfa(pp.Tpfa):
         """ Overwrite MPFA method to be consistent with the Biot dt convention.
         """
         a, b = super().assemble_matrix_rhs(g, data)
+
         dt = data[pp.PARAMETERS][self.keyword]["time_step"]
         a = a * dt
         b = b * dt
@@ -209,7 +210,10 @@ class ImplicitTpfa(pp.Tpfa):
 
 class ImplicitUpwind(pp.Upwind):
     """
-    Multiply all contributions by the time step and advection weight.
+    Multiply all contributions by the time step and advection weight. 
+    The latter may be a scalar or cellwise values, in which case the upwind
+    value is used. Note that the interior cell value is taken for BCs, 
+    regardless of the direction of the flux on the boundary.
     """
 
     def assemble_matrix_rhs(self, g, data):
@@ -217,12 +221,16 @@ class ImplicitUpwind(pp.Upwind):
             data["flow_faces"] = sps.csr_matrix([0.0])
             return sps.csr_matrix([0.0]), np.array([0.0])
 
-        parameter_dictionary = data[pp.PARAMETERS][self.keyword]
-        dt = parameter_dictionary["time_step"]
-        w = parameter_dictionary["advection_weight"] * dt
+        parameter_dictionary = data[pp.PARAMETERS]
+        dt = parameter_dictionary[self.keyword]["time_step"]
+        # Obtain the cellwise advection weights
+        w = parameter_dictionary.expand_scalars(
+            g.num_cells, self.keyword, "advection_weight"
+        )[0]
+        *dt
         a, b = super().assemble_matrix_rhs(g, data)
-        a = a * w
-        b = b * w
+        a = a * sps.diags(w)
+        b = b * sps.diags(w)
         return a, b
 
 
@@ -258,10 +266,18 @@ class ImplicitUpwindCoupling(pp.UpwindCoupling):
         # Normal component of the velocity from the higher dimensional grid
 
         # @ALL: This should perhaps be defined by a globalized keyword
-        parameter_dictionary_master = data_master[pp.PARAMETERS][self.keyword]
+        parameter_dictionary_master = data_master[pp.PARAMETERS]
+        parameter_dictionary_slave = data_slave[pp.PARAMETERS]
         lam_flux = data_edge[pp.PARAMETERS][self.keyword]["darcy_flux"]
-        dt = parameter_dictionary_master["time_step"]
-        w = parameter_dictionary_master["advection_weight"] * dt
+        dt = parameter_dictionary_master[self.keyword]["time_step"]
+        w_master = parameter_dictionary_master.expand_scalars(
+            g_master.num_cells, self.keyword, "advection_weight"
+        )[0]
+        *dt
+        w_slave = parameter_dictionary_slave.expand_scalars(
+            g_slave.num_cells, self.keyword, "advection_weight"
+        )[0]
+        *dt
         # Retrieve the number of degrees of both grids
         # Create the block matrix for the contributions
         g_m = data_edge["mortar_grid"]
@@ -301,12 +317,14 @@ class ImplicitUpwindCoupling(pp.UpwindCoupling):
         # If fluid flux(lam_flux) is positive we use the upper value as weight,
         # i.e., T_masterat * fluid_flux = lambda.
         # We set cc[2, 0] = T_masterat * fluid_flux
-        cc[2, 0] = sps.diags(w * lam_flux * flag) * hat_P_avg * div.T
+        # import pdb
+        # pdb.set_trace()
+        cc[2, 0] = sps.diags(lam_flux * flag) * hat_P_avg * div.T * sps.diags(w_master)
 
         # If fluid flux is negative we use the lower value as weight,
         # i.e., T_check * fluid_flux = lambda.
         # we set cc[2, 1] = T_check * fluid_flux
-        cc[2, 1] = sps.diags(w * lam_flux * not_flag) * check_P_avg
+        cc[2, 1] = sps.diags(lam_flux * not_flag) * check_P_avg * sps.diags(w_slave)
 
         # The rhs of T * fluid_flux = lambda
         # Recover the information for the grid-grid mapping

--- a/test/integration/test_biot.py
+++ b/test/integration/test_biot.py
@@ -217,7 +217,10 @@ class BiotTest(unittest.TestCase):
         general_assembler = pp.Assembler(gb)
         general_assembler.discretize(
             term_filter=[
-                "!stress_divergence", "!pressure_gradient", "!displacement_divergence", "!stabilization"
+                "!stress_divergence",
+                "!pressure_gradient",
+                "!displacement_divergence",
+                "!stabilization",
             ]
         )
         A, b = general_assembler.assemble_matrix_rhs()

--- a/test/unit/test_implicit_euler.py
+++ b/test/unit/test_implicit_euler.py
@@ -1,0 +1,53 @@
+""" Various tests of the derived implicit euler discretizations.
+
+TODO: Expand!
+"""
+import numpy as np
+import unittest
+import porepy as pp
+
+
+class TestImplicitUpwind(unittest.TestCase):
+    def test_1d_heterogeneous_weights(self):
+        """ Check that the weights are upwinded.
+        """
+        g = pp.CartGrid(3, 1)
+        g.compute_geometry()
+
+        solver = pp.utils.derived_discretizations.implicit_euler.ImplicitUpwind()
+        dis = solver.darcy_flux(g, [2, 0, 0])
+
+        bf = g.tags["domain_boundary_faces"].nonzero()[0]
+        bc = pp.BoundaryCondition(g, bf, bf.size * ["dir"])
+        bc_val = np.array([2, 0, 0, 2]).ravel("F")
+        specified_parameters = {
+            "bc": bc,
+            "bc_values": bc_val,
+            "darcy_flux": dis,
+            "time_step": 1,
+            "advection_weight": np.arange(2, 5),
+        }
+        data = pp.initialize_default_data(g, {}, "transport", specified_parameters)
+
+        solver.discretize(g, data)
+
+        M, rhs = solver.assemble_matrix_rhs(g, data)
+        # First row:    flux x a_w[0] = 2 x 2, which flows out of the cell (+)
+        # Second row:   flux x a_w[0] = 2 x 2, which flows into the cell (-)
+        #               flux x a_w[1] = 2 x 3, which flows out of the cell (+)
+        # Last row:     flux x a_w[1] = 2 x 3,, which flows into the cell (-)
+        #               flux x a_w[2] = 2 x 4, which flows out of the cell (+)
+        M_known = np.array([[4, 0, 0], [-4, 6, 0], [0, -6, 8]])
+        # Left boundary (first cell): Influx x bc_val x advection_weight[0]
+        #                                 = 2 x 2 x 2.
+        # Right boundary (last cell): outflux => rhs = 0
+        rhs_known = np.array([8, 0, 0])
+
+        rtol = 1e-15
+        atol = rtol
+        self.assertTrue(np.allclose(M.todense(), M_known, rtol, atol))
+        self.assertTrue(np.allclose(rhs, rhs_known, rtol, atol))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unit/test_parameters.py
+++ b/test/unit/test_parameters.py
@@ -119,6 +119,17 @@ class TestParameters(unittest.TestCase):
         )
         self.assertNotIn("array_key", self.p["other_kw"])
 
+    def test_expand_scalars(self):
+        """ Expand scalars to arrays
+        """
+        self.p.update_dictionaries(["dummy_kw"], [{"scalar": 1, "number": 2}])
+        keys = ["scalar", "number", "not_present"]
+        defaults = [3] * 3
+        array_list = self.p.expand_scalars(2, "dummy_kw", keys, defaults)
+        for i in range(3):
+            self.assertEqual(array_list[i].size, 2)
+            self.assertEqual(np.sum(array_list[i]), 2 * (i + 1))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
 ### Expanding scalar parameters to arrays.
Useful for parameters which are usually assigned as a scalar/homogeneous value, but may occasionally be heterogeneous, e.g. cellwise.
For now used in ImplicitUpwind, ImplicitUpwindCoupling, DivU and ColoumbContact.