### PR TITLE
MortarGrid sides are identified by Enum

### DIFF
--- a/src/porepy/fracs/meshing.py
+++ b/src/porepy/fracs/meshing.py
@@ -20,6 +20,7 @@ from porepy.grids.grid_bucket import GridBucket
 from porepy.utils import mcolon
 
 logger = logging.getLogger(__name__)
+mortar_sides = mortar_grid.MortarSides
 
 
 def grid_list_to_grid_bucket(
@@ -288,10 +289,10 @@ def create_mortar_grids(gb, ensure_matching_face_cell=True, **kwargs):
         if np.all(num_sides > 1):
             # we are in a two sides situation
             side_g = {
-                mortar_grid.LEFT_SIDE: lg.copy(),
-                mortar_grid.RIGHT_SIDE: lg.copy(),
+                mortar_sides.LEFT_SIDE: lg.copy(),
+                mortar_sides.RIGHT_SIDE: lg.copy(),
             }
         else:
             # the tag name is just a place-holder we assume left side
-            side_g = {mortar_grid.LEFT_SIDE: lg.copy()}
+            side_g = {mortar_sides.LEFT_SIDE: lg.copy()}
         d["mortar_grid"] = mortar_grid.MortarGrid(lg.dim, side_g, d["face_cells"])

--- a/src/porepy/grids/grid_bucket.py
+++ b/src/porepy/grids/grid_bucket.py
@@ -20,6 +20,7 @@ import numpy as np
 from scipy import sparse as sps
 
 import porepy as pp
+from porepy.grids import mortar_grid
 from porepy.utils import setmembership
 
 
@@ -922,7 +923,9 @@ class GridBucket:
     def replace_grids(
         self,
         g_map: Optional[Dict[pp.Grid, pp.Grid]] = None,
-        mg_map: Optional[Dict[pp.MortarGrid, Dict[int, pp.Grid]]] = None,
+        mg_map: Optional[
+            Dict[pp.MortarGrid, Dict[mortar_grid.MortarSides, pp.Grid]]
+        ] = None,
         tol: float = 1e-6,
     ) -> None:
         """Replace grids and / or mortar grids in the mixed-dimensional grid.

--- a/src/porepy/grids/grid_extrusion.py
+++ b/src/porepy/grids/grid_extrusion.py
@@ -131,12 +131,12 @@ def extrude_grid_bucket(gb: pp.GridBucket, z: np.ndarray) -> Tuple[pp.GridBucket
         # Create a mortar grid, add to data of new edge
         if len(face_on_other_side) == 0:  # Only one side
             side_g = {
-                mortar_grid.LEFT_SIDE: gl_new.copy(),
+                mortar_grid.MortarSides.LEFT_SIDE: gl_new.copy(),
             }
         else:
             side_g = {
-                mortar_grid.LEFT_SIDE: gl_new.copy(),
-                mortar_grid.RIGHT_SIDE: gl_new.copy(),
+                mortar_grid.MortarSides.LEFT_SIDE: gl_new.copy(),
+                mortar_grid.MortarSides.RIGHT_SIDE: gl_new.copy(),
             }
 
         # Construct mortar grid, with instructions on which faces belong to which side

--- a/src/porepy/numerics/fracture_deformation/propagate_fracture.py
+++ b/src/porepy/numerics/fracture_deformation/propagate_fracture.py
@@ -17,6 +17,7 @@ import numpy as np
 import scipy.sparse as sps
 
 import porepy as pp
+from porepy.grids import mortar_grid
 
 
 def propagate_fractures(gb: pp.GridBucket, faces: Dict[pp.Grid, np.ndarray]) -> None:
@@ -325,7 +326,10 @@ def _update_mortar_grid(
 
     # The new mortar grid is constructed to be matching with g_l.
     # If splitting is undertaken for a non-matching grid, all bets are off.
-    side_grids = {1: g_l, 2: g_l}
+    side_grids = {
+        mortar_grid.MortarSides.LEFT_SIDE: g_l,
+        mortar_grid.MortarSides.RIGHT_SIDE: g_l,
+    }
     mg_new = pp.MortarGrid(
         g_l.dim, side_grids, d_e["face_cells"], face_duplicate_ind=other_side_new
     )

--- a/src/porepy/viz/exporter.py
+++ b/src/porepy/viz/exporter.py
@@ -368,7 +368,7 @@ class Exporter:
             d["grid_dim"] = g.dim * ones
             d["grid_node_number"] = d["node_number"] * ones
             d["is_mortar"] = 0 * ones
-            d["mortar_side"] = int(pp.grids.mortar_grid.NONE_SIDE) * ones
+            d["mortar_side"] = pp.grids.mortar_grid.MortarSides.NONE_SIDE.value * ones
 
         # collect the data and extra data in a single stack for each dimension
         for dim in self.dims:
@@ -407,7 +407,7 @@ class Exporter:
                 ones = np.ones(g.num_cells, dtype=np.int)
                 d["grid_dim"][side] = g.dim * ones
                 d["is_mortar"][side] = ones
-                d["mortar_side"][side] = int(side) * ones
+                d["mortar_side"][side] = side.value * ones
                 d["cell_id"][side] = np.arange(g.num_cells, dtype=np.int) + mg_num_cells
                 mg_num_cells += g.num_cells
                 d["grid_edge_number"][side] = d["edge_number"] * ones

--- a/test/unit/test_contact_conditions.py
+++ b/test/unit/test_contact_conditions.py
@@ -835,8 +835,8 @@ class ContactModel2d(ContactMechanics):
 
         # Construct mortar grid
         side_grids = {
-            mortar_grid.LEFT_SIDE: g_1d.copy(),
-            mortar_grid.RIGHT_SIDE: g_1d.copy(),
+            mortar_grid.MortarSides.LEFT_SIDE: g_1d.copy(),
+            mortar_grid.MortarSides.RIGHT_SIDE: g_1d.copy(),
         }
 
         data = np.array([1, 1])

--- a/test/unit/test_grid_bucket.py
+++ b/test/unit/test_grid_bucket.py
@@ -1,11 +1,12 @@
+""" Various tests of GridBucket functionality. Covers getters and setters, topologial
+information on the bucket, and pickling and unpickling of buckets.
+"""
 import unittest
+import pickle
 
 import numpy as np
-import scipy.sparse as sps
-
+from test import test_utils
 import porepy as pp
-from porepy.fracs import meshing
-from porepy.grids.grid_bucket import GridBucket
 
 
 class MockGrid(pp.Grid):
@@ -619,6 +620,15 @@ class TestBucket(unittest.TestCase):
         self.assertTrue(np.all(g1.face_centers == gb.face_centers(cond)))
 
 
+def test_pickle_bucket():
+    fracs = [np.array([[0, 2], [1, 1]]), np.array([[1, 1], [0, 2]])]
+    gb = pp.meshing.cart_grid(fracs, [2, 2])
+
+    fn = "tmp.grid_bucket"
+    pickle.dump(gb, open(fn, "wb"))
+    gb_read = pickle.load(open(fn, "rb"))
+
+    test_utils.compare_grid_buckets(gb, gb_read)
+
 if __name__ == "__main__":
-    TestBucket().test_contains_node()
     unittest.main()

--- a/test/unit/test_grid_refinement.py
+++ b/test/unit/test_grid_refinement.py
@@ -134,7 +134,7 @@ class TestGridRefinement2dSimplex(unittest.TestCase):
         self.assertTrue(np.allclose(np.bincount(parent, h.cell_volumes), 0.5))
 
 
-# ------------------------------------------------------------------------------#
+
 """ EK: I can no longer recall the intention behind these tests - they seem to
 be related to an early implementation of mortar functionality. The tests are
 disabled for now, but should be brought back to life at some point.
@@ -272,7 +272,6 @@ class TestRefinementGridBucket(unittest.TestCase):
             self.assertTrue(np.allclose(d["face_cells"].todense(), known_face_cells))
 """
 
-# ------------------------------------------------------------------------------#
 
 
 class TestRefinementMortarGrid(unittest.TestCase):
@@ -525,7 +524,7 @@ class TestRefinementMortarGrid(unittest.TestCase):
 
             mg = d["mortar_grid"]
             new_side_grids = {
-                s: refinement.remesh_1d(g, num_nodes=int(s) + 3)
+                s: refinement.remesh_1d(g, num_nodes=s.value + 3)
                 for s, g in mg.side_grids.items()
             }
 

--- a/test/unit/test_mortars.py
+++ b/test/unit/test_mortars.py
@@ -5,12 +5,14 @@ Created on Sat Nov 11 18:23:11 2017
 
 @author: Eirik Keilegavlen
 """
-
+import pickle
+import pytest
 import unittest
 
 import numpy as np
 import scipy.sparse as sps
 
+from test import test_utils
 import porepy as pp
 
 
@@ -1019,6 +1021,31 @@ class TestMeshReplacement3d(unittest.TestCase):
         self.assertTrue(np.abs(p1h[0, 4] - 0.5) < 1e-6)
         self.assertTrue(np.abs(p1h[1, 7] - 0.5) < 1e-6)
         self.assertTrue(np.abs(p1h[1, 8] - 0.5) < 1e-6)
+
+
+@pytest.mark.parametrize("g",[         pp.PointGrid([0, 0, 0]),
+        pp.CartGrid([2]),
+        pp.CartGrid([2, 2]),
+        pp.StructuredTriangleGrid([2, 2]),]
+)
+def test_pickle_mortar_grid(g):
+    fn = 'tmp.grid'
+    g.compute_geometry()
+    mg = pp.MortarGrid(g.dim, {0: g, 1: g})
+
+    pickle.dump(mg, open(fn, 'wb'))
+    mg_read = pickle.load(open(fn, 'rb'))
+
+    test_utils.compare_mortar_grids(mg, mg_read)
+
+    mg_one_sided = pp.MortarGrid(g.dim, {0: g})
+
+    pickle.dump(mg, open(fn, 'wb'))
+    mg_read = pickle.load(open(fn, 'rb'))
+
+    test_utils.compare_mortar_grids(mg_one_sided, mg_read)
+
+    test_utils.delete_file(fn)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This leaves a more robust implementation than previously, when we relied on accessing module-level constants outside the module.

Also, added tests to check pickling of `Grid`, `MortarGrid` and `GridBucket`.