### PR TITLE
Change sign convention in contact conditions

### DIFF
--- a/src/porepy/grids/mortar_grid.py
+++ b/src/porepy/grids/mortar_grid.py
@@ -653,8 +653,8 @@ class MortarGrid:
             # the indexing [1] and [2] (and not [0])
             data = np.hstack(
                 (
-                    np.ones(self.side_grids[1].num_cells * nd),
-                    -np.ones(self.side_grids[2].num_cells * nd),
+                    -np.ones(self.side_grids[1].num_cells * nd),
+                    np.ones(self.side_grids[2].num_cells * nd),
                 )
             )
             return sps.dia_matrix((data, 0), shape=(nd * nc, nd * nc))

--- a/src/porepy/numerics/contact_mechanics/contact_conditions.py
+++ b/src/porepy/numerics/contact_mechanics/contact_conditions.py
@@ -332,7 +332,7 @@ class ColoumbContact:
                 # direction, a contribution from the previous iterate enters to cancel
                 # the gap
                 r_n = gap[i] - np.dot(d_gap[:, i], cumulative_tangential_jump[:, i].T)
-                # assert np.isclose(r_n, initial_gap[i])  # TODO: Agree on cumulative with EK
+
                 r_t = r + friction_bound[i] * v
                 r = np.vstack((r_t, r_n))
                 # Unit contribution from tangential force

--- a/src/porepy/numerics/contact_mechanics/contact_conditions.py
+++ b/src/porepy/numerics/contact_mechanics/contact_conditions.py
@@ -17,7 +17,7 @@ See also contact_mechanics_interface_laws.py.
 Signs of displacement jumps are reversed compared to Berge due to the PorePy definition
 of the jump as [[ var ]] = var_k - var_j, which implies that positive normal jumps
 correspond to fracture opening. Note that the fracture normal is in agreement with
-Berge, i.e. it equals the outwards normal on the j side. 
+Berge, i.e. it equals the outwards normal on the j side.
 
 Option added to the Berge model:
 Include a simple relationship between the gap and tangential displacements, i.e.

--- a/src/porepy/numerics/contact_mechanics/contact_conditions.py
+++ b/src/porepy/numerics/contact_mechanics/contact_conditions.py
@@ -12,22 +12,26 @@ at the previous time step. The state should be available in
 
 and may usually be set to zero for stationary problems. The ColoumbContact
 discretization operates on relative tangential jumps and absolute normal jumps.
-See also contact_mechanics_interface_laws.py
+See also contact_mechanics_interface_laws.py.
+
+Signs of displacement jumps are reversed compared to Berge due to the PorePy definition
+of the jump as [[ var ]] = var_k - var_j, which implies that positive normal jumps
+correspond to fracture opening. Note that the fracture normal is in agreement with
+Berge, i.e. it equals the outwards normal on the j side. 
 
 Option added to the Berge model:
 Include a simple relationship between the gap and tangential displacements, i.e.
 
-   g = g_0 - tan(dilation_angle) * || u_t ||,
+   g = g_0 + tan(dilation_angle) * || u_t ||,
 
 with g_0 indicating initial gap distance. This only affects the normal relations when
 fractures are in contact. The relation [u_n^{k+1}] = g of eqs. 30 and 31 becomes
 
    u_n^{k+1} - Dg^k \dot u_t^{k+1} = g^k - Dg \dot u_t^{k},
 
