### PR TITLE
feat: Filter Assembler operations

### DIFF
--- a/src/porepy/__init__.py
+++ b/src/porepy/__init__.py
@@ -109,6 +109,7 @@ from porepy.numerics.interface_laws.elliptic_interface_laws import (
 )
 
 from porepy.numerics.interface_laws.cell_dof_face_dof_map import CellDofFaceDofMap
+from porepy.numerics.mixed_dim import assembler_filters
 from porepy.numerics.mixed_dim.assembler import Assembler
 
 import porepy.numerics

--- a/src/porepy/grids/structured.py
+++ b/src/porepy/grids/structured.py
@@ -297,12 +297,11 @@ class CartGrid(TensorGrid):
 
         Parameters
         ----------
-        nx (np.ndarray): Number of cells in each direction. Should be 2D or 3D
+        nx (np.ndarray): Number of cells in each direction. Should be 1d, 2d or 3d.
+            1d grids can also be specified by a scalar.
         physdims (np.ndarray): Physical dimensions in each direction.
             Defaults to same as nx, that is, cells of unit size.
         """
-
-        #        nx = nx.astype(np.int)
 
         if physdims is None:
             physdims = nx
@@ -315,6 +314,9 @@ class CartGrid(TensorGrid):
         # TensorGrid constructor
         if len(dims) == 0:
             nodes_x = np.linspace(0, physdims, nx + 1)
+            super(self.__class__, self).__init__(nodes_x, name=name)
+        elif dims[0] == 1:
+            nodes_x = np.linspace(0, physdims, nx[0] + 1).ravel()
             super(self.__class__, self).__init__(nodes_x, name=name)
         elif dims[0] == 2:
             nodes_x = np.linspace(0, physdims[0], nx[0] + 1)

--- a/src/porepy/models/contact_mechanics_model.py
+++ b/src/porepy/models/contact_mechanics_model.py
@@ -495,7 +495,8 @@ class ContactMechanics(porepy.models.abstract_model.AbstractModel):
 
     def before_newton_iteration(self):
         # Re-discretize the nonlinear term
-        self.assembler.discretize(term_filter=self.friction_coupling_term)
+        filt = pp.assembler_filters.ListFilter(term_list=[self.friction_coupling_term])
+        self.assembler.discretize(filt=filt)
 
     def after_newton_iteration(self, solution_vector):
         """

--- a/src/porepy/numerics/discretization.py
+++ b/src/porepy/numerics/discretization.py
@@ -34,6 +34,60 @@ class Discretization(abc.ABC):
         """
         pass
 
+    def update_discretization(self, g: pp.Grid, data: Dict) -> None:
+        """ Partial update of discretization.
+
+        Intended use is when the discretization should be updated, e.g. because of
+        changes in parameters, grid geometry or grid topology, and it is not
+        desirable to recompute the discretization on the entire grid. A typical case
+        will be when the discretization operation is costly, and only a minor update
+        is necessary.
+
+        The updates can generally come as a combination of two forms:
+            1) The discretization on part of the grid should be recomputed.
+            2) The old discretization can be used (in parts of the grid), but the
+               numbering of unknowns has changed, and the discretization should be
+               reorder accordingly.
+
+        By default, this method will simply forward the call to the standard
+        discretize method. Discretization methods that wants a tailored approach
+        should override the standard implementation.
+
+        Information on the basis for the update should be stored in a field
+
+            data['update_discretization']
+
+        this should be a dictionary with up to six keys:
+
+            modified_cells, modified_faces, modified_nodes
+
+        define cells, faces and nodes that have been modified (either parameters,
+        geometry or topology), and should be rediscretized. It is up to the
+        discretization method to implement the change necessary by this modification.
+        Note that depending on the computational stencil of the discretization method,
+        a grid quantity may be rediscretized even if it is not marked as modified.
+        The dictionary should further have keys:
+
+            map_cells, map_faces, map_nodes
+
+        these should specify 2 x n np.ndarrays, that maps old (first row) to new
+        (second row) indices of unchanged grid quantities. The index of all cells,
+        faces and nodes should be found in *exactly one* of the respective modified
+        and map fields.
+
+        It is up to the caller to specify which parts of the grid to recompute, and
+        how to update the numbering of degrees of freedom. If the discretization
+        method does not provide a tailored implementation for update, it is not
+        necessary to provide this information.
+
+        Parameters:
+            g (pp.Grid): Grid to be rediscretized.
+            data (dictionary): With discretization parameters.
+
+        """
+        # Default behavior is to discretize everything
+        self.discretize(g, data)
+
     @abc.abstractmethod
     def assemble_matrix_rhs(
         self, g: pp.Grid, data: Dict

--- a/src/porepy/numerics/mixed_dim/assembler.py
+++ b/src/porepy/numerics/mixed_dim/assembler.py
@@ -180,6 +180,15 @@ class Assembler:
 
             return matrix, rhs
 
+    def update_discretization(self) -> None:
+        """ Update discretizations without a full rediscretization.
+
+        For the moment this is a placeholder method which will be expanded to
+        utilize corresponding update_discretization() methods in individual
+        discretization classes.
+        """
+        self.discretize()
+
     def discretize(
         self,
         variable_filter: List[str] = None,

--- a/src/porepy/numerics/mixed_dim/assembler_filters.py
+++ b/src/porepy/numerics/mixed_dim/assembler_filters.py
@@ -29,7 +29,7 @@ class AssemblerFilter(abc.ABC):
     @abc.abstractmethod
     def filter(
         self,
-        grid: Optional[grid_like_type] = None,
+        grids: Optional[grid_like_type] = None,
         variables: Optional[Union[str, List[str]]] = None,
         terms: Optional[str] = None,
     ) -> bool:
@@ -60,7 +60,7 @@ class AllPassFilter(AssemblerFilter):
 
     def filter(
         self,
-        grid: Optional[grid_like_type] = None,
+        grids: Optional[grid_like_type] = None,
         variables: Optional[Union[str, List[str]]] = None,
         terms: Optional[str] = None,
     ) -> bool:
@@ -146,8 +146,8 @@ class ListFilter(AssemblerFilter):
     def filter(
         self,
         grids: Optional[grid_like_type] = None,
-        variables: Optional[Union[str, List[str]]] = None,
-        terms: Optional[str] = None,
+        variables: Optional[List[str]] = None,
+        terms: Optional[List[str]] = None,
     ):
         """ Filter grids (in a general sense), variables and discretization terms.
 

