### PR TITLE
Rename master/slave by primary/secondary 

### DIFF
--- a/src/porepy/grids/coarsening.py
+++ b/src/porepy/grids/coarsening.py
@@ -260,11 +260,11 @@ def _generate_coarse_grid_gb(gb, subdiv):
         # Construct the coarse grids
         face_map = _generate_coarse_grid_single(g, partition, True)
 
-        # Update all the master_to_mortar_int for all the 'edges' connected to the grid
+        # Update all the primary_to_mortar_int for all the 'edges' connected to the grid
         # We update also all the face_cells
         for e, d in gb.edges_of_node(g):
             # The indices that need to be mapped to the new grid
-            m2m = d["mortar_grid"].master_to_mortar_int().tocsr()
+            m2m = d["mortar_grid"].primary_to_mortar_int().tocsr()
             indices = m2m.indices
 
             # Map indices
@@ -276,7 +276,7 @@ def _generate_coarse_grid_gb(gb, subdiv):
             # Create the new matrix
             shape = (m2m.shape[0], g.num_faces)
             new_m2m = sps.csr_matrix((m2m.data, indices, m2m.indptr), shape=shape)
-            d["mortar_grid"]._master_to_mortar_int = new_m2m.tocsc()
+            d["mortar_grid"]._primary_to_mortar_int = new_m2m.tocsc()
 
             # update also the face_cells map
             face_cells = d["face_cells"].tocsr()
@@ -354,7 +354,7 @@ def generate_seeds(gb):
 
         # recover the mapping between the slave and the master grid
         mg = gb._edges[(g_h, g)]["mortar_grid"]
-        m2m = mg.master_to_mortar_int()
+        m2m = mg.primary_to_mortar_int()
         l2m = mg.slave_to_mortar_int()
         # this is the old face_cells mapping
         face_cells = l2m.T * m2m

--- a/src/porepy/grids/coarsening.py
+++ b/src/porepy/grids/coarsening.py
@@ -264,8 +264,8 @@ def _generate_coarse_grid_gb(gb, subdiv):
         # We update also all the face_cells
         for e, d in gb.edges_of_node(g):
             # The indices that need to be mapped to the new grid
-            m2m = d["mortar_grid"].primary_to_mortar_int().tocsr()
-            indices = m2m.indices
+            primary_to_mortar = d["mortar_grid"].primary_to_mortar_int().tocsr()
+            indices = primary_to_mortar.indices
 
             # Map indices
             mask = np.argsort(indices)
@@ -274,9 +274,11 @@ def _generate_coarse_grid_gb(gb, subdiv):
             indices = indices[np.argsort(mask)]
 
             # Create the new matrix
-            shape = (m2m.shape[0], g.num_faces)
-            new_m2m = sps.csr_matrix((m2m.data, indices, m2m.indptr), shape=shape)
-            d["mortar_grid"]._primary_to_mortar_int = new_m2m.tocsc()
+            shape = (primary_to_mortar.shape[0], g.num_faces)
+            new_primary_to_mortar = sps.csr_matrix(
+                (primary_to_mortar.data, indices, primary_to_mortar.indptr), shape=shape
+            )
+            d["mortar_grid"]._primary_to_mortar_int = new_primary_to_mortar.tocsc()
 
             # update also the face_cells map
             face_cells = d["face_cells"].tocsr()
@@ -354,10 +356,10 @@ def generate_seeds(gb):
 
         # recover the mapping between the secondary and the primary grid
         mg = gb._edges[(g_h, g)]["mortar_grid"]
-        m2m = mg.primary_to_mortar_int()
-        l2m = mg.secondary_to_mortar_int()
+        primary_to_mortar = mg.primary_to_mortar_int()
+        secondary_to_mortar = mg.secondary_to_mortar_int()
         # this is the old face_cells mapping
-        face_cells = l2m.T * m2m
+        face_cells = secondary_to_mortar.T * primary_to_mortar
 
         interf_cells, interf_faces, _ = sps.find(face_cells)
         index = np.in1d(interf_cells, cells).nonzero()[0]

--- a/src/porepy/grids/coarsening.py
+++ b/src/porepy/grids/coarsening.py
@@ -355,7 +355,7 @@ def generate_seeds(gb):
         # recover the mapping between the slave and the master grid
         mg = gb._edges[(g_h, g)]["mortar_grid"]
         m2m = mg.primary_to_mortar_int()
-        l2m = mg.slave_to_mortar_int()
+        l2m = mg.secondary_to_mortar_int()
         # this is the old face_cells mapping
         face_cells = l2m.T * m2m
 

--- a/src/porepy/grids/coarsening.py
+++ b/src/porepy/grids/coarsening.py
@@ -352,7 +352,7 @@ def generate_seeds(gb):
         index = np.in1d(faces, tips).nonzero()[0]
         cells = np.unique(cells[index])
 
-        # recover the mapping between the slave and the master grid
+        # recover the mapping between the secondary and the master grid
         mg = gb._edges[(g_h, g)]["mortar_grid"]
         m2m = mg.primary_to_mortar_int()
         l2m = mg.secondary_to_mortar_int()

--- a/src/porepy/grids/coarsening.py
+++ b/src/porepy/grids/coarsening.py
@@ -352,7 +352,7 @@ def generate_seeds(gb):
         index = np.in1d(faces, tips).nonzero()[0]
         cells = np.unique(cells[index])
 
-        # recover the mapping between the secondary and the master grid
+        # recover the mapping between the secondary and the primary grid
         mg = gb._edges[(g_h, g)]["mortar_grid"]
         m2m = mg.primary_to_mortar_int()
         l2m = mg.secondary_to_mortar_int()

--- a/src/porepy/grids/fv_sub_grid.py
+++ b/src/porepy/grids/fv_sub_grid.py
@@ -75,12 +75,12 @@ class FvSubGrid(pp.Grid):
         self.face_areas = g.face_areas / num_nodes_per_face
         self.face_areas = self.face_areas[subcell_topology.fno_unique]
         if hasattr(g, "frac_pairs"):
-            is_master = np.zeros(g.num_faces, dtype=np.bool)
+            is_primary = np.zeros(g.num_faces, dtype=np.bool)
             is_secondary = np.zeros(g.num_faces, dtype=np.bool)
-            is_master[g.frac_pairs[0]] = True
+            is_primary[g.frac_pairs[0]] = True
             is_secondary[g.frac_pairs[1]] = True
-            is_master_hf = is_master[subcell_topology.fno_unique]
+            is_primary_hf = is_primary[subcell_topology.fno_unique]
             is_secondary_hf = is_secondary[subcell_topology.fno_unique]
             self.frac_pairs = np.vstack(
-                (np.where(is_master_hf)[0], np.where(is_secondary_hf)[0])
+                (np.where(is_primary_hf)[0], np.where(is_secondary_hf)[0])
             )

--- a/src/porepy/grids/fv_sub_grid.py
+++ b/src/porepy/grids/fv_sub_grid.py
@@ -76,11 +76,11 @@ class FvSubGrid(pp.Grid):
         self.face_areas = self.face_areas[subcell_topology.fno_unique]
         if hasattr(g, "frac_pairs"):
             is_master = np.zeros(g.num_faces, dtype=np.bool)
-            is_slave = np.zeros(g.num_faces, dtype=np.bool)
+            is_secondary = np.zeros(g.num_faces, dtype=np.bool)
             is_master[g.frac_pairs[0]] = True
-            is_slave[g.frac_pairs[1]] = True
+            is_secondary[g.frac_pairs[1]] = True
             is_master_hf = is_master[subcell_topology.fno_unique]
-            is_slave_hf = is_slave[subcell_topology.fno_unique]
+            is_secondary_hf = is_secondary[subcell_topology.fno_unique]
             self.frac_pairs = np.vstack(
-                (np.where(is_master_hf)[0], np.where(is_slave_hf)[0])
+                (np.where(is_master_hf)[0], np.where(is_secondary_hf)[0])
             )

--- a/src/porepy/grids/grid_bucket.py
+++ b/src/porepy/grids/grid_bucket.py
@@ -957,7 +957,7 @@ class GridBucket:
                 mg = d["mortar_grid"]
                 if mg.dim == g_new.dim:
                     # update the mortar grid of the same dimension
-                    mg.update_slave(g_new, tol)
+                    mg.update_secondary(g_new, tol)
                 else:  # g_new.dim == mg.dim + 1
                     mg.update_primary(g_new, g_old, tol)
 

--- a/src/porepy/grids/grid_bucket.py
+++ b/src/porepy/grids/grid_bucket.py
@@ -959,7 +959,7 @@ class GridBucket:
                     # update the mortar grid of the same dimension
                     mg.update_slave(g_new, tol)
                 else:  # g_new.dim == mg.dim + 1
-                    mg.update_master(g_new, g_old, tol)
+                    mg.update_primary(g_new, g_old, tol)
 
     def _find_shared_face(self, g0: pp.Grid, g1: pp.Grid, g_l: pp.Grid) -> np.ndarray:
         """

--- a/src/porepy/grids/match_grids.py
+++ b/src/porepy/grids/match_grids.py
@@ -157,7 +157,7 @@ def match_grids_along_1d_mortar(
         ValueError: If the matching procedure goes wrong.
 
     Returns:
-        sps.csr_matrix: Matrix that can be used to update mg._master_to_mortar_int.
+        sps.csr_matrix: Matrix that can be used to update mg._primary_to_mortar_int.
 
     """
 
@@ -249,7 +249,7 @@ def match_grids_along_1d_mortar(
 
     # First create a virtual 1d grid along the line, using nodes from the old grid
     # Identify faces in the old grid that is on the boundary
-    _, faces_on_boundary_old, _ = sps.find(mg._master_to_mortar_int)
+    _, faces_on_boundary_old, _ = sps.find(mg._primary_to_mortar_int)
     # Find the nodes of those faces
     nodes_on_boundary_old = nodes_of_faces(g_old, faces_on_boundary_old)
     nodes_1d_old = g_old.nodes[:, nodes_on_boundary_old]

--- a/src/porepy/grids/match_grids.py
+++ b/src/porepy/grids/match_grids.py
@@ -150,7 +150,7 @@ def match_grids_along_1d_mortar(
         g_new (pp.Grid): New 2d grid. Should have faces split along the 1d line.
             Dimension 2.
         g_old (pp.Grid): Old 2d grid. Dimension 2. The mappings in mg from mortar to
-            master should be set for this grid.
+            primary should be set for this grid.
         tol (double): Tolerance used in comparison of geometric quantities.
 
     Raises:

--- a/src/porepy/grids/mortar_grid.py
+++ b/src/porepy/grids/mortar_grid.py
@@ -805,7 +805,7 @@ class BoundaryMortar(MortarGrid):
             + "Face_cell mapping from the LEFT_SIDE grid to the mortar grid\n"
             + str(self.primary_to_mortar_int)
             + "\n"
-            + "Face_cell mapping from the SLAVE_SIDE grid to the mortar grid\n"
+            + "Face_cell mapping from the RIGHT_SIDE grid to the mortar grid\n"
             + str(self.secondary_to_mortar_int)
         )
 

--- a/src/porepy/grids/mortar_grid.py
+++ b/src/porepy/grids/mortar_grid.py
@@ -174,7 +174,7 @@ class MortarGrid:
             + "Number of cells in lower-dimensional neighbor "
             + f"{self.mortar_to_secondary_int().shape[0]}\n"
             + "Number of faces in higher-dimensional neighbor "
-            + f"{self.mortar_to_master_int().shape[0]}\n"
+            + f"{self.mortar_to_primary_int().shape[0]}\n"
         )
 
         return s
@@ -526,7 +526,7 @@ class MortarGrid:
     # found by taking transposes, and switching average and integration (since we are
     # changing which side we are taking the area relative to.
 
-    def mortar_to_master_int(self, nd: int = 1) -> sps.spmatrix:
+    def mortar_to_primary_int(self, nd: int = 1) -> sps.spmatrix:
         """Project values from the mortar to faces of master, by summing quantities
         from the mortar side.
 
@@ -568,7 +568,7 @@ class MortarGrid:
         """
         return self._convert_to_vector_variable(self.slave_to_mortar_avg().T, nd)
 
-    def mortar_to_master_avg(self, nd: int = 1) -> sps.spmatrix:
+    def mortar_to_primary_avg(self, nd: int = 1) -> sps.spmatrix:
         """Project values from the mortar to faces of master, by averaging
         quantities from the mortar side.
 

--- a/src/porepy/grids/mortar_grid.py
+++ b/src/porepy/grids/mortar_grid.py
@@ -323,7 +323,7 @@ class MortarGrid:
         self._secondary_to_mortar_int = sps.bmat(matrix, format="csc")
         self._check_mappings()
 
-    def update_master(self, g_new: pp.Grid, g_old: pp.Grid, tol: float = None):
+    def update_primary(self, g_new: pp.Grid, g_old: pp.Grid, tol: float = None):
         """
         Update the _secondary_to_mortar_int map when the lower dimensional grid is changed.
 

--- a/src/porepy/grids/mortar_grid.py
+++ b/src/porepy/grids/mortar_grid.py
@@ -172,7 +172,7 @@ class MortarGrid:
             + f"Number of cells {self.num_cells}\n"
             + f"Number of sides {len(self.side_grids)}\n"
             + "Number of cells in lower-dimensional neighbor "
-            + f"{self.mortar_to_slave_int().shape[0]}\n"
+            + f"{self.mortar_to_secondary_int().shape[0]}\n"
             + "Number of faces in higher-dimensional neighbor "
             + f"{self.mortar_to_master_int().shape[0]}\n"
         )
@@ -547,7 +547,7 @@ class MortarGrid:
         """
         return self._convert_to_vector_variable(self.master_to_mortar_avg().T, nd)
 
-    def mortar_to_slave_int(self, nd: int = 1) -> sps.spmatrix:
+    def mortar_to_secondary_int(self, nd: int = 1) -> sps.spmatrix:
         """Project values from the mortar to cells at the slave, by summing quantities
         from the mortar side.
 
@@ -590,7 +590,7 @@ class MortarGrid:
         """
         return self._convert_to_vector_variable(self.master_to_mortar_int().T, nd)
 
-    def mortar_to_slave_avg(self, nd: int = 1) -> sps.spmatrix:
+    def mortar_to_secondary_avg(self, nd: int = 1) -> sps.spmatrix:
         """Project values from the mortar to slave, by averaging quantities from the
         mortar side.
 
@@ -637,7 +637,7 @@ class MortarGrid:
         Example: Take the difference between right and left variables, and
         project to the slave grid by
 
-            mortar_to_slave_avg() * sign_of_mortar_sides()
+            mortar_to_secondary_avg() * sign_of_mortar_sides()
 
         NOTE: The flux variables in flow and transport equations are defined as
         positive from master to slave. Hence the two sides have different

--- a/src/porepy/grids/mortar_grid.py
+++ b/src/porepy/grids/mortar_grid.py
@@ -278,7 +278,7 @@ class MortarGrid:
 
         self._check_mappings()
 
-    def update_slave(self, new_g: pp.Grid, tol: float = None) -> None:
+    def update_secondary(self, new_g: pp.Grid, tol: float = None) -> None:
         """
         Update the _secondary_to_mortar_int map when the lower dimensional grid is changed.
 
@@ -334,7 +334,7 @@ class MortarGrid:
                 Defaults to self.tol.
 
         """
-        # TODO: Why is the signature of this method different from update_slave?
+        # TODO: Why is the signature of this method different from update_secondary?
         if tol is None:
             tol = self.tol
 

--- a/src/porepy/grids/mortar_grid.py
+++ b/src/porepy/grids/mortar_grid.py
@@ -35,7 +35,7 @@ class MortarGrid:
             num_faces x num_cells. In the beginning we assume matching grids,
             but it can be modified by calling refine_mortar(). The matrix
             elements represent the ratio between the geometrical objects.
-        _slave_to_mortar_int (sps.csc-matrix): Cell-cell relationships between the
+        _secondary_to_mortar_int (sps.csc-matrix): Cell-cell relationships between the
             mortar grids and the low dimensional grid. Matrix size:
             num_cells x num_cells. Matrix elements represent the ratio between
             the geometrical objects.
@@ -155,7 +155,7 @@ class MortarGrid:
         # It is composed by two identity matrices since we are assuming matching
         # grids here.
         identity = [[sps.identity(num_cells)]] * self.num_sides()
-        self._slave_to_mortar_int: sps.spmatrix = sps.bmat(identity, format="csc")
+        self._secondary_to_mortar_int: sps.spmatrix = sps.bmat(identity, format="csc")
 
     def __repr__(self) -> str:
         """
@@ -266,7 +266,7 @@ class MortarGrid:
         # Once the global matrix is constructed the new low_to_mortar_int and
         # high_to_mortar_int maps are updated.
         matrix = sps.bmat(matrix)
-        self._slave_to_mortar_int = matrix * self._slave_to_mortar_int
+        self._secondary_to_mortar_int = matrix * self._secondary_to_mortar_int
         self._primary_to_mortar_int = matrix * self._primary_to_mortar_int
 
         # Update the side grids
@@ -280,7 +280,7 @@ class MortarGrid:
 
     def update_slave(self, new_g: pp.Grid, tol: float = None) -> None:
         """
-        Update the _slave_to_mortar_int map when the lower dimensional grid is changed.
+        Update the _secondary_to_mortar_int map when the lower dimensional grid is changed.
 
         Parameter:
             new_g (pp.Grid): The new slave grid.
@@ -320,12 +320,12 @@ class MortarGrid:
             matrix[pos, 0] = split_matrix[side]
 
         # Update the low_to_mortar_int map. No need to update the high_to_mortar_int.
-        self._slave_to_mortar_int = sps.bmat(matrix, format="csc")
+        self._secondary_to_mortar_int = sps.bmat(matrix, format="csc")
         self._check_mappings()
 
     def update_master(self, g_new: pp.Grid, g_old: pp.Grid, tol: float = None):
         """
-        Update the _slave_to_mortar_int map when the lower dimensional grid is changed.
+        Update the _secondary_to_mortar_int map when the lower dimensional grid is changed.
 
         Parameter:
             g_new (pp.Grid): The new master grid.
@@ -439,7 +439,7 @@ class MortarGrid:
         """
         return self._convert_to_vector_variable(self._primary_to_mortar_int, nd)
 
-    def slave_to_mortar_int(self, nd: int = 1) -> sps.spmatrix:
+    def secondary_to_mortar_int(self, nd: int = 1) -> sps.spmatrix:
         """Project values from cells on the slave side to the mortar, by
         summing quantities from the slave side.
 
@@ -458,7 +458,7 @@ class MortarGrid:
                 Size: g_slave.num_cells x mortar_grid.num_cells.
 
         """
-        return self._convert_to_vector_variable(self._slave_to_mortar_int, nd)
+        return self._convert_to_vector_variable(self._secondary_to_mortar_int, nd)
 
     def primary_to_mortar_avg(self, nd: int = 1) -> sps.spmatrix:
         """Project values from faces of master to the mortar, by averaging quantities
@@ -483,7 +483,7 @@ class MortarGrid:
         scaled_mat = self._row_sum_scaling_matrix(self._primary_to_mortar_int)
         return self._convert_to_vector_variable(scaled_mat, nd)
 
-    def slave_to_mortar_avg(self, nd: int = 1) -> sps.spmatrix:
+    def secondary_to_mortar_avg(self, nd: int = 1) -> sps.spmatrix:
         """Project values from cells at the slave to the mortar, by averaging
         quantities from the slave side.
 
@@ -503,7 +503,7 @@ class MortarGrid:
                 Size: g_slave.num_cells x mortar_grid.num_cells.
 
         """
-        scaled_mat = self._row_sum_scaling_matrix(self._slave_to_mortar_int)
+        scaled_mat = self._row_sum_scaling_matrix(self._secondary_to_mortar_int)
         return self._convert_to_vector_variable(scaled_mat, nd)
 
     def _row_sum_scaling_matrix(self, mat):
@@ -566,7 +566,7 @@ class MortarGrid:
                 Size: mortar_grid.num_cells x g_slave_num_faces.
 
         """
-        return self._convert_to_vector_variable(self.slave_to_mortar_avg().T, nd)
+        return self._convert_to_vector_variable(self.secondary_to_mortar_avg().T, nd)
 
     def mortar_to_primary_avg(self, nd: int = 1) -> sps.spmatrix:
         """Project values from the mortar to faces of master, by averaging
@@ -610,7 +610,7 @@ class MortarGrid:
                 Size: mortar_grid.num_cells x g_slave.num_faces.
 
         """
