### PR TITLE
Fixed memory bug in MPFA: Sparse matrix was converted to dense

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     - uses: actions/checkout@v2
     
     - name: Setup Python ${{ matrix.python-version}}
-      uses: actions/setup-python@v1.2.0
+      uses: actions/setup-python@v2
       with:
         # Version range or exact version of a Python version to use, using SemVer's version range syntax.
         python-version: ${{ matrix.python-version}}

--- a/src/porepy/numerics/fv/mpfa.py
+++ b/src/porepy/numerics/fv/mpfa.py
@@ -1146,7 +1146,7 @@ class Mpfa(pp.FVElliptic):
         if nd == 0:
             return 0
 
-        num_cell_nodes = g.cell_nodes().toarray().sum(axis=1)
+        num_cell_nodes = g.cell_nodes().sum(axis=1)
 
         # Number of unknowns around a vertex: nd per cell that share the vertex for
         # pressure gradients, and one per cell (cell center pressure)
@@ -1158,7 +1158,7 @@ class Mpfa(pp.FVElliptic):
 
         # The discretization of Darcy's law will require nd (that is, a gradient)
         # per sub-face.
-        num_sub_face = g.face_nodes.toarray().sum()
+        num_sub_face = g.face_nodes.sum()
         darcy_size = nd * num_sub_face
 
         # Balancing of fluxes will require 2*nd (gradient on both sides) fields per


### PR DESCRIPTION
Was there a reason to convert the matrices to dense matrices, @keileg ? For large grids the conversion is unfeasible (e.g. 200 000 cells -> 64 GB memory)