--- a/src/porepy/numerics/mixed_dim/discretization_filters.py
+++ b/src/porepy/numerics/mixed_dim/discretization_filters.py
@@ -1,0 +1,105 @@
+""" Discretization filters to allow partial discretization or assembly.
+
+Content: 
+
+Credits: Design idea and main implementation by Haakon Ervik.
+
+"""
+import abc
+from typing import List, Callable, Optional, Union, Tuple
+
+from porepy import Grid
+
+# Discretizations can be defined either on a subdomain, on an
+# edge (Tuple of two grids), or it is a coupling between
+# two subdomains and an interface
+grid_like_type = Union[Grid, Tuple[Grid, Grid], Tuple[Grid, Grid, Tuple[Grid, Grid]]]
+
+
+class DiscretizationFilter(abc.ABC):
+    """ Abstract base class of filters for use with the Assembler.
+    """
+
+    @abc.abstractmethod
+    def node_filter(
+            self,
+            discr: NodeDiscretization,
+            node_or_edge: Union[Grid, Tuple[Grid, Grid]],
+    ) -> bool:
+        pass
+
+    @abc.abstractmethod
+    def edge_coupling_filter(
+            self,
+            discr: CouplingDiscretization,
+    ) -> bool:
+        pass
+
+    @abc.abstractmethod
+    def filter(
+            self, grid_like: 
+            )
+
+
+
+class AllPassFilter(DiscretizationFilter):
+
+    def node_filter(self, *_) -> bool:
+        return True
+
+    def edge_coupling_filter(self, *_) -> bool:
+        return True
+
+
+class ListFilter(DiscretizationFilter):
+    def __init__(self, variable_list, term_list):
+        self.variable_list: Optional[List[str]] = variable_list
+        self.term_list: Optional[List[str]] = term_list
+
+        self.var_filter: Callable[[str], bool] = self.make_filter(self.variable_list)
+        self.term_filter: Callable[[str], bool] = self.make_filter(self.term_list)
+
+    def node_filter(
+            self, discr: NodeDiscretization, _,
+    ) -> bool:
+        vf, tf = self.var_filter, self.term_filter
+        return vf(discr.var) and tf(discr.term_key)
+
+    def edge_coupling_filter(
+            self, discr: CouplingDiscretization,
+    ) -> bool:
+        vf, tf = self.var_filter, self.term_filter
+        if discr.g_h and discr.g_l:
+            return (
+                vf(discr.master_var)
+                and vf(discr.slave_var)
+                and vf(discr.edge_var)
+            )
+
+    def make_filter(self, var_term_list: Optional[List[str]]) -> Callable[[str], bool]:
+        """ Construct a filter for variable and terms
+
+        The result is a callable which takes one argument (a string).
+        I
+        filter is a list of strings.
+        """
+        def return_true(s):
+            return True
+
+        if not var_term_list:
+            # If not variable or term list is passed, return a Callable
+            # that always returns True.
+            return return_true
+
+        def _var_term_filter(x):
+            include = set(key for key in var_term_list if not key.startswith("!"))
+            exclude = set(key[1:] for key in var_term_list if key.startswith("!"))
+            if include:
+                # Keep elements only in include.
+                include.difference_update(exclude)
+                return x in include
+            elif exclude:
+                # Keep elements not in exclude
+                return x not in exclude
+
+        return _var_term_filter

