### PR TITLE
Removed recursive loop in normal computation and made it more robust

### DIFF
--- a/src/porepy/geometry/map_geometry.py
+++ b/src/porepy/geometry/map_geometry.py
@@ -332,13 +332,17 @@ def compute_normal(pts, check=True):
     normal: np.array, 1x3, the normal.
 
     """
-
     assert pts.shape[1] > 2
-    normal = np.cross(pts[:, 0] - pts[:, 1], pts[:, 2] - pts[:, 1])
-    if check and np.allclose(normal, np.zeros(3)):
-        return compute_normal(pts[:, 1:])
-    else:
-        return normal / np.linalg.norm(normal)
+    normal = np.zeros(3)
+    count = 0
+    max_count = pts.shape[1]
+    while np.allclose(normal, np.zeros(3)) and count <= max_count:
+        count += 1
+        normal = np.cross(pts[:, 0] - pts[:, 1], pts[:, 2] - np.mean(pts, axis=1))
+        pts = pts[:, 1:]
+        if not check:
+            break
+    return normal / np.linalg.norm(normal)
 
 
 def compute_normals_1d(pts):


### PR DESCRIPTION
I think everyone agrees with removing the recursion. However, I am not sure about the change to using the mean for one of the points. I guess this may fail for some rare cases? The old way was no good on Cartesian grids, since points then are ordered by rows (if the grid is large enough we reach the maximum level of recursion). After removing the recursive loop, it will work on Cartesian grids without the mean, but you have to loop over the first row of cells, and end up with a normal and tangential vector that are almost parallel. 

Any thoughts ?