### PR TITLE
Fix bug in pip editable install mode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,5 +29,5 @@ mypy = "^0.790"
 flake8 = "^3.8.3"
 
 [build-system]
-requires = ["poetry>=0.12"]
+requires = ["poetry>=0.12", "setuptools"]
 build-backend = "poetry.masonry.api"


### PR DESCRIPTION
I'm not entirely sure what's causing the error. It seems to be related either to `setuptools` or to `poetry`, or maybe both. Thus, this is more or less a brute force fix. I've found it here: https://github.com/python-poetry/poetry/issues/3001