--- a/test/integration/test_biot.py
+++ b/test/integration/test_biot.py
@@ -223,9 +223,8 @@ class BiotTest(unittest.TestCase):
                 "!displacement_divergence",
                 "!stabilization",
             ],
-            )
-        general_assembler.discretize(filt=filt
         )
+        general_assembler.discretize(filt=filt)
         A, b = general_assembler.assemble_matrix_rhs()
 
         # Re-discretize and assemble using the Biot class

--- a/test/integration/test_biot.py
+++ b/test/integration/test_biot.py
@@ -137,7 +137,8 @@ class BiotTest(unittest.TestCase):
         }
         # Assemble. Also discretizes the flow terms (fluid_mass and fluid_flux)
         general_assembler = pp.Assembler(gb)
-        general_assembler.discretize(term_filter=["fluid_mass", "fluid_flux"])
+        filt = pp.assembler_filters.ListFilter(term_list=["fluid_mass", "fluid_flux"])
+        general_assembler.discretize(filt=filt)
         A, b = general_assembler.assemble_matrix_rhs()
 
         # Re-discretize and assemble using the Biot class
@@ -215,13 +216,15 @@ class BiotTest(unittest.TestCase):
         }
         # Assemble. Also discretizes the flow terms (fluid_mass and fluid_flux)
         general_assembler = pp.Assembler(gb)
-        general_assembler.discretize(
-            term_filter=[
+        filt = pp.assembler_filters.ListFilter(
+            term_list=[
                 "!stress_divergence",
                 "!pressure_gradient",
                 "!displacement_divergence",
                 "!stabilization",
-            ]
+            ],
+            )
+        general_assembler.discretize(filt=filt
         )
         A, b = general_assembler.assemble_matrix_rhs()
 
@@ -320,8 +323,9 @@ class BiotTest(unittest.TestCase):
         biot_discretizer._discretize_mech(g, d)
 
         general_assembler = pp.Assembler(gb)
+        filt = pp.assembler_filters.ListFilter(term_list=["fluid_mass", "fluid_flux"])
         # Discretize terms that are not handled by the call to biot_discretizer
-        general_assembler.discretize(term_filter=["fluid_mass", "fluid_flux"])
+        general_assembler.discretize(filt=filt)
 
         times = np.arange(5)
         for _ in times:

--- a/test/unit/test_assembler.py
+++ b/test/unit/test_assembler.py
@@ -35,6 +35,7 @@ import unittest
 import porepy as pp
 from test.test_utils import permute_matrix_vector
 import porepy.numerics.interface_laws.abstract_interface_law
+from porepy.numerics.mixed_dim.assembler_filters import ListFilter
 
 
 class TestAssembler(unittest.TestCase):
@@ -242,11 +243,13 @@ class TestAssembler(unittest.TestCase):
                 }
             }
 
+        filt = ListFilter(variable_list=["var_11"])
+
         # Give a false variable name