-with Dg = dg/du_t. For the above g, we have Dg = -tan(dilation_angle) * u_t / || u_t ||.
-For the case u_t = 0, we extend the Jacobian to the limit value from the positive side
-(arbitrary choice between + and -), i.e.
-    dg/du_t(|| u_t || = 0) = lim_{|| u_t || -> 0 +} dg/du_t = - tan(dilation_angle).
+with Dg = dg/du_t. For the above g, we have Dg = tan(dilation_angle) * u_t / || u_t ||.
+For the case u_t = 0, we extend the Jacobian to 0, i.e.
+    dg/du_t(|| u_t || = 0) = 0.
 """
 import numpy as np
 
@@ -240,7 +244,7 @@ class ColoumbContact:
         norm_displacement_jump_tangential = np.linalg.norm(
             cumulative_tangential_jump, axis=0
         )
-        gap = initial_gap - np.tan(dilation_angle) * norm_displacement_jump_tangential
+        gap = initial_gap + np.tan(dilation_angle) * norm_displacement_jump_tangential
 
         # Compute dg/du_t = - tan(dilation_angle) u_t / || u_t ||
         # Avoid dividing by zero if u_t = 0. In this case, we extend to the limit value
@@ -252,7 +256,7 @@ class ColoumbContact:
         # Compute dg/du_t where u_t is nonzero
         tan = np.atleast_2d(np.tan(dilation_angle)[ind])
         d_gap[:, ind] = (
-            -tan
+            tan
             * cumulative_tangential_jump[:, ind]
             / norm_displacement_jump_tangential[ind]
         )
@@ -263,7 +267,7 @@ class ColoumbContact:
         friction_bound = (
             friction_coefficient
             * np.clip(
-                -contact_force_normal + c_num_normal * (displacement_jump_normal - gap),
+                -contact_force_normal - c_num_normal * (displacement_jump_normal - gap),
                 0,
                 np.inf,
             )
@@ -279,28 +283,12 @@ class ColoumbContact:
             contact_force_normal, displacement_jump_normal, c_num_normal, gap
         )
         # Check criterion for sliding
-        sliding_criterion = self._sliding(
+        sliding_bc = self._sliding(
             contact_force_tangential,
             displacement_jump_tangential,
             friction_bound,
             c_num_tangential,
         )
-        # Find cells with non-zero tangential traction. This excludes cells that were
-        # not in contact in the previous iteration.
-        # non_zero_tangential_traction = (
-        #     np.sum(contact_force_tangential ** 2, axis=0) > self.tol ** 2
-        # )
-
-        # The discretization of the sliding state tacitly assumes that the tangential
-        # traction in the previous iteration - or else we will divide by zero.
-        # Therefore, only allow for sliding if the tangential traciton is non-zero.
-        # In practice this means that a cell is not allowed to go directly from
-        # non-penetration to sliding.
-        # This feature was turned off due to convergence issues.
-        # TODO: Either purge entirely or, if found to be useful in some simulations,
-        # convert to a optional feature.
-        sliding_bc = sliding_criterion
-        # np.logical_and(sliding_criterion, non_zero_tangential_traction)
 
         # Structures for storing the computed coefficients.
         displacement_weight = []  # Multiplies displacement jump
@@ -335,8 +323,9 @@ class ColoumbContact:
                 )
 
                 # There is no interaction between displacement jumps in normal and
-                # tangential direction
-                L = np.hstack((loc_displacement_tangential, np.atleast_2d(zer).T))
+                # tangential direction. Opposite sign compared to Berge because
+                # of jump conventions being opposite.
+                L = -np.hstack((loc_displacement_tangential, np.atleast_2d(zer).T))
                 normal_displacement = np.hstack((-d_gap[:, i], 1))
                 loc_displacement_weight = np.vstack((L, normal_displacement))
                 # Right hand side is computed from (24-25). In the normal
@@ -460,7 +449,7 @@ class ColoumbContact:
         """
         # Use thresholding to not pick up faces that are just about sticking
         # Not sure about the sensitivity to the tolerance parameter here.