-        return self._convert_to_vector_variable(self.slave_to_mortar_int().T, nd)
+        return self._convert_to_vector_variable(self.secondary_to_mortar_int().T, nd)
 
     def _convert_to_vector_variable(
         self, matrix: sps.spmatrix, nd: int
@@ -686,7 +686,7 @@ class MortarGrid:
         if not (row_sum.min() > tol):
             raise ValueError("Check not satisfied for the master grid")
 
-        row_sum = self._slave_to_mortar_int.sum(axis=1)
+        row_sum = self._secondary_to_mortar_int.sum(axis=1)
         if not (row_sum.min() > tol):
             raise ValueError("Check not satisfied for the slave grid")
 
@@ -706,7 +706,7 @@ class BoundaryMortar(MortarGrid):
         side_grids (dictionary of Grid): Contains the mortar grid under the key
             "mortar_grid". Is included for consistency with MortarGrid
         sides (array of integers with values in {0, 1, 2}): ordering of the sides.
-        slave_to_mortar_int (sps.csc-matrix): Face-cell relationships between the
+        secondary_to_mortar_int (sps.csc-matrix): Face-cell relationships between the
             slave grid and the mortar grid. Matrix size:
             num_faces x num_cells. In the beginning we assume matching grids,
             but it can be modified by calling refine_mortar(). The matrix
@@ -726,7 +726,7 @@ class BoundaryMortar(MortarGrid):
         """Initialize the mortar grid
 
         See class documentation for further description of parameters.
-        The slave_to_mortar_int and primary_to_mortar_int are identity mapping.
+        The secondary_to_mortar_int and primary_to_mortar_int are identity mapping.
 
         Parameters
         ----------
@@ -786,7 +786,7 @@ class BoundaryMortar(MortarGrid):
         self._primary_to_mortar_int = sps.csc_matrix(
             (data.astype(np.float), (cells, master_f)), shape=shape_master
         )
-        self._slave_to_mortar_int = sps.csc_matrix(
+        self._secondary_to_mortar_int = sps.csc_matrix(
             (data.astype(np.float), (cells, slave_f)), shape=shape_slave
         )
 
@@ -806,7 +806,7 @@ class BoundaryMortar(MortarGrid):
             + str(self.primary_to_mortar_int)
             + "\n"
             + "Face_cell mapping from the SLAVE_SIDE grid to the mortar grid\n"
-            + str(self.slave_to_mortar_int)
+            + str(self.secondary_to_mortar_int)
         )
 
         return s
@@ -835,7 +835,7 @@ class BoundaryMortar(MortarGrid):
             + "to the cells of the mortar grid. \nRows indicate the mortar"
             + " cell id, columns indicate the slave_grid face id"
             + "\n"
-            + str(self.slave_to_mortar_int)
+            + str(self.secondary_to_mortar_int)
         )
 
         return s

--- a/src/porepy/models/contact_mechanics_biot_model.py
+++ b/src/porepy/models/contact_mechanics_biot_model.py
@@ -226,7 +226,7 @@ class ContactMechanicsBiot(contact_model.ContactMechanics):
             a_l = self.aperture(g_l)
             # Take trace of and then project specific volumes from g_h
             v_h = (
-                mg.master_to_mortar_avg()
+                mg.primary_to_mortar_avg()
                 * np.abs(g_h.cell_faces)
                 * self.specific_volume(g_h)
             )

--- a/src/porepy/models/contact_mechanics_biot_model.py
+++ b/src/porepy/models/contact_mechanics_biot_model.py
@@ -232,7 +232,7 @@ class ContactMechanicsBiot(contact_model.ContactMechanics):
             )
             # Division by a/2 may be thought of as taking the gradient in the normal
             # direction of the fracture.
-            normal_diffusivity = kappa * 2 / (mg.slave_to_mortar_avg() * a_l)
+            normal_diffusivity = kappa * 2 / (mg.secondary_to_mortar_avg() * a_l)
             # The interface flux is to match fluxes across faces of g_h,
             # and therefore need to be weighted by the corresponding
             # specific volumes

--- a/src/porepy/models/contact_mechanics_model.py
+++ b/src/porepy/models/contact_mechanics_model.py
@@ -440,7 +440,7 @@ class ContactMechanics(porepy.models.abstract_model.AbstractModel):
                 else:
                     u_e = d_e[pp.STATE][self.mortar_displacement_variable]
 
-                stress += bound_stress_discr * mg.mortar_to_master_avg(nd=self.Nd) * u_e
+                stress += bound_stress_discr * mg.mortar_to_primary_avg(nd=self.Nd) * u_e
 
         d[pp.STATE]["stress"] = stress
 

--- a/src/porepy/models/contact_mechanics_model.py
+++ b/src/porepy/models/contact_mechanics_model.py
@@ -387,7 +387,7 @@ class ContactMechanics(porepy.models.abstract_model.AbstractModel):
         else:
             mortar_u = data_edge[pp.STATE][self.mortar_displacement_variable]
         displacement_jump_global_coord = (
-            mg.mortar_to_slave_avg(nd=self.Nd)
+            mg.mortar_to_secondary_avg(nd=self.Nd)
             * mg.sign_of_mortar_sides(nd=self.Nd)
             * mortar_u
         )

--- a/src/porepy/models/contact_mechanics_model.py
+++ b/src/porepy/models/contact_mechanics_model.py
@@ -440,7 +440,9 @@ class ContactMechanics(porepy.models.abstract_model.AbstractModel):
                 else:
                     u_e = d_e[pp.STATE][self.mortar_displacement_variable]
 
-                stress += bound_stress_discr * mg.mortar_to_primary_avg(nd=self.Nd) * u_e
+                stress += (
+                    bound_stress_discr * mg.mortar_to_primary_avg(nd=self.Nd) * u_e
+                )
 
         d[pp.STATE]["stress"] = stress
 

--- a/src/porepy/models/thm_model.py
+++ b/src/porepy/models/thm_model.py
@@ -198,7 +198,7 @@ class THM(parent_model.ContactMechanicsBiot):
             )  #
             # Division by a/2 may be thought of as taking the gradient in the normal
             # direction of the fracture.
-            normal_diffusivity = kappa * 2 / (mg.slave_to_mortar_avg() * a_l)
+            normal_diffusivity = kappa * 2 / (mg.secondary_to_mortar_avg() * a_l)
             # The interface flux is to match fluxes across faces of g_h,
             # and therefore need to be weighted by the corresponding
             # specific volumes

--- a/src/porepy/models/thm_model.py
+++ b/src/porepy/models/thm_model.py
@@ -192,7 +192,7 @@ class THM(parent_model.ContactMechanicsBiot):
 
             a_l = self.aperture(g_l)
             v_h = (
-                mg.master_to_mortar_avg()
+                mg.primary_to_mortar_avg()
                 * np.abs(g_h.cell_faces)
                 * self.specific_volume(g_h)
             )  #

--- a/src/porepy/numerics/contact_mechanics/contact_conditions.py
+++ b/src/porepy/numerics/contact_mechanics/contact_conditions.py
@@ -158,7 +158,7 @@ class ColoumbContact:
         parameters_h = data_h[pp.PARAMETERS][self.discr_h.keyword]
         constit_h = parameters_h["fourth_order_tensor"]
         mean_constit = (
-            mg.mortar_to_slave_avg()
+            mg.mortar_to_secondary_avg()
             * mg.master_to_mortar_avg()
             * 0.5
             * np.abs(g_h.cell_faces * (constit_h.mu + constit_h.lmbda))
@@ -207,12 +207,12 @@ class ColoumbContact:
             self.mortar_displacement_variable
         ]
         displacement_jump_global_coord_iterate = (
-            mg.mortar_to_slave_avg(nd=self.dim)
+            mg.mortar_to_secondary_avg(nd=self.dim)
             * mg.sign_of_mortar_sides(nd=self.dim)
             * previous_displacement_iterate
         )
         displacement_jump_global_coord_time = (
-            mg.mortar_to_slave_avg(nd=self.dim)
+            mg.mortar_to_secondary_avg(nd=self.dim)
             * mg.sign_of_mortar_sides(nd=self.dim)
             * previous_displacement_time
         )

--- a/src/porepy/numerics/contact_mechanics/contact_conditions.py
+++ b/src/porepy/numerics/contact_mechanics/contact_conditions.py
@@ -600,7 +600,7 @@ def set_projections(gb: pp.GridBucket) -> None:
         _, g_h = gb.nodes_of_edge(e)
 
         # Find faces of the higher dimensional grid that coincide with the mortar
-        # grid. Go via the master to mortar projection
+        # grid. Go via the primary to mortar projection
         # Convert matrix to csr, then the relevant face indices are found from
         # the (column) indices
         faces_on_surface = mg.primary_to_mortar_int().tocsr().indices

--- a/src/porepy/numerics/contact_mechanics/contact_conditions.py
+++ b/src/porepy/numerics/contact_mechanics/contact_conditions.py
@@ -159,7 +159,7 @@ class ColoumbContact:
         constit_h = parameters_h["fourth_order_tensor"]
         mean_constit = (
             mg.mortar_to_secondary_avg()
-            * mg.master_to_mortar_avg()
+            * mg.primary_to_mortar_avg()
             * 0.5
             * np.abs(g_h.cell_faces * (constit_h.mu + constit_h.lmbda))
         )
@@ -603,7 +603,7 @@ def set_projections(gb: pp.GridBucket) -> None:
         # grid. Go via the master to mortar projection
         # Convert matrix to csr, then the relevant face indices are found from
         # the (column) indices
-        faces_on_surface = mg.master_to_mortar_int().tocsr().indices
+        faces_on_surface = mg.primary_to_mortar_int().tocsr().indices
 
         # Find out whether the boundary faces have outwards pointing normal vectors
         # Negative sign implies that the normal vector points inwards.
@@ -622,7 +622,7 @@ def set_projections(gb: pp.GridBucket) -> None:
         # (below).
         # NOTE: Use a single normal vector to span the tangential and normal space,
         # thus assuming the surface is planar.
-        outwards_unit_vector_mortar = mg.master_to_mortar_int().dot(unit_normal.T).T
+        outwards_unit_vector_mortar = mg.primary_to_mortar_int().dot(unit_normal.T).T
 
         # NOTE: The normal vector is based on the first cell in the mortar grid,
         # and will be pointing from that cell towards the other side of the

--- a/src/porepy/numerics/fv/biot.py
+++ b/src/porepy/numerics/fv/biot.py
@@ -1559,7 +1559,7 @@ class DivU(Discretization):
         if grid_swap:
             proj = mg.mortar_to_secondary_avg(nd=g.dim)
         else:
-            proj = mg.mortar_to_master_avg(nd=g.dim)
+            proj = mg.mortar_to_primary_avg(nd=g.dim)
 
         matrix_dictionary = data[pp.DISCRETIZATION_MATRICES][self.flow_keyword]
         biot_alpha = data[pp.PARAMETERS][self.flow_keyword]["biot_alpha"]

--- a/src/porepy/numerics/fv/biot.py
+++ b/src/porepy/numerics/fv/biot.py
@@ -1542,10 +1542,10 @@ class DivU(Discretization):
             data_edge (dictionary): Data dictionary for the edge in the
                 mixed-dimensional grid.
             grid_swap (boolean): If True, the grid g is identified with the @
-                slave side of the mortar grid in data_adge.
+                secondary side of the mortar grid in data_adge.
             cc (block matrix, 3x3): Block matrix for the coupling condition.
                 The first and second rows and columns are identified with the
-                master and slave side; the third belongs to the edge variable.
+                master and secondary side; the third belongs to the edge variable.
                 The discretization of the relevant term is done in-place in cc.
             matrix (block matrix 3x3): Discretization matrix for the edge and
                 the two adjacent nodes.
@@ -1602,10 +1602,10 @@ class DivU(Discretization):
             data_edge (dictionary): Data dictionary for the edge in the
                 mixed-dimensional grid.
             grid_swap (boolean): If True, the grid g is identified with the @
-                slave side of the mortar grid in data_adge.
+                secondary side of the mortar grid in data_adge.
             cc (block matrix, 3x3): Block matrix for the coupling condition.
                 The first and second rows and columns are identified with the
-                master and slave side; the third belongs to the edge variable.
+                master and secondary side; the third belongs to the edge variable.
                 The discretization of the relevant term is done in-place in cc.
             matrix (block matrix 3x3): Discretization matrix for the edge and
                 the two adjacent nodes.
@@ -1618,13 +1618,13 @@ class DivU(Discretization):
 
         # From the mortar displacements, we want to
         # 1) Take the jump between the two mortar sides,
-        # 2) Project to the slave grid and
+        # 2) Project to the secondary grid and
         # 3) Extract the normal component.
 
         # Define projections and rotations
         nd = g.dim + 1
         proj = mg.mortar_to_secondary_avg(nd=nd)
-        jump_on_slave = proj * mg.sign_of_mortar_sides(nd=nd)
+        jump_on_secondary = proj * mg.sign_of_mortar_sides(nd=nd)
         rotation = data_edge["tangential_normal_projection"]
         normal_component = rotation.project_normal(g.num_cells)
 
@@ -1632,9 +1632,9 @@ class DivU(Discretization):
         biot_alpha = data[pp.PARAMETERS].expand_scalars(
             g.num_cells, self.flow_keyword, ["biot_alpha"]
         )[0]
-        # Project the previous solution to the slave grid
+        # Project the previous solution to the secondary grid
         previous_displacement_jump_global_coord = (
-            jump_on_slave * data_edge[pp.STATE][self.mortar_variable]
+            jump_on_secondary * data_edge[pp.STATE][self.mortar_variable]
         )
         # Rotated displacement jumps. These are in the local coordinates, on
         # the lower-dimensional grid
@@ -1646,7 +1646,7 @@ class DivU(Discretization):
         # Finally, we integrate over the cell volume.
         vol = sps.dia_matrix((g.cell_volumes, 0), shape=(g.num_cells, g.num_cells))
         cc[self_ind, 2] += (
-            sps.diags(biot_alpha) * vol * normal_component * jump_on_slave
+            sps.diags(biot_alpha) * vol * normal_component * jump_on_secondary
         )
 
         # We assume implicit Euler in Biot, thus the div_u term appears

--- a/src/porepy/numerics/fv/biot.py
+++ b/src/porepy/numerics/fv/biot.py
@@ -1545,7 +1545,7 @@ class DivU(Discretization):
                 secondary side of the mortar grid in data_adge.
             cc (block matrix, 3x3): Block matrix for the coupling condition.
                 The first and second rows and columns are identified with the
-                master and secondary side; the third belongs to the edge variable.
+                primary and secondary side; the third belongs to the edge variable.
                 The discretization of the relevant term is done in-place in cc.
             matrix (block matrix 3x3): Discretization matrix for the edge and
                 the two adjacent nodes.
@@ -1605,7 +1605,7 @@ class DivU(Discretization):
                 secondary side of the mortar grid in data_adge.
             cc (block matrix, 3x3): Block matrix for the coupling condition.
                 The first and second rows and columns are identified with the
-                master and secondary side; the third belongs to the edge variable.
+                primary and secondary side; the third belongs to the edge variable.
                 The discretization of the relevant term is done in-place in cc.
             matrix (block matrix 3x3): Discretization matrix for the edge and
                 the two adjacent nodes.

--- a/src/porepy/numerics/fv/biot.py
+++ b/src/porepy/numerics/fv/biot.py
@@ -1557,7 +1557,7 @@ class DivU(Discretization):
         mg = data_edge["mortar_grid"]
 
         if grid_swap:
-            proj = mg.mortar_to_slave_avg(nd=g.dim)
+            proj = mg.mortar_to_secondary_avg(nd=g.dim)
         else:
             proj = mg.mortar_to_master_avg(nd=g.dim)
 
@@ -1623,7 +1623,7 @@ class DivU(Discretization):
 
         # Define projections and rotations
         nd = g.dim + 1
-        proj = mg.mortar_to_slave_avg(nd=nd)
+        proj = mg.mortar_to_secondary_avg(nd=nd)
         jump_on_slave = proj * mg.sign_of_mortar_sides(nd=nd)
         rotation = data_edge["tangential_normal_projection"]
         normal_component = rotation.project_normal(g.num_cells)

--- a/src/porepy/numerics/fv/fv_elliptic.py
+++ b/src/porepy/numerics/fv/fv_elliptic.py
@@ -248,7 +248,7 @@ class FVElliptic(pp.EllipticDiscretization):
         if use_slave_proj:
             proj = mg.mortar_to_secondary_int()
         else:
-            proj = mg.mortar_to_master_int()
+            proj = mg.mortar_to_primary_int()
 
         if g.dim > 0 and bound_flux.shape[0] != g.num_faces:
             # If bound flux is gven as sub-faces we have to map it from sub-faces
@@ -343,7 +343,7 @@ class FVElliptic(pp.EllipticDiscretization):
             proj_int = mg.mortar_to_secondary_int()
         else:
             proj = mg.master_to_mortar_avg()
-            proj_int = mg.mortar_to_master_int()
+            proj_int = mg.mortar_to_primary_int()
 
         cc[2, self_ind] += proj * matrix_dictionary[self.bound_pressure_cell_matrix_key]
         cc[2, 2] += (

--- a/src/porepy/numerics/fv/fv_elliptic.py
+++ b/src/porepy/numerics/fv/fv_elliptic.py
@@ -339,7 +339,7 @@ class FVElliptic(pp.EllipticDiscretization):
         parameter_dictionary = data[pp.PARAMETERS][self.keyword]
 
         if use_slave_proj:
-            proj = mg.slave_to_mortar_avg()
+            proj = mg.secondary_to_mortar_avg()
             proj_int = mg.mortar_to_secondary_int()
         else:
             proj = mg.primary_to_mortar_avg()
@@ -399,7 +399,7 @@ class FVElliptic(pp.EllipticDiscretization):
         parameter_dictionary = data[pp.PARAMETERS][self.keyword]
 
         if use_slave_proj:
-            proj = mg.slave_to_mortar_avg()
+            proj = mg.secondary_to_mortar_avg()
         else:
             proj = mg.primary_to_mortar_avg()
 
@@ -486,7 +486,7 @@ class FVElliptic(pp.EllipticDiscretization):
         """
         mg = data_edge["mortar_grid"]
 
-        proj = mg.slave_to_mortar_avg()
+        proj = mg.secondary_to_mortar_avg()
 
         cc[2, self_ind] -= proj
 

--- a/src/porepy/numerics/fv/fv_elliptic.py
+++ b/src/porepy/numerics/fv/fv_elliptic.py
@@ -246,7 +246,7 @@ class FVElliptic(pp.EllipticDiscretization):
         mg = data_edge["mortar_grid"]
 
         if use_slave_proj:
-            proj = mg.mortar_to_slave_int()
+            proj = mg.mortar_to_secondary_int()
         else:
             proj = mg.mortar_to_master_int()
 
@@ -295,7 +295,7 @@ class FVElliptic(pp.EllipticDiscretization):
         """
         mg = data_edge["mortar_grid"]
 
-        proj = mg.mortar_to_slave_int()
+        proj = mg.mortar_to_secondary_int()
 
         cc[self_ind, 2] -= proj
 
@@ -340,7 +340,7 @@ class FVElliptic(pp.EllipticDiscretization):
 
         if use_slave_proj:
             proj = mg.slave_to_mortar_avg()
-            proj_int = mg.mortar_to_slave_int()
+            proj_int = mg.mortar_to_secondary_int()
         else:
             proj = mg.master_to_mortar_avg()
             proj_int = mg.mortar_to_master_int()

--- a/src/porepy/numerics/fv/fv_elliptic.py
+++ b/src/porepy/numerics/fv/fv_elliptic.py
@@ -225,7 +225,7 @@ class FVElliptic(pp.EllipticDiscretization):
                 mixed-dimensional grid.
             cc (block matrix, 3x3): Block matrix for the coupling condition.
                 The first and second rows and columns are identified with the
-                master and secondary side; the third belongs to the edge variable.
+                primary and secondary side; the third belongs to the edge variable.
                 The discretization of the relevant term is done in-place in cc.
             matrix (block matrix 3x3): Discretization matrix for the edge and
                 the two adjacent nodes.
@@ -283,7 +283,7 @@ class FVElliptic(pp.EllipticDiscretization):
                 mixed-dimensional grid.
             cc (block matrix, 3x3): Block matrix for the coupling condition.
                 The first and second rows and columns are identified with the
-                master and secondary side; the third belongs to the edge variable.
+                primary and secondary side; the third belongs to the edge variable.
                 The discretization of the relevant term is done in-place in cc.
             matrix (block matrix 3x3): Discretization matrix for the edge and
                 the two adjacent nodes.
@@ -321,7 +321,7 @@ class FVElliptic(pp.EllipticDiscretization):
                 mixed-dimensional grid.
             cc (block matrix, 3x3): Block matrix for the coupling condition.
                 The first and second rows and columns are identified with the
-                master and secondary side; the third belongs to the edge variable.
+                primary and secondary side; the third belongs to the edge variable.
                 The discretization of the relevant term is done in-place in cc.
             matrix (block matrix 3x3): Discretization matrix for the edge and
                 the two adjacent nodes.
@@ -381,7 +381,7 @@ class FVElliptic(pp.EllipticDiscretization):
                 mixed-dimensional grid.
             cc (block matrix, 3x3): Block matrix for the coupling condition.
                 The first and second rows and columns are identified with the
-                master and secondary side; the third belongs to the edge variable.
+                primary and secondary side; the third belongs to the edge variable.
                 The discretization of the relevant term is done in-place in cc.
             matrix (block matrix 3x3): Discretization matrix for the edge and
                 the two adjacent nodes.
@@ -435,12 +435,12 @@ class FVElliptic(pp.EllipticDiscretization):
                 grid to the main grid.
             cc (block matrix, 3x3): Block matrix of size 3 x 3, whwere each block represents
                 coupling between variables on this interface. Index 0, 1 and 2
-                represent the master grid, the primary and secondary interface,
+                represent the primary grid, the primary and secondary interface,
                 respectively.
             matrix (block matrix 3x3): Discretization matrix for the edge and
                 the two adjacent nodes.
             rhs (block_array 3x1): Block matrix of size 3 x 1, representing the right hand
-                side of this coupling. Index 0, 1 and 2 represent the master grid,
+                side of this coupling. Index 0, 1 and 2 represent the primary grid,
                 the primary and secondary interface, respectively.
 
         """
@@ -475,7 +475,7 @@ class FVElliptic(pp.EllipticDiscretization):
                 mixed-dimensional grid.
             cc (block matrix, 3x3): Block matrix for the coupling condition.
                 The first and second rows and columns are identified with the
-                master and secondary side; the third belongs to the edge variable.
+                primary and secondary side; the third belongs to the edge variable.
                 The discretization of the relevant term is done in-place in cc.
             matrix (block matrix 3x3): Discretization matrix for the edge and
                 the two adjacent nodes.
@@ -519,7 +519,7 @@ class EllipticDiscretizationZeroPermeability(FVElliptic):
 
     NOTICE: There seems  no point in assigning this method as the higher-dimensional
     discretization. Accordingly, the methods for assembly of interface contributions
-    from the master side of a mortar grid are delibierately designed to fail.
+    from the primary side of a mortar grid are delibierately designed to fail.
 
     """
 
@@ -580,7 +580,7 @@ class EllipticDiscretizationZeroPermeability(FVElliptic):
                 mixed-dimensional grid.
             cc (block matrix, 3x3): Block matrix for the coupling condition.
                 The first and second rows and columns are identified with the
-                master and secondary side; the third belongs to the edge variable.
+                primary and secondary side; the third belongs to the edge variable.
                 The discretization of the relevant term is done in-place in cc.
             matrix (block matrix 3x3): Discretization matrix for the edge and
                 the two adjacent nodes.
@@ -615,7 +615,7 @@ class EllipticDiscretizationZeroPermeability(FVElliptic):
                 mixed-dimensional grid.
             cc (block matrix, 3x3): Block matrix for the coupling condition.
                 The first and second rows and columns are identified with the
-                master and secondary side; the third belongs to the edge variable.
+                primary and secondary side; the third belongs to the edge variable.
                 The discretization of the relevant term is done in-place in cc.
             matrix (block matrix 3x3): Discretization matrix for the edge and
                 the two adjacent nodes.

--- a/src/porepy/numerics/fv/fv_elliptic.py
+++ b/src/porepy/numerics/fv/fv_elliptic.py
@@ -204,7 +204,7 @@ class FVElliptic(pp.EllipticDiscretization):
         return -div * bound_flux * bc_val - div * vector_source_discr * vector_source
 
     def assemble_int_bound_flux(
-        self, g, data, data_edge, cc, matrix, rhs, self_ind, use_slave_proj=False
+        self, g, data, data_edge, cc, matrix, rhs, self_ind, use_secondary_proj=False
     ):
         """Assemble the contribution from an internal boundary, manifested as a
         flux boundary condition.
@@ -225,7 +225,7 @@ class FVElliptic(pp.EllipticDiscretization):
                 mixed-dimensional grid.
             cc (block matrix, 3x3): Block matrix for the coupling condition.
                 The first and second rows and columns are identified with the
-                master and slave side; the third belongs to the edge variable.
+                master and secondary side; the third belongs to the edge variable.
                 The discretization of the relevant term is done in-place in cc.
             matrix (block matrix 3x3): Discretization matrix for the edge and
                 the two adjacent nodes.
@@ -233,7 +233,7 @@ class FVElliptic(pp.EllipticDiscretization):
                 the two adjacent nodes.
             self_ind (int): Index in cc and matrix associated with this node.
                 Should be either 1 or 2.
-            use_slave_proj (boolean): If True, the slave side projection operator is
+            use_secondary_proj (boolean): If True, the secondary side projection operator is
                 used. Needed for periodic boundary conditions.
 
         """
@@ -245,7 +245,7 @@ class FVElliptic(pp.EllipticDiscretization):
         # Projection operators to grid
         mg = data_edge["mortar_grid"]
 
-        if use_slave_proj:
+        if use_secondary_proj:
             proj = mg.mortar_to_secondary_int()
         else:
             proj = mg.mortar_to_primary_int()
@@ -283,7 +283,7 @@ class FVElliptic(pp.EllipticDiscretization):
                 mixed-dimensional grid.
             cc (block matrix, 3x3): Block matrix for the coupling condition.
                 The first and second rows and columns are identified with the
-                master and slave side; the third belongs to the edge variable.
+                master and secondary side; the third belongs to the edge variable.
                 The discretization of the relevant term is done in-place in cc.
             matrix (block matrix 3x3): Discretization matrix for the edge and
                 the two adjacent nodes.
@@ -300,7 +300,7 @@ class FVElliptic(pp.EllipticDiscretization):
         cc[self_ind, 2] -= proj
 
     def assemble_int_bound_pressure_trace(
-        self, g, data, data_edge, cc, matrix, rhs, self_ind, use_slave_proj=False
+        self, g, data, data_edge, cc, matrix, rhs, self_ind, use_secondary_proj=False
     ):
         """Assemble the contribution from an internal
         boundary, manifested as a condition on the boundary pressure.
@@ -321,7 +321,7 @@ class FVElliptic(pp.EllipticDiscretization):
                 mixed-dimensional grid.
             cc (block matrix, 3x3): Block matrix for the coupling condition.
                 The first and second rows and columns are identified with the
-                master and slave side; the third belongs to the edge variable.
+                master and secondary side; the third belongs to the edge variable.
                 The discretization of the relevant term is done in-place in cc.
             matrix (block matrix 3x3): Discretization matrix for the edge and
                 the two adjacent nodes.
@@ -329,7 +329,7 @@ class FVElliptic(pp.EllipticDiscretization):
                 the two adjacent nodes.
             self_ind (int): Index in cc and matrix associated with this node.
                 Should be either 1 or 2.
-            use_slave_proj (boolean): If True, the slave side projection operator is
+            use_secondary_proj (boolean): If True, the secondary side projection operator is
                 used. Needed for periodic boundary conditions.
 
         """
@@ -338,7 +338,7 @@ class FVElliptic(pp.EllipticDiscretization):
         matrix_dictionary = data[pp.DISCRETIZATION_MATRICES][self.keyword]
         parameter_dictionary = data[pp.PARAMETERS][self.keyword]
 
-        if use_slave_proj:
+        if use_secondary_proj:
             proj = mg.secondary_to_mortar_avg()
             proj_int = mg.mortar_to_secondary_int()
         else:
@@ -366,7 +366,7 @@ class FVElliptic(pp.EllipticDiscretization):
         rhs[2] -= proj * vector_source_discr * vector_source
 
     def assemble_int_bound_pressure_trace_rhs(
-        self, g, data, data_edge, cc, rhs, self_ind, use_slave_proj=False
+        self, g, data, data_edge, cc, rhs, self_ind, use_secondary_proj=False
     ):
         """Assemble the rhs contribution from an internal
         boundary, manifested as a condition on the boundary pressure.
@@ -381,7 +381,7 @@ class FVElliptic(pp.EllipticDiscretization):
                 mixed-dimensional grid.
             cc (block matrix, 3x3): Block matrix for the coupling condition.
                 The first and second rows and columns are identified with the
-                master and slave side; the third belongs to the edge variable.
+                master and secondary side; the third belongs to the edge variable.
                 The discretization of the relevant term is done in-place in cc.
             matrix (block matrix 3x3): Discretization matrix for the edge and
                 the two adjacent nodes.
@@ -389,7 +389,7 @@ class FVElliptic(pp.EllipticDiscretization):
                 the two adjacent nodes.
             self_ind (int): Index in cc and matrix associated with this node.
                 Should be either 1 or 2.
-            use_slave_proj (boolean): If True, the slave side projection operator is
+            use_secondary_proj (boolean): If True, the secondary side projection operator is
                 used. Needed for periodic boundary conditions.
 
         """
@@ -398,7 +398,7 @@ class FVElliptic(pp.EllipticDiscretization):
         matrix_dictionary = data[pp.DISCRETIZATION_MATRICES][self.keyword]
         parameter_dictionary = data[pp.PARAMETERS][self.keyword]
 
-        if use_slave_proj:
+        if use_secondary_proj:
             proj = mg.secondary_to_mortar_avg()
         else:
             proj = mg.primary_to_mortar_avg()
@@ -475,7 +475,7 @@ class FVElliptic(pp.EllipticDiscretization):
                 mixed-dimensional grid.
             cc (block matrix, 3x3): Block matrix for the coupling condition.
                 The first and second rows and columns are identified with the
-                master and slave side; the third belongs to the edge variable.
+                master and secondary side; the third belongs to the edge variable.
                 The discretization of the relevant term is done in-place in cc.
             matrix (block matrix 3x3): Discretization matrix for the edge and
                 the two adjacent nodes.
@@ -563,7 +563,7 @@ class EllipticDiscretizationZeroPermeability(FVElliptic):
         return np.zeros(self.ndof(g))
 
     def assemble_int_bound_flux(
-        self, g, data, data_edge, cc, matrix, rhs, self_ind, use_slave_proj=False
+        self, g, data, data_edge, cc, matrix, rhs, self_ind, use_secondary_proj=False
     ):
         """Assemble the contribution from an internal boundary, manifested as a
         flux boundary condition.
@@ -580,7 +580,7 @@ class EllipticDiscretizationZeroPermeability(FVElliptic):
                 mixed-dimensional grid.
             cc (block matrix, 3x3): Block matrix for the coupling condition.
                 The first and second rows and columns are identified with the
-                master and slave side; the third belongs to the edge variable.
+                master and secondary side; the third belongs to the edge variable.
                 The discretization of the relevant term is done in-place in cc.
             matrix (block matrix 3x3): Discretization matrix for the edge and
                 the two adjacent nodes.
@@ -588,7 +588,7 @@ class EllipticDiscretizationZeroPermeability(FVElliptic):
                 the two adjacent nodes.
             self_ind (int): Index in cc and matrix associated with this node.
                 Should be either 1 or 2.
-            use_slave_proj (boolean): If True, the slave side projection operator is
+            use_secondary_proj (boolean): If True, the secondary side projection operator is
                 used. Needed for periodic boundary conditions.
 
         """
@@ -598,7 +598,7 @@ class EllipticDiscretizationZeroPermeability(FVElliptic):
         )
 
     def assemble_int_bound_pressure_trace(
-        self, g, data, data_edge, cc, matrix, rhs, self_ind, use_slave_proj=False
+        self, g, data, data_edge, cc, matrix, rhs, self_ind, use_secondary_proj=False
     ):
         """Assemble the contribution from an internal
         boundary, manifested as a condition on the boundary pressure.
@@ -615,7 +615,7 @@ class EllipticDiscretizationZeroPermeability(FVElliptic):
                 mixed-dimensional grid.
             cc (block matrix, 3x3): Block matrix for the coupling condition.
                 The first and second rows and columns are identified with the
-                master and slave side; the third belongs to the edge variable.
+                master and secondary side; the third belongs to the edge variable.
                 The discretization of the relevant term is done in-place in cc.
             matrix (block matrix 3x3): Discretization matrix for the edge and
                 the two adjacent nodes.
@@ -623,7 +623,7 @@ class EllipticDiscretizationZeroPermeability(FVElliptic):
                 the two adjacent nodes.
             self_ind (int): Index in cc and matrix associated with this node.
                 Should be either 1 or 2.
-            use_slave_proj (boolean): If True, the slave side projection operator is
+            use_secondary_proj (boolean): If True, the secondary side projection operator is
                 used. Needed for periodic boundary conditions.
 
         """

--- a/src/porepy/numerics/fv/fv_elliptic.py
+++ b/src/porepy/numerics/fv/fv_elliptic.py
@@ -342,7 +342,7 @@ class FVElliptic(pp.EllipticDiscretization):
             proj = mg.slave_to_mortar_avg()
             proj_int = mg.mortar_to_secondary_int()
         else:
-            proj = mg.master_to_mortar_avg()
+            proj = mg.primary_to_mortar_avg()
             proj_int = mg.mortar_to_primary_int()
 
         cc[2, self_ind] += proj * matrix_dictionary[self.bound_pressure_cell_matrix_key]
@@ -401,7 +401,7 @@ class FVElliptic(pp.EllipticDiscretization):
         if use_slave_proj:
             proj = mg.slave_to_mortar_avg()
         else:
-            proj = mg.master_to_mortar_avg()
+            proj = mg.primary_to_mortar_avg()
 
         # Add contribution from boundary conditions to the pressure at the fracture
         # faces. For TPFA this will be zero, but for MPFA we will get a contribution

--- a/src/porepy/numerics/fv/fvutils.py
+++ b/src/porepy/numerics/fv/fvutils.py
@@ -1832,7 +1832,7 @@ def compute_darcy_flux(
         bound_flux = d_h[pp.DISCRETIZATION_MATRICES][keyword]["bound_flux"]
         induced_flux = (
             bound_flux
-            * d["mortar_grid"].mortar_to_master_int()
+            * d["mortar_grid"].mortar_to_primary_int()
             * extract_variable(d, lam_name)
         )
         # Remove contribution directly on the boundary faces.

--- a/src/porepy/numerics/interface_laws/abstract_interface_law.py
+++ b/src/porepy/numerics/interface_laws/abstract_interface_law.py
@@ -64,9 +64,9 @@ class AbstractInterfaceLaw(abc.ABC):
 
         Parameters:
             g_h: Grid of the master domanin.
-            g_l: Grid of the slave domain.
+            g_l: Grid of the secondary domain.
             data_h: Data dictionary for the master domain.
-            data_l: Data dictionary for the slave domain.
+            data_l: Data dictionary for the secondary domain.
             data_edge: Data dictionary for the edge between the domains.
 
         """
@@ -96,9 +96,9 @@ class AbstractInterfaceLaw(abc.ABC):
 
         Parameters:
             g_h: Grid of the master domanin.
-            g_l: Grid of the slave domain.
+            g_l: Grid of the secondary domain.
             data_h: Data dictionary for the master domain.
-            data_l: Data dictionary for the slave domain.
+            data_l: Data dictionary for the secondary domain.
             data_edge: Data dictionary for the edge between the domains.
 
         """
@@ -108,9 +108,9 @@ class AbstractInterfaceLaw(abc.ABC):
     def assemble_matrix_rhs(
         self,
         g_master: pp.Grid,
-        g_slave: pp.Grid,
+        g_secondary: pp.Grid,
         data_master: Dict,
-        data_slave: Dict,
+        data_secondary: Dict,
         data_edge: Dict,
         matrix: np.ndarray,
     ) -> Union[np.ndarray, np.ndarray]:
@@ -121,19 +121,19 @@ class AbstractInterfaceLaw(abc.ABC):
 
         Parameters:
             g_master: Grid on one neighboring subdomain.
-            g_slave: Grid on the other neighboring subdomain.
+            g_secondary: Grid on the other neighboring subdomain.
             data_master: Data dictionary for the master suddomain
-            data_slave: Data dictionary for the slave subdomain.
+            data_secondary: Data dictionary for the secondary subdomain.
             data_edge: Data dictionary for the edge between the subdomains
             matrix_master: original discretization for the master subdomain
 
         Returns:
             np.array: Block matrix of size 3 x 3, whwere each block represents
                 coupling between variables on this interface. Index 0, 1 and 2
-                represent the master, slave and mortar variable, respectively.
+                represent the master, secondary and mortar variable, respectively.
             np.array: Block matrix of size 3 x 1, representing the right hand
                 side of this coupling. Index 0, 1 and 2 represent the master,
-                slave and mortar variable, respectively.
+                secondary and mortar variable, respectively.
 
         """
         pass
@@ -141,9 +141,9 @@ class AbstractInterfaceLaw(abc.ABC):
     def assemble_matrix(
         self,
         g_master: pp.Grid,
-        g_slave: pp.Grid,
+        g_secondary: pp.Grid,
         data_master: Dict,
-        data_slave: Dict,
+        data_secondary: Dict,
         data_edge: Dict,
         matrix: np.ndarray,
     ) -> np.ndarray:
@@ -156,29 +156,29 @@ class AbstractInterfaceLaw(abc.ABC):
 
         Parameters:
             g_master: Grid on one neighboring subdomain.
-            g_slave: Grid on the other neighboring subdomain.
+            g_secondary: Grid on the other neighboring subdomain.
             data_master: Data dictionary for the master suddomain
-            data_slave: Data dictionary for the slave subdomain.
+            data_secondary: Data dictionary for the secondary subdomain.
             data_edge: Data dictionary for the edge between the subdomains
             matrix_master: original discretization for the master subdomain
 
         Returns:
             np.array: Block matrix of size 3 x 3, whwere each block represents
                 coupling between variables on this interface. Index 0, 1 and 2
-                represent the master, slave and mortar variable, respectively.
+                represent the master, secondary and mortar variable, respectively.
 
         """
         A, _ = self.assemble_matrix_rhs(
-            g_master, g_slave, data_master, data_slave, data_edge, matrix
+            g_master, g_secondary, data_master, data_secondary, data_edge, matrix
         )
         return A
 
     def assemble_rhs(
         self,
         g_master: pp.Grid,
-        g_slave: pp.Grid,
+        g_secondary: pp.Grid,
         data_master: Dict,
-        data_slave: Dict,
+        data_secondary: Dict,
         data_edge: Dict,
         matrix: np.ndarray,
     ) -> np.ndarray:
@@ -191,65 +191,65 @@ class AbstractInterfaceLaw(abc.ABC):
 
         Parameters:
             g_master: Grid on one neighboring subdomain.
-            g_slave: Grid on the other neighboring subdomain.
+            g_secondary: Grid on the other neighboring subdomain.
             data_master: Data dictionary for the master suddomain
-            data_slave: Data dictionary for the slave subdomain.
+            data_secondary: Data dictionary for the secondary subdomain.
             data_edge: Data dictionary for the edge between the subdomains
             matrix_master: original discretization for the master subdomain
 
         Returns:
             np.array: Block matrix of size 3 x 3, whwere each block represents
                 coupling between variables on this interface. Index 0, 1 and 2
-                represent the master, slave and mortar variable, respectively.
+                represent the master, secondary and mortar variable, respectively.
 
         """
         _, b = self.assemble_matrix_rhs(
-            g_master, g_slave, data_master, data_slave, data_edge, matrix
+            g_master, g_secondary, data_master, data_secondary, data_edge, matrix
         )
         return b
 
     def _define_local_block_matrix(
         self,
         g_master: pp.Grid,
-        g_slave: pp.Grid,
+        g_secondary: pp.Grid,
         discr_master: Discretization,
-        discr_slave: Discretization,
+        discr_secondary: Discretization,
         mg: pp.MortarGrid,
         matrix: np.ndarray,
     ) -> Union[np.ndarray, np.ndarray]:
         """Initialize a block matrix and right hand side for the local linear
-        system of the master and slave grid and the interface.
+        system of the master and secondary grid and the interface.
 
         The generated block matrix is 3x3, where each block is initialized as
         a sparse matrix with size corresponding to the number of dofs for
-        the master, slave and mortar variables for this interface law.
+        the master, secondary and mortar variables for this interface law.
 
         Parameters:
             g_master: Grid on one neighboring subdomain.
-            g_slave: Grid on the other neighboring subdomain.
+            g_secondary: Grid on the other neighboring subdomain.
             data_master: Data dictionary for the master suddomain
-            data_slave: Data dictionary for the slave subdomain.
+            data_secondary: Data dictionary for the secondary subdomain.
             data_edge: Data dictionary for the edge between the subdomains
             matrix_master: original discretization for the master subdomain
 
         Returns:
             np.array: Block matrix of size 3 x 3, whwere each block represents
                 coupling between variables on this interface. Index 0, 1 and 2
-                represent the master, slave and mortar variable, respectively.
+                represent the master, secondary and mortar variable, respectively.
                 Each of the blocks have an empty sparse matrix with size
                 corresponding to the number of dofs of the grid and variable.
             np.array: Block matrix of size 3 x 1, representing the right hand
                 side of this coupling. Index 0, 1 and 2 represent the master,
-                slave and mortar variable, respectively.
+                secondary and mortar variable, respectively.
 
         """
 
         master_ind = 0
-        slave_ind = 1
+        secondary_ind = 1
         mortar_ind = 2
 
         dof_master = discr_master.ndof(g_master)
-        dof_slave = discr_slave.ndof(g_slave)
+        dof_secondary = discr_secondary.ndof(g_secondary)
         dof_mortar = self.ndof(mg)
 
         if not dof_master == matrix[master_ind, master_ind].shape[1]:
@@ -258,9 +258,9 @@ class AbstractInterfaceLaw(abc.ABC):
             in the coupling discretization must match the number of dofs given by the matrix
             """
             )
-        elif not dof_slave == matrix[master_ind, slave_ind].shape[1]:
+        elif not dof_secondary == matrix[master_ind, secondary_ind].shape[1]:
             raise ValueError(
-                """The number of dofs of the slave discretization given
+                """The number of dofs of the secondary discretization given
             in the coupling discretization must match the number of dofs given by the matrix
             """
             )