-        general_assembler = pp.Assembler(gb, active_variables="var_11")
-        A, b = general_assembler.assemble_matrix_rhs()
-        self.assertTrue(A.shape == (0, 0))
-        self.assertTrue(b.size == 0)
+        general_assembler = pp.Assembler(gb)
+        A, b = general_assembler.assemble_matrix_rhs(filt=filt)
+        self.assertTrue(A.data.size == 0)
+        self.assertTrue(np.sum(np.abs(b)) == 0)
 
     def test_explicitly_define_edge_variable_active(self):
         """ Explicitly define edge and node variables as active. The result should
@@ -281,9 +284,7 @@ class TestAssembler(unittest.TestCase):
                 }
             }
 
-        general_assembler = pp.Assembler(
-            gb, active_variables=[variable_name, variable_name_edge]
-        )
+        general_assembler = pp.Assembler(gb)
         A, b = general_assembler.assemble_matrix_rhs()
 
         A_known = np.array([[1, 0, 1], [0, 2, 1], [-1, -1, 1]])
@@ -324,59 +325,18 @@ class TestAssembler(unittest.TestCase):
                 }
             }
 
-        general_assembler = pp.Assembler(gb, active_variables=[variable_name])
-        A, b = general_assembler.assemble_matrix_rhs()
+        general_assembler = pp.Assembler(gb)
+        filt = ListFilter(variable_list=[variable_name])
+        A, b = general_assembler.assemble_matrix_rhs(filt=filt)
 
-        A_known = np.array([[1, 0], [0, 2]])
+        # System matrix, the coupling terms should not have been assembled
+        A_known = np.zeros((3, 3))
         g1_ind = general_assembler.block_dof[(g1, variable_name)]
+        g2_ind = general_assembler.block_dof[(g2, variable_name)]
         A_known[g1_ind, g1_ind] = 1
+        A_known[g2_ind, g2_ind] = 2
 
         self.assertTrue(np.allclose(A_known, A.todense()))
-
-    def test_define_edge_variable_active_node_variable_inactive(self):
-        """ Define edge-variable as inactive. The resulting system should have
-        no coupling term.
-
-        """
-
-        gb = self.define_gb()
-        variable_name = "variable_1"
-        node_variable_2 = "node_variable_2"
-        variable_name_edge = "variable_edge"
-        discretization_operator = "operator_discr"
-        for g, d in gb:
-
-            if g.grid_num == 1:
-                d[pp.PRIMARY_VARIABLES] = {variable_name: {"cells": 1}}
-                d[pp.DISCRETIZATION] = {
-                    variable_name: {discretization_operator: MockNodeDiscretization(1)}
-                }
-                g1 = g
-            else:
-                d[pp.PRIMARY_VARIABLES] = {node_variable_2: {"cells": 1}}
-                d[pp.DISCRETIZATION] = {
-                    variable_name: {discretization_operator: MockNodeDiscretization(2)}
-                }
-                g2 = g
-
-        for e, d in gb.edges():
-            d[pp.PRIMARY_VARIABLES] = {variable_name_edge: {"cells": 1}}
-            d[pp.COUPLING_DISCRETIZATION] = {
-                "coupling_discretization": {
-                    g1: (variable_name, discretization_operator),
-                    g2: (node_variable_2, discretization_operator),
-                    e: (variable_name_edge, MockEdgeDiscretization(1, 1)),
-                }
-            }
-        with self.assertRaises(ValueError) as context:
-            _ = pp.Assembler(gb, active_variables=[variable_name, variable_name_edge])
-            self.assertTrue(
-                "Edge variable "
-                + variable_name_edge
-                + " is coupled to an inactive node variable "
-                + node_variable_2
-                in context.exception
-            )
 
     def test_single_variable_multiple_node_discretizations(self):
         """ A single variable, with multiple discretizations for one of the nodes
@@ -562,10 +522,11 @@ class TestAssembler(unittest.TestCase):
                 variable_name_2: {operator: MockNodeDiscretization(6)},
             }
 
-        general_assembler = pp.Assembler(gb, active_variables=[variable_name_2])
-        A, _ = general_assembler.assemble_matrix_rhs()
+        general_assembler = pp.Assembler(gb)
+        filt = ListFilter(variable_list=[variable_name_2])
+        A, _ = general_assembler.assemble_matrix_rhs(filt=filt)
 
-        A_known = np.zeros((3, 3))
+        A_known = np.zeros((6, 6))
 
         g12_ind = general_assembler.block_dof[(g1, variable_name_2)]
         g22_ind = general_assembler.block_dof[(g2, variable_name_2)]
@@ -577,16 +538,115 @@ class TestAssembler(unittest.TestCase):
 
         assert np.allclose(A_known, A.todense())
 
