### PR TITLE
Update .gitignore to include MacOS-related files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ bin/*
 *.eps
 *.pdf
 .eggs/
+*.nbc
+*.nbi
+*.egg-info
+*.DS_Store


### PR DESCRIPTION
Small PR to include a few file extensions that should be ignored in MacOS. This will make PR's way easier for Mac users.