@@ -270,16 +270,16 @@ class AbstractInterfaceLaw(abc.ABC):
             in the coupling discretization must match the number of dofs given by the matrix
             """
             )
-        # We know the number of dofs from the master and slave side from their
+        # We know the number of dofs from the master and secondary side from their
         # discretizations
-        dof = np.array([dof_master, dof_slave, dof_mortar])
+        dof = np.array([dof_master, dof_secondary, dof_mortar])
         cc = np.array([sps.coo_matrix((i, j)) for i in dof for j in dof])
         cc = cc.reshape((3, 3))
 
         # The rhs is just zeros
         rhs = np.empty(3, dtype=np.object)
         rhs[master_ind] = np.zeros(dof_master)
-        rhs[slave_ind] = np.zeros(dof_slave)
+        rhs[secondary_ind] = np.zeros(dof_secondary)
         rhs[mortar_ind] = np.zeros(dof_mortar)
 
         return cc, rhs
@@ -293,29 +293,29 @@ class AbstractInterfaceLaw(abc.ABC):
         matrix: np.ndarray,
     ) -> Union[np.ndarray, np.ndarray]:
         """Initialize a block matrix and right hand side for the local linear
-        system of the master and slave grid and the interface.
+        system of the master and secondary grid and the interface.
 
         The generated block matrix is 3x3, where each block is initialized as
         a sparse matrix with size corresponding to the number of dofs for
-        the master, slave and mortar variables for this interface law.
+        the master, secondary and mortar variables for this interface law.
 
         Parameters:
             g_master: Grid on one neighboring subdomain.
-            g_slave: Grid on the other neighboring subdomain.
+            g_secondary: Grid on the other neighboring subdomain.
             data_master: Data dictionary for the master suddomain
-            data_slave: Data dictionary for the slave subdomain.
+            data_secondary: Data dictionary for the secondary subdomain.
             data_edge: Data dictionary for the edge between the subdomains
             matrix_master: original discretization for the master subdomain
 
         Returns:
             np.array: Block matrix of size 3 x 3, whwere each block represents
                 coupling between variables on this interface. Index 0, 1 and 2
-                represent the master, slave and mortar variable, respectively.
+                represent the master, secondary and mortar variable, respectively.
                 Each of the blocks have an empty sparse matrix with size
                 corresponding to the number of dofs of the grid and variable.
             np.array: Block matrix of size 3 x 1, representing the right hand
                 side of this coupling. Index 0, 1 and 2 represent the master,
-                slave and mortar variable, respectively.
+                secondary and mortar variable, respectively.
 
         """
 
@@ -335,7 +335,7 @@ class AbstractInterfaceLaw(abc.ABC):
             )
         elif not dof_mortar_primary == matrix[grid_ind, primary_ind].shape[1]:
             raise ValueError(
-                """The number of dofs of the slave discretization given
+                """The number of dofs of the secondary discretization given
             in the coupling discretization must match the number of dofs given by the matrix
             """
             )
@@ -345,7 +345,7 @@ class AbstractInterfaceLaw(abc.ABC):
             in the coupling discretization must match the number of dofs given by the matrix
             """
             )
-        # We know the number of dofs from the master and slave side from their
+        # We know the number of dofs from the master and secondary side from their
         # discretizations
         dof = np.array([dof_grid, dof_mortar_primary, dof_mortar_secondary])
         cc = np.array([sps.coo_matrix((i, j)) for i in dof for j in dof])
@@ -456,10 +456,10 @@ class AbstractInterfaceLaw(abc.ABC):
         Returns:
             np.array: Block matrix of size 3 x 3, whwere each block represents
                 coupling between variables on this interface. Index 0, 1 and 2
-                represent the master, slave and mortar variable, respectively.
+                represent the master, secondary and mortar variable, respectively.
             np.array: Block matrix of size 3 x 1, representing the right hand
                 side of this coupling. Index 0, 1 and 2 represent the master,
-                slave and mortar variable, respectively.
+                secondary and mortar variable, respectively.
 
         """
         if self.edge_coupling_via_low_dim:

--- a/src/porepy/numerics/interface_laws/abstract_interface_law.py
+++ b/src/porepy/numerics/interface_laws/abstract_interface_law.py
@@ -63,9 +63,9 @@ class AbstractInterfaceLaw(abc.ABC):
         interface.
 
         Parameters:
-            g_h: Grid of the master domanin.
+            g_h: Grid of the primary domanin.
             g_l: Grid of the secondary domain.
-            data_h: Data dictionary for the master domain.
+            data_h: Data dictionary for the primary domain.
             data_l: Data dictionary for the secondary domain.
             data_edge: Data dictionary for the edge between the domains.
 
@@ -95,9 +95,9 @@ class AbstractInterfaceLaw(abc.ABC):
 
 
         Parameters:
-            g_h: Grid of the master domanin.
+            g_h: Grid of the primary domanin.
             g_l: Grid of the secondary domain.
-            data_h: Data dictionary for the master domain.
+            data_h: Data dictionary for the primary domain.
             data_l: Data dictionary for the secondary domain.
             data_edge: Data dictionary for the edge between the domains.
 
@@ -107,9 +107,9 @@ class AbstractInterfaceLaw(abc.ABC):
     @abc.abstractmethod
     def assemble_matrix_rhs(
         self,
-        g_master: pp.Grid,
+        g_primary: pp.Grid,
         g_secondary: pp.Grid,
-        data_master: Dict,
+        data_primary: Dict,
         data_secondary: Dict,
         data_edge: Dict,
         matrix: np.ndarray,
@@ -120,19 +120,19 @@ class AbstractInterfaceLaw(abc.ABC):
         The matrix will be
 
         Parameters:
-            g_master: Grid on one neighboring subdomain.
+            g_primary: Grid on one neighboring subdomain.
             g_secondary: Grid on the other neighboring subdomain.
-            data_master: Data dictionary for the master suddomain
+            data_primary: Data dictionary for the primary suddomain
             data_secondary: Data dictionary for the secondary subdomain.
             data_edge: Data dictionary for the edge between the subdomains
-            matrix_master: original discretization for the master subdomain
+            matrix_primary: original discretization for the primary subdomain
 
         Returns:
             np.array: Block matrix of size 3 x 3, whwere each block represents
                 coupling between variables on this interface. Index 0, 1 and 2
-                represent the master, secondary and mortar variable, respectively.
+                represent the primary, secondary and mortar variable, respectively.
             np.array: Block matrix of size 3 x 1, representing the right hand
-                side of this coupling. Index 0, 1 and 2 represent the master,
+                side of this coupling. Index 0, 1 and 2 represent the primary,
                 secondary and mortar variable, respectively.
 
         """
@@ -140,9 +140,9 @@ class AbstractInterfaceLaw(abc.ABC):
 
     def assemble_matrix(
         self,
-        g_master: pp.Grid,
+        g_primary: pp.Grid,
         g_secondary: pp.Grid,
-        data_master: Dict,
+        data_primary: Dict,
         data_secondary: Dict,
         data_edge: Dict,
         matrix: np.ndarray,
@@ -155,29 +155,29 @@ class AbstractInterfaceLaw(abc.ABC):
         by some discretization methods.
 
         Parameters:
-            g_master: Grid on one neighboring subdomain.
+            g_primary: Grid on one neighboring subdomain.
             g_secondary: Grid on the other neighboring subdomain.
-            data_master: Data dictionary for the master suddomain
+            data_primary: Data dictionary for the primary suddomain
             data_secondary: Data dictionary for the secondary subdomain.
             data_edge: Data dictionary for the edge between the subdomains
-            matrix_master: original discretization for the master subdomain
+            matrix_primary: original discretization for the primary subdomain
 
         Returns:
             np.array: Block matrix of size 3 x 3, whwere each block represents
                 coupling between variables on this interface. Index 0, 1 and 2
-                represent the master, secondary and mortar variable, respectively.
+                represent the primary, secondary and mortar variable, respectively.
 
         """
         A, _ = self.assemble_matrix_rhs(
-            g_master, g_secondary, data_master, data_secondary, data_edge, matrix
+            g_primary, g_secondary, data_primary, data_secondary, data_edge, matrix
         )
         return A
 
     def assemble_rhs(
         self,
-        g_master: pp.Grid,
+        g_primary: pp.Grid,
         g_secondary: pp.Grid,
-        data_master: Dict,
+        data_primary: Dict,
         data_secondary: Dict,
         data_edge: Dict,
         matrix: np.ndarray,
@@ -190,95 +190,95 @@ class AbstractInterfaceLaw(abc.ABC):
         by some discretization methods.
 
         Parameters:
-            g_master: Grid on one neighboring subdomain.
+            g_primary: Grid on one neighboring subdomain.
             g_secondary: Grid on the other neighboring subdomain.
-            data_master: Data dictionary for the master suddomain
+            data_primary: Data dictionary for the primary suddomain
             data_secondary: Data dictionary for the secondary subdomain.
             data_edge: Data dictionary for the edge between the subdomains
-            matrix_master: original discretization for the master subdomain
+            matrix_primary: original discretization for the primary subdomain
 
         Returns:
             np.array: Block matrix of size 3 x 3, whwere each block represents
                 coupling between variables on this interface. Index 0, 1 and 2
-                represent the master, secondary and mortar variable, respectively.
+                represent the primary, secondary and mortar variable, respectively.
 
         """
         _, b = self.assemble_matrix_rhs(
-            g_master, g_secondary, data_master, data_secondary, data_edge, matrix
+            g_primary, g_secondary, data_primary, data_secondary, data_edge, matrix
         )
         return b
 
     def _define_local_block_matrix(
         self,
-        g_master: pp.Grid,
+        g_primary: pp.Grid,
         g_secondary: pp.Grid,
-        discr_master: Discretization,
+        discr_primary: Discretization,
         discr_secondary: Discretization,
         mg: pp.MortarGrid,
         matrix: np.ndarray,
     ) -> Union[np.ndarray, np.ndarray]:
         """Initialize a block matrix and right hand side for the local linear
-        system of the master and secondary grid and the interface.
+        system of the primary and secondary grid and the interface.
 
         The generated block matrix is 3x3, where each block is initialized as
         a sparse matrix with size corresponding to the number of dofs for
-        the master, secondary and mortar variables for this interface law.
+        the primary, secondary and mortar variables for this interface law.
 
         Parameters:
-            g_master: Grid on one neighboring subdomain.
+            g_primary: Grid on one neighboring subdomain.
             g_secondary: Grid on the other neighboring subdomain.
-            data_master: Data dictionary for the master suddomain
+            data_primary: Data dictionary for the primary suddomain
             data_secondary: Data dictionary for the secondary subdomain.
             data_edge: Data dictionary for the edge between the subdomains
-            matrix_master: original discretization for the master subdomain
+            matrix_primary: original discretization for the primary subdomain
 
         Returns:
             np.array: Block matrix of size 3 x 3, whwere each block represents
                 coupling between variables on this interface. Index 0, 1 and 2
-                represent the master, secondary and mortar variable, respectively.
+                represent the primary, secondary and mortar variable, respectively.
                 Each of the blocks have an empty sparse matrix with size
                 corresponding to the number of dofs of the grid and variable.
             np.array: Block matrix of size 3 x 1, representing the right hand
-                side of this coupling. Index 0, 1 and 2 represent the master,
+                side of this coupling. Index 0, 1 and 2 represent the primary,
                 secondary and mortar variable, respectively.
 
         """
 
-        master_ind = 0
+        primary_ind = 0
         secondary_ind = 1
         mortar_ind = 2
 
-        dof_master = discr_master.ndof(g_master)
+        dof_primary = discr_primary.ndof(g_primary)
         dof_secondary = discr_secondary.ndof(g_secondary)
         dof_mortar = self.ndof(mg)
 
-        if not dof_master == matrix[master_ind, master_ind].shape[1]:
+        if not dof_primary == matrix[primary_ind, primary_ind].shape[1]:
             raise ValueError(
-                """The number of dofs of the master discretization given
+                """The number of dofs of the primary discretization given
             in the coupling discretization must match the number of dofs given by the matrix
             """
             )
-        elif not dof_secondary == matrix[master_ind, secondary_ind].shape[1]:
+        elif not dof_secondary == matrix[primary_ind, secondary_ind].shape[1]:
             raise ValueError(
                 """The number of dofs of the secondary discretization given
             in the coupling discretization must match the number of dofs given by the matrix
             """
             )
-        elif not self.ndof(mg) == matrix[master_ind, mortar_ind].shape[1]:
+        elif not self.ndof(mg) == matrix[primary_ind, mortar_ind].shape[1]:
             raise ValueError(
                 """The number of dofs of the edge discretization given
             in the coupling discretization must match the number of dofs given by the matrix
             """
             )
-        # We know the number of dofs from the master and secondary side from their
+        # We know the number of dofs from the primary and secondary side from their
         # discretizations
-        dof = np.array([dof_master, dof_secondary, dof_mortar])
+        dof = np.array([dof_primary, dof_secondary, dof_mortar])
         cc = np.array([sps.coo_matrix((i, j)) for i in dof for j in dof])
         cc = cc.reshape((3, 3))
 
         # The rhs is just zeros
         rhs = np.empty(3, dtype=np.object)
-        rhs[master_ind] = np.zeros(dof_master)
+        rhs[primary_ind] = np.zeros(dof_primary)
         rhs[secondary_ind] = np.zeros(dof_secondary)
         rhs[mortar_ind] = np.zeros(dof_mortar)
 
@@ -293,28 +293,28 @@ class AbstractInterfaceLaw(abc.ABC):
         matrix: np.ndarray,
     ) -> Union[np.ndarray, np.ndarray]:
         """Initialize a block matrix and right hand side for the local linear
-        system of the master and secondary grid and the interface.
+        system of the primary and secondary grid and the interface.
 
         The generated block matrix is 3x3, where each block is initialized as
         a sparse matrix with size corresponding to the number of dofs for
-        the master, secondary and mortar variables for this interface law.
+        the primary, secondary and mortar variables for this interface law.
 
         Parameters:
-            g_master: Grid on one neighboring subdomain.
+            g_primary: Grid on one neighboring subdomain.
             g_secondary: Grid on the other neighboring subdomain.
-            data_master: Data dictionary for the master suddomain
+            data_primary: Data dictionary for the primary suddomain
             data_secondary: Data dictionary for the secondary subdomain.
             data_edge: Data dictionary for the edge between the subdomains
-            matrix_master: original discretization for the master subdomain
+            matrix_primary: original discretization for the primary subdomain
 
         Returns:
             np.array: Block matrix of size 3 x 3, whwere each block represents
                 coupling between variables on this interface. Index 0, 1 and 2
-                represent the master, secondary and mortar variable, respectively.
+                represent the primary, secondary and mortar variable, respectively.
                 Each of the blocks have an empty sparse matrix with size
                 corresponding to the number of dofs of the grid and variable.
             np.array: Block matrix of size 3 x 1, representing the right hand
-                side of this coupling. Index 0, 1 and 2 represent the master,
+                side of this coupling. Index 0, 1 and 2 represent the primary,
                 secondary and mortar variable, respectively.
 
         """
@@ -329,7 +329,7 @@ class AbstractInterfaceLaw(abc.ABC):
 
         if not dof_grid == matrix[grid_ind, grid_ind].shape[1]:
             raise ValueError(
-                """The number of dofs of the master discretization given
+                """The number of dofs of the primary discretization given
             in the coupling discretization must match the number of dofs given by the matrix
             """
             )
@@ -345,7 +345,7 @@ class AbstractInterfaceLaw(abc.ABC):
             in the coupling discretization must match the number of dofs given by the matrix
             """
             )
-        # We know the number of dofs from the master and secondary side from their
+        # We know the number of dofs from the primary and secondary side from their
         # discretizations
         dof = np.array([dof_grid, dof_mortar_primary, dof_mortar_secondary])
         cc = np.array([sps.coo_matrix((i, j)) for i in dof for j in dof])
@@ -401,10 +401,10 @@ class AbstractInterfaceLaw(abc.ABC):
         Returns:
             np.array: Block matrix of size 3 x 3, whwere each block represents
                 coupling between variables on this interface. Index 0, 1 and 2
-                represent the master grid, the primary and secondary interface,
+                represent the primary grid, the primary and secondary interface,
                 respectively.
             np.array: Block matrix of size 3 x 1, representing the right hand
-                side of this coupling. Index 0, 1 and 2 represent the master grid,
+                side of this coupling. Index 0, 1 and 2 represent the primary grid,
                 the primary and secondary interface, respectively.
 
         """
@@ -456,9 +456,9 @@ class AbstractInterfaceLaw(abc.ABC):
         Returns:
             np.array: Block matrix of size 3 x 3, whwere each block represents
                 coupling between variables on this interface. Index 0, 1 and 2
-                represent the master, secondary and mortar variable, respectively.
+                represent the primary, secondary and mortar variable, respectively.
             np.array: Block matrix of size 3 x 1, representing the right hand
-                side of this coupling. Index 0, 1 and 2 represent the master,
+                side of this coupling. Index 0, 1 and 2 represent the primary,
                 secondary and mortar variable, respectively.
 
         """

--- a/src/porepy/numerics/interface_laws/cell_dof_face_dof_map.py
+++ b/src/porepy/numerics/interface_laws/cell_dof_face_dof_map.py
@@ -146,7 +146,7 @@ class CellDofFaceDofMap(object):
         return np.zeros(self.ndof(g))
 
     def assemble_int_bound_flux(
-        self, g, data, data_edge, cc, matrix, rhs, self_ind, use_slave_proj
+        self, g, data, data_edge, cc, matrix, rhs, self_ind, use_secondary_proj
     ):
         """Abstract method. Assemble the contribution from an internal
         boundary, manifested as a flux boundary condition.
@@ -167,7 +167,7 @@ class CellDofFaceDofMap(object):
                 mixed-dimensional grid.
             cc (block matrix, 3x3): Block matrix for the coupling condition.
                 The first and second rows and columns are identified with the
-                master and slave side; the third belongs to the edge variable.
+                master and secondary side; the third belongs to the edge variable.
                 The discretization of the relevant term is done in-place in cc.
             matrix (block matrix 3x3): Discretization matrix for the edge and
                 the two adjacent nodes.
@@ -175,7 +175,7 @@ class CellDofFaceDofMap(object):
                 the two adjacent nodes.
             self_ind (int): Index in cc and matrix associated with this node.
                 Should be either 1 or 2.
-            use_slave_proj (boolean): If True, the slave side projection operator is
+            use_secondary_proj (boolean): If True, the secondary side projection operator is
                 used. Needed for periodic boundary conditions.
 
         """
@@ -201,7 +201,7 @@ class CellDofFaceDofMap(object):
                 mixed-dimensional grid.
             cc (block matrix, 3x3): Block matrix for the coupling condition.
                 The first and second rows and columns are identified with the
-                master and slave side; the third belongs to the edge variable.
+                master and secondary side; the third belongs to the edge variable.
                 The discretization of the relevant term is done in-place in cc.
             matrix (block matrix 3x3): Discretization matrix for the edge and
                 the two adjacent nodes.
@@ -218,7 +218,7 @@ class CellDofFaceDofMap(object):
         cc[self_ind, 2] -= proj.T
 
     def assemble_int_bound_pressure_trace(
-        self, g, data, data_edge, cc, matrix, rhs, self_ind, use_slave_proj
+        self, g, data, data_edge, cc, matrix, rhs, self_ind, use_secondary_proj
     ):
         """Abstract method. Assemble the contribution from an internal
         boundary, manifested as a condition on the boundary pressure.
@@ -239,7 +239,7 @@ class CellDofFaceDofMap(object):
                 mixed-dimensional grid.
             cc (block matrix, 3x3): Block matrix for the coupling condition.
                 The first and second rows and columns are identified with the
-                master and slave side; the third belongs to the edge variable.
+                master and secondary side; the third belongs to the edge variable.
                 The discretization of the relevant term is done in-place in cc.
             matrix (block matrix 3x3): Discretization matrix for the edge and
                 the two adjacent nodes.
@@ -247,7 +247,7 @@ class CellDofFaceDofMap(object):
                 the two adjacent nodes.
             self_ind (int): Index in cc and matrix associated with this node.
                 Should be either 1 or 2.
-            use_slave_proj (boolean): If True, the slave side projection operator is
+            use_secondary_proj (boolean): If True, the secondary side projection operator is
                 used. Needed for periodic boundary conditions.
 
         """
@@ -275,7 +275,7 @@ class CellDofFaceDofMap(object):
                 mixed-dimensional grid.
             cc (block matrix, 3x3): Block matrix for the coupling condition.
                 The first and second rows and columns are identified with the
-                master and slave side; the third belongs to the edge variable.
+                master and secondary side; the third belongs to the edge variable.
                 The discretization of the relevant term is done in-place in cc.
             matrix (block matrix 3x3): Discretization matrix for the edge and
                 the two adjacent nodes.

--- a/src/porepy/numerics/interface_laws/cell_dof_face_dof_map.py
+++ b/src/porepy/numerics/interface_laws/cell_dof_face_dof_map.py
@@ -167,7 +167,7 @@ class CellDofFaceDofMap(object):
                 mixed-dimensional grid.
             cc (block matrix, 3x3): Block matrix for the coupling condition.
                 The first and second rows and columns are identified with the
-                master and secondary side; the third belongs to the edge variable.
+                primary and secondary side; the third belongs to the edge variable.
                 The discretization of the relevant term is done in-place in cc.
             matrix (block matrix 3x3): Discretization matrix for the edge and
                 the two adjacent nodes.
@@ -201,7 +201,7 @@ class CellDofFaceDofMap(object):
                 mixed-dimensional grid.
             cc (block matrix, 3x3): Block matrix for the coupling condition.
                 The first and second rows and columns are identified with the
-                master and secondary side; the third belongs to the edge variable.
+                primary and secondary side; the third belongs to the edge variable.
                 The discretization of the relevant term is done in-place in cc.
             matrix (block matrix 3x3): Discretization matrix for the edge and
                 the two adjacent nodes.
@@ -239,7 +239,7 @@ class CellDofFaceDofMap(object):
                 mixed-dimensional grid.
             cc (block matrix, 3x3): Block matrix for the coupling condition.
                 The first and second rows and columns are identified with the
-                master and secondary side; the third belongs to the edge variable.
+                primary and secondary side; the third belongs to the edge variable.
                 The discretization of the relevant term is done in-place in cc.
             matrix (block matrix 3x3): Discretization matrix for the edge and
                 the two adjacent nodes.
@@ -275,7 +275,7 @@ class CellDofFaceDofMap(object):
                 mixed-dimensional grid.
             cc (block matrix, 3x3): Block matrix for the coupling condition.
                 The first and second rows and columns are identified with the
-                master and secondary side; the third belongs to the edge variable.
+                primary and secondary side; the third belongs to the edge variable.
                 The discretization of the relevant term is done in-place in cc.
             matrix (block matrix 3x3): Discretization matrix for the edge and
                 the two adjacent nodes.
@@ -291,7 +291,7 @@ class CellDofFaceDofMap(object):
 
         cc[2, self_ind] -= proj
 
-    def enforce_neumann_int_bound(self, g_master, data_edge, matrix, self_ind):
+    def enforce_neumann_int_bound(self, g_primary, data_edge, matrix, self_ind):
         """Enforce Neumann boundary conditions on a given system matrix.
 
         Methods based on a mixed variational form will need this function to

--- a/src/porepy/numerics/interface_laws/cell_dof_face_dof_map.py
+++ b/src/porepy/numerics/interface_laws/cell_dof_face_dof_map.py
@@ -213,7 +213,7 @@ class CellDofFaceDofMap(object):
         """
         mg = data_edge["mortar_grid"]
 
-        proj = mg.slave_to_mortar_avg()
+        proj = mg.secondary_to_mortar_avg()
 
         cc[self_ind, 2] -= proj.T
 
