### PR TITLE
fix: set dilation angle all tangential directions

### DIFF
--- a/src/porepy/numerics/contact_mechanics/contact_conditions.py
+++ b/src/porepy/numerics/contact_mechanics/contact_conditions.py
@@ -249,7 +249,7 @@ class ColoumbContact:
             np.isclose(cumulative_tangential_jump, 0, rtol=self.tol, atol=self.tol)
         )[0]
         d_gap = np.zeros((g_l.dim, g_l.num_cells))
-        d_gap[-1, :] = -np.tan(dilation_angle)
+        d_gap[:] = -np.tan(dilation_angle)
         # Compute dg/du_t where u_t is nonzero
         tan = np.atleast_2d(np.tan(dilation_angle)[ind])
         d_gap[:, ind] = (


### PR DESCRIPTION
Solving dilation within the Newton iterations in contact mechanics is done through the dilation equation
`g = g_0 - tan(dilation_angle) * || u_t ||`
The Jacobian of this method is used to predict the update of the dilation in the next newton iteration:
`u_n^{k+1} = g^k + Dg \dot ( u_t^{k+1} - u_t^{k} )`
where `Dg = dg/du_t` is the Jacobian (derivative) of `g` with respect to `u_t`. We get
`Dg = -tan(dilation_angle) * u_t / || u_t ||`

In the case ` u_t = 0`, the Jacobian is extended to the limit as 
`dg/du_t(|| u_t || = 0) = lim_{|| u_t || -> 0 +} dg/du_t = [t, t]^T` (for 2D fractures), where `t = - tan(dilation_angle)`

This PR fixes an issue where `Dg` in the case ` u_t = 0` was only set in one of the two in-fracture tangential directions.
Previously, the code read
```python
d_gap[-1, :] = -np.tan(dilation_angle)
```
The fix proposes
```python
d_gap[:] = -np.tan(dilation_angle)
```

In practice, this means that if `-np.tan(dilation_angle) = [1.5, 3.6]`, instead of
```python
d_gap = array([[0,   0],
               [1.5, 3.6]])
```
with the old code, we now have
```python
d_gap = array([[1.5, 3.6],
               [1.5, 3.6]])
```