-    def test_two_variables_one_active_one_false_active_variable(self):
-        """ Define two variables, the define as active one of the variables, and
-        another active variable that is not used in the grid. This should be
-        equivalent to defining a single active variable
+    def test_filter_grid(self):
+        # Use a list filter to only discretize on one node
+        variable_name = "variable_1"
+        variable_name_edge = "variable_edge"
+        operator_1 = "operator_1"
+        for g, d in gb:
+            d[pp.PRIMARY_VARIABLES] = {variable_name: {"cells": 1}}
+            if g.grid_num == 1:
+                d[pp.DISCRETIZATION] = {
+                    variable_name: {operator_1: MockNodeDiscretization(1)}
+                }
+                g1 = g
+            else:
+                d[pp.DISCRETIZATION] = {
+                    variable_name: {operator_1: MockNodeDiscretization(2)}
+                }
+                g2 = g
+
+        for e, d in gb.edges():
+            d[pp.PRIMARY_VARIABLES] = {variable_name_edge: {"cells": 1}}
+            d[pp.COUPLING_DISCRETIZATION] = {
+                "coupling_discretization_1": {
+                    g1: (variable_name, operator_1),
+                    g2: (variable_name, operator_1),
+                    e: (variable_name_edge, MockEdgeDiscretization(1, 1)),
+                },
+                "coupling_discretization_2": {
+                    g1: (variable_name, operator_1),
+                    g2: (variable_name, operator_1),
+                    e: (variable_name_edge, MockEdgeDiscretization(-3, 1)),
+                },
+            }
+
+        general_assembler = pp.Assembler(gb)
+        A, _ = general_assembler.assemble_matrix_rhs()
+
+        A_known = np.array([[0, 0, 2], [0, 0, 2], [-2, -2, -2]])
+        g1_ind = general_assembler.block_dof[(g1, variable_name)]
+        g2_ind = general_assembler.block_dof[(g2, variable_name)]
+        A_known[g1_ind, g1_ind] = 1
+        A_known[g2_ind, g2_ind] = 2
+        assert np.allclose(A_known, A.todense())
+
+    def test_two_variables_no_coupling(self):
+        """ Two variables, no coupling between the variables. Test that the
+        assembler can deal with more than one variable.
+        """
+        gb = self.define_gb()
+        variable_name_1 = "variable_1"
+        variable_name_2 = "variable_2"
+        variable_name_edge_1 = "variable_edge_1"
+        variable_name_edge_2 = "variable_edge_2"
+        operator_1 = "operator_1"
+        for g, d in gb:
+            d[pp.PRIMARY_VARIABLES] = {
+                variable_name_1: {"cells": 1},
+                variable_name_2: {"cells": 1},
+            }
+            if g.grid_num == 1:
+                d[pp.DISCRETIZATION] = {
+                    variable_name_1: {operator_1: MockNodeDiscretization(1)},
+                    variable_name_2: {operator_1: MockNodeDiscretization(2)},
+                }
+                g1 = g
+            else:
+                d[pp.DISCRETIZATION] = {
+                    variable_name_1: {operator_1: MockNodeDiscretization(3)},
+                    variable_name_2: {operator_1: MockNodeDiscretization(4)},
+                }
+                g2 = g
+
+        for e, d in gb.edges():
+            d[pp.PRIMARY_VARIABLES] = {
+                variable_name_edge_1: {"cells": 1},
+                variable_name_edge_2: {"cells": 1},
+            }
+            d[pp.DISCRETIZATION] = {
+                variable_name_edge_1: {operator_1: MockNodeDiscretization(5)},
+                variable_name_edge_2: {operator_1: MockNodeDiscretization(6)},
+            }
+
+        general_assembler = pp.Assembler(gb)
+        A, _ = general_assembler.assemble_matrix_rhs()
+
+        A_known = np.zeros((6, 6))
+
+        g11_ind = general_assembler.block_dof[(g1, variable_name_1)]
+        g12_ind = general_assembler.block_dof[(g1, variable_name_2)]
+        g21_ind = general_assembler.block_dof[(g2, variable_name_1)]
+        g22_ind = general_assembler.block_dof[(g2, variable_name_2)]
+        e1_ind = general_assembler.block_dof[(e, variable_name_edge_1)]
+        e2_ind = general_assembler.block_dof[(e, variable_name_edge_2)]
+        A_known[g11_ind, g11_ind] = 1
+        A_known[g12_ind, g12_ind] = 2
+        A_known[g21_ind, g21_ind] = 3
+        A_known[g22_ind, g22_ind] = 4
+        A_known[e1_ind, e1_ind] = 5
+        A_known[e2_ind, e2_ind] = 6
+        assert np.allclose(A_known, A.todense())
+
+    def test_two_variables_one_active(self):
+        """ Define two variables, but then only assemble with respect to one
+        of them. Should result in what is effectively a 1-variable system
 
         """
         gb = self.define_gb()
-        variable_name_1 = "var_1"
-        variable_name_2 = "var_2"
-        operator = "op"
+        variable_name_1 = "variable_1"
+        variable_name_2 = "variable_2"
+        operator = "operator"
         for g, d in gb:
             d[pp.PRIMARY_VARIABLES] = {
                 variable_name_1: {"cells": 1},
@@ -615,16 +675,11 @@ class TestAssembler(unittest.TestCase):
                 variable_name_2: {operator: MockNodeDiscretization(6)},
             }
 
-        general_assembler = pp.Assembler(
-            gb,
-            active_variables=[
-                variable_name_2,
-                "variable_name_not_among_defined_variables",
-            ],
-        )
-        A, _ = general_assembler.assemble_matrix_rhs()
+        general_assembler = pp.Assembler(gb)
+        filt = ListFilter(variable_list=[variable_name_2])
+        A, _ = general_assembler.assemble_matrix_rhs(filt=filt)
 
-        A_known = np.zeros((3, 3))
+        A_known = np.zeros((6, 6))
 
         g12_ind = general_assembler.block_dof[(g1, variable_name_2)]
         g22_ind = general_assembler.block_dof[(g2, variable_name_2)]
@@ -633,10 +688,66 @@ class TestAssembler(unittest.TestCase):
         A_known[g12_ind, g12_ind] = 2
         A_known[g22_ind, g22_ind] = 4
         A_known[e2_ind, e2_ind] = 6
+
         assert np.allclose(A_known, A.todense())
 
-    ### Tests with coupling internal to each node
+    def test_filter_grid(self):
+        # Use a list filter to only discretize on one node
+        gb = self.define_gb()
 
+        # Variable name assigned on nodes. Same for both grids
+        variable_name = "variable_1"
+        # Edge variable
+        variable_name_e = "edge_variable"
+
+        # Keyword for discretization operators.
+        term_g1 = "operator_1"
+        term_g2 = "operator_2"
+        term_e = "operator_coupling"
+
+        for g, d in gb:
+            d[pp.PRIMARY_VARIABLES] = {variable_name: {"cells": 1}}
+            if g.grid_num == 1:
+                d[pp.DISCRETIZATION] = {
+                    variable_name: {term_g1: MockNodeDiscretization(1)}
+                }
+                g1 = g
+            else:
+                d[pp.DISCRETIZATION] = {
+                    variable_name: {term_g2: MockNodeDiscretization(2)}
+                }
+                g2 = g
+
+        for e, d in gb.edges():
+            d[pp.PRIMARY_VARIABLES] = {variable_name_e: {"cells": 1}}
+            d[pp.DISCRETIZATION] = {variable_name_e: {term_e: MockNodeDiscretization(7)}}
+            d[pp.COUPLING_DISCRETIZATION] = {
+                term_e: {
+                    g1: (variable_name, term_g1),
+                    g2: (variable_name, term_g2),
+                    e: (variable_name_e, MockEdgeDiscretization(1, 1)),
+                }
+            }
+
+        general_assembler = pp.Assembler(gb)
+        g1_ind = general_assembler.block_dof[(g1, variable_name)]
+        g2_ind = general_assembler.block_dof[(g2, variable_name)]
+        e_ind = general_assembler.block_dof[(e, variable_name_e)]
+        
+        # Only grid 1
+        filt = ListFilter(grid_list=[g1])
+        A, b = general_assembler.assemble_matrix_rhs(filt=filt)
+        A_known = np.zeros((3, 3))
+        A_known[g1_ind, g1_ind] = 1
+        self.assertTrue(np.allclose(A_known, A.todense())) 
+
+        filt = ListFilter(grid_list=[e])
+        A, b = general_assembler.assemble_matrix_rhs(filt=filt)
+        A_known = np.zeros((3, 3))
+        A_known[e_ind, e_ind] = 7
+        self.assertTrue(np.allclose(A_known, A.todense())) 
+
+    ### Tests with coupling internal to each node
     def test_two_variables_coupling_within_node_and_edge(self):
         """ Two variables, coupling between the variables internal to each node.
         No coupling in the edge variable