@@ -287,7 +287,7 @@ class CellDofFaceDofMap(object):
         """
         mg = data_edge["mortar_grid"]
 
-        proj = mg.slave_to_mortar_avg()
+        proj = mg.secondary_to_mortar_avg()
 
         cc[2, self_ind] -= proj
 

--- a/src/porepy/numerics/interface_laws/contact_mechanics_interface_laws.py
+++ b/src/porepy/numerics/interface_laws/contact_mechanics_interface_laws.py
@@ -174,7 +174,7 @@ class PrimalContactCoupling(
         cc[slave_ind, mortar_ind] = (
             displacement_jump_discr
             * projection.project_tangential_normal(g_slave.num_cells)
-            * mg.mortar_to_slave_avg(nd=ambient_dimension)
+            * mg.mortar_to_secondary_avg(nd=ambient_dimension)
             * mg.sign_of_mortar_sides(nd=ambient_dimension)
         )
 
@@ -186,7 +186,7 @@ class PrimalContactCoupling(
         ].copy()
         rotated_jumps = (
             projection.project_tangential_normal(g_slave.num_cells)
-            * mg.mortar_to_slave_avg(nd=ambient_dimension)
+            * mg.mortar_to_secondary_avg(nd=ambient_dimension)
             * mg.sign_of_mortar_sides(nd=ambient_dimension)
             * previous_time_step_displacements
         )

--- a/src/porepy/numerics/interface_laws/contact_mechanics_interface_laws.py
+++ b/src/porepy/numerics/interface_laws/contact_mechanics_interface_laws.py
@@ -211,7 +211,7 @@ class PrimalContactCoupling(
         # switch direction of the stress on boundary for the higher dimensional domain: The
         # contact forces are defined as negative in contact, whereas the sign of the higher
         # dimensional stresses are defined according to the direction of the normal vector.
-        faces_on_fracture_surface = mg.master_to_mortar_int().tocsr().indices
+        faces_on_fracture_surface = mg.primary_to_mortar_int().tocsr().indices
         sign_switcher = pp.grid_utils.switch_sign_if_inwards_normal(
             g_master, ambient_dimension, faces_on_fracture_surface
         )
@@ -222,14 +222,14 @@ class PrimalContactCoupling(
         # Switch the direction of the vectors to obtain the traction as defined
         # by the outwards pointing normal vector.
         traction_from_master = (
-            mg.master_to_mortar_int(nd=ambient_dimension)
+            mg.primary_to_mortar_int(nd=ambient_dimension)
             * sign_switcher
             * master_stress
         )
         cc[mortar_ind, master_ind] = traction_from_master
         # Stress contribution from boundary conditions.
         rhs[mortar_ind] = -(
-            mg.master_to_mortar_int(nd=ambient_dimension)
+            mg.primary_to_mortar_int(nd=ambient_dimension)
             * sign_switcher
             * master_bound_stress
             * master_bc_values
@@ -240,7 +240,7 @@ class PrimalContactCoupling(
         # Switch the direction of the vectors, so that for all faces, a positive
         # force points into the fracture surface.
         traction_from_mortar = (
-            mg.master_to_mortar_int(nd=ambient_dimension)
+            mg.primary_to_mortar_int(nd=ambient_dimension)
             * sign_switcher
             * master_bound_stress
             * mg.mortar_to_primary_avg(nd=ambient_dimension)
@@ -321,13 +321,13 @@ class PrimalContactCoupling(
         # Ambient dimension.
         Nd = g_between.dim
 
-        faces_on_fracture_surface = mg_prim.master_to_mortar_int().tocsr().indices
+        faces_on_fracture_surface = mg_prim.primary_to_mortar_int().tocsr().indices
         sign_switcher = pp.grid_utils.switch_sign_if_inwards_normal(
             g_between, Nd, faces_on_fracture_surface
         )
 
         proj_sec = mg_sec.mortar_to_primary_avg(nd=Nd)
-        proj_prim = mg_prim.master_to_mortar_int(nd=Nd)
+        proj_prim = mg_prim.primary_to_mortar_int(nd=Nd)
 
         # Discretization of boundary conditions
         bound_stress = data_between[pp.DISCRETIZATION_MATRICES][
@@ -443,7 +443,7 @@ class MatrixScalarToForceBalance(
         # A diagonal operator is needed to switch the sign of vectors on
         # higher-dimensional faces that point into the fracture surface, see
         # PrimalContactCoupling.
-        faces_on_fracture_surface = mg.master_to_mortar_int().tocsr().indices
+        faces_on_fracture_surface = mg.primary_to_mortar_int().tocsr().indices
         sign_switcher = pp.grid_utils.switch_sign_if_inwards_normal(
             g_master, ambient_dimension, faces_on_fracture_surface
         )
@@ -455,7 +455,7 @@ class MatrixScalarToForceBalance(
         # iii) Map to the mortar grid.
         # iv) Minus according to - alpha grad p already in the discretization matrix
         master_scalar_to_master_traction = (
-            mg.master_to_mortar_int(nd=ambient_dimension)
+            mg.primary_to_mortar_int(nd=ambient_dimension)
             * sign_switcher
             * master_scalar_gradient
         )
@@ -546,7 +546,7 @@ class FractureScalarToForceBalance(
         # Construct the dot product between normals on fracture faces and the identity
         # matrix. Similar sign switching as above is needed (this one operating on
         # fracture faces only).
-        faces_on_fracture_surface = mg.master_to_mortar_int().tocsr().indices
+        faces_on_fracture_surface = mg.primary_to_mortar_int().tocsr().indices
         sgn = g_master.sign_of_faces(faces_on_fracture_surface)
         fracture_normals = g_master.face_normals[
             :ambient_dimension, faces_on_fracture_surface

--- a/src/porepy/numerics/interface_laws/contact_mechanics_interface_laws.py
+++ b/src/porepy/numerics/interface_laws/contact_mechanics_interface_laws.py
@@ -264,7 +264,7 @@ class PrimalContactCoupling(
         contact_traction_to_mortar = (
             mg.sign_of_mortar_sides(nd=ambient_dimension)
             * projection.project_tangential_normal(mg.num_cells).T
-            * mg.slave_to_mortar_int(nd=ambient_dimension)
+            * mg.secondary_to_mortar_int(nd=ambient_dimension)
         )
         cc[mortar_ind, slave_ind] = contact_traction_to_mortar
 
@@ -566,7 +566,7 @@ class FractureScalarToForceBalance(
         # forces by
         # T_contact - n dot I p,
         # hence the minus.
-        slave_pressure_to_contact_traction = -(n_dot_I * mg.slave_to_mortar_int(nd=1))
+        slave_pressure_to_contact_traction = -(n_dot_I * mg.secondary_to_mortar_int(nd=1))
         # Minus to obtain -T_slave + T_master = 0, i.e. from placing the two
         # terms on the same side of the equation, as also done in PrimalContactCoupling.
         cc[mortar_ind, slave_ind] = -slave_pressure_to_contact_traction

--- a/src/porepy/numerics/interface_laws/contact_mechanics_interface_laws.py
+++ b/src/porepy/numerics/interface_laws/contact_mechanics_interface_laws.py
@@ -44,7 +44,9 @@ class PrimalContactCoupling(
     See also contact_conditions.py
     """
 
-    def __init__(self, keyword, discr_primary, discr_secondary, use_surface_discr=False):
+    def __init__(
+        self, keyword, discr_primary, discr_secondary, use_surface_discr=False
+    ):
         super(PrimalContactCoupling, self).__init__(keyword)
         self.mortar_displacement_variable = "mortar_u"
         self.discr_primary = discr_primary