-        return self._l2(-Tt + ct * ut) - bf > self.tol
+        return self._l2(-Tt - ct * ut) - bf > self.tol
 
     def _penetration(
         self, Tn: np.ndarray, un: np.ndarray, cn: np.ndarray, gap: np.ndarray
@@ -479,7 +468,7 @@ class ColoumbContact:
 
         """
         # Not sure about the sensitivity to the tolerance parameter here.
-        return (-Tn + cn * (un - gap)) > self.tol
+        return (-Tn - cn * (un - gap)) > self.tol
 
     #####
     ## Below here are different help function for calculating the Newton step
@@ -487,17 +476,17 @@ class ColoumbContact:
 
     def _e(self, Tt: np.ndarray, cut: np.ndarray, bf: np.ndarray) -> np.ndarray:
         # Compute part of (32) in Berge et al.
-        return bf / self._l2(-Tt + cut)
+        return bf / self._l2(-Tt - cut)
 
     def _Q(self, Tt: np.ndarray, cut: np.ndarray, bf: np.ndarray) -> np.ndarray:
         # Implementation of the term Q involved in the calculation of (32) in Berge
         # et al.
         # This is the regularized Q
-        numerator = -Tt.dot((-Tt + cut).T)
+        numerator = -Tt.dot((-Tt - cut).T)
 
         # Regularization to avoid issues during the iterations to avoid dividing by
         # zero if the faces are not in contact durign iterations.
-        denominator = max(bf, self._l2(-Tt)) * self._l2(-Tt + cut)
+        denominator = max(bf, self._l2(-Tt)) * self._l2(-Tt - cut)
 
         return numerator / denominator
 
@@ -510,7 +499,7 @@ class ColoumbContact:
 
     def _hf(self, Tt: np.ndarray, cut: np.ndarray, bf: np.ndarray) -> np.ndarray:
         # This is the product e * Q * (-Tt + cut), used in computation of r in (32)
-        return self._e(Tt, cut, bf) * self._Q(Tt, cut, bf).dot(-Tt + cut)
+        return self._e(Tt, cut, bf) * self._Q(Tt, cut, bf).dot(-Tt - cut)
 
     def _sliding_coefficients(
         self, Tt: np.ndarray, ut: np.ndarray, bf: np.ndarray, c: np.ndarray
@@ -545,7 +534,7 @@ class ColoumbContact:
             return (
                 0 * Id,
                 bf * np.ones((Id.shape[0], 1)),
-                (-Tt + cut) / self._l2(-Tt + cut),
+                (-Tt - cut) / self._l2(-Tt - cut),
             )
 
         # Compute the coefficient M
@@ -557,7 +546,7 @@ class ColoumbContact:
         # Avoid division by zero:
         l2_Tt = self._l2(-Tt)
         if l2_Tt > self.tol:
-            alpha = -Tt.T.dot(-Tt + cut) / (l2_Tt * self._l2(-Tt + cut))
+            alpha = -Tt.T.dot(-Tt - cut) / (l2_Tt * self._l2(-Tt - cut))
             # Parameter delta.
             # NOTE: The denominator bf is correct. The definition given in Berge is wrong.
             delta = min(l2_Tt / bf, 1)
@@ -572,7 +561,7 @@ class ColoumbContact:
 
         L = c * (IdM_inv - Id)
         r = -IdM_inv.dot(self._hf(Tt, cut, bf))
-        v = IdM_inv.dot(-Tt + cut) / self._l2(-Tt + cut)
+        v = IdM_inv.dot(-Tt - cut) / self._l2(-Tt - cut)
 
         return L, r, v
 

--- a/src/porepy/numerics/fv/biot.py
+++ b/src/porepy/numerics/fv/biot.py
@@ -1526,19 +1526,17 @@ class DivU(Discretization):
         # The same procedure is applied to the unknown displacements, by assembling the
         # jump operator, projection and normal component extraction in the coupling matrix.
         # Finally, we integrate over the cell volume.
-        # The jump on the slave is defined to be negative for an open fracture (!),
-        # hence the negative sign.
         vol = sps.dia_matrix((g.cell_volumes, 0), shape=(g.num_cells, g.num_cells))
-        cc[self_ind, 2] -= (
+        cc[self_ind, 2] += (
             sps.diags(biot_alpha) * vol * normal_component * jump_on_slave
         )
 
         # We assume implicit Euler in Biot, thus the div_u term appears
         # on the rhs as div_u^{k-1}. This results in a contribution to the
         # rhs for the coupling variable also.
-        # See note above on sign. This term is negative (u^k - u^{k-1}), and moved to
+        # This term is negative (u^k - u^{k-1}) and moved to
         # the rhs, yielding the same sign as for the k term on the lhs.
-        rhs[self_ind] -= sps.diags(biot_alpha) * vol * previous_displacement_jump_normal
+        rhs[self_ind] += sps.diags(biot_alpha) * vol * previous_displacement_jump_normal
 
 
 class BiotStabilization(Discretization):

--- a/src/porepy/numerics/interface_laws/contact_mechanics_interface_laws.py
+++ b/src/porepy/numerics/interface_laws/contact_mechanics_interface_laws.py
@@ -248,7 +248,7 @@ class PrimalContactCoupling(
 
         ## Second, the contact stress is mapped to the mortar grid.
         # We have for the positive (first) and negative (second) side of the mortar that
-        # T_slave = T_master_pos = -T_master_neg,
+        # T_slave = T_master_j = -T_master_k,
         # so we need to map the slave traction with the corresponding signs to match the
         # mortar tractions.
 
@@ -257,14 +257,15 @@ class PrimalContactCoupling(
         # (note the inverse rotation is given by a transpose).
         # Finally, the contact stresses will be felt in different directions by
         # the two sides of the mortar grids (Newton's third law), hence
-        # adjust the signs
+        # adjust the signs: sign_of_mortar_sides gives a minus for the j side and
+        # plus for the k side, yielding the two equations
+        # - T_slave + T_master_j = 0    and T_slave + T_master_k = 0
         contact_traction_to_mortar = (
             mg.sign_of_mortar_sides(nd=ambient_dimension)
             * projection.project_tangential_normal(mg.num_cells).T
             * mg.slave_to_mortar_int(nd=ambient_dimension)
         )
-        # Minus to obtain -T_slave + T_master = 0.
-        cc[mortar_ind, slave_ind] = -contact_traction_to_mortar
+        cc[mortar_ind, slave_ind] = contact_traction_to_mortar
 
         matrix += cc
 

--- a/test/integration/test_contact_mechanics.py
+++ b/test/integration/test_contact_mechanics.py
@@ -48,7 +48,7 @@ class TestContactMechanics(unittest.TestCase):
         u_mortar, contact_force = self._solve(setup)
 
         # All components should be open in the normal direction
-        self.assertTrue(np.all(u_mortar[1] < 0))
+        self.assertTrue(np.all(u_mortar[1] > 0))
 
         # By symmetry (reasonable to expect from this grid), the jump in tangential
         # deformation should be zero.
@@ -67,7 +67,7 @@ class TestContactMechanics(unittest.TestCase):
         u_mortar, contact_force = self._solve(setup)
 
         # All components should be open in the normal direction
-        self.assertTrue(np.all(u_mortar[1] < 0))
+        self.assertTrue(np.all(u_mortar[1] > 0))
 
         # By symmetry (reasonable to expect from this grid), the jump in tangential
         # deformation should be zero.

--- a/test/integration/test_contact_mechanics_biot.py
+++ b/test/integration/test_contact_mechanics_biot.py
@@ -85,7 +85,7 @@ class TestContactMechanicsBiot(unittest.TestCase):
         # setup.subtract_fracture_pressure = False
         u_mortar, contact_force, fracture_pressure = self._solve(setup)
         # All components should be open in the normal direction
-        self.assertTrue(np.all(u_mortar[1] < 0))
+        self.assertTrue(np.all(u_mortar[1] > 0))
 
         # By symmetry (reasonable to expect from this grid), the jump in tangential
         # deformation should be zero.
@@ -108,7 +108,7 @@ class TestContactMechanicsBiot(unittest.TestCase):
         u_mortar, contact_force, fracture_pressure = self._solve(setup)
 
         # All components should be open in the normal direction
-        self.assertTrue(np.all(u_mortar[1] < 0))
+        self.assertTrue(np.all(u_mortar[1] > 0))
 
         # By symmetry (reasonable to expect from this grid), the jump in tangential
         # deformation should be zero.
@@ -165,7 +165,7 @@ class TestContactMechanicsBiot(unittest.TestCase):
         u_mortar, contact_force, fracture_pressure = self._solve(setup)
 
         # All components should be open in the normal direction
-        self.assertTrue(np.all(u_mortar[1] < 0))
+        self.assertTrue(np.all(u_mortar[1] > 0))
 
         # By symmetry (reasonable to expect from this grid), the jump in tangential
         # deformation should be zero.
@@ -193,7 +193,7 @@ class TestContactMechanicsBiot(unittest.TestCase):
         # setup.subtract_fracture_pressure = False
         u_mortar, contact_force, fracture_pressure = self._solve(setup)
         # All components should be open in the normal direction
-        self.assertTrue(np.all(u_mortar[1] < 0))
+        self.assertTrue(np.all(u_mortar[1] > 0))
 
         # By symmetry (reasonable to expect from this grid), the jump in tangential
         # deformation should be zero.

--- a/test/integration/test_dilation.py
+++ b/test/integration/test_dilation.py
@@ -49,7 +49,7 @@ class TestDilation(unittest.TestCase):
         setup = SetupContactMechanics(
             ux_south=0.0, uy_south=0.0, ux_north=0, uy_north=0
         )
-        setup.initial_gap = -1e-4
+        setup.initial_gap = 1e-4
         u_mortar, contact_force = self._solve(setup)
 
         # All cells should be displaced in the normal direction
@@ -66,7 +66,7 @@ class TestDilation(unittest.TestCase):
         setup = SetupContactMechanics(
             ux_south=0.0, uy_south=0.001, ux_north=0, uy_north=0
         )
-        setup.initial_gap = -1e-4 * np.random.rand(2)
+        setup.initial_gap = 1e-4 * np.random.rand(2)
         u_mortar, contact_force = self._solve(setup)
 
         # Normal displacement should equal initial gap
@@ -80,7 +80,7 @@ class TestDilation(unittest.TestCase):
         setup = SetupContactMechanics(
             ux_south=0.01, uy_south=0.001, ux_north=0, uy_north=0
         )
-        setup.initial_gap = -1e-4 * np.random.rand(2)
+        setup.initial_gap = 1e-4 * np.random.rand(2)
         u_mortar, contact_force = self._solve(setup)
 
         # Normal displacement should equal initial gap
@@ -98,7 +98,7 @@ class TestDilation(unittest.TestCase):
         u_mortar, contact_force = self._solve(setup)
 
         # We expect dilation
-        self.assertTrue(np.all(u_mortar[1] < setup.zero_tol))
+        self.assertTrue(np.all(u_mortar[1] > setup.zero_tol))
         # Check that the ratio between displacement jumps equals the dilation angle
         abs_u = np.absolute(u_mortar)
         self.assertTrue(
@@ -118,7 +118,7 @@ class TestDilation(unittest.TestCase):
         u_mortar, contact_force = self._solve(setup)
 
         # We expect dilation
-        self.assertTrue(np.all(u_mortar[1] < 1e-7))
+        self.assertTrue(np.all(u_mortar[1] > 1e-7))
         # Check that the ratio between displacement jumps equals the dilation angle
         abs_u = np.absolute(u_mortar)
         self.assertTrue(
@@ -173,7 +173,7 @@ class TestDilation(unittest.TestCase):
         u_mortar_0, contact_force_0 = self._solve(setup)
         # Should be open
         self.assertTrue(np.all(np.isclose(contact_force_0[1], 0)))
-        self.assertTrue(np.all(u_mortar_0[1] < setup.zero_tol))
+        self.assertTrue(np.all(u_mortar_0[1] > setup.zero_tol))
         # but no tangential displacement
         self.assertTrue(np.all(np.isclose(u_mortar_0[0], 0)))
         # Second step
@@ -184,7 +184,7 @@ class TestDilation(unittest.TestCase):
         # We have displaced more in the second step:
         sign = np.sign(u_mortar_1[0, 0])
         self.assertTrue(np.all(sign * (u_mortar_0[0] - u_mortar_1[0]) < setup.zero_tol))
-        self.assertTrue(np.all(u_mortar_0[1] - u_mortar_1[1] > setup.zero_tol))
+        self.assertTrue(np.all(u_mortar_1[1] - u_mortar_0[1] > setup.zero_tol))
 
 
 class SetupContactMechanics(

--- a/test/integration/test_thm.py
+++ b/test/integration/test_thm.py
@@ -140,7 +140,7 @@ class TestContactMechanicsTHM(unittest.TestCase):
         )
 
         # All components should be open in the normal direction
-        self.assertTrue(np.all(u_mortar[1] < 0))
+        self.assertTrue(np.all(u_mortar[1] > 0))
 
         # By symmetry (reasonable to expect from this grid), the jump in tangential
         # deformation should be zero.
@@ -165,7 +165,7 @@ class TestContactMechanicsTHM(unittest.TestCase):
         )
 
         # All components should be open in the normal direction
-        self.assertTrue(np.all(u_mortar[1] < 0))
+        self.assertTrue(np.all(u_mortar[1] > 0))
 
         # By symmetry (reasonable to expect from this grid), the jump in tangential
         # deformation should be zero.
@@ -211,7 +211,7 @@ class TestContactMechanicsTHM(unittest.TestCase):
         )
 
         # All components should be open in the normal direction
-        self.assertTrue(np.all(u_mortar[1] < 0))
+        self.assertTrue(np.all(u_mortar[1] > 0))
 
         # By symmetry (reasonable to expect from this grid), the jump in tangential
         # deformation should be zero.
@@ -248,7 +248,7 @@ class TestContactMechanicsTHM(unittest.TestCase):
             setup
         )
         self.assertTrue(np.all(np.isclose(fracture_pressure, -4.31072866e-06)))
-        self.assertTrue(np.all(np.isclose(u_mortar[1], -9.99187742e-04)))
+        self.assertTrue(np.all(np.isclose(u_mortar[1], 9.99187742e-04)))
         self.assertTrue(np.all(np.isclose(fracture_temperature, 0.0)))
 
     def test_pull_north_reduce_to_TM(self):
@@ -272,7 +272,7 @@ class TestContactMechanicsTHM(unittest.TestCase):
             setup
         )
         self.assertTrue(np.all(np.isclose(fracture_temperature, -2.05192594e-06)))
-        self.assertTrue(np.all(np.isclose(u_mortar[1], -1.00061081e-03)))
+        self.assertTrue(np.all(np.isclose(u_mortar[1], 1.00061081e-03)))
         self.assertTrue(np.all(np.isclose(fracture_pressure, 0.0)))
 
 


### PR DESCRIPTION
The sign convention for the jump operators used in contact conditions is changed, so that an open fracture has a positive normal displacement.