@@ -728,9 +839,7 @@ class TestAssembler(unittest.TestCase):
 
         # Next, define both variables to be active. Should be equivalent to
         # runing without the variables argument
-        permuted_assembler = pp.Assembler(
-            gb, active_variables=[variable_name_1, variable_name_2]
-        )
+        permuted_assembler = pp.Assembler(gb)
 
         A_2, b_2 = permuted_assembler.assemble_matrix_rhs()
         A_2_permuted, _ = permute_matrix_vector(
@@ -743,73 +852,7 @@ class TestAssembler(unittest.TestCase):
         )
         self.assertTrue(np.allclose(A_known, A_2_permuted.todense()))
 
-    def test_two_variables_coupling_within_node_and_edge_one_active(self):
-        """ Two variables, coupling between the variables internal to each node.
-        One active variable.
-        """
-        gb = self.define_gb()
-        variable_name_1 = "var_1"
-        variable_name_2 = "var_2"
-        operator = "operator"
-        operator_edge = "operator_edge"
-        for g, d in gb:
-            d[pp.PRIMARY_VARIABLES] = {
-                variable_name_1: {"cells": 1},
-                variable_name_2: {"cells": 1},
-            }
-            if g.grid_num == 1:
-                d[pp.DISCRETIZATION] = {
-                    variable_name_1: {operator: MockNodeDiscretization(1)},
-                    variable_name_2: {operator: MockNodeDiscretization(2)},
-                    variable_name_1
-                    + "_"
-                    + variable_name_2: {operator: MockNodeDiscretization(5)},
-                }
-                g1 = g
-            else:
-                d[pp.DISCRETIZATION] = {
-                    variable_name_1: {operator: MockNodeDiscretization(3)},
-                    variable_name_2: {operator: MockNodeDiscretization(4)},
-                    variable_name_2
-                    + "_"
-                    + variable_name_1: {operator: MockNodeDiscretization(6)},
-                }
-                g2 = g
-
-        for e, d in gb.edges():
-            d[pp.PRIMARY_VARIABLES] = {
-                variable_name_1: {"cells": 1},
-                variable_name_2: {"cells": 1},
-            }
-            d[pp.DISCRETIZATION] = {
-                variable_name_1: {operator_edge: MockNodeDiscretization(7)},
-                variable_name_2: {operator_edge: MockNodeDiscretization(8)},
-                variable_name_1
-                + "_"
-                + variable_name_2: {operator_edge: MockNodeDiscretization(6)},
-                variable_name_2
-                + "_"
-                + variable_name_1: {operator_edge: MockNodeDiscretization(1)},
-            }
-
-        general_assembler = pp.Assembler(gb, active_variables=variable_name_1)
-        A, _ = general_assembler.assemble_matrix_rhs()
-
-        A_known = np.zeros((3, 3))
-
-        g11_ind = general_assembler.block_dof[(g1, variable_name_1)]
-        g21_ind = general_assembler.block_dof[(g2, variable_name_1)]
-        e1_ind = general_assembler.block_dof[(e, variable_name_1)]
-        A_known[g11_ind, g11_ind] = 1
-
-        A_known[g21_ind, g21_ind] = 3
-
-        A_known[e1_ind, e1_ind] = 7
-
-        self.assertTrue(np.allclose(A_known, A.todense()))
-
     # Tests with node-edge couplings