@@ -376,9 +378,9 @@ class MatrixScalarToForceBalance(
             keyword used for storage of the gradP discretization. If the GradP class is
                 used, this is the keyword associated with the mechanical parameters.
             discr_primary and
-            discr_secondary are the discretization objects operating on the primary and secondary
-                pressure, respectively. Used for #DOFs. In FV, one cell variable is
-                expected.
+            discr_secondary are the discretization objects operating on the primary and
+                secondary pressure, respectively. Used for #DOFs. In FV, one cell
+                variable is expected.
         """
         super(MatrixScalarToForceBalance, self).__init__(keyword)
         # Set node discretizations
@@ -426,9 +428,9 @@ class MatrixScalarToForceBalance(
             g_primary, g_secondary, self.discr_primary, self.discr_secondary, mg, matrix
         )
 
-        primary_scalar_gradient = data_primary[pp.DISCRETIZATION_MATRICES][self.keyword][
-            "grad_p"
-        ]
+        primary_scalar_gradient = data_primary[pp.DISCRETIZATION_MATRICES][
+            self.keyword
+        ]["grad_p"]
 
         # We want to modify the stress balance posed on the edge to account for the
         # scalar (usually pressure) contribution.
@@ -490,9 +492,9 @@ class FractureScalarToForceBalance(
             keyword used for storage of the gradP discretization. If the GradP class is
                 used, this is the keyword associated with the mechanical parameters.
             discr_primary and
-            discr_secondary are the discretization objects operating on the primary and secondary
-                pressure, respectively. Used for #DOFs. In FV, one cell variable is
-                expected.
+            discr_secondary are the discretization objects operating on the primary and
+                secondary pressure, respectively. Used for #DOFs. In FV, one cell
+                variable is expected.
         """
         super(FractureScalarToForceBalance, self).__init__(keyword)
         # Set node discretizations
@@ -566,7 +568,9 @@ class FractureScalarToForceBalance(
         # forces by
         # T_contact - n dot I p,
         # hence the minus.
-        secondary_pressure_to_contact_traction = -(n_dot_I * mg.secondary_to_mortar_int(nd=1))
+        secondary_pressure_to_contact_traction = -(
+            n_dot_I * mg.secondary_to_mortar_int(nd=1)
+        )
         # Minus to obtain -T_secondary + T_primary = 0, i.e. from placing the two
         # terms on the same side of the equation, as also done in PrimalContactCoupling.
         cc[mortar_ind, secondary_ind] = -secondary_pressure_to_contact_traction

--- a/src/porepy/numerics/interface_laws/contact_mechanics_interface_laws.py
+++ b/src/porepy/numerics/interface_laws/contact_mechanics_interface_laws.py
@@ -145,7 +145,7 @@ class PrimalContactCoupling(
         cc[master_ind, mortar_ind] = (
             master_divergence
             * master_bound_stress
-            * mg.mortar_to_master_avg(nd=ambient_dimension)
+            * mg.mortar_to_primary_avg(nd=ambient_dimension)
         )
 
         ### Equation for the slave side
@@ -243,7 +243,7 @@ class PrimalContactCoupling(
             mg.master_to_mortar_int(nd=ambient_dimension)
             * sign_switcher
             * master_bound_stress
-            * mg.mortar_to_master_avg(nd=ambient_dimension)
+            * mg.mortar_to_primary_avg(nd=ambient_dimension)
         )
         cc[mortar_ind, mortar_ind] = traction_from_mortar
 
@@ -326,7 +326,7 @@ class PrimalContactCoupling(
             g_between, Nd, faces_on_fracture_surface
         )
 
-        proj_sec = mg_sec.mortar_to_master_avg(nd=Nd)
+        proj_sec = mg_sec.mortar_to_primary_avg(nd=Nd)
         proj_prim = mg_prim.master_to_mortar_int(nd=Nd)
 
         # Discretization of boundary conditions

--- a/src/porepy/numerics/interface_laws/elliptic_discretization.py
+++ b/src/porepy/numerics/interface_laws/elliptic_discretization.py
@@ -134,7 +134,7 @@ class EllipticDiscretization(Discretization):
         matrix: np.ndarray,
         rhs: np.ndarray,
         self_ind: int,
-        use_slave_proj: bool,
+        use_secondary_proj: bool,
     ) -> None:
         """Abstract method. Assemble the contribution from an internal
         boundary, manifested as a flux boundary condition.
@@ -154,16 +154,16 @@ class EllipticDiscretization(Discretization):
             data_edge (dictionary): Data dictionary for the edge in the
                 mixed-dimensional grid.
             grid_swap (boolean): If True, the grid g is identified with the @
-                slave side of the mortar grid in data_adge.
+                secondary side of the mortar grid in data_adge.
             cc (block matrix, 3x3): Block matrix for the coupling condition.
                 The first and second rows and columns are identified with the
-                master and slave side; the third belongs to the edge variable.
+                master and secondary side; the third belongs to the edge variable.
                 The discretization of the relevant term is done in-place in cc.
             matrix (block matrix 3x3): Discretization matrix for the edge and
                 the two adjacent nodes.
             self_ind (int): Index in cc and matrix associated with this node.
                 Should be either 1 or 2.
-            use_slave_proj (boolean): If True, the slave side projection operator is
+            use_secondary_proj (boolean): If True, the secondary side projection operator is
                 used. Needed for periodic boundary conditions.
 
         """
@@ -198,10 +198,10 @@ class EllipticDiscretization(Discretization):
             data_edge (dictionary): Data dictionary for the edge in the
                 mixed-dimensional grid.
             grid_swap (boolean): If True, the grid g is identified with the @
-                slave side of the mortar grid in data_adge.
+                secondary side of the mortar grid in data_adge.
             cc (block matrix, 3x3): Block matrix for the coupling condition.
                 The first and second rows and columns are identified with the
-                master and slave side; the third belongs to the edge variable.
+                master and secondary side; the third belongs to the edge variable.
                 The discretization of the relevant term is done in-place in cc.
             matrix (block matrix 3x3): Discretization matrix for the edge and
                 the two adjacent nodes.
@@ -221,7 +221,7 @@ class EllipticDiscretization(Discretization):
         matrix: np.ndarray,
         rhs: np.ndarray,
         self_ind: int,
-        use_slave_proj: bool,
+        use_secondary_proj: bool,
     ) -> None:
         """Abstract method. Assemble the contribution from an internal
         boundary, manifested as a condition on the boundary pressure.
@@ -241,10 +241,10 @@ class EllipticDiscretization(Discretization):
             data_edge (dictionary): Data dictionary for the edge in the
                 mixed-dimensional grid.
             grid_swap (boolean): If True, the grid g is identified with the @
-                slave side of the mortar grid in data_adge.
+                secondary side of the mortar grid in data_adge.
             cc (block matrix, 3x3): Block matrix for the coupling condition.
                 The first and second rows and columns are identified with the
-                master and slave side; the third belongs to the edge variable.
+                master and secondary side; the third belongs to the edge variable.
                 The discretization of the relevant term is done in-place in cc.
             matrix (block matrix 3x3): Discretization matrix for the edge and
                 the two adjacent nodes.
@@ -252,7 +252,7 @@ class EllipticDiscretization(Discretization):
                 the two adjacent nodes.
             self_ind (int): Index in cc and matrix associated with this node.
                 Should be either 1 or 2.
-            use_slave_proj (boolean): If True, the slave side projection operator is
+            use_secondary_proj (boolean): If True, the secondary side projection operator is
                 used. Needed for periodic boundary conditions.
 
         """
@@ -323,7 +323,7 @@ class EllipticDiscretization(Discretization):
                 mixed-dimensional grid.
             cc (block matrix, 3x3): Block matrix for the coupling condition.
                 The first and second rows and columns are identified with the
-                master and slave side; the third belongs to the edge variable.
+                master and secondary side; the third belongs to the edge variable.
                 The discretization of the relevant term is done in-place in cc.
             matrix (block matrix 3x3): Discretization matrix for the edge and
                 the two adjacent nodes.

--- a/src/porepy/numerics/interface_laws/elliptic_discretization.py
+++ b/src/porepy/numerics/interface_laws/elliptic_discretization.py
@@ -157,7 +157,7 @@ class EllipticDiscretization(Discretization):
                 secondary side of the mortar grid in data_adge.
             cc (block matrix, 3x3): Block matrix for the coupling condition.
                 The first and second rows and columns are identified with the
-                master and secondary side; the third belongs to the edge variable.
+                primary and secondary side; the third belongs to the edge variable.
                 The discretization of the relevant term is done in-place in cc.
             matrix (block matrix 3x3): Discretization matrix for the edge and
                 the two adjacent nodes.
@@ -201,7 +201,7 @@ class EllipticDiscretization(Discretization):
                 secondary side of the mortar grid in data_adge.
             cc (block matrix, 3x3): Block matrix for the coupling condition.
                 The first and second rows and columns are identified with the
-                master and secondary side; the third belongs to the edge variable.
+                primary and secondary side; the third belongs to the edge variable.
                 The discretization of the relevant term is done in-place in cc.
             matrix (block matrix 3x3): Discretization matrix for the edge and
                 the two adjacent nodes.
@@ -244,7 +244,7 @@ class EllipticDiscretization(Discretization):
                 secondary side of the mortar grid in data_adge.
             cc (block matrix, 3x3): Block matrix for the coupling condition.
                 The first and second rows and columns are identified with the
-                master and secondary side; the third belongs to the edge variable.
+                primary and secondary side; the third belongs to the edge variable.
                 The discretization of the relevant term is done in-place in cc.
             matrix (block matrix 3x3): Discretization matrix for the edge and
                 the two adjacent nodes.
@@ -282,12 +282,12 @@ class EllipticDiscretization(Discretization):
                 grid to the main grid.
            cc (block matrix, 3x3): Block matrix of size 3 x 3, whwere each block
                 represents coupling between variables on this interface. Index 0, 1 and
-                2 represent the master grid, the primary and secondary interface,
+                2 represent the primary grid, the primary and secondary interface,
                 respectively.
            matrix (block matrix 3x3): Discretization matrix for the edge and
                 the two adjacent nodes.
            rhs (block_array 3x1): Block matrix of size 3 x 1, representing the right
-                hand side of this coupling. Index 0, 1 and 2 represent the master grid,
+                hand side of this coupling. Index 0, 1 and 2 represent the primary grid,
                 the primary and secondary interface, respectively.
 
         """
@@ -323,7 +323,7 @@ class EllipticDiscretization(Discretization):
                 mixed-dimensional grid.
             cc (block matrix, 3x3): Block matrix for the coupling condition.
                 The first and second rows and columns are identified with the
-                master and secondary side; the third belongs to the edge variable.
+                primary and secondary side; the third belongs to the edge variable.
                 The discretization of the relevant term is done in-place in cc.
             matrix (block matrix 3x3): Discretization matrix for the edge and
                 the two adjacent nodes.

--- a/src/porepy/numerics/interface_laws/elliptic_interface_laws.py
+++ b/src/porepy/numerics/interface_laws/elliptic_interface_laws.py
@@ -305,7 +305,7 @@ class RobinCoupling(
         # become more complex. This probably assumes that a FluxPressureContinuity
         # discretization is applied on the relevant mortar grid.
         if isinstance(mg_primary, pp.BoundaryMortar) and edge_primary[0] == g:
-            proj_pressure = mg_primary.slave_to_mortar_avg()
+            proj_pressure = mg_primary.secondary_to_mortar_avg()
         if isinstance(mg_secondary, pp.BoundaryMortar) and edge_secondary[0] == g:
             proj_flux = mg_secondary.mortar_to_secondary_int()
 

--- a/src/porepy/numerics/interface_laws/elliptic_interface_laws.py
+++ b/src/porepy/numerics/interface_laws/elliptic_interface_laws.py
@@ -307,7 +307,7 @@ class RobinCoupling(
         if isinstance(mg_primary, pp.BoundaryMortar) and edge_primary[0] == g:
             proj_pressure = mg_primary.slave_to_mortar_avg()
         if isinstance(mg_secondary, pp.BoundaryMortar) and edge_secondary[0] == g:
-            proj_flux = mg_secondary.mortar_to_slave_int()
+            proj_flux = mg_secondary.mortar_to_secondary_int()
 
         cc, rhs = self._define_local_block_matrix_edge_coupling(
             g, self.discr_master, mg_primary, mg_secondary, matrix

--- a/src/porepy/numerics/interface_laws/elliptic_interface_laws.py
+++ b/src/porepy/numerics/interface_laws/elliptic_interface_laws.py
@@ -299,7 +299,7 @@ class RobinCoupling(
         # Normally, the projections will be pressure from the master (high-dim node)
         # to the primary mortar, and flux from secondary mortar to master
         proj_pressure = mg_primary.master_to_mortar_avg()
-        proj_flux = mg_secondary.mortar_to_master_int()
+        proj_flux = mg_secondary.mortar_to_primary_int()
 
         # If the primary and / or secondary mortar is a boundary mortar grid, things
         # become more complex. This probably assumes that a FluxPressureContinuity

--- a/src/porepy/numerics/interface_laws/elliptic_interface_laws.py
+++ b/src/porepy/numerics/interface_laws/elliptic_interface_laws.py
@@ -23,11 +23,11 @@ class RobinCoupling(
 
     """
 
-    def __init__(self, keyword, discr_master, discr_secondary=None):
+    def __init__(self, keyword, discr_primary, discr_secondary=None):
         super(RobinCoupling, self).__init__(keyword)
         if discr_secondary is None:
-            discr_secondary = discr_master
-        self.discr_master = discr_master
+            discr_secondary = discr_primary
+        self.discr_primary = discr_primary
         self.discr_secondary = discr_secondary
 
         # This interface law will have direct interface coupling to represent
@@ -49,7 +49,7 @@ class RobinCoupling(
         # or not. This leaves the case when one neighbor is mixed, the other is FV; in
         # this case, we use a K-scaling, but it is not clear what is best.
         if isinstance(
-            discr_master, pp.numerics.vem.dual_elliptic.DualElliptic
+            discr_primary, pp.numerics.vem.dual_elliptic.DualElliptic
         ) and isinstance(discr_secondary, pp.numerics.vem.dual_elliptic.DualElliptic):
             self.kinv_scaling = True
         else:
@@ -64,16 +64,16 @@ class RobinCoupling(
         edge data.
 
         Parameters:
-            g_h: Grid of the master domanin.
+            g_h: Grid of the primary domanin.
             g_l: Grid of the secondary domain.
-            data_h: Data dictionary for the master domain.
+            data_h: Data dictionary for the primary domain.
             data_l: Data dictionary for the secondary domain.
             data_edge: Data dictionary for the edge between the domains.
 
         """
         matrix_dictionary_edge = data_edge[pp.DISCRETIZATION_MATRICES][self.keyword]
         parameter_dictionary_edge = data_edge[pp.PARAMETERS][self.keyword]
-        parameter_dictionary_h = data_h[pp.PARAMETERS][self.discr_master.keyword]
+        parameter_dictionary_h = data_h[pp.PARAMETERS][self.discr_primary.keyword]
         # Mortar data structure.
         mg = data_edge["mortar_grid"]
 
@@ -175,15 +175,15 @@ class RobinCoupling(
             )
 
     def assemble_matrix_rhs(
-        self, g_master, g_secondary, data_master, data_secondary, data_edge, matrix
+        self, g_primary, g_secondary, data_primary, data_secondary, data_edge, matrix
     ):
         """Assemble the dicretization of the interface law, and its impact on
         the neighboring domains.
 
         Parameters:
-            g_master: Grid on one neighboring subdomain.
+            g_primary: Grid on one neighboring subdomain.
             g_secondary: Grid on the other neighboring subdomain.
-            data_master: Data dictionary for the master suddomain
+            data_primary: Data dictionary for the primary suddomain
             data_secondary: Data dictionary for the secondary subdomain.
             data_edge: Data dictionary for the edge between the subdomains.
                 If gravity is taken into consideration, the parameter sub-
@@ -202,10 +202,10 @@ class RobinCoupling(
         parameter_dictionary_edge = data_edge[pp.PARAMETERS][self.keyword]
         mg = data_edge["mortar_grid"]
 
-        master_ind = 0
+        primary_ind = 0
         secondary_ind = 1
         cc, rhs = self._define_local_block_matrix(
-            g_master, g_secondary, self.discr_master, self.discr_secondary, mg, matrix
+            g_primary, g_secondary, self.discr_primary, self.discr_secondary, mg, matrix
         )
 
         # The convention, for now, is to put the higher dimensional information
@@ -213,11 +213,11 @@ class RobinCoupling(
         # and mortar variables in the third
         cc[2, 2] = matrix_dictionary_edge[self.mortar_discr_key]
 
-        self.discr_master.assemble_int_bound_pressure_trace(
-            g_master, data_master, data_edge, cc, matrix, rhs, master_ind
+        self.discr_primary.assemble_int_bound_pressure_trace(
+            g_primary, data_primary, data_edge, cc, matrix, rhs, primary_ind
         )
-        self.discr_master.assemble_int_bound_flux(
-            g_master, data_master, data_edge, cc, matrix, rhs, master_ind
+        self.discr_primary.assemble_int_bound_flux(
+            g_primary, data_primary, data_edge, cc, matrix, rhs, primary_ind
         )
 
         self.discr_secondary.assemble_int_bound_pressure_cell(
@@ -256,8 +256,8 @@ class RobinCoupling(
 
         matrix += cc
 
-        self.discr_master.enforce_neumann_int_bound(
-            g_master, data_edge, matrix, master_ind
+        self.discr_primary.enforce_neumann_int_bound(
+            g_primary, data_edge, matrix, primary_ind
         )
 
         return matrix, rhs
@@ -287,17 +287,17 @@ class RobinCoupling(
         Returns:
             np.array: Block matrix of size 3 x 3, whwere each block represents
                 coupling between variables on this interface. Index 0, 1 and 2
-                represent the master, secondary and mortar variable, respectively.
+                represent the primary, secondary and mortar variable, respectively.
             np.array: Block matrix of size 3 x 1, representing the right hand
-                side of this coupling. Index 0, 1 and 2 represent the master,
+                side of this coupling. Index 0, 1 and 2 represent the primary,
                 secondary and mortar variable, respectively.
 
         """
         mg_primary = data_primary_edge["mortar_grid"]
         mg_secondary = data_secondary_edge["mortar_grid"]
 
-        # Normally, the projections will be pressure from the master (high-dim node)
-        # to the primary mortar, and flux from secondary mortar to master
+        # Normally, the projections will be pressure from the primary (high-dim node)
+        # to the primary mortar, and flux from secondary mortar to primary
         proj_pressure = mg_primary.primary_to_mortar_avg()
         proj_flux = mg_secondary.mortar_to_primary_int()
 
@@ -310,11 +310,11 @@ class RobinCoupling(
             proj_flux = mg_secondary.mortar_to_secondary_int()
 
         cc, rhs = self._define_local_block_matrix_edge_coupling(
-            g, self.discr_master, mg_primary, mg_secondary, matrix
+            g, self.discr_primary, mg_primary, mg_secondary, matrix
         )
 
         # Assemble contribution between higher dimensions.
-        self.discr_master.assemble_int_bound_pressure_trace_between_interfaces(
+        self.discr_primary.assemble_int_bound_pressure_trace_between_interfaces(
             g, data_grid, proj_pressure, proj_flux, cc, matrix, rhs
         )
         # Scale the equations (this will modify from K^-1 to K scaling if relevant)
@@ -344,15 +344,15 @@ class FluxPressureContinuity(RobinCoupling):
     v_m = lambda
     v_s = -lambda
     p_m - p_s = 0
-    where subscript m and s is for master and secondary, v is the flux, p the pressure,
+    where subscript m and s is for primary and secondary, v is the flux, p the pressure,
     and lambda the mortar variable.
 
     """
 
-    def __init__(self, keyword, discr_master, discr_secondary=None):
+    def __init__(self, keyword, discr_primary, discr_secondary=None):
         if discr_secondary is None:
-            discr_secondary = discr_master
-        self.discr_master = discr_master
+            discr_secondary = discr_primary
+        self.discr_primary = discr_primary
         self.discr_secondary = discr_secondary
 
         # This interface law will have direct interface coupling to represent
@@ -366,9 +366,9 @@ class FluxPressureContinuity(RobinCoupling):
         """Nothing really to do here
 
         Parameters:
-            g_h: Grid of the master domanin.
+            g_h: Grid of the primary domanin.
             g_l: Grid of the secondary domain.
-            data_h: Data dictionary for the master domain.
+            data_h: Data dictionary for the primary domain.
             data_l: Data dictionary for the secondary domain.
             data_edge: Data dictionary for the edge between the domains.
 
@@ -376,18 +376,18 @@ class FluxPressureContinuity(RobinCoupling):
         pass
 
     def assemble_rhs(
-        self, g_master, g_secondary, data_master, data_secondary, data_edge, matrix
+        self, g_primary, g_secondary, data_primary, data_secondary, data_edge, matrix
     ):
         """Assemble the dicretization of the interface law, and its impact on
         the neighboring domains.
 
         Parameters:
-            g_master: Grid on one neighboring subdomain.
+            g_primary: Grid on one neighboring subdomain.
             g_secondary: Grid on the other neighboring subdomain.
-            data_master: Data dictionary for the master suddomain
+            data_primary: Data dictionary for the primary suddomain
             data_secondary: Data dictionary for the secondary subdomain.
             data_edge: Data dictionary for the edge between the subdomains
-            matrix_master: original discretization for the master subdomain
+            matrix_primary: original discretization for the primary subdomain
             matrix_secondary: original discretization for the secondary subdomain
 
         """
@@ -396,94 +396,94 @@ class FluxPressureContinuity(RobinCoupling):
         # Compared to self.assemble_matrix_rhs(), the method short cuts parts of the
         # assembly that only give contributions to the matrix.
 
-        master_ind = 0
+        primary_ind = 0
         secondary_ind = 1
 
         # Generate matrix for the coupling.
         mg = data_edge["mortar_grid"]
-        cc_master, rhs_master = self._define_local_block_matrix(
-            g_master, g_secondary, self.discr_master, self.discr_secondary, mg, matrix
+        cc_primary, rhs_primary = self._define_local_block_matrix(
+            g_primary, g_secondary, self.discr_primary, self.discr_secondary, mg, matrix
         )
-        # I got some problems with pointers when doing rhs_master = rhs_secondary.copy()
+        # I got some problems with pointers when doing rhs_primary = rhs_secondary.copy()
         # so just reconstruct everything.
         rhs_secondary = np.empty(3, dtype=np.object)
-        rhs_secondary[master_ind] = np.zeros_like(rhs_master[master_ind])
-        rhs_secondary[secondary_ind] = np.zeros_like(rhs_master[secondary_ind])
-        rhs_secondary[2] = np.zeros_like(rhs_master[2])
+        rhs_secondary[primary_ind] = np.zeros_like(rhs_primary[primary_ind])
+        rhs_secondary[secondary_ind] = np.zeros_like(rhs_primary[secondary_ind])
+        rhs_secondary[2] = np.zeros_like(rhs_primary[2])
 
-        # If master and secondary is the same grid, they should contribute to the same
+        # If primary and secondary is the same grid, they should contribute to the same
         # row and coloumn. When the assembler assigns matrix[idx] it will only add
-        # the secondary information because of duplicate indices (master and secondary is the same).
-        # We therefore write the both master and secondary info to the secondary index.
-        if g_master == g_secondary:
-            master_ind = 1
+        # the secondary information because of duplicate indices (primary and secondary is the same).
+        # We therefore write the both primary and secondary info to the secondary index.
+        if g_primary == g_secondary:
+            primary_ind = 1
         else:
-            master_ind = 0
+            primary_ind = 0
 
-        self.discr_master.assemble_int_bound_pressure_trace_rhs(
-            g_master, data_master, data_edge, cc_master, rhs_master, master_ind
+        self.discr_primary.assemble_int_bound_pressure_trace_rhs(
+            g_primary, data_primary, data_edge, cc_primary, rhs_primary, primary_ind
         )
 
-        if g_master.dim == g_secondary.dim:
+        if g_primary.dim == g_secondary.dim:
             rhs_secondary[2] = -rhs_secondary[2]
-        rhs = rhs_master + rhs_secondary
+        rhs = rhs_primary + rhs_secondary
 
         return rhs
 
     def assemble_matrix_rhs(
-        self, g_master, g_secondary, data_master, data_secondary, data_edge, matrix
+        self, g_primary, g_secondary, data_primary, data_secondary, data_edge, matrix
     ):
         """Assemble the dicretization of the interface law, and its impact on
         the neighboring domains.
 
         Parameters:
-            g_master: Grid on one neighboring subdomain.
+            g_primary: Grid on one neighboring subdomain.
             g_secondary: Grid on the other neighboring subdomain.
-            data_master: Data dictionary for the master suddomain
+            data_primary: Data dictionary for the primary suddomain
             data_secondary: Data dictionary for the secondary subdomain.
             data_edge: Data dictionary for the edge between the subdomains
-            matrix_master: original discretization for the master subdomain
+            matrix_primary: original discretization for the primary subdomain
             matrix_secondary: original discretization for the secondary subdomain
 
         """
-        master_ind = 0
+        primary_ind = 0
         secondary_ind = 1
 
         # Generate matrix for the coupling.
         mg = data_edge["mortar_grid"]
-        cc_master, rhs_master = self._define_local_block_matrix(
-            g_master, g_secondary, self.discr_master, self.discr_secondary, mg, matrix
+        cc_primary, rhs_primary = self._define_local_block_matrix(
+            g_primary, g_secondary, self.discr_primary, self.discr_secondary, mg, matrix
         )
 
-        cc_secondary = cc_master.copy()
+        cc_secondary = cc_primary.copy()
 
-        # I got some problems with pointers when doing rhs_master = rhs_secondary.copy()
+        # I got some problems with pointers when doing rhs_primary = rhs_secondary.copy()
         # so just reconstruct everything.
         rhs_secondary = np.empty(3, dtype=np.object)
-        rhs_secondary[master_ind] = np.zeros_like(rhs_master[master_ind])
-        rhs_secondary[secondary_ind] = np.zeros_like(rhs_master[secondary_ind])
-        rhs_secondary[2] = np.zeros_like(rhs_master[2])
+        rhs_secondary[primary_ind] = np.zeros_like(rhs_primary[primary_ind])
+        rhs_secondary[secondary_ind] = np.zeros_like(rhs_primary[secondary_ind])
+        rhs_secondary[2] = np.zeros_like(rhs_primary[2])
 
-        # The convention, for now, is to put the master grid information
+        # The convention, for now, is to put the primary grid information
         # in the first column and row in matrix, secondary grid in the second
         # and mortar variables in the third
-        # If master and secondary is the same grid, they should contribute to the same
+        # If primary and secondary is the same grid, they should contribute to the same
         # row and coloumn. When the assembler assigns matrix[idx] it will only add
-        # the secondary information because of duplicate indices (master and secondary is the same).
-        # We therefore write the both master and secondary info to the secondary index.
-        if g_master == g_secondary:
-            master_ind = 1
+        # the secondary information because of duplicate indices (primary and secondary is the same).
+        # We therefore write the both primary and secondary info to the secondary index.
+        if g_primary == g_secondary:
+            primary_ind = 1
         else:
-            master_ind = 0
+            primary_ind = 0
 
-        self.discr_master.assemble_int_bound_pressure_trace(
-            g_master, data_master, data_edge, cc_master, matrix, rhs_master, master_ind
+        self.discr_primary.assemble_int_bound_pressure_trace(
+            g_primary, data_primary, data_edge, cc_primary, matrix, rhs_primary, primary_ind
         )
-        self.discr_master.assemble_int_bound_flux(
-            g_master, data_master, data_edge, cc_master, matrix, rhs_master, master_ind
+        self.discr_primary.assemble_int_bound_flux(
+            g_primary, data_primary, data_edge, cc_primary, matrix, rhs_primary, primary_ind
         )
 
-        if g_master.dim == g_secondary.dim:
+        if g_primary.dim == g_secondary.dim:
             # Consider this terms only if the grids are of the same dimension, by
             # imposing the same condition with a different sign, due to the normal
             self.discr_secondary.assemble_int_bound_pressure_trace(
@@ -509,7 +509,7 @@ class FluxPressureContinuity(RobinCoupling):
             )
             # We now have to flip the sign of some of the matrices
             # First we flip the sign of the secondary flux because the mortar flux points
-            # from the master to the secondary, i.e., flux_s = -mortar_flux
+            # from the primary to the secondary, i.e., flux_s = -mortar_flux
             cc_secondary[secondary_ind, 2] = -cc_secondary[secondary_ind, 2]
             # Then we flip the sign for the pressure continuity since we have
             # We have that p_m - p_s = 0.
@@ -528,7 +528,7 @@ class FluxPressureContinuity(RobinCoupling):
                 g_secondary, data_secondary, data_edge, cc_secondary, matrix, rhs_secondary, secondary_ind
             )
 
-        # Now, the matrix cc = cc_secondary + cc_master expresses the flux and pressure
+        # Now, the matrix cc = cc_secondary + cc_primary expresses the flux and pressure
         # continuities over the mortars.
         # cc[0] -> flux_m = mortar_flux
         # cc[1] -> flux_s = -mortar_flux
@@ -536,22 +536,22 @@ class FluxPressureContinuity(RobinCoupling):
 
         # Computational savings: Only add non-zero components.
         # Exception: The case with equal dimension of the two neighboring grids.
-        if g_master.dim == g_secondary.dim:
-            matrix += cc_master + cc_secondary
+        if g_primary.dim == g_secondary.dim:
+            matrix += cc_primary + cc_secondary
         else:
-            matrix[0, 2] += cc_master[0, 2]
+            matrix[0, 2] += cc_primary[0, 2]
             matrix[1, 2] += cc_secondary[1, 2]
             for col in range(3):
-                matrix[2, col] += cc_master[2, col] + cc_secondary[2, col]
+                matrix[2, col] += cc_primary[2, col] + cc_secondary[2, col]
 
-        rhs = rhs_master + rhs_secondary
+        rhs = rhs_primary + rhs_secondary
 
-        self.discr_master.enforce_neumann_int_bound(
-            g_master, data_edge, matrix, master_ind
+        self.discr_primary.enforce_neumann_int_bound(
+            g_primary, data_edge, matrix, primary_ind
         )
 
         # Consider this terms only if the grids are of the same dimension
-        if g_master.dim == g_secondary.dim:
+        if g_primary.dim == g_secondary.dim:
             self.discr_secondary.enforce_neumann_int_bound(
                 g_secondary, data_edge, matrix, secondary_ind
             )

--- a/src/porepy/numerics/interface_laws/elliptic_interface_laws.py
+++ b/src/porepy/numerics/interface_laws/elliptic_interface_laws.py
@@ -122,7 +122,7 @@ class RobinCoupling(
         normals_h = g_h.face_normals.copy()
 
         # projection matrix
-        proj = mg.master_to_mortar_avg()
+        proj = mg.primary_to_mortar_avg()
 
         # Ensure that the normal vectors point out of g_h
         # Indices of faces neighboring this mortar grid
@@ -298,7 +298,7 @@ class RobinCoupling(
 
         # Normally, the projections will be pressure from the master (high-dim node)
         # to the primary mortar, and flux from secondary mortar to master
-        proj_pressure = mg_primary.master_to_mortar_avg()
+        proj_pressure = mg_primary.primary_to_mortar_avg()
         proj_flux = mg_secondary.mortar_to_primary_int()
 
         # If the primary and / or secondary mortar is a boundary mortar grid, things

--- a/src/porepy/numerics/interface_laws/elliptic_interface_laws.py
+++ b/src/porepy/numerics/interface_laws/elliptic_interface_laws.py
@@ -413,8 +413,9 @@ class FluxPressureContinuity(RobinCoupling):
 
         # If primary and secondary is the same grid, they should contribute to the same
         # row and coloumn. When the assembler assigns matrix[idx] it will only add
-        # the secondary information because of duplicate indices (primary and secondary is the same).
-        # We therefore write the both primary and secondary info to the secondary index.
+        # the secondary information because of duplicate indices (primary and secondary
+        # is the same). We therefore write the both primary and secondary info to the
+        # secondary index.
         if g_primary == g_secondary:
             primary_ind = 1
         else:
@@ -468,19 +469,32 @@ class FluxPressureContinuity(RobinCoupling):
         # in the first column and row in matrix, secondary grid in the second
         # and mortar variables in the third
         # If primary and secondary is the same grid, they should contribute to the same
-        # row and coloumn. When the assembler assigns matrix[idx] it will only add
-        # the secondary information because of duplicate indices (primary and secondary is the same).
-        # We therefore write the both primary and secondary info to the secondary index.
+        # row and column. When the assembler assigns matrix[idx] it will only add
+        # the secondary information because of duplicate indices (primary and secondary
+        # is the same). We therefore write the both primary and secondary info to the
+        # secondary index.
         if g_primary == g_secondary:
             primary_ind = 1
         else:
             primary_ind = 0
 
         self.discr_primary.assemble_int_bound_pressure_trace(
-            g_primary, data_primary, data_edge, cc_primary, matrix, rhs_primary, primary_ind
+            g_primary,
+            data_primary,
+            data_edge,
+            cc_primary,
+            matrix,
+            rhs_primary,
+            primary_ind,
         )
         self.discr_primary.assemble_int_bound_flux(
-            g_primary, data_primary, data_edge, cc_primary, matrix, rhs_primary, primary_ind
+            g_primary,
+            data_primary,
+            data_edge,
+            cc_primary,
+            matrix,
+            rhs_primary,
+            primary_ind,
         )
 
         if g_primary.dim == g_secondary.dim:
@@ -521,11 +535,23 @@ class FluxPressureContinuity(RobinCoupling):
             # imposing pressure trace continuity and conservation of the normal flux
             # through the lower dimensional object.
             self.discr_secondary.assemble_int_bound_pressure_cell(
-                g_secondary, data_secondary, data_edge, cc_secondary, matrix, rhs_secondary, secondary_ind
+                g_secondary,
+                data_secondary,
+                data_edge,
+                cc_secondary,
+                matrix,
+                rhs_secondary,
+                secondary_ind,
             )
 
             self.discr_secondary.assemble_int_bound_source(
-                g_secondary, data_secondary, data_edge, cc_secondary, matrix, rhs_secondary, secondary_ind
+                g_secondary,
+                data_secondary,
+                data_edge,
+                cc_secondary,
+                matrix,
+                rhs_secondary,
+                secondary_ind,
             )
 
         # Now, the matrix cc = cc_secondary + cc_primary expresses the flux and pressure

--- a/src/porepy/numerics/interface_laws/hyperbolic_interface_laws.py
+++ b/src/porepy/numerics/interface_laws/hyperbolic_interface_laws.py
@@ -103,7 +103,7 @@ class UpwindCoupling(
         # i.e., T_check * fluid_flux = lambda.
         # we set cc[2, 1] = T_check * fluid_flux
         # Use averaged projection operator for an intensive quantity
-        cc[2, 1] = sps.diags(lam_flux * not_flag) * mg.slave_to_mortar_avg()
+        cc[2, 1] = sps.diags(lam_flux * not_flag) * mg.secondary_to_mortar_avg()
 
         # The rhs of T * fluid_flux = lambda
         # Recover the information for the grid-grid mapping

--- a/src/porepy/numerics/interface_laws/hyperbolic_interface_laws.py
+++ b/src/porepy/numerics/interface_laws/hyperbolic_interface_laws.py
@@ -24,7 +24,9 @@ class UpwindCoupling(
     def ndof(self, mg):
         return mg.num_cells
 
-    def discretize(self, g_primary, g_secondary, data_primary, data_secondary, data_edge):
+    def discretize(
+        self, g_primary, g_secondary, data_primary, data_secondary, data_edge
+    ):
         pass
 
     def assemble_matrix_rhs(

--- a/src/porepy/numerics/interface_laws/hyperbolic_interface_laws.py
+++ b/src/porepy/numerics/interface_laws/hyperbolic_interface_laws.py
@@ -97,7 +97,7 @@ class UpwindCoupling(
         # i.e., T_masterat * fluid_flux = lambda.
         # We set cc[2, 0] = T_masterat * fluid_flux
         # Use averaged projection operator for an intensive quantity
-        cc[2, 0] = sps.diags(lam_flux * flag) * mg.master_to_mortar_avg() * trace_h
+        cc[2, 0] = sps.diags(lam_flux * flag) * mg.primary_to_mortar_avg() * trace_h
 
         # If fluid flux is negative we use the lower value as weight,
         # i.e., T_check * fluid_flux = lambda.

--- a/src/porepy/numerics/interface_laws/hyperbolic_interface_laws.py
+++ b/src/porepy/numerics/interface_laws/hyperbolic_interface_laws.py
@@ -90,7 +90,7 @@ class UpwindCoupling(
         cc[0, 2] = face_to_cell_h * mg.mortar_to_master_int()
 
         # transport out of lower is -lambda
-        cc[1, 2] = -mg.mortar_to_slave_int()
+        cc[1, 2] = -mg.mortar_to_secondary_int()
 
         # Discretisation of mortars
         # If fluid flux(lam_flux) is positive we use the upper value as weight,

--- a/src/porepy/numerics/interface_laws/hyperbolic_interface_laws.py
+++ b/src/porepy/numerics/interface_laws/hyperbolic_interface_laws.py
@@ -24,11 +24,11 @@ class UpwindCoupling(
     def ndof(self, mg):
         return mg.num_cells
 
-    def discretize(self, g_master, g_slave, data_master, data_slave, data_edge):
+    def discretize(self, g_master, g_secondary, data_master, data_secondary, data_edge):
         pass
 
     def assemble_matrix_rhs(
-        self, g_master, g_slave, data_master, data_slave, data_edge, matrix
+        self, g_master, g_secondary, data_master, data_secondary, data_edge, matrix
     ):
         """
         Construct the matrix (and right-hand side) for the coupling conditions.
@@ -36,10 +36,10 @@ class UpwindCoupling(
 
         Parameters:
             g_master: grid of higher dimension
-            g_slave: grid of lower dimension
+            g_secondary: grid of lower dimension
             data_master: dictionary which stores the data for the higher dimensional
                 grid
-            data_slave: dictionary which stores the data for the lower dimensional
+            data_secondary: dictionary which stores the data for the lower dimensional
                 grid
             data_edge: dictionary which stores the data for the edges of the grid
                 bucket
@@ -60,7 +60,7 @@ class UpwindCoupling(
         # Create the block matrix for the contributions
         mg = data_edge["mortar_grid"]
 
-        # We know the number of dofs from the master and slave side from their
+        # We know the number of dofs from the master and secondary side from their
         # discretizations
         dof = np.array([matrix[0, 0].shape[1], matrix[1, 1].shape[1], mg.num_cells])
         cc = np.array([sps.coo_matrix((i, j)) for i in dof for j in dof])
@@ -109,7 +109,7 @@ class UpwindCoupling(
         # Recover the information for the grid-grid mapping
         cc[2, 2] = -sps.eye(mg.num_cells)
 
-        if data_master["node_number"] == data_slave["node_number"]:
+        if data_master["node_number"] == data_secondary["node_number"]:
             # All contributions to be returned to the same block of the
             # global matrix in this case
             cc = np.array([np.sum(cc, axis=(0, 1))])
@@ -122,9 +122,9 @@ class UpwindCoupling(
     def cfl(
         self,
         g_master,
-        g_slave,
+        g_secondary,
         data_master,
-        data_slave,
+        data_secondary,
         data_edge,
         d_name="mortar_solution",
     ):
@@ -139,10 +139,10 @@ class UpwindCoupling(
 
         Parameters:
             g_master: grid of higher dimension
-            g_slave: grid of lower dimension
+            g_secondary: grid of lower dimension
             data_master: dictionary which stores the data for the higher dimensional
                 grid
-            data_slave: dictionary which stores the data for the lower dimensional
+            data_secondary: dictionary which stores the data for the lower dimensional
                 grid
             data: dictionary which stores the data for the edges of the grid
                 bucket
@@ -159,38 +159,38 @@ class UpwindCoupling(
         # Retrieve the darcy_flux, which is mandatory
 
         aperture_master = data_master["param"].get_aperture()
-        aperture_slave = data_slave["param"].get_aperture()
-        phi_slave = data_slave["param"].get_porosity()
+        aperture_secondary = data_secondary["param"].get_aperture()
+        phi_secondary = data_secondary["param"].get_porosity()
         mg = data_edge["mortar_grid"]
         darcy_flux = np.zeros(g_master.num_faces)
         darcy_flux[mg.high_to_mortar_int.nonzero()[1]] = data_edge[d_name]
-        if g_master.dim == g_slave.dim:
+        if g_master.dim == g_secondary.dim:
             # More or less same as below, except we have cell_cells in the place
             # of face_cells (see grid_bucket.duplicate_without_dimension).
             phi_master = data_master["param"].get_porosity()
-            cells_slave, cells_master = data_edge["face_cells"].nonzero()
+            cells_secondary, cells_master = data_edge["face_cells"].nonzero()
             not_zero = ~np.isclose(np.zeros(darcy_flux.shape), darcy_flux, atol=0)
             if not np.any(not_zero):
                 return np.Inf
 
             diff = (
                 g_master.cell_centers[:, cells_master]
-                - g_slave.cell_centers[:, cells_slave]
+                - g_secondary.cell_centers[:, cells_secondary]
             )
             dist = np.linalg.norm(diff, 2, axis=0)
 
             # Use minimum of cell values for convenience
-            phi_slave = phi_slave[cells_slave]
+            phi_secondary = phi_secondary[cells_secondary]
             phi_master = phi_master[cells_master]
             apt_master = aperture_master[cells_master]
-            apt_slave = aperture_slave[cells_slave]
-            coeff = np.minimum(phi_master, phi_slave) * np.minimum(
-                apt_master, apt_slave
+            apt_secondary = aperture_secondary[cells_secondary]
+            coeff = np.minimum(phi_master, phi_secondary) * np.minimum(
+                apt_master, apt_secondary
             )
             return np.amin(np.abs(np.divide(dist, darcy_flux)) * coeff)
 
         # Recover the information for the grid-grid mapping
-        cells_slave, faces_master, _ = sps.find(data_edge["face_cells"])
+        cells_secondary, faces_master, _ = sps.find(data_edge["face_cells"])
 
         # Detect and remove the faces which have zero in "darcy_flux"
         not_zero = ~np.isclose(
@@ -199,18 +199,18 @@ class UpwindCoupling(
         if not np.any(not_zero):
             return np.inf
 
-        cells_slave = cells_slave[not_zero]
+        cells_secondary = cells_secondary[not_zero]
         faces_master = faces_master[not_zero]
         # Mapping from faces_master to cell_master
         cell_faces_master = g_master.cell_faces.tocsr()[faces_master, :]
         cells_master = cell_faces_master.nonzero()[1][not_zero]
         # Retrieve and map additional data
         aperture_master = aperture_master[cells_master]
-        aperture_slave = aperture_slave[cells_slave]
-        phi_slave = phi_slave[cells_slave]
+        aperture_secondary = aperture_secondary[cells_secondary]
+        phi_secondary = phi_secondary[cells_secondary]
         # Compute discrete distance cell to face centers for the lower
         # dimensional grid
-        dist = 0.5 * np.divide(aperture_slave, aperture_master)
+        dist = 0.5 * np.divide(aperture_secondary, aperture_master)
         # Since darcy_flux is multiplied by the aperture wighted face areas, we
         # divide through that quantity to get velocities in [length/time]
         velocity = np.divide(
@@ -218,4 +218,4 @@ class UpwindCoupling(
             g_master.face_areas[faces_master] * aperture_master,
         )
         # deltaT is deltaX/velocity with coefficient
-        return np.amin(np.abs(np.divide(dist, velocity)) * phi_slave)
+        return np.amin(np.abs(np.divide(dist, velocity)) * phi_secondary)

--- a/src/porepy/numerics/interface_laws/hyperbolic_interface_laws.py
+++ b/src/porepy/numerics/interface_laws/hyperbolic_interface_laws.py
@@ -24,20 +24,20 @@ class UpwindCoupling(
     def ndof(self, mg):
         return mg.num_cells
 
-    def discretize(self, g_master, g_secondary, data_master, data_secondary, data_edge):
+    def discretize(self, g_primary, g_secondary, data_primary, data_secondary, data_edge):
         pass
 
     def assemble_matrix_rhs(
-        self, g_master, g_secondary, data_master, data_secondary, data_edge, matrix
+        self, g_primary, g_secondary, data_primary, data_secondary, data_edge, matrix
     ):
         """
         Construct the matrix (and right-hand side) for the coupling conditions.
         Note: the right-hand side is not implemented now.
 
         Parameters:
-            g_master: grid of higher dimension
+            g_primary: grid of higher dimension
             g_secondary: grid of lower dimension
-            data_master: dictionary which stores the data for the higher dimensional
+            data_primary: dictionary which stores the data for the higher dimensional
                 grid
             data_secondary: dictionary which stores the data for the lower dimensional
                 grid
@@ -60,7 +60,7 @@ class UpwindCoupling(
         # Create the block matrix for the contributions
         mg = data_edge["mortar_grid"]
 
-        # We know the number of dofs from the master and secondary side from their
+        # We know the number of dofs from the primary and secondary side from their
         # discretizations
         dof = np.array([matrix[0, 0].shape[1], matrix[1, 1].shape[1], mg.num_cells])
         cc = np.array([sps.coo_matrix((i, j)) for i in dof for j in dof])
@@ -71,7 +71,7 @@ class UpwindCoupling(
         # mapping from upper dim cellls to faces
         # The mortars always points from upper to lower, so we don't flip any
         # signs
-        face_to_cell_h = np.abs(pp.fvutils.scalar_divergence(g_master))
+        face_to_cell_h = np.abs(pp.fvutils.scalar_divergence(g_primary))
         # We also need a trace-like projection from cells to faces
         trace_h = face_to_cell_h.T
 
@@ -94,8 +94,8 @@ class UpwindCoupling(
 
         # Discretisation of mortars
         # If fluid flux(lam_flux) is positive we use the upper value as weight,
-        # i.e., T_masterat * fluid_flux = lambda.
-        # We set cc[2, 0] = T_masterat * fluid_flux
+        # i.e., T_primaryat * fluid_flux = lambda.
+        # We set cc[2, 0] = T_primaryat * fluid_flux
         # Use averaged projection operator for an intensive quantity
         cc[2, 0] = sps.diags(lam_flux * flag) * mg.primary_to_mortar_avg() * trace_h
 
@@ -109,7 +109,7 @@ class UpwindCoupling(
         # Recover the information for the grid-grid mapping
         cc[2, 2] = -sps.eye(mg.num_cells)
 
-        if data_master["node_number"] == data_secondary["node_number"]:
+        if data_primary["node_number"] == data_secondary["node_number"]:
             # All contributions to be returned to the same block of the
             # global matrix in this case
             cc = np.array([np.sum(cc, axis=(0, 1))])
@@ -121,9 +121,9 @@ class UpwindCoupling(
 
     def cfl(
         self,
-        g_master,
+        g_primary,
         g_secondary,
-        data_master,
+        data_primary,
         data_secondary,
         data_edge,
         d_name="mortar_solution",
@@ -138,9 +138,9 @@ class UpwindCoupling(
             Normal velocity at each face, weighted by the face area.
 
         Parameters:
-            g_master: grid of higher dimension
+            g_primary: grid of higher dimension
             g_secondary: grid of lower dimension
-            data_master: dictionary which stores the data for the higher dimensional
+            data_primary: dictionary which stores the data for the higher dimensional
                 grid
             data_secondary: dictionary which stores the data for the lower dimensional
                 grid
@@ -153,69 +153,69 @@ class UpwindCoupling(
         Note: the design of this function has not been updated according
         to the mortar structure. Instead, mg.high_to_mortar_int.nonzero()[1]
         is used to map the 'mortar_solution' (one flux for each mortar dof) to
-        the old darcy_flux (one flux for each g_master face).
+        the old darcy_flux (one flux for each g_primary face).
 
         """
         # Retrieve the darcy_flux, which is mandatory
 
-        aperture_master = data_master["param"].get_aperture()
+        aperture_primary = data_primary["param"].get_aperture()
         aperture_secondary = data_secondary["param"].get_aperture()
         phi_secondary = data_secondary["param"].get_porosity()
         mg = data_edge["mortar_grid"]
-        darcy_flux = np.zeros(g_master.num_faces)
+        darcy_flux = np.zeros(g_primary.num_faces)
         darcy_flux[mg.high_to_mortar_int.nonzero()[1]] = data_edge[d_name]
-        if g_master.dim == g_secondary.dim:
+        if g_primary.dim == g_secondary.dim:
             # More or less same as below, except we have cell_cells in the place
             # of face_cells (see grid_bucket.duplicate_without_dimension).
-            phi_master = data_master["param"].get_porosity()
-            cells_secondary, cells_master = data_edge["face_cells"].nonzero()
+            phi_primary = data_primary["param"].get_porosity()
+            cells_secondary, cells_primary = data_edge["face_cells"].nonzero()
             not_zero = ~np.isclose(np.zeros(darcy_flux.shape), darcy_flux, atol=0)
             if not np.any(not_zero):
                 return np.Inf
 
             diff = (
-                g_master.cell_centers[:, cells_master]
+                g_primary.cell_centers[:, cells_primary]
                 - g_secondary.cell_centers[:, cells_secondary]
             )
             dist = np.linalg.norm(diff, 2, axis=0)
 
             # Use minimum of cell values for convenience
             phi_secondary = phi_secondary[cells_secondary]
-            phi_master = phi_master[cells_master]
-            apt_master = aperture_master[cells_master]
+            phi_primary = phi_primary[cells_primary]
+            apt_primary = aperture_primary[cells_primary]
             apt_secondary = aperture_secondary[cells_secondary]
-            coeff = np.minimum(phi_master, phi_secondary) * np.minimum(
-                apt_master, apt_secondary
+            coeff = np.minimum(phi_primary, phi_secondary) * np.minimum(
+                apt_primary, apt_secondary
             )
             return np.amin(np.abs(np.divide(dist, darcy_flux)) * coeff)
 
         # Recover the information for the grid-grid mapping
-        cells_secondary, faces_master, _ = sps.find(data_edge["face_cells"])
+        cells_secondary, faces_primary, _ = sps.find(data_edge["face_cells"])
 
         # Detect and remove the faces which have zero in "darcy_flux"
         not_zero = ~np.isclose(
-            np.zeros(faces_master.size), darcy_flux[faces_master], atol=0
+            np.zeros(faces_primary.size), darcy_flux[faces_primary], atol=0
         )
         if not np.any(not_zero):
             return np.inf
 
         cells_secondary = cells_secondary[not_zero]
-        faces_master = faces_master[not_zero]
-        # Mapping from faces_master to cell_master
-        cell_faces_master = g_master.cell_faces.tocsr()[faces_master, :]
-        cells_master = cell_faces_master.nonzero()[1][not_zero]
+        faces_primary = faces_primary[not_zero]
+        # Mapping from faces_primary to cell_primary
+        cell_faces_primary = g_primary.cell_faces.tocsr()[faces_primary, :]
+        cells_primary = cell_faces_primary.nonzero()[1][not_zero]
         # Retrieve and map additional data
-        aperture_master = aperture_master[cells_master]
+        aperture_primary = aperture_primary[cells_primary]
         aperture_secondary = aperture_secondary[cells_secondary]
         phi_secondary = phi_secondary[cells_secondary]
         # Compute discrete distance cell to face centers for the lower
         # dimensional grid
-        dist = 0.5 * np.divide(aperture_secondary, aperture_master)
+        dist = 0.5 * np.divide(aperture_secondary, aperture_primary)
         # Since darcy_flux is multiplied by the aperture wighted face areas, we
         # divide through that quantity to get velocities in [length/time]
         velocity = np.divide(
-            darcy_flux[faces_master],
-            g_master.face_areas[faces_master] * aperture_master,
+            darcy_flux[faces_primary],
+            g_primary.face_areas[faces_primary] * aperture_primary,
         )
         # deltaT is deltaX/velocity with coefficient
         return np.amin(np.abs(np.divide(dist, velocity)) * phi_secondary)

--- a/src/porepy/numerics/interface_laws/hyperbolic_interface_laws.py
+++ b/src/porepy/numerics/interface_laws/hyperbolic_interface_laws.py
@@ -87,7 +87,7 @@ class UpwindCoupling(
 
         # Transport out of upper equals lambda.
         # Use integrated projcetion operator; the flux is an extensive quantity
-        cc[0, 2] = face_to_cell_h * mg.mortar_to_master_int()
+        cc[0, 2] = face_to_cell_h * mg.mortar_to_primary_int()
 
         # transport out of lower is -lambda
         cc[1, 2] = -mg.mortar_to_secondary_int()

--- a/src/porepy/numerics/mixed_dim/assembler.py
+++ b/src/porepy/numerics/mixed_dim/assembler.py
@@ -514,7 +514,11 @@ class Assembler:
             # Check if this is filtered out
             if not filt.filter(
                 grids=[combination.coupling],
-                variables=[combination.primary, combination.secondary, combination.edge],
+                variables=[
+                    combination.primary,
+                    combination.secondary,
+                    combination.edge,
+                ],
                 terms=[combination.term],
             ):
                 continue
@@ -1072,7 +1076,11 @@ class Assembler:
                 )
                 grid_variable_term_combinations.append(
                     CouplingVariableTerm(
-                        (g_primary, g_secondary, e), key_edge, key_primary, key_secondary, term
+                        (g_primary, g_secondary, e),
+                        key_edge,
+                        key_primary,
+                        key_secondary,
+                        term,
                     )
                 )
         # Array version of the number of dofs per node/edge and variable

--- a/src/porepy/numerics/mixed_dim/assembler.py
+++ b/src/porepy/numerics/mixed_dim/assembler.py
@@ -25,7 +25,7 @@ GridVariableTerm.col.__doc__ = (
 GridVariableTerm.term.__doc__ = "Term for this discretization"
 
 CouplingVariableTerm = namedtuple(
-    "CouplingVariableTerm", ["coupling", "edge", "master", "slave", "term"]
+    "CouplingVariableTerm", ["coupling", "edge", "master", "secondary", "term"]
 )
 
 
@@ -497,8 +497,8 @@ class Assembler:
                 "scalar_coupling_term": {                           <-- coupling_key
                     g_h: ("pressure", "diffusion"),                 <-- (master_var_key,
                                                                          master_term_key)
-                    g_l: ("pressure", "diffusion"),                 <-- (slave_var_key,
-                                                                         slave_term_key)
+                    g_l: ("pressure", "diffusion"),                 <-- (secondary_var_key,
+                                                                         secondary_term_key)
                     e: (
                         "mortar_pressure",                          <-- edge_var_key
                         pp.RobinCoupling("flow", pp.Mpfa("flow"),   <-- edge_discr
@@ -514,13 +514,13 @@ class Assembler:
             # Check if this is filtered out
             if not filt.filter(
                 grids=[combination.coupling],
-                variables=[combination.master, combination.slave, combination.edge],
+                variables=[combination.master, combination.secondary, combination.edge],
                 terms=[combination.term],
             ):
                 continue
 
-            g_master, g_slave, e = combination.coupling
-            data_slave = self.gb.node_props(g_slave)
+            g_master, g_secondary, e = combination.coupling
+            data_secondary = self.gb.node_props(g_secondary)
             data_master = self.gb.node_props(g_master)
             data_edge = self.gb.edge_props(e)
 
@@ -559,46 +559,46 @@ class Assembler:
                 mat_key_master = self._variable_term_key(
                     master_term_key, master_var_key, master_var_key
                 )
-            # Do similar operations for the slave variable.
-            slave_vals: Tuple[str, str] = coupling.get(g_slave, None)
-            if slave_vals is None:
-                slave_var_key = ""
-                slave_term_key = ""
+            # Do similar operations for the secondary variable.
+            secondary_vals: Tuple[str, str] = coupling.get(g_secondary, None)
+            if secondary_vals is None:
+                secondary_var_key = ""
+                secondary_term_key = ""
                 si = None
 
-                # If operation is 'assemble', set mat_key_slave to None here
+                # If operation is 'assemble', set mat_key_secondary to None here
                 # and throw and error when the 'matrix' dictionary is accessed.
-                mat_key_slave = None
+                mat_key_secondary = None
             else:
-                slave_var_key, slave_term_key = slave_vals
+                secondary_var_key, secondary_term_key = secondary_vals
 
-                si = self.block_dof.get((g_slave, slave_var_key))
+                si = self.block_dof.get((g_secondary, secondary_var_key))
                 # Also define the key to access the matrix of the discretization of
-                # the slave variable on the slave node.
-                mat_key_slave = self._variable_term_key(
-                    slave_term_key, slave_var_key, slave_var_key
+                # the secondary variable on the secondary node.
+                mat_key_secondary = self._variable_term_key(
+                    secondary_term_key, secondary_var_key, secondary_var_key
                 )
 
             # Key to the matrix dictionary used to access this coupling
             # discretization.
             mat_key = self._variable_term_key(
-                term_key, edge_var_key, slave_var_key, master_var_key
+                term_key, edge_var_key, secondary_var_key, master_var_key
             )
 
             # Now there are three options (and a fourth, invalid one):
-            # The standard case is that both slave and master variables
-            # are used in the coupling. Alternatively, only one of the master or slave is
+            # The standard case is that both secondary and master variables
+            # are used in the coupling. Alternatively, only one of the master or secondary is
             # used. The fourth alternative, none of them are active, is not
             # considered valid, and raises an error message.
             if mi is not None and si is not None:
                 if operation == "discretize":
                     edge_discr.discretize(
-                        g_master, g_slave, data_master, data_slave, data_edge
+                        g_master, g_secondary, data_master, data_secondary, data_edge
                     )
 
                 elif operation == "update_discretization":
                     edge_discr.discretize(
-                        g_master, g_slave, data_master, data_slave, data_edge
+                        g_master, g_secondary, data_master, data_secondary, data_edge
                     )
 
                 elif operation == "assemble":
@@ -607,12 +607,12 @@ class Assembler:
                     # Local here refers to the variable and term on the two
                     # nodes, together with the relavant mortar variable and term
                     # Associate the first variable with master, the second with
-                    # slave, and the final with edge.
+                    # secondary, and the final with edge.
                     loc_mat, _ = self._assign_matrix_vector(
                         self.full_dof[[mi, si, ei]], sps_matrix
                     )
 
-                    # Pick out the discretizations on the master and slave node
+                    # Pick out the discretizations on the master and secondary node
                     # for the relevant variables.
                     # There should be no contribution or modification of the
                     # [0, 1] and [1, 0] terms, since the variables are only
@@ -625,12 +625,12 @@ class Assembler:
                             f"of dimension {g_master.dim}, for the "
                             f"coupling term {term_key}."
                         )
-                    if mat_key_slave:
-                        loc_mat[1, 1] = matrix[mat_key_slave][si, si]  # type:ignore
+                    if mat_key_secondary:
+                        loc_mat[1, 1] = matrix[mat_key_secondary][si, si]  # type:ignore
                     else:
                         raise ValueError(
-                            f"No discretization found on the slave grid "
-                            f"of dimension {g_slave.dim}, for the "
+                            f"No discretization found on the secondary grid "
+                            f"of dimension {g_secondary.dim}, for the "
                             f"coupling term {term_key}."
                         )
 
@@ -639,27 +639,27 @@ class Assembler:
                     if assemble_matrix_only:
                         tmp_mat = edge_discr.assemble_matrix(
                             g_master,
-                            g_slave,
+                            g_secondary,
                             data_master,
-                            data_slave,
+                            data_secondary,
                             data_edge,
                             loc_mat,
                         )
                     elif assemble_rhs_only:
                         loc_rhs = edge_discr.assemble_rhs(
                             g_master,
-                            g_slave,
+                            g_secondary,
                             data_master,
-                            data_slave,
+                            data_secondary,
                             data_edge,
                             loc_mat,
                         )
                     else:
                         tmp_mat, loc_rhs = edge_discr.assemble_matrix_rhs(
                             g_master,
-                            g_slave,
+                            g_secondary,
                             data_master,
-                            data_slave,
+                            data_secondary,
                             data_edge,
                             loc_mat,
                         )
@@ -671,10 +671,10 @@ class Assembler:
                         matrix[mat_key][(mi, si), ei] = tmp_mat[  # type:ignore
                             (0, 1), 2
                         ]
-                        # Also update the discretization on the master and slave
+                        # Also update the discretization on the master and secondary
                         # nodes
                         matrix[mat_key_master][mi, mi] = tmp_mat[0, 0]  # type:ignore
-                        matrix[mat_key_slave][si, si] = tmp_mat[1, 1]  # type:ignore
+                        matrix[mat_key_secondary][si, si] = tmp_mat[1, 1]  # type:ignore
 
                     if not assemble_matrix_only:
                         # Finally take care of the right hand side
@@ -713,7 +713,7 @@ class Assembler:
                         ]
                         matrix[mat_key][mi, ei] = tmp_mat[0, 1]  # type:ignore
 
-                        # Also update the discretization on the master and slave
+                        # Also update the discretization on the master and secondary
                         # nodes
                         matrix[mat_key_master][mi, mi] = tmp_mat[0, 0]  # type:ignore
 
@@ -725,26 +725,26 @@ class Assembler:
                 # mi is None
                 # The operation is a simplified version of the full option above.
                 if operation in ("discretize", "update_discretization"):
-                    edge_discr.discretize(g_slave, data_slave, data_edge)
+                    edge_discr.discretize(g_secondary, data_secondary, data_edge)
                 elif operation == "assemble":
 
                     loc_mat, _ = self._assign_matrix_vector(
                         self.full_dof[[si, ei]], sps_matrix
                     )
-                    loc_mat[0, 0] = matrix[mat_key_slave][si, si]  # type:ignore
+                    loc_mat[0, 0] = matrix[mat_key_secondary][si, si]  # type:ignore
                     if assemble_matrix_only:
                         tmp_mat = edge_discr.assemble_matrix(
-                            g_slave, data_slave, data_edge, loc_mat
+                            g_secondary, data_secondary, data_edge, loc_mat
                         )
 
                     elif assemble_rhs_only:
                         loc_rhs = edge_discr.assemble_rhs(
-                            g_slave, data_slave, data_edge, loc_mat
+                            g_secondary, data_secondary, data_edge, loc_mat
                         )
 
                     else:
                         tmp_mat, loc_rhs = edge_discr.assemble_matrix_rhs(
-                            g_slave, data_slave, data_edge, loc_mat
+                            g_secondary, data_secondary, data_edge, loc_mat
                         )
 
                     if not assemble_rhs_only:
@@ -753,9 +753,9 @@ class Assembler:
                         ]
                         matrix[mat_key][si, ei] = tmp_mat[0, 1]  # type:ignore
 
-                        # Also update the discretization on the master and slave
+                        # Also update the discretization on the master and secondary
                         # nodes
-                        matrix[mat_key_slave][si, si] = tmp_mat[0, 0]  # type:ignore
+                        matrix[mat_key_secondary][si, si] = tmp_mat[0, 0]  # type:ignore
                     if not assemble_matrix_only:
                         rhs[mat_key][[si, ei]] += loc_rhs
 
@@ -803,7 +803,7 @@ class Assembler:
                     # Local here refers to the variable and term on the two
                     # nodes, together with the relavant mortar variable and term
                     # Associate the first variable with master, the second with
-                    # slave, and the final with edge.
+                    # secondary, and the final with edge.
                     loc_mat, _ = self._assign_matrix_vector(
                         self.full_dof[[mi, ei, oi]], sps_matrix
                     )
@@ -823,7 +823,7 @@ class Assembler:
                     rhs[mat_key][ei] += loc_rhs[1]  # type:ignore
 
             if operation == "assemble" and edge_discr.edge_coupling_via_low_dim:
-                for other_edge, data_other in self.gb.edges_of_node(g_slave):
+                for other_edge, data_other in self.gb.edges_of_node(g_secondary):
 
                     # Skip the case where the primary and secondary edge is the same
                     if other_edge == e:
@@ -852,7 +852,7 @@ class Assembler:
                     # Local here refers to the variable and term on the two
                     # nodes, together with the relavant mortar variable and term
                     # Associate the first variable with master, the second with
-                    # slave, and the final with edge.
+                    # secondary, and the final with edge.
                     loc_mat, _ = self._assign_matrix_vector(
                         self.full_dof[[si, ei, oi]], sps_matrix
                     )
@@ -860,7 +860,7 @@ class Assembler:
                         tmp_mat,
                         loc_rhs,
                     ) = edge_discr.assemble_edge_coupling_via_high_dim(
-                        g_slave, data_slave, data_edge, data_other, loc_mat
+                        g_secondary, data_secondary, data_edge, data_other, loc_mat
                     )
                     matrix[mat_key][ei, oi] = tmp_mat[1, 2]  # type:ignore
                     rhs[mat_key][ei] += loc_rhs[1]
@@ -1029,7 +1029,7 @@ class Assembler:
                         )
             # Finally, identify variable combinations for coupling terms.
             # This involves both the neighboring grids
-            g_slave, g_master = self.gb.nodes_of_edge(e)
+            g_secondary, g_master = self.gb.nodes_of_edge(e)
 
             discr = d.get(pp.COUPLING_DISCRETIZATION, None)
             if discr is None:
@@ -1040,7 +1040,7 @@ class Assembler:
                 # diffusion), val contains the coupling information
 
                 # Identify this term in the discretization by the variable names
-                # on the edge, the variable names of the slave and master grid
+                # on the edge, the variable names of the secondary and master grid
                 # in that order, and finally the term name.
                 # There is a tacit assumption here that self.gb.nodes_of_edge return the
                 # grids in the same order here and in the assembly. This should be okay.
@@ -1050,16 +1050,16 @@ class Assembler:
                 key_edge: str = val.get(e)[0]
 
                 # Get name of the edge variable, if it exists
-                key_slave = val.get(g_slave)
-                if key_slave is not None:
-                    key_slave = key_slave[0]
+                key_secondary = val.get(g_secondary)
+                if key_secondary is not None:
+                    key_secondary = key_secondary[0]
 
                 else:
                     # This can happen if the the coupling is one-sided, e.g.
-                    # it does not consider the slave grid.
+                    # it does not consider the secondary grid.
                     # An empty string will give no impact on the generated
                     # combination of variable names and discretizaiton terms
-                    key_slave = ""
+                    key_secondary = ""
 
                 key_master = val.get(g_master)
                 if key_master is not None:
@@ -1068,11 +1068,11 @@ class Assembler:
                     key_master = ""
 
                 variable_combinations.append(
-                    self._variable_term_key(term, key_edge, key_slave, key_master)
+                    self._variable_term_key(term, key_edge, key_secondary, key_master)
                 )
                 grid_variable_term_combinations.append(
                     CouplingVariableTerm(
-                        (g_master, g_slave, e), key_edge, key_master, key_slave, term
+                        (g_master, g_secondary, e), key_edge, key_master, key_secondary, term
                     )
                 )
         # Array version of the number of dofs per node/edge and variable

--- a/src/porepy/numerics/vem/dual_elliptic.py
+++ b/src/porepy/numerics/vem/dual_elliptic.py
@@ -391,7 +391,7 @@ class DualElliptic(
                 mixed-dimensional grid.
             cc (block matrix, 3x3): Block matrix for the coupling condition.
                 The first and second rows and columns are identified with the
-                master and secondary side; the third belongs to the edge variable.
+                primary and secondary side; the third belongs to the edge variable.
                 The discretization of the relevant term is done in-place in cc.
             matrix (block matrix 3x3): Discretization matrix for the edge and
                 the two adjacent nodes.
@@ -443,7 +443,7 @@ class DualElliptic(
                 mixed-dimensional grid.
             cc (block matrix, 3x3): Block matrix for the coupling condition.
                 The first and second rows and columns are identified with the
-                master and secondary side; the third belongs to the edge variable.
+                primary and secondary side; the third belongs to the edge variable.
                 The discretization of the relevant term is done in-place in cc.
             matrix (block matrix 3x3): Discretization matrix for the edge and
                 the two adjacent nodes.
@@ -491,7 +491,7 @@ class DualElliptic(
                 mixed-dimensional grid.
             cc (block matrix, 3x3): Block matrix for the coupling condition.
                 The first and second rows and columns are identified with the
-                master and secondary side; the third belongs to the edge variable.
+                primary and secondary side; the third belongs to the edge variable.
                 The discretization of the relevant term is done in-place in cc.
             matrix (block matrix 3x3): Discretization matrix for the edge and
                 the two adjacent nodes.
@@ -531,7 +531,7 @@ class DualElliptic(
                 mixed-dimensional grid.
             cc (block matrix, 3x3): Block matrix for the coupling condition.
                 The first and second rows and columns are identified with the
-                master and secondary side; the third belongs to the edge variable.
+                primary and secondary side; the third belongs to the edge variable.
                 The discretization of the relevant term is done in-place in cc.
             matrix (block matrix 3x3): Discretization matrix for the edge and
                 the two adjacent nodes.
@@ -571,12 +571,12 @@ class DualElliptic(
                 mixed-dimensional grid.
             cc (block matrix, 3x3): Block matrix of size 3 x 3, whwere each block represents
                 coupling between variables on this interface. Index 0, 1 and 2
-                represent the master grid, the primary and secondary interface,
+                represent the primary grid, the primary and secondary interface,
                 respectively.
             matrix (block matrix 3x3): Discretization matrix for the edge and
                 the two adjacent nodes.
             rhs (block_array 3x1): Block matrix of size 3 x 1, representing the right hand
-                side of this coupling. Index 0, 1 and 2 represent the master grid,
+                side of this coupling. Index 0, 1 and 2 represent the primary grid,
                 the primary and secondary interface, respectively.
 
         """
@@ -613,7 +613,7 @@ class DualElliptic(
                 secondary side of the mortar grid in data_adge.
             cc (block matrix, 3x3): Block matrix for the coupling condition.
                 The first and second rows and columns are identified with the
-                master and secondary side; the third belongs to the edge variable.
+                primary and secondary side; the third belongs to the edge variable.
                 The discretization of the relevant term is done in-place in cc.
             matrix (block matrix 3x3): Discretization matrix for the edge and
                 the two adjacent nodes.

--- a/src/porepy/numerics/vem/dual_elliptic.py
+++ b/src/porepy/numerics/vem/dual_elliptic.py
@@ -370,7 +370,7 @@ class DualElliptic(
         matrix: np.ndarray,
         rhs: np.ndarray,
         self_ind: int,
-        use_slave_proj: bool = False,
+        use_secondary_proj: bool = False,
     ) -> None:
         """Abstract method. Assemble the contribution from an internal
         boundary, manifested as a flux boundary condition.
@@ -391,7 +391,7 @@ class DualElliptic(
                 mixed-dimensional grid.
             cc (block matrix, 3x3): Block matrix for the coupling condition.
                 The first and second rows and columns are identified with the
-                master and slave side; the third belongs to the edge variable.
+                master and secondary side; the third belongs to the edge variable.
                 The discretization of the relevant term is done in-place in cc.
             matrix (block matrix 3x3): Discretization matrix for the edge and
                 the two adjacent nodes.
@@ -399,14 +399,14 @@ class DualElliptic(
                 the two adjacent nodes.
             self_ind (int): Index in cc and matrix associated with this node.
                 Should be either 1 or 2.
-            use_slave_proj (boolean): If True, the slave side projection operator is
+            use_secondary_proj (boolean): If True, the secondary side projection operator is
                 used. Needed for periodic boundary conditions.
 
         """
 
         # The matrix must be the VEM discretization matrix.
         mg = data_edge["mortar_grid"]
-        if use_slave_proj:
+        if use_secondary_proj:
             proj = mg.mortar_to_secondary_int()
         else:
             proj = mg.mortar_to_primary_int()
@@ -443,7 +443,7 @@ class DualElliptic(
                 mixed-dimensional grid.
             cc (block matrix, 3x3): Block matrix for the coupling condition.
                 The first and second rows and columns are identified with the
-                master and slave side; the third belongs to the edge variable.
+                master and secondary side; the third belongs to the edge variable.
                 The discretization of the relevant term is done in-place in cc.
             matrix (block matrix 3x3): Discretization matrix for the edge and
                 the two adjacent nodes.
@@ -470,7 +470,7 @@ class DualElliptic(
         matrix: np.ndarray,
         rhs: np.ndarray,
         self_ind: int,
-        use_slave_proj: bool = False,
+        use_secondary_proj: bool = False,
     ) -> None:
         """Abstract method. Assemble the contribution from an internal
         boundary, manifested as a condition on the boundary pressure.
@@ -491,7 +491,7 @@ class DualElliptic(
                 mixed-dimensional grid.
             cc (block matrix, 3x3): Block matrix for the coupling condition.
                 The first and second rows and columns are identified with the
-                master and slave side; the third belongs to the edge variable.
+                master and secondary side; the third belongs to the edge variable.
                 The discretization of the relevant term is done in-place in cc.
             matrix (block matrix 3x3): Discretization matrix for the edge and
                 the two adjacent nodes.
@@ -499,13 +499,13 @@ class DualElliptic(
                 the two adjacent nodes.
             self_ind (int): Index in cc and matrix associated with this node.
                 Should be either 1 or 2.
-            use_slave_proj (boolean): If True, the slave side projection operator is
+            use_secondary_proj (boolean): If True, the secondary side projection operator is
                 used. Needed for periodic boundary conditions.
 
         """
         mg = data_edge["mortar_grid"]
 
-        if use_slave_proj:
+        if use_secondary_proj:
             proj = mg.mortar_to_secondary_int()
         else:
             proj = mg.mortar_to_primary_int()
@@ -516,7 +516,7 @@ class DualElliptic(
         cc[2, 2] -= hat_E_int.T * matrix[self_ind, self_ind] * hat_E_int
 
     def assemble_int_bound_pressure_trace_rhs(
-        self, g, data, data_edge, cc, rhs, self_ind, use_slave_proj=False
+        self, g, data, data_edge, cc, rhs, self_ind, use_secondary_proj=False
     ):
         """Assemble the rhs contribution from an internal
         boundary, manifested as a condition on the boundary pressure.
@@ -531,7 +531,7 @@ class DualElliptic(
                 mixed-dimensional grid.
             cc (block matrix, 3x3): Block matrix for the coupling condition.
                 The first and second rows and columns are identified with the
-                master and slave side; the third belongs to the edge variable.
+                master and secondary side; the third belongs to the edge variable.
                 The discretization of the relevant term is done in-place in cc.
             matrix (block matrix 3x3): Discretization matrix for the edge and
                 the two adjacent nodes.
@@ -539,7 +539,7 @@ class DualElliptic(
                 the two adjacent nodes.
             self_ind (int): Index in cc and matrix associated with this node.
                 Should be either 1 or 2.
-            use_slave_proj (boolean): If True, the slave side projection operator is
+            use_secondary_proj (boolean): If True, the secondary side projection operator is
                 used. Needed for periodic boundary conditions.
 
         """
@@ -610,10 +610,10 @@ class DualElliptic(
             data_edge (dictionary): Data dictionary for the edge in the
                 mixed-dimensional grid.
             grid_swap (boolean): If True, the grid g is identified with the @
-                slave side of the mortar grid in data_adge.
+                secondary side of the mortar grid in data_adge.
             cc (block matrix, 3x3): Block matrix for the coupling condition.
                 The first and second rows and columns are identified with the
-                master and slave side; the third belongs to the edge variable.
+                master and secondary side; the third belongs to the edge variable.
                 The discretization of the relevant term is done in-place in cc.
             matrix (block matrix 3x3): Discretization matrix for the edge and
                 the two adjacent nodes.

--- a/src/porepy/numerics/vem/dual_elliptic.py
+++ b/src/porepy/numerics/vem/dual_elliptic.py
@@ -407,7 +407,7 @@ class DualElliptic(
         # The matrix must be the VEM discretization matrix.
         mg = data_edge["mortar_grid"]
         if use_slave_proj:
-            proj = mg.mortar_to_slave_int()
+            proj = mg.mortar_to_secondary_int()
         else:
             proj = mg.mortar_to_master_int()
 
@@ -506,7 +506,7 @@ class DualElliptic(
         mg = data_edge["mortar_grid"]
 
         if use_slave_proj:
-            proj = mg.mortar_to_slave_int()
+            proj = mg.mortar_to_secondary_int()
         else:
             proj = mg.mortar_to_master_int()
 

--- a/src/porepy/numerics/vem/dual_elliptic.py
+++ b/src/porepy/numerics/vem/dual_elliptic.py
@@ -46,7 +46,7 @@ def project_flux(gb, discr, flux, P0_flux, mortar_key="mortar_solution"):
                     continue
                 # project the mortar variable back to the higher dimensional
                 # problem
-                # edge_flux += sign * g_m.mortar_to_master_int() * d_e[pp.STATE][mortar_key]
+                # edge_flux += sign * g_m.mortar_to_primary_int() * d_e[pp.STATE][mortar_key]
                 edge_flux += (
                     sign * g_m.master_to_mortar_avg().T * d_e[pp.STATE][mortar_key]
                 )
@@ -409,7 +409,7 @@ class DualElliptic(
         if use_slave_proj:
             proj = mg.mortar_to_secondary_int()
         else:
-            proj = mg.mortar_to_master_int()
+            proj = mg.mortar_to_primary_int()
 
         hat_E_int = self._velocity_dof(g, mg, proj)
         cc[self_ind, 2] += matrix[self_ind, self_ind] * hat_E_int
@@ -508,7 +508,7 @@ class DualElliptic(
         if use_slave_proj:
             proj = mg.mortar_to_secondary_int()
         else:
-            proj = mg.mortar_to_master_int()
+            proj = mg.mortar_to_primary_int()
 
         hat_E_int = self._velocity_dof(g, mg, proj)
 
@@ -651,7 +651,7 @@ class DualElliptic(
         """
         mg = data_edge["mortar_grid"]
 
-        hat_E_int = self._velocity_dof(g, mg, mg.mortar_to_master_int())
+        hat_E_int = self._velocity_dof(g, mg, mg.mortar_to_primary_int())
 
         dof = np.where(hat_E_int.sum(axis=1).A.astype(np.bool))[0]
         norm = np.linalg.norm(matrix[self_ind, self_ind].diagonal(), np.inf)

--- a/src/porepy/numerics/vem/dual_elliptic.py
+++ b/src/porepy/numerics/vem/dual_elliptic.py
@@ -48,7 +48,7 @@ def project_flux(gb, discr, flux, P0_flux, mortar_key="mortar_solution"):
                 # problem
                 # edge_flux += sign * g_m.mortar_to_primary_int() * d_e[pp.STATE][mortar_key]
                 edge_flux += (
-                    sign * g_m.master_to_mortar_avg().T * d_e[pp.STATE][mortar_key]
+                    sign * g_m.primary_to_mortar_avg().T * d_e[pp.STATE][mortar_key]
                 )
 
         d[pp.STATE][P0_flux] = discr.project_flux(g, edge_flux + d[pp.STATE][flux], d)

--- a/src/porepy/numerics/vem/dual_elliptic.py
+++ b/src/porepy/numerics/vem/dual_elliptic.py
@@ -455,7 +455,7 @@ class DualElliptic(
         """
         mg = data_edge["mortar_grid"]
 
-        proj = mg.slave_to_mortar_avg()
+        proj = mg.secondary_to_mortar_avg()
 
         A = proj.T
         shape = (g.num_faces, A.shape[1])
@@ -625,7 +625,7 @@ class DualElliptic(
         """
         mg = data_edge["mortar_grid"]
 
-        proj = mg.slave_to_mortar_avg()
+        proj = mg.secondary_to_mortar_avg()
 
         A = proj.T
         shape = (g.num_faces, A.shape[1])

--- a/src/porepy/utils/derived_discretizations/implicit_euler.py
+++ b/src/porepy/utils/derived_discretizations/implicit_euler.py
@@ -66,7 +66,7 @@ class ImplicitMpfa(pp.Mpfa):
         mg = data_edge["mortar_grid"]
 
         if use_slave_proj:
-            proj = mg.mortar_to_slave_int()
+            proj = mg.mortar_to_secondary_int()
         else:
             proj = mg.mortar_to_master_int()
 
@@ -115,7 +115,7 @@ class ImplicitMpfa(pp.Mpfa):
         """
         mg = data_edge["mortar_grid"]
 
-        proj = mg.mortar_to_slave_int()
+        proj = mg.mortar_to_secondary_int()
         dt = data[pp.PARAMETERS][self.keyword]["time_step"]
         cc[self_ind, 2] -= proj * dt
 
@@ -153,7 +153,7 @@ class ImplicitTpfa(pp.Tpfa):
         mg = data_edge["mortar_grid"]
 
         if use_slave_proj:
-            proj = mg.mortar_to_slave_int()
+            proj = mg.mortar_to_secondary_int()
         else:
             proj = mg.mortar_to_master_int()
 
@@ -202,7 +202,7 @@ class ImplicitTpfa(pp.Tpfa):
         """
         mg = data_edge["mortar_grid"]
 
-        proj = mg.mortar_to_slave_int()
+        proj = mg.mortar_to_secondary_int()
         dt = data[pp.PARAMETERS][self.keyword]["time_step"]
         cc[self_ind, 2] -= proj * dt
 

--- a/src/porepy/utils/derived_discretizations/implicit_euler.py
+++ b/src/porepy/utils/derived_discretizations/implicit_euler.py
@@ -296,7 +296,7 @@ class ImplicitUpwindCoupling(pp.UpwindCoupling):
         # Projection from mortar to upper dimenional faces
         hat_P_avg = g_m.primary_to_mortar_avg()
         # Projection from mortar to lower dimensional cells
-        check_P_avg = g_m.slave_to_mortar_avg()
+        check_P_avg = g_m.secondary_to_mortar_avg()
 
         # mapping from upper dim cellls to faces
         # The mortars always points from upper to lower, so we don't flip any

--- a/src/porepy/utils/derived_discretizations/implicit_euler.py
+++ b/src/porepy/utils/derived_discretizations/implicit_euler.py
@@ -68,7 +68,7 @@ class ImplicitMpfa(pp.Mpfa):
         if use_slave_proj:
             proj = mg.mortar_to_secondary_int()
         else:
-            proj = mg.mortar_to_master_int()
+            proj = mg.mortar_to_primary_int()
 
         if g.dim > 0 and bound_flux.shape[0] != g.num_faces:
             # If bound flux is gven as sub-faces we have to map it from sub-faces
@@ -155,7 +155,7 @@ class ImplicitTpfa(pp.Tpfa):
         if use_slave_proj:
             proj = mg.mortar_to_secondary_int()
         else:
-            proj = mg.mortar_to_master_int()
+            proj = mg.mortar_to_primary_int()
 
         if g.dim > 0 and bound_flux.shape[0] != g.num_faces:
             # If bound flux is gven as sub-faces we have to map it from sub-faces

--- a/src/porepy/utils/derived_discretizations/implicit_euler.py
+++ b/src/porepy/utils/derived_discretizations/implicit_euler.py
@@ -52,7 +52,7 @@ class ImplicitMpfa(pp.Mpfa):
         return a, b
 
     def assemble_int_bound_flux(
-        self, g, data, data_edge, cc, matrix, rhs, self_ind, use_slave_proj=False
+        self, g, data, data_edge, cc, matrix, rhs, self_ind, use_secondary_proj=False
     ):
         """
         Overwrite the MPFA method to be consistent with the Biot dt convention
@@ -65,7 +65,7 @@ class ImplicitMpfa(pp.Mpfa):
         # Projection operators to grid
         mg = data_edge["mortar_grid"]
 
-        if use_slave_proj:
+        if use_secondary_proj:
             proj = mg.mortar_to_secondary_int()
         else:
             proj = mg.mortar_to_primary_int()
@@ -103,7 +103,7 @@ class ImplicitMpfa(pp.Mpfa):
                 mixed-dimensional grid.
             cc (block matrix, 3x3): Block matrix for the coupling condition.
                 The first and second rows and columns are identified with the
-                master and slave side; the third belongs to the edge variable.
+                master and secondary side; the third belongs to the edge variable.
                 The discretization of the relevant term is done in-place in cc.
             matrix (block matrix 3x3): Discretization matrix for the edge and
                 the two adjacent nodes.
@@ -139,7 +139,7 @@ class ImplicitTpfa(pp.Tpfa):
         return a, b
 
     def assemble_int_bound_flux(
-        self, g, data, data_edge, cc, matrix, rhs, self_ind, use_slave_proj=False
+        self, g, data, data_edge, cc, matrix, rhs, self_ind, use_secondary_proj=False
     ):
         """
         Overwrite the MPFA method to be consistent with the Biot dt convention
@@ -152,7 +152,7 @@ class ImplicitTpfa(pp.Tpfa):
         # Projection operators to grid
         mg = data_edge["mortar_grid"]
 
-        if use_slave_proj:
+        if use_secondary_proj:
             proj = mg.mortar_to_secondary_int()
         else:
             proj = mg.mortar_to_primary_int()
@@ -190,7 +190,7 @@ class ImplicitTpfa(pp.Tpfa):
                 mixed-dimensional grid.
             cc (block matrix, 3x3): Block matrix for the coupling condition.
                 The first and second rows and columns are identified with the
-                master and slave side; the third belongs to the edge variable.
+                master and secondary side; the third belongs to the edge variable.
                 The discretization of the relevant term is done in-place in cc.
             matrix (block matrix 3x3): Discretization matrix for the edge and
                 the two adjacent nodes.
@@ -241,7 +241,7 @@ class ImplicitUpwindCoupling(pp.UpwindCoupling):
     """
 
     def assemble_matrix_rhs(
-        self, g_master, g_slave, data_master, data_slave, data_edge, matrix
+        self, g_master, g_secondary, data_master, data_secondary, data_edge, matrix
     ):
         """
         Construct the matrix (and right-hand side) for the coupling conditions.
@@ -250,10 +250,10 @@ class ImplicitUpwindCoupling(pp.UpwindCoupling):
         Parameters:
             matrix: Uncoupled discretization matrix.
             g_master: grid of higher dimension
-            g_slave: grid of lower dimension
+            g_secondary: grid of lower dimension
             data_master: dictionary which stores the data for the higher dimensional
                 grid
-            data_slave: dictionary which stores the data for the lower dimensional
+            data_secondary: dictionary which stores the data for the lower dimensional
                 grid
             data: dictionary which stores the data for the edges of the grid
                 bucket
@@ -268,7 +268,7 @@ class ImplicitUpwindCoupling(pp.UpwindCoupling):
 
         # @ALL: This should perhaps be defined by a globalized keyword
         parameter_dictionary_master = data_master[pp.PARAMETERS]
-        parameter_dictionary_slave = data_slave[pp.PARAMETERS]
+        parameter_dictionary_secondary = data_secondary[pp.PARAMETERS]
         lam_flux = data_edge[pp.PARAMETERS][self.keyword]["darcy_flux"]
         dt = parameter_dictionary_master[self.keyword]["time_step"]
         w_master = (
@@ -277,9 +277,9 @@ class ImplicitUpwindCoupling(pp.UpwindCoupling):
             )[0]
             * dt
         )
-        w_slave = (
-            parameter_dictionary_slave.expand_scalars(
-                g_slave.num_cells, self.keyword, ["advection_weight"]
+        w_secondary = (
+            parameter_dictionary_secondary.expand_scalars(
+                g_secondary.num_cells, self.keyword, ["advection_weight"]
             )[0]
             * dt
         )
@@ -287,7 +287,7 @@ class ImplicitUpwindCoupling(pp.UpwindCoupling):
         # Create the block matrix for the contributions
         g_m = data_edge["mortar_grid"]
 
-        # We know the number of dofs from the master and slave side from their
+        # We know the number of dofs from the master and secondary side from their
         # discretizations
         dof = np.array([matrix[0, 0].shape[1], matrix[1, 1].shape[1], g_m.num_cells])
         cc = np.array([sps.coo_matrix((i, j)) for i in dof for j in dof])
@@ -329,13 +329,13 @@ class ImplicitUpwindCoupling(pp.UpwindCoupling):
         # If fluid flux is negative we use the lower value as weight,
         # i.e., T_check * fluid_flux = lambda.
         # we set cc[2, 1] = T_check * fluid_flux
-        cc[2, 1] = sps.diags(lam_flux * not_flag) * check_P_avg * sps.diags(w_slave)
+        cc[2, 1] = sps.diags(lam_flux * not_flag) * check_P_avg * sps.diags(w_secondary)
 
         # The rhs of T * fluid_flux = lambda
         # Recover the information for the grid-grid mapping
         cc[2, 2] = -sps.eye(g_m.num_cells)
 
-        if data_master["node_number"] == data_slave["node_number"]:
+        if data_master["node_number"] == data_secondary["node_number"]:
             # All contributions to be returned to the same block of the
             # global matrix in this case
             cc = np.array([np.sum(cc, axis=(0, 1))])

--- a/src/porepy/utils/derived_discretizations/implicit_euler.py
+++ b/src/porepy/utils/derived_discretizations/implicit_euler.py
@@ -294,7 +294,7 @@ class ImplicitUpwindCoupling(pp.UpwindCoupling):
         cc = cc.reshape((3, 3))
 
         # Projection from mortar to upper dimenional faces
-        hat_P_avg = g_m.master_to_mortar_avg()
+        hat_P_avg = g_m.primary_to_mortar_avg()
         # Projection from mortar to lower dimensional cells
         check_P_avg = g_m.slave_to_mortar_avg()
 

--- a/test/integration/test_DFN.py
+++ b/test/integration/test_DFN.py
@@ -424,11 +424,11 @@ def setup_discr_mvem(gb, key="flow"):
             d[pp.DISCRETIZATION] = {key: {"flux": p_trace}}
 
     for e, d in gb.edges():
-        g_slave, g_master = gb.nodes_of_edge(e)
+        g_secondary, g_master = gb.nodes_of_edge(e)
         d[pp.PRIMARY_VARIABLES] = {key: {"cells": 1}}
         d[pp.COUPLING_DISCRETIZATION] = {
             "flux": {
-                g_slave: (key, "flux"),
+                g_secondary: (key, "flux"),
                 g_master: (key, "flux"),
                 e: (key, interface),
             }
@@ -452,11 +452,11 @@ def setup_discr_tpfa(gb, key="flow"):
             d[pp.DISCRETIZATION] = {key: {"flux": p_trace}}
 
     for e, d in gb.edges():
-        g_slave, g_master = gb.nodes_of_edge(e)
+        g_secondary, g_master = gb.nodes_of_edge(e)
         d[pp.PRIMARY_VARIABLES] = {key: {"cells": 1}}
         d[pp.COUPLING_DISCRETIZATION] = {
             "flux": {
-                g_slave: (key, "flux"),
+                g_secondary: (key, "flux"),
                 g_master: (key, "flux"),
                 e: (key, interface),
             }

--- a/test/integration/test_DFN.py
+++ b/test/integration/test_DFN.py
@@ -424,12 +424,12 @@ def setup_discr_mvem(gb, key="flow"):
             d[pp.DISCRETIZATION] = {key: {"flux": p_trace}}
 
     for e, d in gb.edges():
-        g_secondary, g_master = gb.nodes_of_edge(e)
+        g_secondary, g_primary = gb.nodes_of_edge(e)
         d[pp.PRIMARY_VARIABLES] = {key: {"cells": 1}}
         d[pp.COUPLING_DISCRETIZATION] = {
             "flux": {
                 g_secondary: (key, "flux"),
-                g_master: (key, "flux"),
+                g_primary: (key, "flux"),
                 e: (key, interface),
             }
         }
@@ -452,12 +452,12 @@ def setup_discr_tpfa(gb, key="flow"):
             d[pp.DISCRETIZATION] = {key: {"flux": p_trace}}
 
     for e, d in gb.edges():
-        g_secondary, g_master = gb.nodes_of_edge(e)
+        g_secondary, g_primary = gb.nodes_of_edge(e)
         d[pp.PRIMARY_VARIABLES] = {key: {"cells": 1}}
         d[pp.COUPLING_DISCRETIZATION] = {
             "flux": {
                 g_secondary: (key, "flux"),
-                g_master: (key, "flux"),
+                g_primary: (key, "flux"),
                 e: (key, interface),
             }
         }

--- a/test/integration/test_TpfaMonoCoupling.py
+++ b/test/integration/test_TpfaMonoCoupling.py
@@ -56,7 +56,7 @@ class TestTpfaCouplingDiffGrids(unittest.TestCase):
             mg = d_e["mortar_grid"]
             g2, g1 = gb.nodes_of_edge(e)
             master_to_m = mg.primary_to_mortar_avg()
-            slave_to_m = mg.slave_to_mortar_avg()
+            slave_to_m = mg.secondary_to_mortar_avg()
 
             master_area = master_to_m * g1.face_areas
             slave_area = slave_to_m * g2.face_areas
@@ -293,7 +293,7 @@ class TestTpfaCouplingPeriodicBc(unittest.TestCase):
             g1, g2 = gb.nodes_of_edge(e)
             if g1 == g2:
                 left_to_m = mg.primary_to_mortar_avg()
-                right_to_m = mg.slave_to_mortar_avg()
+                right_to_m = mg.secondary_to_mortar_avg()
             else:
                 continue
             d1 = gb.node_props(g1)

--- a/test/integration/test_TpfaMonoCoupling.py
+++ b/test/integration/test_TpfaMonoCoupling.py
@@ -55,13 +55,13 @@ class TestTpfaCouplingDiffGrids(unittest.TestCase):
         for e, d_e in gb.edges():
             mg = d_e["mortar_grid"]
             g2, g1 = gb.nodes_of_edge(e)
-            master_to_m = mg.primary_to_mortar_avg()
+            primary_to_m = mg.primary_to_mortar_avg()
             secondary_to_m = mg.secondary_to_mortar_avg()
 
-            master_area = master_to_m * g1.face_areas
+            primary_area = primary_to_m * g1.face_areas
             secondary_area = secondary_to_m * g2.face_areas
 
-            self.assertTrue(np.allclose(d_e[pp.STATE]["mortar_flux"] / master_area, 1))
+            self.assertTrue(np.allclose(d_e[pp.STATE]["mortar_flux"] / primary_area, 1))
             self.assertTrue(np.allclose(d_e[pp.STATE]["mortar_flux"] / secondary_area, 1))
 
     def generate_grids(self, n, xmax, ymax, split):

--- a/test/integration/test_TpfaMonoCoupling.py
+++ b/test/integration/test_TpfaMonoCoupling.py
@@ -55,7 +55,7 @@ class TestTpfaCouplingDiffGrids(unittest.TestCase):
         for e, d_e in gb.edges():
             mg = d_e["mortar_grid"]
             g2, g1 = gb.nodes_of_edge(e)
-            master_to_m = mg.master_to_mortar_avg()
+            master_to_m = mg.primary_to_mortar_avg()
             slave_to_m = mg.slave_to_mortar_avg()
 
             master_area = master_to_m * g1.face_areas
@@ -292,7 +292,7 @@ class TestTpfaCouplingPeriodicBc(unittest.TestCase):
             mg = d_e["mortar_grid"]
             g1, g2 = gb.nodes_of_edge(e)
             if g1 == g2:
-                left_to_m = mg.master_to_mortar_avg()
+                left_to_m = mg.primary_to_mortar_avg()
                 right_to_m = mg.slave_to_mortar_avg()
             else:
                 continue

--- a/test/integration/test_TpfaMonoCoupling.py
+++ b/test/integration/test_TpfaMonoCoupling.py
@@ -56,13 +56,13 @@ class TestTpfaCouplingDiffGrids(unittest.TestCase):
             mg = d_e["mortar_grid"]
             g2, g1 = gb.nodes_of_edge(e)
             master_to_m = mg.primary_to_mortar_avg()
-            slave_to_m = mg.secondary_to_mortar_avg()
+            secondary_to_m = mg.secondary_to_mortar_avg()
 
             master_area = master_to_m * g1.face_areas
-            slave_area = slave_to_m * g2.face_areas
+            secondary_area = secondary_to_m * g2.face_areas
 
             self.assertTrue(np.allclose(d_e[pp.STATE]["mortar_flux"] / master_area, 1))
-            self.assertTrue(np.allclose(d_e[pp.STATE]["mortar_flux"] / slave_area, 1))
+            self.assertTrue(np.allclose(d_e[pp.STATE]["mortar_flux"] / secondary_area, 1))
 
     def generate_grids(self, n, xmax, ymax, split):
         g1 = pp.CartGrid([split * n, ymax * n], physdims=[split, ymax])

--- a/test/integration/test_coarsening.py
+++ b/test/integration/test_coarsening.py
@@ -141,7 +141,7 @@ class BasicsTest(unittest.TestCase):
         known = np.array([1, 5, 18, 19])
 
         for _, d in gb.edges():
-            faces = sps.find(d["mortar_grid"].master_to_mortar_int())[1]
+            faces = sps.find(d["mortar_grid"].primary_to_mortar_int())[1]
             self.assertTrue(np.array_equal(faces, known))
 
     # ------------------------------------------------------------------------------#
@@ -186,7 +186,7 @@ class BasicsTest(unittest.TestCase):
 
             # Test
             for e_d in gb.edges():
-                faces = sps.find(e_d[1]["mortar_grid"].master_to_mortar_int())[1]
+                faces = sps.find(e_d[1]["mortar_grid"].primary_to_mortar_int())[1]
 
                 if (e_d[0][0].dim == 0 and e_d[0][1].dim == 1) or (
                     e_d[0][0].dim == 1 and e_d[0][1].dim == 0
@@ -225,7 +225,7 @@ class BasicsTest(unittest.TestCase):
         known = np.array([1, 4, 7, 10, 44, 45, 46, 47])
 
         for _, d in gb.edges():
-            indices, faces, _ = sps.find(d["mortar_grid"].master_to_mortar_int())
+            indices, faces, _ = sps.find(d["mortar_grid"].primary_to_mortar_int())
             self.assertTrue(np.array_equal(indices, known_indices))
             self.assertTrue(np.array_equal(faces, known))
 
@@ -432,7 +432,7 @@ class BasicsTest(unittest.TestCase):
             # Test
             for e_d in gb.edges():
                 indices, faces, _ = sps.find(
-                    e_d[1]["mortar_grid"].master_to_mortar_int()
+                    e_d[1]["mortar_grid"].primary_to_mortar_int()
                 )
 
                 if (e_d[0][0].dim == 1 and e_d[0][1].dim == 2) or (
@@ -891,7 +891,7 @@ class BasicsTest(unittest.TestCase):
         known = np.array([6, 7, 10, 11])
 
         for _, d in gb.edges():
-            indices, faces, _ = sps.find(d["mortar_grid"].master_to_mortar_int())
+            indices, faces, _ = sps.find(d["mortar_grid"].primary_to_mortar_int())
             self.assertTrue(np.array_equal(faces, known))
             self.assertTrue(np.array_equal(indices, known_indices))
 
@@ -910,7 +910,7 @@ class BasicsTest(unittest.TestCase):
         known = np.array([6, 9])
 
         for _, d in gb.edges():
-            indices, faces, _ = sps.find(d["mortar_grid"].master_to_mortar_int())
+            indices, faces, _ = sps.find(d["mortar_grid"].primary_to_mortar_int())
             self.assertTrue(np.array_equal(faces, known))
             self.assertTrue(np.array_equal(indices, known_indices))
 
@@ -933,7 +933,7 @@ class BasicsTest(unittest.TestCase):
         known = np.array([6, 10])
 
         for _, d in gb.edges():
-            indices, faces, _ = sps.find(d["mortar_grid"].master_to_mortar_int())
+            indices, faces, _ = sps.find(d["mortar_grid"].primary_to_mortar_int())
             self.assertTrue(np.array_equal(faces, known))
             self.assertTrue(np.array_equal(indices, known_indices))
 
@@ -952,7 +952,7 @@ class BasicsTest(unittest.TestCase):
         known = np.array([6, 9])
 
         for _, d in gb.edges():
-            indices, faces, _ = sps.find(d["mortar_grid"].master_to_mortar_int())
+            indices, faces, _ = sps.find(d["mortar_grid"].primary_to_mortar_int())
             self.assertTrue(np.array_equal(faces, known))
             self.assertTrue(np.array_equal(indices, known_indices))
 
@@ -975,7 +975,7 @@ class BasicsTest(unittest.TestCase):
         known = np.array([7, 10])
 
         for _, d in gb.edges():
-            indices, faces, _ = sps.find(d["mortar_grid"].master_to_mortar_int())
+            indices, faces, _ = sps.find(d["mortar_grid"].primary_to_mortar_int())
             self.assertTrue(np.array_equal(faces, known))
             self.assertTrue(np.array_equal(indices, known_indices))
 
@@ -1011,7 +1011,7 @@ class BasicsTest(unittest.TestCase):
             # Test
             for e_d in gb.edges():
                 indices, faces, _ = sps.find(
-                    e_d[1]["mortar_grid"].master_to_mortar_int()
+                    e_d[1]["mortar_grid"].primary_to_mortar_int()
                 )
 
                 if (e_d[0][0].dim == 0 and e_d[0][1].dim == 1) or (
@@ -1074,7 +1074,7 @@ class BasicsTest(unittest.TestCase):
             # Test
             for e_d in gb.edges():
                 indices, faces, _ = sps.find(
-                    e_d[1]["mortar_grid"].master_to_mortar_int()
+                    e_d[1]["mortar_grid"].primary_to_mortar_int()
                 )
 
                 if (e_d[0][0].dim == 0 and e_d[0][1].dim == 1) or (
@@ -1252,7 +1252,7 @@ class BasicsTest(unittest.TestCase):
             # Test
             for e_d in gb.edges():
                 indices, faces, _ = sps.find(
-                    e_d[1]["mortar_grid"].master_to_mortar_int()
+                    e_d[1]["mortar_grid"].primary_to_mortar_int()
                 )
 
                 if (e_d[0][0].dim == 0 and e_d[0][1].dim == 1) or (

--- a/test/integration/test_contact_mechanics.py
+++ b/test/integration/test_contact_mechanics.py
@@ -27,7 +27,7 @@ class TestContactMechanics(unittest.TestCase):
         contact_force = d_1[pp.STATE][setup.contact_traction_variable]
 
         displacement_jump_global_coord = (
-            mg.mortar_to_slave_avg(nd=nd) * mg.sign_of_mortar_sides(nd=nd) * u_mortar
+            mg.mortar_to_secondary_avg(nd=nd) * mg.sign_of_mortar_sides(nd=nd) * u_mortar
         )
         projection = d_m["tangential_normal_projection"]
 

--- a/test/integration/test_contact_mechanics_biot.py
+++ b/test/integration/test_contact_mechanics_biot.py
@@ -63,7 +63,7 @@ class TestContactMechanicsBiot(unittest.TestCase):
         fracture_pressure = d_1[pp.STATE][setup.scalar_variable]
 
         displacement_jump_global_coord = (
-            mg.mortar_to_slave_avg(nd=nd) * mg.sign_of_mortar_sides(nd=nd) * u_mortar
+            mg.mortar_to_secondary_avg(nd=nd) * mg.sign_of_mortar_sides(nd=nd) * u_mortar
         )
         projection = d_m["tangential_normal_projection"]
 

--- a/test/integration/test_dilation.py
+++ b/test/integration/test_dilation.py
@@ -30,7 +30,7 @@ class TestDilation(unittest.TestCase):
         contact_force = d_1[pp.STATE][setup.contact_traction_variable]
 
         displacement_jump_global_coord = (
-            mg.mortar_to_slave_avg(nd=nd) * mg.sign_of_mortar_sides(nd=nd) * u_mortar
+            mg.mortar_to_secondary_avg(nd=nd) * mg.sign_of_mortar_sides(nd=nd) * u_mortar
         )
         projection = d_m["tangential_normal_projection"]
 

--- a/test/integration/test_thm.py
+++ b/test/integration/test_thm.py
@@ -114,7 +114,7 @@ class TestContactMechanicsTHM(unittest.TestCase):
         fracture_temperature = d_1[pp.STATE][setup.temperature_variable]
 
         displacement_jump_global_coord = (
-            mg.mortar_to_slave_avg(nd=nd) * mg.sign_of_mortar_sides(nd=nd) * u_mortar
+            mg.mortar_to_secondary_avg(nd=nd) * mg.sign_of_mortar_sides(nd=nd) * u_mortar
         )
         projection = d_m["tangential_normal_projection"]
 

--- a/test/integration/test_upwind_coupling.py
+++ b/test/integration/test_upwind_coupling.py
@@ -1627,9 +1627,9 @@ def add_constant_darcy_flux(gb, upwind, flux, a):
             g_h.get_all_boundary_faces()
         )
         mg = d["mortar_grid"]
-        sign = mg.master_to_mortar_avg() * sign
+        sign = mg.primary_to_mortar_avg() * sign
         #        d["param"] = pp.Parameters(g_h)
-        darcy_flux_e = sign * (d["mortar_grid"].master_to_mortar_avg() * darcy_flux)
+        darcy_flux_e = sign * (d["mortar_grid"].primary_to_mortar_avg() * darcy_flux)
         if pp.PARAMETERS not in d:
             d[pp.PARAMETERS] = pp.Parameters(
                 mg, ["transport"], [{"darcy_flux": darcy_flux_e}]

--- a/test/unit/test_assembler.py
+++ b/test/unit/test_assembler.py
@@ -1788,7 +1788,7 @@ class MockEdgeDiscretization(
         self.off_diag_val = off_diag_val
 
     def assemble_matrix_rhs(
-        self, g_master, g_secondary, data_master, data_secondary, data_edge, local_matrix
+        self, g_primary, g_secondary, data_primary, data_secondary, data_edge, local_matrix
     ):
 
         dof = [local_matrix[0, i].shape[1] for i in range(local_matrix.shape[1])]
@@ -1819,7 +1819,7 @@ class MockEdgeDiscretizationModifiesNode(
         self.off_diag_val = off_diag_val
 
     def assemble_matrix_rhs(
-        self, g_master, g_secondary, data_master, data_secondary, data_edge, local_matrix
+        self, g_primary, g_secondary, data_primary, data_secondary, data_edge, local_matrix
     ):
 
         dof = [local_matrix[0, i].shape[1] for i in range(local_matrix.shape[1])]
@@ -1832,7 +1832,7 @@ class MockEdgeDiscretizationModifiesNode(
         cc[0, 2] = sps.coo_matrix(self.off_diag_val)
         cc[1, 2] = sps.coo_matrix(self.off_diag_val)
 
-        if g_master.grid_num == 1:
+        if g_primary.grid_num == 1:
             local_matrix[0, 0] += sps.coo_matrix(self.off_diag_val)
             local_matrix[1, 1] += sps.coo_matrix(2 * self.off_diag_val)
         else:
@@ -1857,7 +1857,7 @@ class MockEdgeDiscretizationOneSided(
         self.diag_val = diag_val
         self.off_diag_val = off_diag_val
 
-    def assemble_matrix_rhs(self, g_master, data_master, data_edge, local_matrix):
+    def assemble_matrix_rhs(self, g_primary, data_primary, data_edge, local_matrix):
 
         dof = [local_matrix[0, i].shape[1] for i in range(local_matrix.shape[1])]
         cc = np.array([sps.coo_matrix((i, j)) for i in dof for j in dof])
@@ -1884,7 +1884,7 @@ class MockEdgeDiscretizationOneSidedModifiesNode(
         self.diag_val = diag_val
         self.off_diag_val = off_diag_val
 
-    def assemble_matrix_rhs(self, g_master, data_master, data_edge, local_matrix):
+    def assemble_matrix_rhs(self, g_primary, data_primary, data_edge, local_matrix):
 
         dof = [local_matrix[0, i].shape[1] for i in range(local_matrix.shape[1])]
         cc = np.array([sps.coo_matrix((i, j)) for i in dof for j in dof])
@@ -1920,7 +1920,7 @@ class MockEdgeDiscretizationEdgeCouplings(
         return mg.num_cells
 
     def assemble_matrix_rhs(
-        self, g_master, g_secondary, data_master, data_secondary, data_edge, local_matrix
+        self, g_primary, g_secondary, data_primary, data_secondary, data_edge, local_matrix
     ):
 
         dof = [local_matrix[0, i].shape[1] for i in range(local_matrix.shape[1])]

--- a/test/unit/test_assembler.py
+++ b/test/unit/test_assembler.py
@@ -1788,7 +1788,7 @@ class MockEdgeDiscretization(
         self.off_diag_val = off_diag_val
 
     def assemble_matrix_rhs(
-        self, g_master, g_slave, data_master, data_slave, data_edge, local_matrix
+        self, g_master, g_secondary, data_master, data_secondary, data_edge, local_matrix
     ):
 
         dof = [local_matrix[0, i].shape[1] for i in range(local_matrix.shape[1])]
@@ -1819,7 +1819,7 @@ class MockEdgeDiscretizationModifiesNode(
         self.off_diag_val = off_diag_val
 
     def assemble_matrix_rhs(
-        self, g_master, g_slave, data_master, data_slave, data_edge, local_matrix
+        self, g_master, g_secondary, data_master, data_secondary, data_edge, local_matrix
     ):
 
         dof = [local_matrix[0, i].shape[1] for i in range(local_matrix.shape[1])]
@@ -1920,7 +1920,7 @@ class MockEdgeDiscretizationEdgeCouplings(
         return mg.num_cells
 
     def assemble_matrix_rhs(
-        self, g_master, g_slave, data_master, data_slave, data_edge, local_matrix
+        self, g_master, g_secondary, data_master, data_secondary, data_edge, local_matrix
     ):
 
         dof = [local_matrix[0, i].shape[1] for i in range(local_matrix.shape[1])]

--- a/test/unit/test_darcy_mortar.py
+++ b/test/unit/test_darcy_mortar.py
@@ -95,7 +95,7 @@ class TestMortar2dSingleFractureCartesianGrid(unittest.TestCase):
         gb.update_nodes({old_g: new_g})
         mg = d["mortar_grid"]
 
-        mg.update_slave(new_g, tol=1e-4)
+        mg.update_secondary(new_g, tol=1e-4)
 
         return gb
 

--- a/test/unit/test_grid_extrusion.py
+++ b/test/unit/test_grid_extrusion.py
@@ -623,13 +623,13 @@ class TestGridBucketExtrusion(unittest.TestCase):
 
         self.assertTrue(np.allclose(np.sort(known_cells_new), np.sort(cells_new)))
 
-        # All mortar cells should be associated with a face in master
-        mortar_cells_in_range_from_master = np.unique(
+        # All mortar cells should be associated with a face in primary
+        mortar_cells_in_range_from_primary = np.unique(
             mg_new.primary_to_mortar_int().tocoo().row
         )
-        self.assertTrue(mortar_cells_in_range_from_master.size == mg_new.num_cells)
+        self.assertTrue(mortar_cells_in_range_from_primary.size == mg_new.num_cells)
         self.assertTrue(
-            np.allclose(mortar_cells_in_range_from_master, np.arange(mg_new.num_cells))
+            np.allclose(mortar_cells_in_range_from_primary, np.arange(mg_new.num_cells))
         )
 
         # All mortar cells should be in the range from secondary

--- a/test/unit/test_grid_extrusion.py
+++ b/test/unit/test_grid_extrusion.py
@@ -616,10 +616,10 @@ class TestGridBucketExtrusion(unittest.TestCase):
             np.allclose(np.sort(known_bound_faces_new), np.sort(bound_faces_new))
         )
 
-        low_cells_old = mg.slave_to_mortar_int().tocoo().col
+        low_cells_old = mg.secondary_to_mortar_int().tocoo().col
         known_cells_new = np.hstack((low_cells_old, low_cells_old + g_1.num_cells))
 
-        cells_new = mg_new.slave_to_mortar_int().tocoo().col
+        cells_new = mg_new.secondary_to_mortar_int().tocoo().col
 
         self.assertTrue(np.allclose(np.sort(known_cells_new), np.sort(cells_new)))
 
@@ -634,7 +634,7 @@ class TestGridBucketExtrusion(unittest.TestCase):
 
         # All mortar cells should be in the range from slave
         mortar_cells_in_range_from_slave = np.unique(
-            mg_new.slave_to_mortar_int().tocoo().row
+            mg_new.secondary_to_mortar_int().tocoo().row
         )
         self.assertTrue(mortar_cells_in_range_from_slave.size == mg_new.num_cells)
         self.assertTrue(

--- a/test/unit/test_grid_extrusion.py
+++ b/test/unit/test_grid_extrusion.py
@@ -632,28 +632,28 @@ class TestGridBucketExtrusion(unittest.TestCase):
             np.allclose(mortar_cells_in_range_from_master, np.arange(mg_new.num_cells))
         )
 
-        # All mortar cells should be in the range from slave
-        mortar_cells_in_range_from_slave = np.unique(
+        # All mortar cells should be in the range from secondary
+        mortar_cells_in_range_from_secondary = np.unique(
             mg_new.secondary_to_mortar_int().tocoo().row
         )
-        self.assertTrue(mortar_cells_in_range_from_slave.size == mg_new.num_cells)
+        self.assertTrue(mortar_cells_in_range_from_secondary.size == mg_new.num_cells)
         self.assertTrue(
             np.allclose(
-                np.sort(mortar_cells_in_range_from_slave), np.arange(mg_new.num_cells)
+                np.sort(mortar_cells_in_range_from_secondary), np.arange(mg_new.num_cells)
             )
         )
 
         g_1_new = gb_new.grids_of_dimension(2)[0]
 
-        # All mortar cells should be associated with two cells in slave
-        slave_cells_in_range_from_mortar = mg_new.mortar_to_secondary_int().tocoo().row
-        self.assertTrue(np.all(np.bincount(slave_cells_in_range_from_mortar) == 2))
+        # All mortar cells should be associated with two cells in secondary
+        secondary_cells_in_range_from_mortar = mg_new.mortar_to_secondary_int().tocoo().row
+        self.assertTrue(np.all(np.bincount(secondary_cells_in_range_from_mortar) == 2))
         self.assertTrue(
-            np.unique(slave_cells_in_range_from_mortar).size == g_1_new.num_cells
+            np.unique(secondary_cells_in_range_from_mortar).size == g_1_new.num_cells
         )
         self.assertTrue(
             np.allclose(
-                np.sort(np.unique(slave_cells_in_range_from_mortar)),
+                np.sort(np.unique(secondary_cells_in_range_from_mortar)),
                 np.arange(g_1_new.num_cells),
             )
         )

--- a/test/unit/test_grid_extrusion.py
+++ b/test/unit/test_grid_extrusion.py
@@ -646,7 +646,7 @@ class TestGridBucketExtrusion(unittest.TestCase):
         g_1_new = gb_new.grids_of_dimension(2)[0]
 
         # All mortar cells should be associated with two cells in slave
-        slave_cells_in_range_from_mortar = mg_new.mortar_to_slave_int().tocoo().row
+        slave_cells_in_range_from_mortar = mg_new.mortar_to_secondary_int().tocoo().row
         self.assertTrue(np.all(np.bincount(slave_cells_in_range_from_mortar) == 2))
         self.assertTrue(
             np.unique(slave_cells_in_range_from_mortar).size == g_1_new.num_cells

--- a/test/unit/test_grid_extrusion.py
+++ b/test/unit/test_grid_extrusion.py
@@ -604,14 +604,14 @@ class TestGridBucketExtrusion(unittest.TestCase):
         mg_new = d["mortar_grid"]
 
         # Check that the old and new grid have
-        bound_faces_old = mg.master_to_mortar_int().tocoo().col
+        bound_faces_old = mg.primary_to_mortar_int().tocoo().col
         # We know from the construction of the grid extruded to 3d that the faces
         # on the fracture boundary will be those in the 2d grid stacked on top of each
         # other
         known_bound_faces_new = np.hstack(
             (bound_faces_old, bound_faces_old + g_2.num_faces)
         )
-        bound_faces_new = mg_new.master_to_mortar_int().tocoo().col
+        bound_faces_new = mg_new.primary_to_mortar_int().tocoo().col
         self.assertTrue(
             np.allclose(np.sort(known_bound_faces_new), np.sort(bound_faces_new))
         )
@@ -625,7 +625,7 @@ class TestGridBucketExtrusion(unittest.TestCase):
 
         # All mortar cells should be associated with a face in master
         mortar_cells_in_range_from_master = np.unique(
-            mg_new.master_to_mortar_int().tocoo().row
+            mg_new.primary_to_mortar_int().tocoo().row
         )
         self.assertTrue(mortar_cells_in_range_from_master.size == mg_new.num_cells)
         self.assertTrue(

--- a/test/unit/test_grid_refinement.py
+++ b/test/unit/test_grid_refinement.py
@@ -358,7 +358,7 @@ class TestRefinementMortarGrid(unittest.TestCase):
 
             mg = d["mortar_grid"]
             self.assertTrue(
-                np.allclose(high_to_mortar_known, mg.master_to_mortar_int().todense())
+                np.allclose(high_to_mortar_known, mg.primary_to_mortar_int().todense())
             )
             self.assertTrue(
                 np.allclose(low_to_mortar_known, mg.slave_to_mortar_int().todense())
@@ -503,7 +503,7 @@ class TestRefinementMortarGrid(unittest.TestCase):
             )
 
             self.assertTrue(
-                np.allclose(high_to_mortar_known, mg.master_to_mortar_int().todense())
+                np.allclose(high_to_mortar_known, mg.primary_to_mortar_int().todense())
             )
             self.assertTrue(
                 np.allclose(low_to_mortar_known, mg.slave_to_mortar_int().todense())
@@ -658,7 +658,7 @@ class TestRefinementMortarGrid(unittest.TestCase):
             )
 
             self.assertTrue(
-                np.allclose(high_to_mortar_known, mg.master_to_mortar_int().todense())
+                np.allclose(high_to_mortar_known, mg.primary_to_mortar_int().todense())
             )
             self.assertTrue(
                 np.allclose(low_to_mortar_known, mg.slave_to_mortar_int().todense())
@@ -767,7 +767,7 @@ class TestRefinementMortarGrid(unittest.TestCase):
             )
 
             self.assertTrue(
-                np.allclose(high_to_mortar_known, mg.master_to_mortar_int().todense())
+                np.allclose(high_to_mortar_known, mg.primary_to_mortar_int().todense())
             )
 
             # The ordering of the cells in the new 1d grid may be flipped on
@@ -884,7 +884,7 @@ class TestRefinementMortarGrid(unittest.TestCase):
             )
 
             self.assertTrue(
-                np.allclose(high_to_mortar_known, mg.master_to_mortar_int().todense())
+                np.allclose(high_to_mortar_known, mg.primary_to_mortar_int().todense())
             )
             # The ordering of the cells in the new 1d grid may be flipped on
             # some systems; therefore allow two configurations
@@ -915,7 +915,7 @@ class TestRefinementMortarGrid(unittest.TestCase):
             mg = d["mortar_grid"]
             indices_known = np.array([0, 1, 2, 3, 4, 5, 6, 7])
             self.assertTrue(
-                np.array_equal(mg.master_to_mortar_int().indices, indices_known)
+                np.array_equal(mg.primary_to_mortar_int().indices, indices_known)
             )
 
             indptr_known = np.array(
@@ -964,11 +964,11 @@ class TestRefinementMortarGrid(unittest.TestCase):
                 ]
             )
             self.assertTrue(
-                np.array_equal(mg.master_to_mortar_int().indptr, indptr_known)
+                np.array_equal(mg.primary_to_mortar_int().indptr, indptr_known)
             )
 
             data_known = np.array([1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0])
-            self.assertTrue(np.array_equal(mg.master_to_mortar_int().data, data_known))
+            self.assertTrue(np.array_equal(mg.primary_to_mortar_int().data, data_known))
 
             indices_known = np.array([0, 4, 1, 5, 2, 6, 3, 7])
             self.assertTrue(

--- a/test/unit/test_grid_refinement.py
+++ b/test/unit/test_grid_refinement.py
@@ -361,7 +361,7 @@ class TestRefinementMortarGrid(unittest.TestCase):
                 np.allclose(high_to_mortar_known, mg.primary_to_mortar_int().todense())
             )
             self.assertTrue(
-                np.allclose(low_to_mortar_known, mg.slave_to_mortar_int().todense())
+                np.allclose(low_to_mortar_known, mg.secondary_to_mortar_int().todense())
             )
 
     def test_mortar_grid_1d_equally_refine_mortar_grids(self):
@@ -506,7 +506,7 @@ class TestRefinementMortarGrid(unittest.TestCase):
                 np.allclose(high_to_mortar_known, mg.primary_to_mortar_int().todense())
             )
             self.assertTrue(
-                np.allclose(low_to_mortar_known, mg.slave_to_mortar_int().todense())
+                np.allclose(low_to_mortar_known, mg.secondary_to_mortar_int().todense())
             )
 
     # ------------------------------------------------------------------------------#
@@ -661,7 +661,7 @@ class TestRefinementMortarGrid(unittest.TestCase):
                 np.allclose(high_to_mortar_known, mg.primary_to_mortar_int().todense())
             )
             self.assertTrue(
-                np.allclose(low_to_mortar_known, mg.slave_to_mortar_int().todense())
+                np.allclose(low_to_mortar_known, mg.secondary_to_mortar_int().todense())
             )
 
     # ------------------------------------------------------------------------------#
@@ -775,10 +775,10 @@ class TestRefinementMortarGrid(unittest.TestCase):
             self.assertTrue(
                 np.logical_or(
                     np.allclose(
-                        low_to_mortar_known, mg.slave_to_mortar_int().todense()
+                        low_to_mortar_known, mg.secondary_to_mortar_int().todense()
                     ),
                     np.allclose(
-                        low_to_mortar_known, mg.slave_to_mortar_int().todense()[::-1]
+                        low_to_mortar_known, mg.secondary_to_mortar_int().todense()[::-1]
                     ),
                 )
             )
@@ -891,10 +891,10 @@ class TestRefinementMortarGrid(unittest.TestCase):
             self.assertTrue(
                 np.logical_or(
                     np.allclose(
-                        low_to_mortar_known, mg.slave_to_mortar_int().todense()
+                        low_to_mortar_known, mg.secondary_to_mortar_int().todense()
                     ),
                     np.allclose(
-                        low_to_mortar_known, mg.slave_to_mortar_int().todense()[::-1]
+                        low_to_mortar_known, mg.secondary_to_mortar_int().todense()[::-1]
                     ),
                 )
             )
@@ -972,16 +972,16 @@ class TestRefinementMortarGrid(unittest.TestCase):
 
             indices_known = np.array([0, 4, 1, 5, 2, 6, 3, 7])
             self.assertTrue(
-                np.array_equal(mg.slave_to_mortar_int().indices, indices_known)
+                np.array_equal(mg.secondary_to_mortar_int().indices, indices_known)
             )
 
             indptr_known = np.array([0, 2, 4, 6, 8])
             self.assertTrue(
-                np.array_equal(mg.slave_to_mortar_int().indptr, indptr_known)
+                np.array_equal(mg.secondary_to_mortar_int().indptr, indptr_known)
             )
 
             data_known = np.array([1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0])
-            self.assertTrue(np.array_equal(mg.slave_to_mortar_int().data, data_known))
+            self.assertTrue(np.array_equal(mg.secondary_to_mortar_int().data, data_known))
 
 
 if __name__ == "__main__":

--- a/test/unit/test_grid_refinement.py
+++ b/test/unit/test_grid_refinement.py
@@ -687,7 +687,7 @@ class TestRefinementMortarGrid(unittest.TestCase):
 
             gb.update_nodes({old_g: new_g})
             mg = d["mortar_grid"]
-            mg.update_slave(new_g, 1e-4)
+            mg.update_secondary(new_g, 1e-4)
 
             high_to_mortar_known = np.matrix(
                 [
@@ -805,7 +805,7 @@ class TestRefinementMortarGrid(unittest.TestCase):
 
             gb.update_nodes({old_g: new_g})
             mg = d["mortar_grid"]
-            mg.update_slave(new_g, 1e-4)
+            mg.update_secondary(new_g, 1e-4)
 
             high_to_mortar_known = np.matrix(
                 [

--- a/test/unit/test_mixed_dim_gravity.py
+++ b/test/unit/test_mixed_dim_gravity.py
@@ -309,7 +309,7 @@ class TestMixedDimGravity(unittest.TestCase):
 
             gb.update_nodes({old_g: new_g})
             mg = d["mortar_grid"]
-            mg.update_slave(new_g, tol=1e-4)
+            mg.update_secondary(new_g, tol=1e-4)
         self.gb = gb
 
     def solve(self, method):

--- a/test/unit/test_mortar_grid.py
+++ b/test/unit/test_mortar_grid.py
@@ -36,8 +36,8 @@ class TestGridMappings1d(unittest.TestCase):
 
         self.assertTrue(mg.num_cells == 1)
         self.assertTrue(mg.num_sides() == 1)
-        self.assertTrue(np.all(mg.master_to_mortar_avg().A == [1, 0, 0]))
-        self.assertTrue(np.all(mg.master_to_mortar_int().A == [1, 0, 0]))
+        self.assertTrue(np.all(mg.primary_to_mortar_avg().A == [1, 0, 0]))
+        self.assertTrue(np.all(mg.primary_to_mortar_int().A == [1, 0, 0]))
         self.assertTrue(np.all(mg.slave_to_mortar_avg().A == [0, 0, 1]))
         self.assertTrue(np.all(mg.slave_to_mortar_int().A == [0, 0, 1]))
 
@@ -62,8 +62,8 @@ class TestGridMappings1d(unittest.TestCase):
 
         self.assertTrue(mg.num_cells == 1)
         self.assertTrue(mg.num_sides() == 1)
-        self.assertTrue(np.all(mg.master_to_mortar_avg().A == [0, 1, 0]))
-        self.assertTrue(np.all(mg.master_to_mortar_int().A == [0, 1, 0]))
+        self.assertTrue(np.all(mg.primary_to_mortar_avg().A == [0, 1, 0]))
+        self.assertTrue(np.all(mg.primary_to_mortar_int().A == [0, 1, 0]))
         self.assertTrue(np.all(mg.slave_to_mortar_avg().A == [0, 1]))
         self.assertTrue(np.all(mg.slave_to_mortar_int().A == [0, 1]))
 

--- a/test/unit/test_mortar_grid.py
+++ b/test/unit/test_mortar_grid.py
@@ -38,8 +38,8 @@ class TestGridMappings1d(unittest.TestCase):
         self.assertTrue(mg.num_sides() == 1)
         self.assertTrue(np.all(mg.primary_to_mortar_avg().A == [1, 0, 0]))
         self.assertTrue(np.all(mg.primary_to_mortar_int().A == [1, 0, 0]))
-        self.assertTrue(np.all(mg.slave_to_mortar_avg().A == [0, 0, 1]))
-        self.assertTrue(np.all(mg.slave_to_mortar_int().A == [0, 0, 1]))
+        self.assertTrue(np.all(mg.secondary_to_mortar_avg().A == [0, 0, 1]))
+        self.assertTrue(np.all(mg.secondary_to_mortar_int().A == [0, 0, 1]))
 
     def test_merge_two_grids(self):
         """
@@ -64,8 +64,8 @@ class TestGridMappings1d(unittest.TestCase):
         self.assertTrue(mg.num_sides() == 1)
         self.assertTrue(np.all(mg.primary_to_mortar_avg().A == [0, 1, 0]))
         self.assertTrue(np.all(mg.primary_to_mortar_int().A == [0, 1, 0]))
-        self.assertTrue(np.all(mg.slave_to_mortar_avg().A == [0, 1]))
-        self.assertTrue(np.all(mg.slave_to_mortar_int().A == [0, 1]))
+        self.assertTrue(np.all(mg.secondary_to_mortar_avg().A == [0, 1]))
+        self.assertTrue(np.all(mg.secondary_to_mortar_int().A == [0, 1]))
 
 
 if __name__ == "__main__":

--- a/test/unit/test_mortars.py
+++ b/test/unit/test_mortars.py
@@ -889,7 +889,7 @@ class TestMeshReplacement3d(unittest.TestCase):
         mg1, mg2 = self._mortar_grids(gb)
 
         proj_1_h = mg1.primary_to_mortar_int().copy()
-        proj_1_l = mg1.slave_to_mortar_int().copy()
+        proj_1_l = mg1.secondary_to_mortar_int().copy()
 
         gn = self.grid_1d(2)
         go = gb.grids_of_dimension(1)[0]
@@ -897,7 +897,7 @@ class TestMeshReplacement3d(unittest.TestCase):
 
         mg1, mg2 = self._mortar_grids(gb)
         p1h = mg1.primary_to_mortar_int().copy()
-        p1l = mg1.slave_to_mortar_int().copy()
+        p1l = mg1.secondary_to_mortar_int().copy()
 
         self.assertTrue((proj_1_h != p1h).nnz == 0)
         self.assertTrue((proj_1_l != p1l).nnz == 0)
@@ -907,7 +907,7 @@ class TestMeshReplacement3d(unittest.TestCase):
         mg1, mg2 = self._mortar_grids(gb)
 
         proj_2_h = mg2.primary_to_mortar_int().copy()
-        proj_2_l = mg2.slave_to_mortar_int().copy()
+        proj_2_l = mg2.secondary_to_mortar_int().copy()
 
         gn = self.grid_2d_two_cells()
         go = gb.grids_of_dimension(2)[0]
@@ -915,7 +915,7 @@ class TestMeshReplacement3d(unittest.TestCase):
 
         mg1, mg2 = self._mortar_grids(gb)
         p2h = mg2.primary_to_mortar_int().copy()
-        p2l = mg2.slave_to_mortar_int().copy()
+        p2l = mg2.secondary_to_mortar_int().copy()
 
         self.assertTrue((proj_2_h != p2h).nnz == 0)
         self.assertTrue((proj_2_l != p2l).nnz == 0)
@@ -931,7 +931,7 @@ class TestMeshReplacement3d(unittest.TestCase):
 
         mg1, mg2 = self._mortar_grids(gb)
         p2h = mg2.primary_to_mortar_int().copy()
-        p2l = mg2.slave_to_mortar_int().copy()
+        p2l = mg2.secondary_to_mortar_int().copy()
 
         self.assertTrue((proj_2_h != p2h).nnz == 0)
         self.assertTrue(np.abs(p2l[0, 0] - 0.5) < 1e-6)
@@ -950,7 +950,7 @@ class TestMeshReplacement3d(unittest.TestCase):
 
         mg1, mg2 = self._mortar_grids(gb)
         p2h = mg2.primary_to_mortar_int().copy()
-        p2l = mg2.slave_to_mortar_int().copy()
+        p2l = mg2.secondary_to_mortar_int().copy()
 
         self.assertTrue((proj_2_h != p2h).nnz == 0)
         self.assertTrue(np.abs(p2l[0, 0] - 0.5) < 1e-6)
@@ -967,9 +967,9 @@ class TestMeshReplacement3d(unittest.TestCase):
         mg1, mg2 = self._mortar_grids(gb)
 
         proj_1_h = mg1.primary_to_mortar_int().copy()
-        proj_1_l = mg1.slave_to_mortar_int().copy()
+        proj_1_l = mg1.secondary_to_mortar_int().copy()
         proj_2_h = mg2.primary_to_mortar_int().copy()
-        proj_2_l = mg2.slave_to_mortar_int().copy()
+        proj_2_l = mg2.secondary_to_mortar_int().copy()
 
         gn = self.grid_2d_two_cells()
         go = gb.grids_of_dimension(2)[0]
@@ -977,9 +977,9 @@ class TestMeshReplacement3d(unittest.TestCase):
 
         mg1, mg2 = self._mortar_grids(gb)
         p1h = mg1.primary_to_mortar_int().copy()
-        p1l = mg1.slave_to_mortar_int().copy()
+        p1l = mg1.secondary_to_mortar_int().copy()
         p2h = mg2.primary_to_mortar_int().copy()
-        p2l = mg2.slave_to_mortar_int().copy()
+        p2l = mg2.secondary_to_mortar_int().copy()
 
         self.assertTrue((proj_1_h != p1h).nnz == 0)
         self.assertTrue((proj_1_l != p1l).nnz == 0)
@@ -990,7 +990,7 @@ class TestMeshReplacement3d(unittest.TestCase):
         gb = self.setup_bucket(pert=True, include_1d=True)
         mg1, mg2 = self._mortar_grids(gb)
         proj_2_h = mg2.primary_to_mortar_int().copy()
-        proj_1_l = mg1.slave_to_mortar_int().copy()
+        proj_1_l = mg1.secondary_to_mortar_int().copy()
 
         gn = self.grid_2d_four_cells(pert=True)
         go = gb.grids_of_dimension(2)[0]
@@ -998,9 +998,9 @@ class TestMeshReplacement3d(unittest.TestCase):
 
         mg1, mg2 = self._mortar_grids(gb)
         p1h = mg1.primary_to_mortar_int().copy()
-        p1l = mg1.slave_to_mortar_int().copy()
+        p1l = mg1.secondary_to_mortar_int().copy()
         p2h = mg2.primary_to_mortar_int().copy()
-        p2l = mg2.slave_to_mortar_int().copy()
+        p2l = mg2.secondary_to_mortar_int().copy()
 
         self.assertTrue((proj_1_l != p1l).nnz == 0)
         self.assertTrue((proj_2_h != p2h).nnz == 0)

--- a/test/unit/test_mortars.py
+++ b/test/unit/test_mortars.py
@@ -91,7 +91,7 @@ class TestReplaceHigherDimensionalGrid(unittest.TestCase):
         for e, d in gb.edges():
             mg = d["mortar_grid"]
 
-        old_projection = mg.master_to_mortar_int().copy()
+        old_projection = mg.primary_to_mortar_int().copy()
 
         g_old = gb.grids_of_dimension(2)[0]
         g_new = g_old.copy()
@@ -102,7 +102,7 @@ class TestReplaceHigherDimensionalGrid(unittest.TestCase):
         for e, d in gb.edges():
             mg = d["mortar_grid"]
 
-        new_projection = mg.master_to_mortar_int()
+        new_projection = mg.primary_to_mortar_int()
 
         # The projections should be identical
         self.assertTrue((old_projection != new_projection).nnz == 0)
@@ -116,7 +116,7 @@ class TestReplaceHigherDimensionalGrid(unittest.TestCase):
         for e, d in gb.edges():
             mg = d["mortar_grid"]
 
-        old_projection = mg.master_to_mortar_int().copy()
+        old_projection = mg.primary_to_mortar_int().copy()
         g_old = gb.grids_of_dimension(2)[0]
 
         # Create a new, finer 2d grid. This is the simplest
@@ -133,7 +133,7 @@ class TestReplaceHigherDimensionalGrid(unittest.TestCase):
         for e, d in gb.edges():
             mg = d["mortar_grid"]
 
-        new_projection = mg.master_to_mortar_int()
+        new_projection = mg.primary_to_mortar_int()
 
         # Check shape
         self.assertTrue(new_projection.shape[0] == old_projection.shape[0])
@@ -159,7 +159,7 @@ class TestReplaceHigherDimensionalGrid(unittest.TestCase):
         for e, d in gb.edges():
             mg = d["mortar_grid"]
 
-        old_projection = mg.master_to_mortar_int().copy()
+        old_projection = mg.primary_to_mortar_int().copy()
         g_old = gb.grids_of_dimension(2)[0]
 
         # Create a new, coarser 2d grid. This is the simplest
@@ -175,7 +175,7 @@ class TestReplaceHigherDimensionalGrid(unittest.TestCase):
         for e, d in gb.edges():
             mg = d["mortar_grid"]
 
-        new_projection = mg.master_to_mortar_int()
+        new_projection = mg.primary_to_mortar_int()
 
         # Check shape
         self.assertTrue(new_projection.shape[0] == old_projection.shape[0])
@@ -204,7 +204,7 @@ class TestReplaceHigherDimensionalGrid(unittest.TestCase):
         for e, d in gb.edges():
             mg = d["mortar_grid"]
 
-        old_projection = mg.master_to_mortar_int().copy()
+        old_projection = mg.primary_to_mortar_int().copy()
         g_old = gb.grids_of_dimension(2)[0]
 
         # Create a new, finer 2d grid. This is the simplest
@@ -228,7 +228,7 @@ class TestReplaceHigherDimensionalGrid(unittest.TestCase):
         for e, d in gb.edges():
             mg = d["mortar_grid"]
 
-        new_projection = mg.master_to_mortar_int()
+        new_projection = mg.primary_to_mortar_int()
 
         # Check shape
         self.assertTrue(new_projection.shape[0] == old_projection.shape[0])
@@ -257,7 +257,7 @@ class TestReplaceHigherDimensionalGrid(unittest.TestCase):
         for e, d in gb.edges():
             mg = d["mortar_grid"]
 
-        old_projection = mg.master_to_mortar_int().copy()
+        old_projection = mg.primary_to_mortar_int().copy()
         g_old = gb.grids_of_dimension(2)[0]
 
         # Create a new, finer 2d grid. This is the simplest
@@ -281,7 +281,7 @@ class TestReplaceHigherDimensionalGrid(unittest.TestCase):
         for e, d in gb.edges():
             mg = d["mortar_grid"]
 
-        new_projection = mg.master_to_mortar_int()
+        new_projection = mg.primary_to_mortar_int()
 
         # Check shape
         self.assertTrue(new_projection.shape[0] == old_projection.shape[0])
@@ -317,7 +317,7 @@ class TestReplaceHigherDimensionalGrid(unittest.TestCase):
         for e, d in gb.edges():
             mg = d["mortar_grid"]
 
-        old_projection = mg.master_to_mortar_int().copy()
+        old_projection = mg.primary_to_mortar_int().copy()
         g_old = gb.grids_of_dimension(2)[0]
 
         # Create a new, finer 2d grid. This is the simplest
@@ -355,7 +355,7 @@ class TestReplaceHigherDimensionalGrid(unittest.TestCase):
         for e, d in gb.edges():
             mg = d["mortar_grid"]
 
-        new_projection = mg.master_to_mortar_int()
+        new_projection = mg.primary_to_mortar_int()
 
         # Check shape
         self.assertTrue(new_projection.shape[0] == old_projection.shape[0])
@@ -386,7 +386,7 @@ class TestReplaceHigherDimensionalGrid(unittest.TestCase):
         for e, d in gb.edges():
             mg = d["mortar_grid"]
 
-        old_projection = mg.master_to_mortar_int().copy()
+        old_projection = mg.primary_to_mortar_int().copy()
         g_old = gb.grids_of_dimension(2)[0]
 
         # Create a new, finer 2d grid. This is the simplest
@@ -419,7 +419,7 @@ class TestReplaceHigherDimensionalGrid(unittest.TestCase):
         for e, d in gb.edges():
             mg = d["mortar_grid"]
 
-        new_projection = mg.master_to_mortar_int()
+        new_projection = mg.primary_to_mortar_int()
 
         # Check shape
         self.assertTrue(new_projection.shape[0] == old_projection.shape[0])
@@ -888,7 +888,7 @@ class TestMeshReplacement3d(unittest.TestCase):
         gb = self.setup_bucket(pert=False)
         mg1, mg2 = self._mortar_grids(gb)
 
-        proj_1_h = mg1.master_to_mortar_int().copy()
+        proj_1_h = mg1.primary_to_mortar_int().copy()
         proj_1_l = mg1.slave_to_mortar_int().copy()
 
         gn = self.grid_1d(2)
@@ -896,7 +896,7 @@ class TestMeshReplacement3d(unittest.TestCase):
         gb.replace_grids({go: gn})
 
         mg1, mg2 = self._mortar_grids(gb)
-        p1h = mg1.master_to_mortar_int().copy()
+        p1h = mg1.primary_to_mortar_int().copy()
         p1l = mg1.slave_to_mortar_int().copy()
 
         self.assertTrue((proj_1_h != p1h).nnz == 0)
@@ -906,7 +906,7 @@ class TestMeshReplacement3d(unittest.TestCase):
         gb = self.setup_bucket(pert=False, include_1d=False)
         mg1, mg2 = self._mortar_grids(gb)
 
-        proj_2_h = mg2.master_to_mortar_int().copy()
+        proj_2_h = mg2.primary_to_mortar_int().copy()
         proj_2_l = mg2.slave_to_mortar_int().copy()
 
         gn = self.grid_2d_two_cells()
@@ -914,7 +914,7 @@ class TestMeshReplacement3d(unittest.TestCase):
         gb.replace_grids(g_map={go: gn})
 
         mg1, mg2 = self._mortar_grids(gb)
-        p2h = mg2.master_to_mortar_int().copy()
+        p2h = mg2.primary_to_mortar_int().copy()
         p2l = mg2.slave_to_mortar_int().copy()
 
         self.assertTrue((proj_2_h != p2h).nnz == 0)
@@ -923,14 +923,14 @@ class TestMeshReplacement3d(unittest.TestCase):
     def test_replace_2d_with_finer_no_1d(self):
         gb = self.setup_bucket(pert=False, include_1d=False)
         mg1, mg2 = self._mortar_grids(gb)
-        proj_2_h = mg2.master_to_mortar_int().copy()
+        proj_2_h = mg2.primary_to_mortar_int().copy()
 
         gn = self.grid_2d_four_cells_no_1d()
         go = gb.grids_of_dimension(2)[0]
         gb.replace_grids({go: gn})
 
         mg1, mg2 = self._mortar_grids(gb)
-        p2h = mg2.master_to_mortar_int().copy()
+        p2h = mg2.primary_to_mortar_int().copy()
         p2l = mg2.slave_to_mortar_int().copy()
 
         self.assertTrue((proj_2_h != p2h).nnz == 0)
@@ -942,14 +942,14 @@ class TestMeshReplacement3d(unittest.TestCase):
     def test_replace_2d_with_finer_no_1d_pert(self):
         gb = self.setup_bucket(pert=True, include_1d=False)
         mg1, mg2 = self._mortar_grids(gb)
-        proj_2_h = mg2.master_to_mortar_int().copy()
+        proj_2_h = mg2.primary_to_mortar_int().copy()
 
         gn = self.grid_2d_four_cells_no_1d(pert=True)
         go = gb.grids_of_dimension(2)[0]
         gb.replace_grids({go: gn})
 
         mg1, mg2 = self._mortar_grids(gb)
-        p2h = mg2.master_to_mortar_int().copy()
+        p2h = mg2.primary_to_mortar_int().copy()
         p2l = mg2.slave_to_mortar_int().copy()
 
         self.assertTrue((proj_2_h != p2h).nnz == 0)
@@ -966,9 +966,9 @@ class TestMeshReplacement3d(unittest.TestCase):
         gb = self.setup_bucket(pert=False, include_1d=True)
         mg1, mg2 = self._mortar_grids(gb)
 
-        proj_1_h = mg1.master_to_mortar_int().copy()
+        proj_1_h = mg1.primary_to_mortar_int().copy()
         proj_1_l = mg1.slave_to_mortar_int().copy()
-        proj_2_h = mg2.master_to_mortar_int().copy()
+        proj_2_h = mg2.primary_to_mortar_int().copy()
         proj_2_l = mg2.slave_to_mortar_int().copy()
 
         gn = self.grid_2d_two_cells()
@@ -976,9 +976,9 @@ class TestMeshReplacement3d(unittest.TestCase):
         gb.replace_grids({go: gn})
 
         mg1, mg2 = self._mortar_grids(gb)
-        p1h = mg1.master_to_mortar_int().copy()
+        p1h = mg1.primary_to_mortar_int().copy()
         p1l = mg1.slave_to_mortar_int().copy()
-        p2h = mg2.master_to_mortar_int().copy()
+        p2h = mg2.primary_to_mortar_int().copy()
         p2l = mg2.slave_to_mortar_int().copy()
 
         self.assertTrue((proj_1_h != p1h).nnz == 0)
@@ -989,7 +989,7 @@ class TestMeshReplacement3d(unittest.TestCase):
     def test_replace_2d_with_finer_pert(self):
         gb = self.setup_bucket(pert=True, include_1d=True)
         mg1, mg2 = self._mortar_grids(gb)
-        proj_2_h = mg2.master_to_mortar_int().copy()
+        proj_2_h = mg2.primary_to_mortar_int().copy()
         proj_1_l = mg1.slave_to_mortar_int().copy()
 
         gn = self.grid_2d_four_cells(pert=True)
@@ -997,9 +997,9 @@ class TestMeshReplacement3d(unittest.TestCase):
         gb.replace_grids({go: gn})
 
         mg1, mg2 = self._mortar_grids(gb)
-        p1h = mg1.master_to_mortar_int().copy()
+        p1h = mg1.primary_to_mortar_int().copy()
         p1l = mg1.slave_to_mortar_int().copy()
-        p2h = mg2.master_to_mortar_int().copy()
+        p2h = mg2.primary_to_mortar_int().copy()
         p2l = mg2.slave_to_mortar_int().copy()
 
         self.assertTrue((proj_1_l != p1l).nnz == 0)


### PR DESCRIPTION
This PR introduces several changes related to the replacement of _master_ and _slave_ by _primary_ and _secondary_, respectively. The changes were made from the top-level and below, affecting files inside `src` and `test`. This affects attributes, variables, methods, and documentation in general. However, the functionality of PorePy remains strictly **unchanged**.

In particular, the following methods from the  `MortarGrid` class will be renamed:
`master_to_mortar_avg` by `primary_to_mortar_avg`
`master_to_mortar_int` by `primary_to_mortar_int`
`slave_to_mortar_avg` by `secondary_to_mortar_avg`
`slave_to_mortar_int` by `secondary_to_mortar_int`
`mortar_to_master_avg` by `mortar_to_primary_avg`
`mortar_to_master_int` by `mortar_to_primary_int`
`mortar_to_slave_avg` by `mortar_to_secondary_avg`
`mortar_to_slave_int` by `mortar_to_secondary_int`
`update_master` by `update_primary`
`update_slave` by `update_secondary`

FYI: I've used an IDE called IntelliJ IDEA to _relatively_ painlessly do the find&replace procedure. It might be useful for the future. To be more specific, if you add the porepy folder as a project, you can use the tool 'Replace in path...'. Note that you have to search for the keyword several times to catch all the occurrences.