### PR TITLE
Error normalization

### DIFF
--- a/src/porepy/grids/match_grids.py
+++ b/src/porepy/grids/match_grids.py
@@ -450,7 +450,7 @@ def gb_refinement(
         else:
             raise NotImplementedError("Unknown refinement mode")
 
-        gb.set_node_prop(g=g, key="coarse_fine_cell_mapping", val=mapping)
+        gb.set_node_prop(grid=g, key="coarse_fine_cell_mapping", val=mapping)
 
 
 def structured_refinement(
@@ -509,7 +509,9 @@ def structured_refinement(
     5. Assemble the mapping.
 
     """
-
+    if g.dim == 0:
+        mapping = sps.csc_matrix((np.ones(1), ([0], [0])))
+        return mapping
     assert g.num_cells < g_ref.num_cells, "Wrong order of input grids"
     assert g.dim == g_ref.dim, "Grids must be of same dimension"
 

--- a/src/porepy/utils/error.py
+++ b/src/porepy/utils/error.py
@@ -1,7 +1,7 @@
 import numpy as np
 import porepy as pp
 import logging
-from typing import List
+from typing import List, Optional
 
 # ------------------------------------------------------------------------------#
 
@@ -13,6 +13,7 @@ def grid_error(
     gb_ref: "pp.GridBucket",
     variable: List[str],
     variable_dof: List[int],
+    normalizations: Optional[List] = None,
 ) -> dict:
     """ Compute grid errors a grid bucket and refined reference grid bucket
 
@@ -29,6 +30,8 @@ def grid_error(
         which variables to compute error over
     variable_dof : List[int]
         Degrees of freedom for each variable in the list 'variable'.
+    normalizations: List of lambda functions used to compute the normalization.
+        Defaults to the norm of the reference solution if not provided.
 
     Returns
     -------
@@ -42,6 +45,10 @@ def grid_error(
         variable = [variable]
     if not isinstance(variable_dof, list):
         variable_dof = [variable_dof]
+    if normalizations is None:
+        normalizations = [lambda sol: np.linalg.norm(sol_ref, axis=0)] * len(variable)
+    elif not isinstance(normalizations, list):
+        normalizations = [normalizations]
     assert len(variable) == len(variable_dof), (
         "Each variable must have associated " "with it a number of degrees of freedom."
     )
@@ -97,8 +104,8 @@ def grid_error(
 
             # axis=0 gives component-wise norm.
             absolute_error = np.linalg.norm(mapped_sol - sol_ref, axis=0)
-            norm_ref = np.linalg.norm(sol_ref, axis=0)
 
+            norm_ref = normalizations[var_idx](sol_ref)
             if np.any(norm_ref < 1e-10):
                 logger.info(
                     f"Relative error not reportable. "


### PR DESCRIPTION
There are far too many options for how to normalize errors! Instead of trying to anticipate them, I introduced "normalizations" to the error computation code, so that the user may specify how to normalize. Defaults to old version, i.e. norm of reference solution.

Also caught a bug and generalized to 0d intersections in the grid matching.