-
     def test_two_variables_coupling_between_node_and_edge(self):
         """ Two variables, coupling between the variables internal to each node.
         No coupling in the edge variable
@@ -897,9 +940,7 @@ class TestAssembler(unittest.TestCase):
 
         # Next, define both variables to be active. Should be equivalent to
         # runing without the variables argument
-        permuted_assembler = pp.Assembler(
-            gb, active_variables=[variable_name_1, variable_name_2]
-        )
+        permuted_assembler = pp.Assembler(gb)
         A_2, b_2 = permuted_assembler.assemble_matrix_rhs()
         A_2_permuted, _ = permute_matrix_vector(
             A_2,
@@ -981,7 +1022,7 @@ class TestAssembler(unittest.TestCase):
 
         # Next, define both variables to be active. Should be equivalent to
         # runing without the variables argument
-        permuted_assembler = pp.Assembler(gb, active_variables=[key_1, key_2])
+        permuted_assembler = pp.Assembler(gb)
         A_2, b_2 = permuted_assembler.assemble_matrix_rhs()
         A_2_permuted, _ = permute_matrix_vector(
             A_2,
@@ -1068,7 +1109,7 @@ class TestAssembler(unittest.TestCase):
 
         # Next, define both variables to be active. Should be equivalent to
         # runing without the variables argument
-        permuted_assembler = pp.Assembler(gb, active_variables=[key_1, key_2])
+        permuted_assembler = pp.Assembler(gb)
         A_2, b_2 = permuted_assembler.assemble_matrix_rhs()
         A_2_permuted, _ = permute_matrix_vector(
             A_2,
@@ -1161,7 +1202,7 @@ class TestAssembler(unittest.TestCase):
 
         # Next, define both variables to be active. Should be equivalent to
         # runing without the variables argument
-        permuted_assembler = pp.Assembler(gb, active_variables=[key_1, key_2])
+        permuted_assembler = pp.Assembler(gb)
         A_2, b_2 = permuted_assembler.assemble_matrix_rhs()
         A_2_permuted, _ = permute_matrix_vector(
             A_2,
@@ -1256,7 +1297,7 @@ class TestAssembler(unittest.TestCase):
 
         # Next, define both variables to be active. Should be equivalent to
         # runing without the variables argument
-        new_assembler = pp.Assembler(gb, active_variables=[key_1, key_2])
+        new_assembler = pp.Assembler(gb)
         A_2, b_2 = general_assembler.assemble_matrix_rhs()
         A_2_permuted, _ = permute_matrix_vector(
             A_2, b_2, new_assembler.block_dof, new_assembler.full_dof, grids, variables
@@ -1496,7 +1537,7 @@ class TestAssembler(unittest.TestCase):
             else:
                 param = np.array([5, 6, 7])
                 d[pp.PARAMETERS] = {key_1: {term: param}}
-                g2_ind = i
+
             i += 1
         for e, d in gb.edges():
             d[pp.PARAMETERS] = {}
@@ -1991,6 +2032,6 @@ class TestAssemblerFilters(unittest.TestCase):
         self.assertFalse(filter.filter(grids=[g2], variables=[var1]))
         self.assertFalse(filter.filter(grids=[g1], variables=[var2]))
 
-
+TestAssembler().test_filter_grid()
 if __name__ == "__main__":
     unittest.main()

--- a/test/unit/test_assembler.py
+++ b/test/unit/test_assembler.py
@@ -720,7 +720,9 @@ class TestAssembler(unittest.TestCase):
 
         for e, d in gb.edges():
             d[pp.PRIMARY_VARIABLES] = {variable_name_e: {"cells": 1}}
-            d[pp.DISCRETIZATION] = {variable_name_e: {term_e: MockNodeDiscretization(7)}}
+            d[pp.DISCRETIZATION] = {
+                variable_name_e: {term_e: MockNodeDiscretization(7)}
+            }
             d[pp.COUPLING_DISCRETIZATION] = {
                 term_e: {
                     g1: (variable_name, term_g1),
@@ -733,19 +735,19 @@ class TestAssembler(unittest.TestCase):
         g1_ind = general_assembler.block_dof[(g1, variable_name)]
         g2_ind = general_assembler.block_dof[(g2, variable_name)]
         e_ind = general_assembler.block_dof[(e, variable_name_e)]
-        
+
         # Only grid 1
         filt = ListFilter(grid_list=[g1])
         A, b = general_assembler.assemble_matrix_rhs(filt=filt)
         A_known = np.zeros((3, 3))
         A_known[g1_ind, g1_ind] = 1
-        self.assertTrue(np.allclose(A_known, A.todense())) 
+        self.assertTrue(np.allclose(A_known, A.todense()))
 
         filt = ListFilter(grid_list=[e])
         A, b = general_assembler.assemble_matrix_rhs(filt=filt)
         A_known = np.zeros((3, 3))
         A_known[e_ind, e_ind] = 7
-        self.assertTrue(np.allclose(A_known, A.todense())) 
+        self.assertTrue(np.allclose(A_known, A.todense()))
 
     ### Tests with coupling internal to each node
     def test_two_variables_coupling_within_node_and_edge(self):
@@ -2031,6 +2033,7 @@ class TestAssemblerFilters(unittest.TestCase):
         self.assertTrue(filter.filter(grids=[g1], variables=[var1]))
         self.assertFalse(filter.filter(grids=[g2], variables=[var1]))
         self.assertFalse(filter.filter(grids=[g1], variables=[var2]))
+
 
 TestAssembler().test_filter_grid()
 if __name__ == "__main__":

--- a/test/unit/test_variable_dictionaries.py
+++ b/test/unit/test_variable_dictionaries.py
@@ -13,7 +13,6 @@ def empty_dict() -> Dict:
 
 
 class TestState:
-
     def test_add_empty_state(self, empty_dict):
         """ Add an empty state dictionary
         """

--- a/test/unit/test_vtk.py
+++ b/test/unit/test_vtk.py
@@ -2530,8 +2530,6 @@ def _gb_1_mortar_grid_vtu():
 """
 
 
-
-
 def _gb_2_grid_pvd():
     return """<?xml version="1.0"?>
 <VTKFile type="Collection" version="0.1" byte_order="LittleEndian" compressor="vtkZLibDataCompressor">


### PR DESCRIPTION
Assembler operations (discretize, assembly) can be assembled with a new AssembleFilter class. 

This generalizes the previous rudimentary filtering options. Filtering can now be done on grids (standard grids, interfaces, or couplings), variable and term names. 

Two filters are available through pp.assembler_filters: AllPassFilter (will be invoked unless a filter is set), and ListFilter.

The old active_variables keyword in the assembler is made defunct.

Runscripts may need to be updated due to these changes. The contact mechanics models have been updated as part of this PR.