### PR TITLE
Upgrade to numpy 1.20 compatibility. drop Python 3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     # https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#specifying-a-python-version
     strategy:
       matrix:
-        python-version:  [3.6, 3.7, 3.8]
+        python-version:  [3.7, 3.8]
       # Complete all versions in matrix even if one fails.
       fail-fast: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install libglu1-mesa
         export LD_LIBRARY_PATH=/usr/local/lib64/:$LD_LIBRARY_PATH
+        pip install -U pip
         pip install -r requirements-dev.txt
         pip install jupyter
         pip install .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ cython = "^0.29.7"
 future = "^0.17.1"
 six = "^1.12.0"
 shapely = {extras = ["vectorized"], version = "^1.7.0"}
-numba = "^0.50.0"
+numba = "^0.52.0"
 scipy = "^1.4.1"
 numpy = "^1.18.5"
 gmsh = "^4.5"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,7 +12,7 @@ shapely[vectorized]
 pytest >= 4.6
 pytest-cov
 pytest-runner
-numba >= 0.52
+numba >= 0.52.0
 gmsh
 flake8
 mypy

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,7 +12,7 @@ shapely[vectorized]
 pytest >= 4.6
 pytest-cov
 pytest-runner
-numba >= 0.50
+numba >= 0.52
 gmsh
 flake8
 mypy

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ future
 six
 shapely
 shapely[vectorized]
-numba>=0.52
+numba>=0.52.0
 gmsh

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ future
 six
 shapely
 shapely[vectorized]
-numba>=0.50
+numba>=0.52
 gmsh

--- a/src/porepy/fracs/fracture_importer.py
+++ b/src/porepy/fracs/fracture_importer.py
@@ -259,8 +259,8 @@ def network_2d_from_csv(
             edges = np.hstack((edges, edges_loc))
             edges_frac_id = np.hstack((edges_frac_id, [fi] * edges_loc.shape[1]))
 
-        edges = edges.astype(np.int)
-        edges_frac_id = edges_frac_id.astype(np.int)
+        edges = edges.astype(int)
+        edges_frac_id = edges_frac_id.astype(int)
 
     else:
         # Let the edges correspond to the ordering of the fractures
@@ -278,10 +278,10 @@ def network_2d_from_csv(
 
     pts, _, old_2_new = pp.utils.setmembership.unique_columns_tol(pts, tol=tol)
 
-    edges[:2] = old_2_new[edges[:2].astype(np.int)]
+    edges[:2] = old_2_new[edges[:2].astype(int)]
 
     to_remove = np.where(edges[0, :] == edges[1, :])[0]
-    edges = np.delete(edges, to_remove, axis=1).astype(np.int)
+    edges = np.delete(edges, to_remove, axis=1).astype(int)
 
     if not np.all(np.diff(edges[:2], axis=0) != 0):
         raise ValueError
@@ -290,7 +290,7 @@ def network_2d_from_csv(
 
     if return_frac_id:
         edges_frac_id = np.delete(edges_frac_id, to_remove)
-        return network, edges_frac_id.astype(np.int)
+        return network, edges_frac_id.astype(int)
     else:
         return network
 

--- a/src/porepy/fracs/fractures_2d.py
+++ b/src/porepy/fracs/fractures_2d.py
@@ -1026,7 +1026,7 @@ class FractureNetwork2d(object):
         cell_type = "line"
 
         # cell connectivity information
-        meshio_cells = np.empty(1, dtype=np.object)
+        meshio_cells = np.empty(1, dtype=object)
         meshio_cells[0] = meshio.CellBlock(cell_type, self.edges.T)
 
         # prepare the points

--- a/src/porepy/fracs/fractures_2d.py
+++ b/src/porepy/fracs/fractures_2d.py
@@ -81,7 +81,7 @@ class FractureNetwork2d(object):
         else:
             self.pts = pts
         if edges is None:
-            self.edges = np.zeros((2, 0), dtype=np.int)
+            self.edges = np.zeros((2, 0), dtype=int)
         else:
             self.edges = edges
         self.domain = domain
@@ -185,12 +185,12 @@ class FractureNetwork2d(object):
             n_self = self_tags.shape[0]
             n_fs = fs_tags.shape[0]
             if n_self < n_fs:
-                extra_tags = np.empty((n_fs - n_self, self.num_frac), dtype=np.int)
+                extra_tags = np.empty((n_fs - n_self, self.num_frac), dtype=int)
                 self_tags = np.vstack((self_tags, extra_tags))
             elif n_self > n_fs:
-                extra_tags = np.empty((n_self - n_fs, fs.num_frac), dtype=np.int)
+                extra_tags = np.empty((n_self - n_fs, fs.num_frac), dtype=int)
                 fs_tags = np.vstack((fs_tags, extra_tags))
-            tags = np.hstack((self_tags, fs_tags)).astype(np.int)
+            tags = np.hstack((self_tags, fs_tags)).astype(int)
             e = np.vstack((e, tags))
 
         if self.domain is not None and fs.domain is not None:
@@ -315,7 +315,7 @@ class FractureNetwork2d(object):
         if tol is None:
             tol = self.tol
         if constraints is None:
-            constraints = np.empty(0, dtype=np.int)
+            constraints = np.empty(0, dtype=int)
         else:
             constraints = np.atleast_1d(constraints)
         constraints = np.sort(constraints)
@@ -342,7 +342,7 @@ class FractureNetwork2d(object):
             to_delete = np.where(np.isin(constraints, edges_deleted))[0]
 
             # Adjust constraint indices for deleted edges
-            adjustment = np.zeros(constraints.size, dtype=np.int)
+            adjustment = np.zeros(constraints.size, dtype=int)
             for e in edges_deleted:
                 # All constraints with index above the deleted edge should be reduced
                 adjustment[constraints > e] += 1
@@ -371,7 +371,7 @@ class FractureNetwork2d(object):
 
         const = constants.GmshConstants()
 
-        tags = np.zeros((2, edges.shape[1]), dtype=np.int)
+        tags = np.zeros((2, edges.shape[1]), dtype=int)
         tags[0][np.logical_not(self.tags["boundary"])] = const.FRACTURE_TAG
         tags[0][self.tags["boundary"]] = const.DOMAIN_BOUNDARY_TAG
         tags[0][constraints] = const.AUXILIARY_TAG
@@ -561,11 +561,11 @@ class FractureNetwork2d(object):
             self.tags["boundary"] = np.array(new_boundary_tags)
 
             self.decomposition["domain_boundary_points"] = num_p + np.arange(
-                dom_p.shape[1], dtype=np.int
+                dom_p.shape[1], dtype=int
             )
         else:
             self.tags["boundary"] = boundary_tags
-            self.decomposition["domain_boundary_points"] = np.empty(0, dtype=np.int)
+            self.decomposition["domain_boundary_points"] = np.empty(0, dtype=int)
             self.edges = e
             self.pts = p
 

--- a/src/porepy/fracs/fractures_3d.py
+++ b/src/porepy/fracs/fractures_3d.py
@@ -929,8 +929,8 @@ class FractureNetwork3d(object):
             # fractures. The indexing is a bit involved, but is based on there being
             # two intersection points for each segment - thus the indices in i0 and i1
             # must be divided by two.
-            on_bound_0 = bound_info[ind_0][np.floor(i0[0] / 2).astype(np.int)]
-            on_bound_1 = bound_info[ind_1][np.floor(i1[0] / 2).astype(np.int)]
+            on_bound_0 = bound_info[ind_0][np.floor(i0[0] / 2).astype(int)]
+            on_bound_1 = bound_info[ind_1][np.floor(i1[0] / 2).astype(int)]
 
             # Add the intersection to the internal list
             self.intersections.append(
@@ -1198,8 +1198,8 @@ class FractureNetwork3d(object):
         )
 
         # Update the edges_2_frac map to refer to the new edges
-        edges_2_frac_new = e_unique.shape[1] * [np.empty(0, dtype=np.int)]
-        is_boundary_edge_new = e_unique.shape[1] * [np.empty(0, dtype=np.int)]
+        edges_2_frac_new = e_unique.shape[1] * [np.empty(0, dtype=int)]
+        is_boundary_edge_new = e_unique.shape[1] * [np.empty(0, dtype=int)]
 
         for old_i, new_i in enumerate(all_2_unique_e):
             edges_2_frac_new[new_i], ind = np.unique(
@@ -1409,7 +1409,7 @@ class FractureNetwork3d(object):
         vertex or as internal.
 
         Returns:
-            list of np.int: indices of fractures, one list item per point.
+            list of int: indices of fractures, one list item per point.
 
         """
         fracs_of_points = []
@@ -1659,7 +1659,7 @@ class FractureNetwork3d(object):
         if inds.size > 0:
             split_frac = np.where(np.bincount(inds) > 1)[0]
         else:
-            split_frac = np.zeros(0, dtype=np.int)
+            split_frac = np.zeros(0, dtype=int)
 
         ind_map = np.delete(old_frac_ind, delete_frac)
 
@@ -1824,7 +1824,7 @@ class FractureNetwork3d(object):
 
         # ... on the points...
         point_tags = constants.NEUTRAL_TAG * np.ones(
-            self.decomposition["points"].shape[1], dtype=np.int
+            self.decomposition["points"].shape[1], dtype=int
         )
         # and the mapping between fractures and edges.
         edges_2_frac = self.decomposition["edges_2_frac"]
@@ -2305,7 +2305,7 @@ class FractureNetwork3d(object):
 
         """
         if constraints is None:
-            constraints = np.array([], dtype=np.int)
+            constraints = np.array([], dtype=int)
 
         # Extract geometrical information.
         p = self.decomposition["points"]
@@ -2337,8 +2337,8 @@ class FractureNetwork3d(object):
 
         # Count the number of times a lines is defined as 'inside' a fracture, and the
         # the number of times this is casued by a constraint
-        in_frac_occurences = np.zeros(edges.shape[1], dtype=np.int)
-        in_frac_occurences_by_constraints = np.zeros(edges.shape[1], dtype=np.int)
+        in_frac_occurences = np.zeros(edges.shape[1], dtype=int)
+        in_frac_occurences_by_constraints = np.zeros(edges.shape[1], dtype=int)
 
         for poly_ind, poly_edges in enumerate(self.decomposition["line_in_frac"]):
             for edge_ind in poly_edges:
@@ -2387,7 +2387,7 @@ class FractureNetwork3d(object):
         intersection_points = []
         for pi in intersection_point_canditates:
             _, edge_ind = np.where(edges == pi)
-            frac_arr = np.array([], dtype=np.int)
+            frac_arr = np.array([], dtype=int)
             for e in edge_ind:
                 frac_arr = np.append(frac_arr, self.decomposition["edges_2_frac"][e])
             unique_fracs = np.unique(frac_arr)
@@ -2599,7 +2599,7 @@ class FractureNetwork3d(object):
         # Intersection points, in 2d coordinates
         ip = np.empty((2, 0))
 
-        other_frac = np.empty(0, dtype=np.int)
+        other_frac = np.empty(0, dtype=int)
 
         for i in isect:
             if i.first.index == frac_num:

--- a/src/porepy/fracs/fractures_3d.py
+++ b/src/porepy/fracs/fractures_3d.py
@@ -206,8 +206,8 @@ class Fracture(object):
 
         to_enforce = np.hstack(
             (
-                np.zeros(self.p.shape[1], dtype=np.bool),
-                np.ones(p.shape[1], dtype=np.bool),
+                np.zeros(self.p.shape[1], dtype=bool),
+                np.ones(p.shape[1], dtype=bool),
             )
         )
         self.p = np.hstack((self.p, p))
@@ -2256,8 +2256,8 @@ class FractureNetwork3d(object):
 
         # construct the meshio data structure
         num_block = len(cell_to_nodes)
-        meshio_cells = np.empty(num_block, dtype=np.object)
-        meshio_cell_id = np.empty(num_block, dtype=np.object)
+        meshio_cells = np.empty(num_block, dtype=object)
+        meshio_cell_id = np.empty(num_block, dtype=object)
 
         for block, (cell_type, cell_block) in enumerate(cell_to_nodes.items()):
             meshio_cells[block] = meshio.CellBlock(cell_type, cell_block)
@@ -2272,7 +2272,7 @@ class FractureNetwork3d(object):
         # store also the data
         for key, val in data.items():
             # for each field create a sub-vector for each geometrically uniform group of cells
-            meshio_data[key] = np.empty(num_block, dtype=np.object)
+            meshio_data[key] = np.empty(num_block, dtype=object)
             # fill up the data
             for block, ids in enumerate(meshio_cell_id):
                 if val.ndim == 1:
@@ -2317,7 +2317,7 @@ class FractureNetwork3d(object):
         frac_tags["boundary"] = frac_tags.get("boundary", []) + [False] * (
             len(self._fractures) - len(frac_tags.get("boundary", []))
         )
-        frac_tags["constraint"] = np.zeros(len(self._fractures), dtype=np.bool)
+        frac_tags["constraint"] = np.zeros(len(self._fractures), dtype=bool)
         frac_tags["constraint"][constraints] = True
 
         # Get preliminary set of tags for the edges. Also find which edges are

--- a/src/porepy/fracs/non_conforming.py
+++ b/src/porepy/fracs/non_conforming.py
@@ -79,7 +79,7 @@ def process_intersections(grids, intersections, global_ind_offset, list_of_grids
     # All connections will be hit upon twice, one from each intersecting fracture.
     # Keep track of which connections have been treated, and can be skipped.
     num_frac = len(grids)
-    isect_is_processed = sps.lil_matrix((num_frac, num_frac), dtype=np.bool)
+    isect_is_processed = sps.lil_matrix((num_frac, num_frac), dtype=bool)
 
     grid_1d_list = []
 
@@ -429,7 +429,7 @@ def update_face_nodes(
     indices = fn.flatten(order="F")
 
     # Trivial updates of data and indptr. Fortunately, this is 2d
-    data = np.ones(fn.size, dtype=np.bool)
+    data = np.ones(fn.size, dtype=bool)
     indptr = np.arange(0, fn.size + 1, nodes_per_face)
     g.face_nodes = sps.csc_matrix((data, indices, indptr))
     g.num_faces = int(fn.size / nodes_per_face)

--- a/src/porepy/fracs/non_conforming.py
+++ b/src/porepy/fracs/non_conforming.py
@@ -534,7 +534,7 @@ def update_cell_faces(
     # with deleted_2_new_faces to match new and old faces
     # Safeguarding (or stupidity?): Only faces along 1d grid have non-negative
     # index, but we should never hit any of the other elements
-    cf_2_f = -np.ones(delete_faces.max() + 1, dtype=np.int)
+    cf_2_f = -np.ones(delete_faces.max() + 1, dtype=int)
     cf_2_f[delete_faces] = np.arange(delete_faces.size)
 
     # Map from faces, as stored in cell_faces,to the corresponding cells

--- a/src/porepy/fracs/simplex.py
+++ b/src/porepy/fracs/simplex.py
@@ -100,7 +100,7 @@ def triangle_grid_from_gmsh(file_name, constraints=None, **kwargs):
     """
 
     if constraints is None:
-        constraints = np.empty(0, dtype=np.int)
+        constraints = np.empty(0, dtype=int)
 
     start_time = time.time()
 
@@ -169,7 +169,7 @@ def line_grid_from_gmsh(file_name, constraints=None, **kwargs):
     """
 
     if constraints is None:
-        constraints = np.empty(0, dtype=np.int)
+        constraints = np.empty(0, dtype=int)
 
     start_time = time.time()
 

--- a/src/porepy/fracs/split_grid.py
+++ b/src/porepy/fracs/split_grid.py
@@ -695,7 +695,7 @@ def find_cell_color(g, cells):
     # Local cell-face and face-node maps.
     assert g.cell_faces.getformat() == "csc"
     cell_faces = sparse_mat.slice_mat(g.cell_faces, c)
-    child_cell_ind = -np.ones(g.num_cells, dtype=np.int)
+    child_cell_ind = -np.ones(g.num_cells, dtype=int)
     child_cell_ind[c] = np.arange(cell_faces.shape[1])
 
     # Create a copy of the cell-face relation, so that we can modify it at

--- a/src/porepy/fracs/tools.py
+++ b/src/porepy/fracs/tools.py
@@ -68,7 +68,7 @@ def determine_mesh_size(pts, pts_on_boundary=None, lines=None, **kwargs):
     num_pts = pts.shape[1]
     pts_extra = np.empty((pts.shape[0], 0))
     dist_extra = np.empty(0)
-    pts_id_extra = np.empty(0, dtype=np.int)
+    pts_id_extra = np.empty(0, dtype=int)
     vals_extra = np.empty(0)
     # For each point we compute the distance between the point and the other
     # pairs of points. We keep the minimum distance between the previously
@@ -115,7 +115,7 @@ def determine_mesh_size(pts, pts_on_boundary=None, lines=None, **kwargs):
             ]
             pts_extra = np.c_[pts_extra, cp[hit[to_add], 0].T]
             pts_id_extra = np.r_[
-                pts_id_extra, line[3] * np.ones(to_add.sum(), dtype=np.int)
+                pts_id_extra, line[3] * np.ones(to_add.sum(), dtype=int)
             ]
             vals_extra = np.r_[vals_extra, vals[hit[to_add]]]
 
@@ -126,7 +126,7 @@ def determine_mesh_size(pts, pts_on_boundary=None, lines=None, **kwargs):
     # consider all the new points together and remove (from the new points) the
     # useless ones.
     extra_ids, inv_index = np.unique(pts_id_extra, return_inverse=True)
-    to_remove = np.empty(0, dtype=np.int)
+    to_remove = np.empty(0, dtype=int)
     for idx, i in enumerate(extra_ids):
         mask = np.flatnonzero(inv_index == idx)
         if mask.size > 1:
@@ -161,7 +161,7 @@ def determine_mesh_size(pts, pts_on_boundary=None, lines=None, **kwargs):
     vals = np.r_[vals, vals_extra]
     # Re-create the lines, considering the new introduced points
     seg_ids = np.unique(lines[3, :])
-    new_lines = np.empty((4, 0), dtype=np.int)
+    new_lines = np.empty((4, 0), dtype=int)
     for seg_id in seg_ids:
         mask_bool = lines[3, :] == seg_id
         extra_mask_bool = pts_id_extra == seg_id
@@ -196,7 +196,7 @@ def determine_mesh_size(pts, pts_on_boundary=None, lines=None, **kwargs):
     # and, beacuse of val, needs additional points we increase the number of
     # lines.
     relax = kwargs.get("relaxation", 0.8)
-    lines = np.empty((4, 0), dtype=np.int)
+    lines = np.empty((4, 0), dtype=int)
     for seg in new_lines.T:
         mesh_size_pt1 = dist_pts[seg[0]]
         mesh_size_pt2 = dist_pts[seg[1]]

--- a/src/porepy/geometry/constrain_geometry.py
+++ b/src/porepy/geometry/constrain_geometry.py
@@ -248,13 +248,13 @@ def polygons_by_polyhedron(polygons, polyhedron, tol=1e-8):
         segments_interior_boundary = []
 
         # Check if individual vertexs are on the boundary
-        vertex_on_boundary = np.zeros(num_vert, np.bool)
+        vertex_on_boundary = np.zeros(num_vert, bool)
         for isect in seg_vert:
             if len(isect) > 0 and not isect[1]:
                 vertex_on_boundary[isect[0]] = 1
 
         # Storage of the intersections associated with each segment of the original polygon
-        isects_of_segment = np.zeros(num_vert, np.object)
+        isects_of_segment = np.zeros(num_vert, object)
         for i in range(num_vert):
             isects_of_segment[i] = []
 

--- a/src/porepy/geometry/constrain_geometry.py
+++ b/src/porepy/geometry/constrain_geometry.py
@@ -80,9 +80,9 @@ def lines_by_polygon(poly_pts, pts, edges):
         int_edges = np.vstack((int_edges, edges[2:, edges_kept]))
     else:
         # If no edges are kept, return an empty array with the right dimensions
-        int_edges = np.empty((edges.shape[0], 0), dtype=np.int)
+        int_edges = np.empty((edges.shape[0], 0), dtype=int)
 
-    return int_pts, int_edges, np.array(edges_kept, dtype=np.int)
+    return int_pts, int_edges, np.array(edges_kept, dtype=int)
 
 
 @pp.time_logger(sections=module_sections)
@@ -218,7 +218,7 @@ def polygons_by_polyhedron(polygons, polyhedron, tol=1e-8):
 
         # First, count the number of times a segment of the polygon is associated with
         # an intersection point
-        count_boundary_segment = np.zeros(num_vert, dtype=np.int)
+        count_boundary_segment = np.zeros(num_vert, dtype=int)
         for isect in seg_vert:
             # Only consider segment intersections, not interior (len==0), and vertexes
             if len(isect) > 0 and isect[1]:
@@ -296,7 +296,7 @@ def polygons_by_polyhedron(polygons, polyhedron, tol=1e-8):
             if len(isects_of_segment[seg_ind]) == 0:
                 continue
             # Index and coordinate of intersection points on this segment
-            loc_isect_ind = np.asarray(isects_of_segment[seg_ind], dtype=np.int).ravel()
+            loc_isect_ind = np.asarray(isects_of_segment[seg_ind], dtype=int).ravel()
 
             # Consider unique intersection points; there may be repititions in cases
             # where the polyhedron has multiple parallel sides.
@@ -341,7 +341,7 @@ def polygons_by_polyhedron(polygons, polyhedron, tol=1e-8):
                 [i for i in segments_interior_boundary]
             ).T
         else:
-            segments_interior_boundary = np.zeros((2, 0), dtype=np.int)
+            segments_interior_boundary = np.zeros((2, 0), dtype=int)
 
         # At this stage, we have identified all segments, possibly with duplicates.
         # Next task is to arrive at a unique representation of the segments.

--- a/src/porepy/geometry/distances.py
+++ b/src/porepy/geometry/distances.py
@@ -509,7 +509,7 @@ def segments_polygon(start, end, poly, tol=1e-5):
     t[non_zero_incline] = -start[2, non_zero_incline] / dz[non_zero_incline]
     # Segments with z=0 along the segment
     zero_along_segment = np.logical_and(
-        non_zero_incline, np.logical_and(t >= 0, t <= 1).astype(np.bool)
+        non_zero_incline, np.logical_and(t >= 0, t <= 1).astype(bool)
     )
 
     x0 = start + (end - start) * t

--- a/src/porepy/geometry/geometry_property_checks.py
+++ b/src/porepy/geometry/geometry_property_checks.py
@@ -109,7 +109,7 @@ def is_ccw_polyline(p1, p2, p3, tol=0, default=False):
 
     # Should there be a scaling of the tolerance relative to the distance
     # between the points?
-    is_ccw = np.ones(num_points, dtype=np.bool)
+    is_ccw = np.ones(num_points, dtype=bool)
     is_ccw[np.abs(cross_product) <= tol] = default
 
     is_ccw[cross_product < -tol] = False
@@ -161,7 +161,7 @@ def point_in_polygon(poly, p, tol=0, default=False):
 
     poly_size = poly.shape[1]
 
-    inside = np.ones(pt.shape[1], dtype=np.bool)
+    inside = np.ones(pt.shape[1], dtype=bool)
     for j in range(poly.shape[1]):
         this_ccw = is_ccw_polyline(
             poly[:, j], poly[:, (j + 1) % poly_size], pt, tol=tol, default=default
@@ -256,7 +256,7 @@ def point_in_polyhedron(polyhedron, test_points, tol=1e-8):
     if test_points.size < 4:
         test_points = test_points.reshape((-1, 1))
 
-    is_inside = np.zeros(test_points.shape[1], dtype=np.bool)
+    is_inside = np.zeros(test_points.shape[1], dtype=bool)
 
     # Loop over all points, check if they are inside.
     for pi in range(test_points.shape[1]):
@@ -299,7 +299,7 @@ def points_are_planar(pts, normal=None, tol=1e-5):
     else:
         normal = normal.flatten() / np.linalg.norm(normal)
 
-    check_all = np.zeros(pts.shape[1] - 1, dtype=np.bool)
+    check_all = np.zeros(pts.shape[1] - 1, dtype=bool)
 
     for idx, p in enumerate(pts[:, 1:].T):
         den = np.linalg.norm(pts[:, 0] - p)

--- a/src/porepy/geometry/geometry_property_checks.py
+++ b/src/porepy/geometry/geometry_property_checks.py
@@ -242,7 +242,7 @@ def point_in_polyhedron(polyhedron, test_points, tol=1e-8):
 
     # Uniquify points, and update triangulation
     upoints, _, ib = pp.utils.setmembership.unique_columns_tol(points, tol=tol)
-    ut = ib[tri.astype(np.int)]
+    ut = ib[tri.astype(int)]
 
     # The in-polyhedra algorithm requires a very particular ordering of the vertexes
     # in the triangulation. Fix this.

--- a/src/porepy/geometry/intersections.py
+++ b/src/porepy/geometry/intersections.py
@@ -488,7 +488,7 @@ def polygons_3d(polys, target_poly=None, tol=1e-8):
     num_polys = len(polys)
 
     # Storage array for storing the index of the intersection points for each polygon
-    isect_pt = np.empty(num_polys, dtype=np.object)
+    isect_pt = np.empty(num_polys, dtype=object)
     # Storage for whehter an intersection is on the boundary of a polygon
     is_bound_isect = np.empty_like(isect_pt)
     # Storage for which segment or vertex of a polygon is intersected
@@ -1351,7 +1351,7 @@ def surface_tessalations(
         x = [poly[i][0] for i in range(len(poly))]
         y = [poly[i][1] for i in range(len(poly))]
 
-        list_of_sets.append((x, y))
+        list_of_sets.append((x, y))  # type: ignore
 
     # The below algorithm relies heavily on shapely's functionality for intersection of
     # polygons. The idea is to intersect represent each set of polygons in the shapely
@@ -1467,10 +1467,9 @@ def surface_tessalations(
             )
 
     # Finally translate the intersected polygons back to a list of np.ndarrays
-    isect_polys: List[np.ndarray] = []
-
-    for px, py in zip(isect_x, isect_y):
-        isect_polys.append(np.vstack((px, py)))
+    isect_polys: List[np.ndarray] = [
+        np.vstack((px, py)) for px, py in zip(isect_x, isect_y)
+    ]
 
     if return_simplexes:
         # Finally, if requested, convert the subdivision into a triangulation.
@@ -1493,10 +1492,11 @@ def surface_tessalations(
         tri: List[np.ndarray] = []
 
         # Loop over all isect_polys, split those with more than three vertexes
-        for pi, poly in enumerate(isect_polys):
+        # EK: Somehow, mypy does not understand poly will be an np.ndarray, thus all ignores
+        for pi, poly in enumerate(isect_polys):  # type: ignore
             if poly.shape[1] == 3:  # type: ignore
                 # Triangles can be used as they are
-                tri.append(poly)
+                tri.append(poly)  # type: ignore
                 cols.append(pi)
                 rows.append(tri_counter)
                 tri_counter += 1
@@ -1508,8 +1508,9 @@ def surface_tessalations(
 
                 # Three representation of the polygon vertexes, by shifting their order
                 start = poly
-                middle = np.roll(poly, -1, axis=1)  # This is the vertex we test
-                end = np.roll(poly, -2, axis=1)
+                # This is the vertex we test
+                middle = np.roll(poly, -1, axis=1)  # type: ignore
+                end = np.roll(poly, -2, axis=1)  # type: ignore
                 # Use ccw test on all vertexes in the polygon
                 is_ccw = np.array(
                     [
@@ -1530,8 +1531,8 @@ def surface_tessalations(
                     # shape, the triangulation will also have bad triangles - to improve
                     # we would need to do a more careful triangulation, adding more
                     # points
-                    center = np.mean(poly, axis=1).reshape((-1, 1))
-                    ext_poly = np.hstack((poly, center)).T
+                    center = np.mean(poly, axis=1).reshape((-1, 1))  # type: ignore
+                    ext_poly = np.hstack((poly, center)).T  # type: ignore
                     for t in Delaunay(ext_poly).simplices:
                         tri.append(ext_poly[t].T)
                         #
@@ -1606,7 +1607,7 @@ def split_intersecting_segments_2d(p, e, tol=1e-4, return_argsort=False):
 
     # Data structure for storage of intersection points. For each fracture,
     # we have an array that will contain the index of the intersections.
-    isect_pt = np.empty(num_lines, dtype=np.object)
+    isect_pt = np.empty(num_lines, dtype=object)
     for i in range(isect_pt.size):
         isect_pt[i] = np.empty(0, dtype=int)
 

--- a/src/porepy/geometry/intersections.py
+++ b/src/porepy/geometry/intersections.py
@@ -1379,7 +1379,7 @@ def surface_tessalations(
     # and the previous mappings are updated to account for the new intersection level.
     nc = len(poly_shapely)
     mappings: List[sps.csr_matrix] = [
-        sps.dia_matrix((np.ones(nc, dtype=np.int), 0), shape=(nc, nc)).tocsr()
+        sps.dia_matrix((np.ones(nc, dtype=int), 0), shape=(nc, nc)).tocsr()
     ]
 
     # Loop over all set of polygons, do intersection with existing
@@ -1443,7 +1443,7 @@ def surface_tessalations(
         # Mapping from the previously conisdered polygon to the newly find dissection.
         # This will be applied to update all previous mappings.
         matrix = sps.coo_matrix(
-            (np.ones(isect_counter, dtype=np.int), (row_poly, col_poly)),
+            (np.ones(isect_counter, dtype=int), (row_poly, col_poly)),
             shape=(isect_counter, len(poly_shapely)),
         ).tocsr()
         for mi in range(len(mappings)):
@@ -1452,7 +1452,7 @@ def surface_tessalations(
         # Add a mapping between the current polygon and the newly found intersection.
         mappings.append(
             sps.coo_matrix(
-                (np.ones(isect_counter, dtype=np.int), (row_new, col_new)),
+                (np.ones(isect_counter, dtype=int), (row_new, col_new)),
                 shape=(isect_counter, len(new_shapely)),
             ).tocsr()
         )
@@ -1549,7 +1549,7 @@ def surface_tessalations(
 
         # Also update the mapping.
         matrix = sps.coo_matrix(
-            (np.ones(len(rows), dtype=np.int), (rows, cols)),
+            (np.ones(len(rows), dtype=int), (rows, cols)),
             shape=(len(rows), len(isect_polys)),
         ).tocsr()
 
@@ -1608,7 +1608,7 @@ def split_intersecting_segments_2d(p, e, tol=1e-4, return_argsort=False):
     # we have an array that will contain the index of the intersections.
     isect_pt = np.empty(num_lines, dtype=np.object)
     for i in range(isect_pt.size):
-        isect_pt[i] = np.empty(0, dtype=np.int)
+        isect_pt[i] = np.empty(0, dtype=int)
 
     # Array of new points, found in the intersection of old ones.
     new_pts = []
@@ -1751,8 +1751,8 @@ def split_intersecting_segments_2d(p, e, tol=1e-4, return_argsort=False):
         # may merge non-intersecting fractures.
         unique_all_pt, _, ib = pp.utils.setmembership.unique_columns_tol(all_pt, tol)
         # Data structure for storing the split edges.
-        new_edge = np.empty((e.shape[0], 0), dtype=np.int)
-        argsort = np.empty(0, dtype=np.int)
+        new_edge = np.empty((e.shape[0], 0), dtype=int)
+        argsort = np.empty(0, dtype=int)
 
         # Loop over all lines, split it into non-overlapping segments.
         for ei in range(num_lines):
@@ -1772,7 +1772,7 @@ def split_intersecting_segments_2d(p, e, tol=1e-4, return_argsort=False):
             order = np.argsort(dist)
             new_inds = inds[order]
             # All new segments share the tags of the old one.
-            loc_tags = e[2:, ei].reshape((-1, 1)) * np.ones(num_branches, dtype=np.int)
+            loc_tags = e[2:, ei].reshape((-1, 1)) * np.ones(num_branches, dtype=int)
             # Define the new segments, in terms of the unique points
             loc_edge = np.vstack((new_inds[:-1], new_inds[1:], loc_tags))
 
@@ -1785,15 +1785,15 @@ def split_intersecting_segments_2d(p, e, tol=1e-4, return_argsort=False):
         new_edge[:2] = np.sort(new_edge[:2], axis=0)
         # Uniquify.
         _, edge_map, _ = pp.utils.setmembership.unique_columns_tol(
-            new_edge[:2].astype(np.int), tol
+            new_edge[:2].astype(int), tol
         )
         new_edge = new_edge[:, edge_map]
         argsort = argsort[edge_map]
 
         if return_argsort:
-            return unique_all_pt, new_edge.astype(np.int), argsort
+            return unique_all_pt, new_edge.astype(int), argsort
         else:
-            return unique_all_pt, new_edge.astype(np.int)
+            return unique_all_pt, new_edge.astype(int)
 
 
 @pp.time_logger(sections=module_sections)

--- a/src/porepy/grids/coarsening.py
+++ b/src/porepy/grids/coarsening.py
@@ -45,7 +45,7 @@ def coarsen(
         partition = create_aggregations(g, **method_kwargs)
 
     elif method.lower() == "by_tpfa":
-        seeds = np.empty(0, dtype=np.int)
+        seeds = np.empty(0, dtype=int)
         if method_kwargs.get("if_seeds", False):
             seeds = generate_seeds(g)
         matrix = _tpfa_matrix(g)
@@ -176,7 +176,7 @@ def _generate_coarse_grid_single(g, subdiv, face_map):
         mask[np.unique(faces_old, return_index=True)[1]] = False
         # extract the indexes of the internal edges, to be discared
         index = np.array(
-            [np.where(faces_old == f)[0] for f in faces_old[mask]], dtype=np.int
+            [np.where(faces_old == f)[0] for f in faces_old[mask]], dtype=int
         ).ravel()
         faces_new = np.delete(faces_old, index)
         cell_faces = np.r_[cell_faces, faces_new]
@@ -345,7 +345,7 @@ def generate_seeds(gb):
     Giving the higher dimensional grid in a grid bucket, generate the seed for
     the tip of lower
     """
-    seeds = np.empty(0, dtype=np.int)
+    seeds = np.empty(0, dtype=int)
 
     if isinstance(gb, grid.Grid):
         return seeds
@@ -401,7 +401,7 @@ def create_aggregations(g, **kwargs):
     partition = dict()
 
     for g in g_list:
-        partition_local = -np.ones(g.num_cells, dtype=np.int)
+        partition_local = -np.ones(g.num_cells, dtype=int)
 
         volumes = g.cell_volumes.copy()
         volumes_checked = volumes.copy()
@@ -490,7 +490,7 @@ def create_aggregations(g, **kwargs):
 @pp.time_logger(sections=module_sections)
 def __get_neigh(cells_id, c2c, partition):
     """Support function for create_aggregations"""
-    neighbors = np.empty(0, dtype=np.int)
+    neighbors = np.empty(0, dtype=int)
 
     for cell_id in np.atleast_1d(cells_id):
         # Extract the neighbors of the current cell
@@ -622,7 +622,7 @@ def create_partition(A, g, seeds=None, **kwargs):
     c2c = np.abs(A) > 0
     c2c_rows, _, _ = sps.find(c2c)
 
-    pairs = np.empty((0, 2), dtype=np.int)
+    pairs = np.empty((0, 2), dtype=int)
     for idx, it in enumerate(np.where(is_coarse)[0]):
         loc = slice(c2c.indptr[it], c2c.indptr[it + 1])
         ind = np.setdiff1d(c2c_rows[loc], it)

--- a/src/porepy/grids/coarsening.py
+++ b/src/porepy/grids/coarsening.py
@@ -150,7 +150,7 @@ def _generate_coarse_grid_single(g, subdiv, face_map):
     # declare the storage array to build the face_nodes map
     face_nodes = np.empty(0, dtype=g.face_nodes.indptr.dtype)
     nodes = np.empty(0, dtype=face_nodes.dtype)
-    visit = np.zeros(g.num_faces, dtype=np.bool)
+    visit = np.zeros(g.num_faces, dtype=bool)
 
     # compute the face_node indexes
     num_nodes_per_face = g.face_nodes.indptr[1:] - g.face_nodes.indptr[:-1]
@@ -172,7 +172,7 @@ def _generate_coarse_grid_single(g, subdiv, face_map):
 
         # reconstruct the cell_faces mapping
         faces_old, _, orient_old = sps.find(g.cell_faces[:, cells_old])
-        mask = np.ones(faces_old.size, dtype=np.bool)
+        mask = np.ones(faces_old.size, dtype=bool)
         mask[np.unique(faces_old, return_index=True)[1]] = False
         # extract the indexes of the internal edges, to be discared
         index = np.array(
@@ -193,7 +193,7 @@ def _generate_coarse_grid_single(g, subdiv, face_map):
             np.sum(
                 [face_node_ind == f for f in faces_new[not_visit]],
                 axis=0,
-                dtype=np.bool,
+                dtype=bool,
             )
         )
         face_nodes = np.r_[face_nodes, face_node_ind[mask]]
@@ -553,7 +553,7 @@ def create_partition(A, g, seeds=None, **kwargs):
     Nc = A.shape[0]
 
     # For each node, which other nodes are strongly connected to it
-    ST = sps.lil_matrix((Nc, Nc), dtype=np.bool)
+    ST = sps.lil_matrix((Nc, Nc), dtype=bool)
 
     # In the first instance, all cells are strongly connected to each other
     At = A.T
@@ -582,9 +582,9 @@ def create_partition(A, g, seeds=None, **kwargs):
     lmbda = np.array([len(s) for s in ST.rows])
 
     # Define coarse nodes
-    candidate = np.ones(Nc, dtype=np.bool)
-    is_fine = np.zeros(Nc, dtype=np.bool)
-    is_coarse = np.zeros(Nc, dtype=np.bool)
+    candidate = np.ones(Nc, dtype=bool)
+    is_fine = np.zeros(Nc, dtype=bool)
+    is_coarse = np.zeros(Nc, dtype=bool)
 
     # cells that are not important for any other cells are on the fine scale.
     for row_id, row in enumerate(ST.rows):
@@ -645,7 +645,7 @@ def create_partition(A, g, seeds=None, **kwargs):
 
     # Primal grid
     NC = coarse.size
-    primal = sps.lil_matrix((NC, Nc), dtype=np.bool)
+    primal = sps.lil_matrix((NC, Nc), dtype=bool)
     primal[np.arange(NC), coarse[np.arange(NC)]] = True
 
     connection = sps.lil_matrix((Nc, Nc), dtype=np.double)

--- a/src/porepy/grids/gmsh/mesh_2_grid.py
+++ b/src/porepy/grids/gmsh/mesh_2_grid.py
@@ -85,7 +85,7 @@ def create_2d_grids(
         surface_tag = gmsh_constants.PHYSICAL_NAME_FRACTURES
 
     if constraints is None:
-        constraints = np.array([], dtype=np.int)
+        constraints = np.array([], dtype=int)
 
     if is_embedded:
         # List of 2D grids, one for each surface
@@ -117,7 +117,7 @@ def create_2d_grids(
 
             # Cells of this surface
             loc_cells = np.where(tri_tags == pn_ind)[0]
-            loc_tri_cells = tri_cells[loc_cells, :].astype(np.int)
+            loc_tri_cells = tri_cells[loc_cells, :].astype(int)
 
             # Find unique points, and a mapping from local to global points
             pind_loc, p_map = np.unique(loc_tri_cells, return_inverse=True)
@@ -253,7 +253,7 @@ def create_1d_grids(
         line_tag = gmsh_constants.PHYSICAL_NAME_FRACTURE_LINE
 
     if constraints is None:
-        constraints = np.empty(0, dtype=np.int)
+        constraints = np.empty(0, dtype=int)
     # Recover lines
     # There will be up to three types of physical lines: intersections (between
     # fractures), fracture tips, and auxiliary lines (to be disregarded)

--- a/src/porepy/grids/gmsh/mesh_2_grid.py
+++ b/src/porepy/grids/gmsh/mesh_2_grid.py
@@ -164,10 +164,10 @@ def create_2d_grids(
         # The reason to do so is because we want to compare faces and line columnwise,
         # i.e., is_line[i] should be true iff faces[:, i] == line[:, j] for ONE j. If
         # you can make numpy do this, you can remove the string formating.
-        tmp = np.core.defchararray.add(faces[0, idxf].astype(str), ",")
-        facestr = np.core.defchararray.add(tmp, faces[1, idxf].astype(str))
-        tmp = np.core.defchararray.add(line[0, idxl].astype(str), ",")
-        linestr = np.core.defchararray.add(tmp, line[1, idxl].astype(str))
+        tmp = np.char.add(faces[0, idxf].astype(str), ",")
+        facestr = np.char.add(tmp, faces[1, idxf].astype(str))
+        tmp = np.char.add(line[0, idxl].astype(str), ",")
+        linestr = np.char.add(tmp, line[1, idxl].astype(str))
 
         is_line = np.isin(facestr, linestr, assume_unique=True)
 
@@ -186,7 +186,7 @@ def create_2d_grids(
         # in the cell_info["line"]. The map phys_names recover the literal name.
         for tag in np.unique(cell_info["line"]):
             tag_name = phys_names[tag].lower() + "_faces"
-            g_2d.tags[tag_name] = np.zeros(g_2d.num_faces, dtype=np.bool)
+            g_2d.tags[tag_name] = np.zeros(g_2d.num_faces, dtype=bool)
             # Add correct tag
             faces = line2face[cell_info["line"] == tag]
             g_2d.tags[tag_name][faces] = True

--- a/src/porepy/grids/grid.py
+++ b/src/porepy/grids/grid.py
@@ -146,7 +146,7 @@ class Grid:
         self.global_point_ind: np.ndarray = np.arange(self.num_nodes)
         self._physical_name_index: int = -1
 
-        self.frac_pairs: np.ndarray = np.array([[]], dtype=np.int)
+        self.frac_pairs: np.ndarray = np.array([[]], dtype=int)
 
         # Add tag for the boundary faces
         if external_tags is None:
@@ -817,11 +817,11 @@ class Grid:
         # Increase the data by one to distinguish cell indices from boundary
         # cells
         data = n.indices + 1
-        cols = ((n.data + 1) / 2).astype("i")
+        cols = ((n.data + 1) / 2).astype(int)
         neighs = sps.coo_matrix((data, (rows, cols))).todense()
         # Subtract 1 to get back to real cell indices
         neighs -= 1
-        neighs = neighs.transpose().A.astype("int")
+        neighs = neighs.transpose().A.astype(int)
         # Finally, we need to switch order of rows to get normal vectors
         # pointing from first to second row.
         return neighs[::-1]
@@ -928,7 +928,7 @@ class Grid:
             min_id = np.argmin(d)
             return min_id, np.sqrt(d[min_id])
 
-        ci = np.empty(p.shape[1], dtype=np.int)
+        ci = np.empty(p.shape[1], dtype=int)
         di = np.empty(p.shape[1])
         for i in range(p.shape[1]):
             ci[i], di[i] = min_dist(p[:, i].reshape((3, -1)))

--- a/src/porepy/grids/grid_bucket.py
+++ b/src/porepy/grids/grid_bucket.py
@@ -1314,9 +1314,9 @@ class GridBucket:
         """
         if cond is None:
             cond = lambda g: True
-        return np.sum(
+        return np.sum(  # type: ignore
             [grid.num_cells for grid in self._nodes.keys() if cond(grid)], dtype=int
-        )  # type: ignore
+        )
 
     @pp.time_logger(sections=module_sections)
     def num_mortar_cells(self, cond: Callable[[pp.Grid], bool] = None) -> int:
@@ -1334,14 +1334,14 @@ class GridBucket:
         """
         if cond is None:
             cond = lambda g: True
-        return np.sum(
+        return np.sum(  # type: ignore
             [
                 data["mortar_grid"].num_cells
                 for _, data in self.edges()
                 if data.get("mortar_grid") and cond(data["mortar_grid"])
             ],
             dtype=int,
-        )  # type: ignore
+        )
 
     @pp.time_logger(sections=module_sections)
     def num_faces(self, cond: Callable[[pp.Grid], bool] = None) -> int:
@@ -1360,10 +1360,8 @@ class GridBucket:
         if cond is None:
             cond = lambda g: True
 
-        return np.sum(
-            [  # type: ignore
-                grid.num_faces for grid in self._nodes.keys() if cond(grid)
-            ]
+        return np.sum(  # type: ignore
+            [grid.num_faces for grid in self._nodes.keys() if cond(grid)]
         )
 
     @pp.time_logger(sections=module_sections)
@@ -1383,10 +1381,8 @@ class GridBucket:
         if cond is None:
             cond = lambda g: True
 
-        return np.sum(
-            [  # type: ignore
-                grid.num_nodes for grid in self._nodes.keys() if cond(grid)
-            ]
+        return np.sum(  # type: ignore
+            [grid.num_nodes for grid in self._nodes.keys() if cond(grid)]
         )
 
     @pp.time_logger(sections=module_sections)

--- a/src/porepy/grids/grid_bucket.py
+++ b/src/porepy/grids/grid_bucket.py
@@ -932,7 +932,7 @@ class GridBucket:
         node_source = np.atleast_2d(g_src.global_point_ind)
         node_target = np.atleast_2d(g_trg.global_point_ind)
         _, trg_2_src_nodes = setmembership.ismember_rows(
-            node_source.astype(np.int32), node_target.astype(np.int32)
+            node_source.astype(int32), node_target.astype(int32)
         )
         return trg_2_src_nodes
 
@@ -1316,7 +1316,7 @@ class GridBucket:
         if cond is None:
             cond = lambda g: True
         return np.sum(
-            [grid.num_cells for grid in self._nodes.keys() if cond(grid)], dtype=np.int
+            [grid.num_cells for grid in self._nodes.keys() if cond(grid)], dtype=int
         )
 
     @pp.time_logger(sections=module_sections)
@@ -1341,7 +1341,7 @@ class GridBucket:
                 for _, data in self.edges()
                 if data.get("mortar_grid") and cond(data["mortar_grid"])
             ],
-            dtype=np.int,
+            dtype=int,
         )
 
     @pp.time_logger(sections=module_sections)

--- a/src/porepy/grids/grid_bucket.py
+++ b/src/porepy/grids/grid_bucket.py
@@ -219,20 +219,19 @@ class GridBucket:
             elif edge[1] == node:
                 neigh.append(edge[0])
 
-        neigh = np.array(neigh)
-
+        neigh_arr = np.array(neigh)
         if not only_higher and not only_lower:
-            return neigh
+            return neigh_arr
         elif only_higher and only_lower:
             raise ValueError("Cannot return both only higher and only lower")
         elif only_higher:
             # Find the neighbours that are higher dimensional
-            is_high = np.array([w.dim > node.dim for w in neigh])
-            return neigh[is_high]
+            is_high = np.array([w.dim > node.dim for w in neigh_arr])
+            return neigh_arr[is_high]
         else:
             # Find the neighbours that are higher dimensional
-            is_low = np.array([w.dim < node.dim for w in neigh])
-            return neigh[is_low]
+            is_low = np.array([w.dim < node.dim for w in neigh_arr])
+            return neigh_arr[is_low]
 
     # ------------ Getters for grids
 
@@ -932,7 +931,7 @@ class GridBucket:
         node_source = np.atleast_2d(g_src.global_point_ind)
         node_target = np.atleast_2d(g_trg.global_point_ind)
         _, trg_2_src_nodes = setmembership.ismember_rows(
-            node_source.astype(int32), node_target.astype(int32)
+            node_source.astype(np.int32_), node_target.astype(int)
         )
         return trg_2_src_nodes
 
@@ -1147,7 +1146,7 @@ class GridBucket:
             if cond(e) and d.get("mortar_grid")
         ]
 
-        return np.amax(np.hstack((diam_g, diam_mg)))
+        return np.amax(np.hstack((diam_g, diam_mg)))  # type: ignore
 
     @pp.time_logger(sections=module_sections)
     def bounding_box(
@@ -1175,7 +1174,7 @@ class GridBucket:
                 "zmax": max_vals[2],
             }
         else:
-            return min_vals, max_vals
+            return min_vals, max_vals  # type: ignore
 
     @pp.time_logger(sections=module_sections)
     def size(self) -> int:
@@ -1193,7 +1192,7 @@ class GridBucket:
             int: Minimum dimension of the grids present in the hierarchy.
 
         """
-        return np.amin([grid.dim for grid, _ in self])
+        return np.amin([grid.dim for grid, _ in self])  # type: ignore
 
     @pp.time_logger(sections=module_sections)
     def dim_max(self) -> int:
@@ -1202,10 +1201,10 @@ class GridBucket:
             int: Maximum dimension of the grids present in the hierarchy.
 
         """
-        return np.amax([grid.dim for grid, _ in self])
+        return np.amax([grid.dim for grid, _ in self])  # type: ignore
 
     @pp.time_logger(sections=module_sections)
-    def all_dims(self) -> np.array:
+    def all_dims(self) -> np.ndarray:
         """
         Returns:
             np.array: Active dimensions of the grids present in the hierarchy.
@@ -1317,7 +1316,7 @@ class GridBucket:
             cond = lambda g: True
         return np.sum(
             [grid.num_cells for grid in self._nodes.keys() if cond(grid)], dtype=int
-        )
+        )  # type: ignore
 
     @pp.time_logger(sections=module_sections)
     def num_mortar_cells(self, cond: Callable[[pp.Grid], bool] = None) -> int:
@@ -1342,7 +1341,7 @@ class GridBucket:
                 if data.get("mortar_grid") and cond(data["mortar_grid"])
             ],
             dtype=int,
-        )
+        )  # type: ignore
 
     @pp.time_logger(sections=module_sections)
     def num_faces(self, cond: Callable[[pp.Grid], bool] = None) -> int:
@@ -1360,7 +1359,12 @@ class GridBucket:
         """
         if cond is None:
             cond = lambda g: True
-        return np.sum([grid.num_faces for grid in self._nodes.keys() if cond(grid)])
+
+        return np.sum(
+            [  # type: ignore
+                grid.num_faces for grid in self._nodes.keys() if cond(grid)
+            ]
+        )
 
     @pp.time_logger(sections=module_sections)
     def num_nodes(self, cond: Callable[[pp.Grid], bool] = None) -> int:
@@ -1378,7 +1382,12 @@ class GridBucket:
         """
         if cond is None:
             cond = lambda g: True
-        return np.sum([grid.num_nodes for grid in self._nodes.keys() if cond(grid)])
+
+        return np.sum(
+            [  # type: ignore
+                grid.num_nodes for grid in self._nodes.keys() if cond(grid)
+            ]
+        )
 
     @pp.time_logger(sections=module_sections)
     def num_graph_nodes(self):

--- a/src/porepy/grids/grid_extrusion.py
+++ b/src/porepy/grids/grid_extrusion.py
@@ -96,14 +96,14 @@ def extrude_grid_bucket(gb: pp.GridBucket, z: np.ndarray) -> Tuple[pp.GridBucket
         face_map = g_map[gh].face_map
 
         # Data structure for the new face-cell map
-        rows = np.empty(0, dtype=np.int)
-        cols = np.empty(0, dtype=np.int)
+        rows = np.empty(0, dtype=int)
+        cols = np.empty(0, dtype=int)
 
         # The standard MortarGrid __init__ assumes that when faces are split because of
         # a fracture, the faces are ordered with one side first, then the other. This
         # will not be True for this layered construction. Instead, keep track of all
         # faces that should be moved to the other side.
-        face_on_other_side = np.empty(0, dtype=np.int)
+        face_on_other_side = np.empty(0, dtype=int)
 
         # Loop over cells in gl would not have been as clean, as each cell is associated
         # with faces on both sides
@@ -378,9 +378,9 @@ def _extrude_2d(g: pp.Grid, z: np.ndarray) -> Tuple[pp.Grid, np.ndarray, np.ndar
             raise ValueError("this should not happen. Is the cell non-convex??")
 
     # Compressed column storage for horizontal faces: Store node indices
-    fn_rows_horizontal = np.array([], dtype=np.int)
+    fn_rows_horizontal = np.array([], dtype=int)
     # .. and pointers to the start of new faces
-    fn_cols_horizontal = np.array(0, dtype=np.int)
+    fn_cols_horizontal = np.array(0, dtype=int)
     # Loop over all layers of nodes (one more than number of cells)
     # This means that the horizontal faces of a given cell is given by its index (bottom)
     # and its index + the number of 2d cells, both offset with the total number of
@@ -405,9 +405,9 @@ def _extrude_2d(g: pp.Grid, z: np.ndarray) -> Tuple[pp.Grid, np.ndarray, np.ndar
     fn_cols_horizontal += num_vertical_faces * nodes_per_face_vertical
 
     # Put together the vertical and horizontal data, create the face-node relation
-    indptr = np.hstack((fn_cols_vertical, fn_cols_horizontal)).astype(np.int)
-    indices = np.hstack((fn_rows_vertical, fn_rows_horizontal)).astype(np.int)
-    data = np.ones(indices.size, dtype=np.int)
+    indptr = np.hstack((fn_cols_vertical, fn_cols_horizontal)).astype(int)
+    indices = np.hstack((fn_rows_vertical, fn_rows_horizontal)).astype(int)
+    data = np.ones(indices.size, dtype=int)
 
     # Finally, construct the face-node sparse matrix
     face_nodes = sps.csc_matrix((data, indices, indptr), shape=(nn_3d, nf_3d))
@@ -431,10 +431,10 @@ def _extrude_2d(g: pp.Grid, z: np.ndarray) -> Tuple[pp.Grid, np.ndarray, np.ndar
     cf_cols_2d = g.cell_faces.indptr
     cf_data_2d = g.cell_faces.data
 
-    cf_rows_vertical = np.array([], dtype=np.int)
+    cf_rows_vertical = np.array([], dtype=int)
     # For the cells, we will store the number of facqes for each cell. This will later
     # be expanded to a full set of cell indices
-    cf_vertical_cell_count = np.array([], dtype=np.int)
+    cf_vertical_cell_count = np.array([], dtype=int)
     cf_data_vertical = np.array([])
 
     for k in range(num_cell_layers):
@@ -464,7 +464,7 @@ def _extrude_2d(g: pp.Grid, z: np.ndarray) -> Tuple[pp.Grid, np.ndarray, np.ndar
     # Bottom layer
     cf_rows_horizontal = num_vertical_faces + np.arange(nc_2d)
     cf_cols_horizontal = np.arange(nc_2d)
-    cf_data_horizontal = -np.ones(nc_2d, dtype=np.int)
+    cf_data_horizontal = -np.ones(nc_2d, dtype=int)
 
     # Intermediate layers, note
     for k in range(1, num_cell_layers):
@@ -573,7 +573,7 @@ def _extrude_1d(
 
     fn_old = g.face_nodes.indices
     # Vertical faces are made by extruding old face-node relation
-    fn_vert = np.empty((2, 0), dtype=np.int)
+    fn_vert = np.empty((2, 0), dtype=int)
     for k in range(num_cell_layers):
         fn_this = k * nn_old + np.vstack((fn_old, nn_old + fn_old))
         fn_vert = np.hstack((fn_vert, fn_this))
@@ -599,7 +599,7 @@ def _extrude_1d(
 
     # Next, cell-faces
     # We know there are exactly four faces for each cell
-    cf_rows = np.empty((4, 0), dtype=np.int)
+    cf_rows = np.empty((4, 0), dtype=int)
     cf_old = g.cell_faces.indices.reshape((2, -1), order="f")
 
     # Create vertical and horizontal faces together
@@ -619,7 +619,7 @@ def _extrude_1d(
     cf_rows = cf_rows.ravel("f")
     cf_cols = np.tile(np.arange(nc_new), (4, 1)).ravel("f")
     # Define positive and negative sides. The choices here are somewhat arbitrary.
-    tmp = np.ones(nc_new, dtype=np.int)
+    tmp = np.ones(nc_new, dtype=int)
     cf_data = np.vstack((-tmp, tmp, -tmp, tmp)).ravel("f")
     cf = sps.coo_matrix((cf_data, (cf_rows, cf_cols)), shape=(nf_new, nc_new)).tocsc()
 

--- a/src/porepy/grids/match_grids.py
+++ b/src/porepy/grids/match_grids.py
@@ -63,8 +63,8 @@ def match_1d(new_1d: pp.Grid, old_1d: pp.Grid, tol: float):
     intersect = pp.intersections.line_tesselation(p1, p2, lines1, lines2)
 
     num = len(intersect)
-    new_g_ind = np.zeros(num, dtype=np.int)
-    old_g_ind = np.zeros(num, dtype=np.int)
+    new_g_ind = np.zeros(num, dtype=int)
+    old_g_ind = np.zeros(num, dtype=int)
     weights = np.zeros(num)
 
     for ind, i in enumerate(intersect):
@@ -126,8 +126,8 @@ def match_2d(new_g: pp.Grid, old_g: pp.Grid, tol: float):
     )
 
     num = len(isect)
-    new_g_ind = np.zeros(num, dtype=np.int)
-    old_g_ind = np.zeros(num, dtype=np.int)
+    new_g_ind = np.zeros(num, dtype=int)
+    old_g_ind = np.zeros(num, dtype=int)
     weights = np.zeros(num)
 
     for ind, i in enumerate(isect):

--- a/src/porepy/grids/mortar_grid.py
+++ b/src/porepy/grids/mortar_grid.py
@@ -105,7 +105,7 @@ class MortarGrid:
         self.tol = tol
 
         # easy access attributes with a fixed ordering of the side grids
-        self.num_cells: np.ndarray = np.sum(
+        self.num_cells: int = np.sum(  # type: ignore
             [g.num_cells for g in self.side_grids.values()], dtype=int
         )
         self.cell_volumes: np.ndarray = np.hstack(
@@ -165,7 +165,7 @@ class MortarGrid:
             g.compute_geometry()
 
         # Update the attributes
-        self.num_cells = np.sum(
+        self.num_cells = np.sum(  # type: ignore
             [g.num_cells for g in self.side_grids.values()], dtype=int
         )
         self.cell_volumes = np.hstack(
@@ -220,7 +220,7 @@ class MortarGrid:
         # diagonal matrix, where in each block we have the mapping between the
         # (relative to side) old grid and the new one.
         matrix_blocks: np.ndarray = np.empty(
-            (self.num_sides(), self.num_sides()), dtype=np.object
+            (self.num_sides(), self.num_sides()), dtype=object
         )
 
         # Loop on all the side grids, if not given an identity matrix is
@@ -288,7 +288,7 @@ class MortarGrid:
         # stored we need to remap it. The resulting matrix will be a block
         # matrix, where in each block we have the mapping between the
         # (relative to side) the new grid and the mortar grid.
-        matrix = np.empty((self.num_sides(), 1), dtype=np.object)
+        matrix = np.empty((self.num_sides(), 1), dtype=object)
 
         for pos, (side, _) in enumerate(self.side_grids.items()):
             matrix[pos, 0] = split_matrix[side]
@@ -663,7 +663,7 @@ class MortarGrid:
 
     @pp.time_logger(sections=module_sections)
     def cell_diameters(self) -> np.ndarray:
-        diams = np.empty(self.num_sides(), dtype=np.object)
+        diams = np.empty(self.num_sides(), dtype=object)
         for pos, (_, g) in enumerate(self.side_grids.items()):
             diams[pos] = g.cell_diameters()
         return np.concatenate(diams).ravel()
@@ -759,10 +759,10 @@ class MortarGrid:
         shape_primary = (self.num_cells, primary_secondary.shape[1])
         shape_secondary = (self.num_cells, primary_secondary.shape[0])
         self._primary_to_mortar_int = sps.csc_matrix(
-            (data.astype(np.float), (cells, primary_f)), shape=shape_primary
+            (data.astype(float), (cells, primary_f)), shape=shape_primary
         )
         self._secondary_to_mortar_int = sps.csc_matrix(
-            (data.astype(np.float), (cells, secondary_f)), shape=shape_secondary
+            (data.astype(float), (cells, secondary_f)), shape=shape_secondary
         )
 
 

--- a/src/porepy/grids/mortar_grid.py
+++ b/src/porepy/grids/mortar_grid.py
@@ -106,7 +106,7 @@ class MortarGrid:
 
         # easy access attributes with a fixed ordering of the side grids
         self.num_cells: np.ndarray = np.sum(
-            [g.num_cells for g in self.side_grids.values()], dtype=np.int
+            [g.num_cells for g in self.side_grids.values()], dtype=int
         )
         self.cell_volumes: np.ndarray = np.hstack(
             [g.cell_volumes for g in self.side_grids.values()]
@@ -166,7 +166,7 @@ class MortarGrid:
 
         # Update the attributes
         self.num_cells = np.sum(
-            [g.num_cells for g in self.side_grids.values()], dtype=np.int
+            [g.num_cells for g in self.side_grids.values()], dtype=int
         )
         self.cell_volumes = np.hstack(
             [g.cell_volumes for g in self.side_grids.values()]

--- a/src/porepy/grids/partition.py
+++ b/src/porepy/grids/partition.py
@@ -50,7 +50,7 @@ def partition_metis(g: pp.Grid, num_part: int) -> np.ndarray:
     # Convert the cells into the format required by pymetis
     adjacency_list = [list(c2c.getrow(i).indices) for i in range(c2c.shape[0])]
     # Call pymetis
-    # It seems it is important that num_part is an int, not an np.int.
+    # It seems it is important that num_part is an int, not an int.
     part = pymetis.part_graph(int(num_part), adjacency=adjacency_list)
 
     # The meaning of the first number returned by pymetis is not clear (poor
@@ -186,7 +186,7 @@ def partition_coordinates(
 
     if g.dim == 0:
         # Nothing really to do here.
-        return np.zeros(g.num_cells, dtype=np.int)
+        return np.zeros(g.num_cells, dtype=int)
 
     # The division into boxes must be done within the active dimensions of the grid.
     # For 1d and 2d grids, this involves a mapping of the grid into its natural

--- a/src/porepy/grids/partition.py
+++ b/src/porepy/grids/partition.py
@@ -325,7 +325,7 @@ def determine_coarse_dimensions(target: int, fine_size: np.ndarray) -> np.ndarra
     # Array to store optimal values. Set the default value to one, this avoids
     # interfering with target_now below.
     optimum = np.ones(nd)
-    found = np.zeros(nd, dtype=np.bool)
+    found = np.zeros(nd, dtype=bool)
 
     # Counter for number of iterations. Should be unnecessary, remove when the
     # code is trusted.
@@ -738,7 +738,7 @@ def overlap(
 
     # Boolean storage of cells in the active set; these are the ones that will
     # be in the overlap
-    active_cells = np.zeros(g.num_cells, dtype=np.bool)
+    active_cells = np.zeros(g.num_cells, dtype=bool)
     # Initialize by the specified cells
     active_cells[cell_ind] = 1
 
@@ -747,7 +747,7 @@ def overlap(
         cn = g.cell_nodes()
 
         # Also introduce active nodes
-        active_nodes = np.zeros(g.num_nodes, dtype=np.bool)
+        active_nodes = np.zeros(g.num_nodes, dtype=bool)
 
         # Gradually increase the size of the cell set
         for _ in range(num_layers):
@@ -766,7 +766,7 @@ def overlap(
         data = np.ones_like(cf.data)
         cf = sps.csc_matrix((data, cf.indices, cf.indptr))
 
-        active_faces = np.zeros(g.num_faces, dtype=np.bool)
+        active_faces = np.zeros(g.num_faces, dtype=bool)
 
         # Gradually increase the size of the cell set
         for _ in range(num_layers):

--- a/src/porepy/grids/point_grid.py
+++ b/src/porepy/grids/point_grid.py
@@ -33,8 +33,8 @@ class PointGrid(Grid):
 
         name = "PointGrid" if name is None else name
 
-        face_nodes = sps.identity(0, np.int, "csr")
-        cell_faces = sps.csr_matrix((0, pt.shape[1]), dtype=np.int)
+        face_nodes = sps.identity(0, int, "csr")
+        cell_faces = sps.csr_matrix((0, pt.shape[1]), dtype=int)
 
         nodes = np.zeros((3, 0))
         self.cell_centers = pt

--- a/src/porepy/grids/refinement.py
+++ b/src/porepy/grids/refinement.py
@@ -47,11 +47,11 @@ def distort_grid_1d(
 
     """
     if fixed_nodes is None:
-        fixed_nodes = np.array([0, g.num_nodes - 1], dtype=np.int)
+        fixed_nodes = np.array([0, g.num_nodes - 1], dtype=int)
     else:
         # Ensure that boundary nodes are also fixed
         fixed_nodes = np.hstack((fixed_nodes, np.array([0, g.num_nodes - 1])))
-        fixed_nodes = np.unique(fixed_nodes).astype(np.int)
+        fixed_nodes = np.unique(fixed_nodes).astype(int)
 
     g.compute_geometry()
     r = ratio * (0.5 - np.random.random(g.num_nodes - 2))
@@ -97,7 +97,7 @@ def refine_grid_1d(g: pp.Grid, ratio: int = 2) -> pp.Grid:
     # occurence of the cell)
     if_add = np.r_[1, np.ediff1d(cell_nodes.indices)].astype(np.bool)
 
-    indices = np.empty(0, dtype=np.int)
+    indices = np.empty(0, dtype=int)
     # Template array of node indices for refined cells
     ind = np.vstack((np.arange(ratio), np.arange(ratio) + 1)).flatten("F")
     nd = np.r_[np.diff(cell_nodes.indices)[1::2], 0]
@@ -182,7 +182,7 @@ def refine_triangle_grid(g: pp.TriangleGrid) -> Union[pp.TriangleGrid, np.ndarra
     binom = ((0, 1), (1, 2), (2, 0))
 
     # Holder for new tessalation.
-    new_tri = np.empty(shape=(nd + 1, g.num_cells, nd + 2), dtype=np.int)
+    new_tri = np.empty(shape=(nd + 1, g.num_cells, nd + 2), dtype=int)
 
     # Loop over combinations
     for ti, b in enumerate(binom):

--- a/src/porepy/grids/refinement.py
+++ b/src/porepy/grids/refinement.py
@@ -8,7 +8,7 @@ Created on Sat Nov 11 17:06:37 2017
 """
 import abc
 from pathlib import Path
-from typing import Dict, Optional, Union
+from typing import Dict, Optional, Tuple, Union
 
 import gmsh
 import numpy as np
@@ -95,7 +95,7 @@ def refine_grid_1d(g: pp.Grid, ratio: int = 2) -> pp.Grid:
     # Array that indicates whether an item in the cell-node relation represents
     # a node not listed before (e.g. whether this is the first or second
     # occurence of the cell)
-    if_add = np.r_[1, np.ediff1d(cell_nodes.indices)].astype(np.bool)
+    if_add = np.r_[1, np.ediff1d(cell_nodes.indices)].astype(bool)
 
     indices = np.empty(0, dtype=int)
     # Template array of node indices for refined cells
@@ -136,7 +136,7 @@ def refine_grid_1d(g: pp.Grid, ratio: int = 2) -> pp.Grid:
     face_nodes = sps.identity(x.shape[1], format="csc")
     cell_faces = sps.csc_matrix(
         (
-            np.ones(indices.size, dtype=np.bool),
+            np.ones(indices.size, dtype=bool),
             indices,
             np.arange(0, indices.size + 1, 2),
         )
@@ -148,7 +148,7 @@ def refine_grid_1d(g: pp.Grid, ratio: int = 2) -> pp.Grid:
 
 
 @pp.time_logger(sections=module_sections)
-def refine_triangle_grid(g: pp.TriangleGrid) -> Union[pp.TriangleGrid, np.ndarray]:
+def refine_triangle_grid(g: pp.TriangleGrid) -> Tuple[pp.TriangleGrid, np.ndarray]:
     """Uniform refinement of triangle grid, all cells are split into four
     subcells by combining existing nodes and face centrers.
 

--- a/src/porepy/grids/simplex.py
+++ b/src/porepy/grids/simplex.py
@@ -184,7 +184,7 @@ class StructuredTriangleGrid(TriangleGrid):
         tri = tri_base
 
         # Loop over all remaining rows in the y-direction.
-        for iter1 in range(nx[1].astype("int64") - 1):
+        for iter1 in range(nx[1].astype(int) - 1):
             # The node numbers are increased by nx[0] + 1 for each row
             tri = np.hstack((tri, tri_base + (iter1 + 1) * (nx[0] + 1)))
 
@@ -340,7 +340,7 @@ class StructuredTetrahedralGrid(TetrahedralGrid):
         physdims (np.ndarray, size 2): domain size. Defaults to nx,
         thus Cartesian cells are unit squares
         """
-        nx = np.asarray(nx)
+        nx = np.asarray(nx).astype(int)
         assert nx.size == 3
 
         if physdims is None:
@@ -409,8 +409,8 @@ class StructuredTetrahedralGrid(TetrahedralGrid):
         # so pre-allocation is possible if this turns out to be a bottleneck
 
         # Loop over all remaining rows in the y-direction.
-        for iter2 in range(nx[2].astype("int64")):
-            for iter1 in range(nx[1].astype("int64")):
+        for iter2 in range(nx[2].astype(int)):
+            for iter1 in range(nx[1].astype(int)):
                 increment = iter2 * nxy + iter1 * (nx[0] + 1)
                 if iter2 == 0 and iter1 == 0:
                     tet = tet_base + increment

--- a/src/porepy/grids/structured.py
+++ b/src/porepy/grids/structured.py
@@ -314,7 +314,7 @@ class CartGrid(TensorGrid):
 
         """
 
-        #        nx = nx.astype(np.int)
+        #        nx = nx.astype(int)
 
         dims = np.asarray(nx).shape
         xmin, ymin, zmin = 0.0, 0.0, 0.0

--- a/src/porepy/models/contact_mechanics_model.py
+++ b/src/porepy/models/contact_mechanics_model.py
@@ -214,7 +214,7 @@ class ContactMechanics(porepy.models.abstract_model.AbstractModel):
         mech_dof = self.assembler.dof_ind(g_max, self.displacement_variable)
 
         # Also find indices for the contact variables
-        contact_dof = np.array([], dtype=np.int)
+        contact_dof = np.array([], dtype=int)
         for e, _ in self.gb.edges():
             if e[0].dim == self._Nd:
                 contact_dof = np.hstack(

--- a/src/porepy/models/contact_mechanics_model.py
+++ b/src/porepy/models/contact_mechanics_model.py
@@ -11,7 +11,7 @@ undergo major changes on little notice.
 """
 import logging
 import time
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple, Union
 
 import numpy as np
 import scipy.sparse as sps
@@ -199,7 +199,7 @@ class ContactMechanics(porepy.models.abstract_model.AbstractModel):
         prev_solution: np.ndarray,
         init_solution: np.ndarray,
         nl_params: Dict[str, Any],
-    ) -> Tuple[float, bool, bool]:
+    ) -> Tuple[float, bool, Union[np.bool_, bool]]:
         g_max = self._nd_grid()
 
         if not self._is_nonlinear_problem():
@@ -247,7 +247,7 @@ class ContactMechanics(porepy.models.abstract_model.AbstractModel):
         # tol_divergence = nl_params["nl_divergence_tol"]
 
         converged = False
-        diverged = False
+        diverged = False  # type: ignore
 
         # Check absolute convergence criterion
         if difference_in_iterates_mech < tol_convergence:

--- a/src/porepy/numerics/fem/rt0.py
+++ b/src/porepy/numerics/fem/rt0.py
@@ -98,15 +98,15 @@ class RT0(pp.numerics.vem.dual_elliptic.DualElliptic):
 
         # Allocate the data to store matrix A entries
         size_A = np.power(g.dim + 1, 2) * g.num_cells
-        rows_A = np.empty(size_A, dtype=np.int)
-        cols_A = np.empty(size_A, dtype=np.int)
+        rows_A = np.empty(size_A, dtype=int)
+        cols_A = np.empty(size_A, dtype=int)
         data_A = np.empty(size_A)
         idx_A = 0
 
         # Allocate the data to store matrix P entries
         size_P = 3 * (g.dim + 1) * g.num_cells
-        rows_P = np.empty(size_P, dtype=np.int)
-        cols_P = np.empty(size_P, dtype=np.int)
+        rows_P = np.empty(size_P, dtype=int)
+        cols_P = np.empty(size_P, dtype=int)
         data_P = np.empty(size_P)
         idx_P = 0
         idx_row_P = 0
@@ -283,7 +283,7 @@ class RT0(pp.numerics.vem.dual_elliptic.DualElliptic):
         faces = faces[np.argsort(cells)]
 
         # initialize the map
-        cell_face_to_opposite_node = np.empty((g.num_cells, g.dim + 1), dtype=np.int)
+        cell_face_to_opposite_node = np.empty((g.num_cells, g.dim + 1), dtype=int)
 
         nodes, _, _ = sps.find(g.face_nodes)
         indptr = g.face_nodes.indptr

--- a/src/porepy/numerics/fem/rt0.py
+++ b/src/porepy/numerics/fem/rt0.py
@@ -258,7 +258,7 @@ class RT0(pp.numerics.vem.dual_elliptic.DualElliptic):
 
     @pp.time_logger(sections=module_sections)
     def _compute_cell_face_to_opposite_node(
-        self, g: pp.Grid, data: np.ndarray, recompute: bool = False
+        self, g: pp.Grid, data: Dict, recompute: bool = False
     ) -> None:
         """Compute a map that given a face return the node on the opposite side,
         typical request of a Raviart-Thomas approximation.

--- a/src/porepy/numerics/fracture_deformation/conforming_propagation.py
+++ b/src/porepy/numerics/fracture_deformation/conforming_propagation.py
@@ -489,7 +489,7 @@ class ConformingFracturePropagation(FracturePropagation):
         )
 
         # Reconstruct non-unique and reshape to edges (first dim is 2 if nd=3)
-        edges_h = np.reshape(nodes_h[ind_l], (nd - 1, faces_l.size), order="f")
+        edges_h = np.reshape(nodes_h[ind_l], (nd - 1, faces_l.size), order="F")
 
         # IMPLEMENTATION NOTE: No attempt at vectorization: Too many pitfalls. In particular,
         # the number of candidate faces is unknown and may differ between the nodes.

--- a/src/porepy/numerics/fracture_deformation/conforming_propagation.py
+++ b/src/porepy/numerics/fracture_deformation/conforming_propagation.py
@@ -150,7 +150,7 @@ class ConformingFracturePropagation(FracturePropagation):
 
             else:
                 # No updates to the geometry.
-                face_list.update({g_l: np.array([], dtype=np.int)})
+                face_list.update({g_l: np.array([], dtype=int)})
 
         pp.propagate_fracture.propagate_fractures(gb, face_list)
 

--- a/src/porepy/numerics/fracture_deformation/propagate_fracture.py
+++ b/src/porepy/numerics/fracture_deformation/propagate_fracture.py
@@ -479,7 +479,7 @@ def _update_connectivity_fracture_grid(
     # ASSUMPTION: This breaks if not all faces have the same number of cells
     # Rewrite is possible, but more technical
     all_faces_l = np.reshape(
-        g_l.face_nodes.indices, (g_l.dim, n_old_faces_l), order="f"
+        g_l.face_nodes.indices, (g_l.dim, n_old_faces_l), order="F"
     )
 
     # Initialize indices and values for the cell_faces update

--- a/src/porepy/numerics/fracture_deformation/propagate_fracture.py
+++ b/src/porepy/numerics/fracture_deformation/propagate_fracture.py
@@ -57,7 +57,7 @@ def propagate_fractures(gb: pp.GridBucket, faces: Dict[pp.Grid, np.ndarray]) -> 
     d_h["split_faces"] = np.empty(0, dtype=int)
 
     # Data structure for keeping track of faces in g_h to be split
-    split_faces = np.empty(0, dtype=np.int)
+    split_faces = np.empty(0, dtype=int)
 
     # By default, we will not update the higher-dimensional grid. This will be
     # changed in the below for loop if the grid gets faces split.
@@ -199,12 +199,12 @@ def propagate_fractures(gb: pp.GridBucket, faces: Dict[pp.Grid, np.ndarray]) -> 
         # Create mappings between the old and and faces and cells in g_l
         arr = np.arange(n_old_faces_l)
         face_map_l = sps.coo_matrix(
-            (np.ones(n_old_faces_l, dtype=np.int), (arr, arr)),
+            (np.ones(n_old_faces_l, dtype=int), (arr, arr)),
             shape=(g_l.num_faces, n_old_faces_l),
         ).tocsr()
         arr = np.arange(n_old_cells_l)
         cell_map_l = sps.coo_matrix(
-            (np.ones(n_old_cells_l, dtype=np.int), (arr, arr)),
+            (np.ones(n_old_cells_l, dtype=int), (arr, arr)),
             shape=(g_l.num_cells, n_old_cells_l),
         ).tocsr()
 
@@ -221,7 +221,7 @@ def propagate_fractures(gb: pp.GridBucket, faces: Dict[pp.Grid, np.ndarray]) -> 
         arr = np.arange(nfh)
         face_map_h.append(
             sps.coo_matrix(
-                (np.ones(nfh, dtype=np.int), (arr, arr)),
+                (np.ones(nfh, dtype=int), (arr, arr)),
                 shape=(g_h.num_faces, nfh),
             ).tocsr()
         )
@@ -370,7 +370,7 @@ def _update_geometry(
         cc = np.empty((3, 0))  # Cell centers
         # Many of the faces will have their quantities computed twice,
         # once from each side. Keep track of which faces we are dealing with
-        face_ind = np.array([], dtype=np.int)
+        face_ind = np.array([], dtype=int)
 
         for ci in new_cells:
             sub_g, fi, _ = pp.partition.extract_subgrid(g_l, ci)
@@ -463,7 +463,7 @@ def _update_connectivity_fracture_grid(
     new_cells_l = np.arange(n_old_cells_l, n_old_cells_l + n_new_cells_l)
 
     # Initialize fields for new faces in g_l
-    new_faces_l = np.empty((g_l.dim, 0), dtype=np.int)
+    new_faces_l = np.empty((g_l.dim, 0), dtype=int)
     new_face_centers_l = np.empty((3, 0))
 
     # Counter of total number of faces in g_l
@@ -484,12 +484,12 @@ def _update_connectivity_fracture_grid(
 
     # Initialize indices and values for the cell_faces update
     ind_f, ind_c, cf_val = (
-        np.empty(0, dtype=np.int),
-        np.empty(0, dtype=np.int),
-        np.empty(0, dtype=np.int),
+        np.empty(0, dtype=int),
+        np.empty(0, dtype=int),
+        np.empty(0, dtype=int),
     )
     # and for the face_nodes update
-    fn_ind_f, fn_ind_n = np.empty(0, dtype=np.int), np.empty(0, dtype=np.int)
+    fn_ind_f, fn_ind_n = np.empty(0, dtype=int), np.empty(0, dtype=int)
 
     # Loop over all new cells to be created
     for i, c in enumerate(new_cells_l):

--- a/src/porepy/numerics/fracture_deformation/propagation_model.py
+++ b/src/porepy/numerics/fracture_deformation/propagation_model.py
@@ -115,7 +115,7 @@ class FracturePropagation(abc.ABC):
         return vals
 
     @pp.time_logger(sections=module_sections)
-    def _map_variables(self, x: np.ndarray) -> None:
+    def _map_variables(self, x: np.ndarray) -> np.ndarray:
         """
         Map variables from old to new grids in d[pp.STATE] and d[pp.STATE][pp.ITERATE].
         Also call update of self.assembler.update_dof_count and update the current

--- a/src/porepy/numerics/fv/biot.py
+++ b/src/porepy/numerics/fv/biot.py
@@ -744,7 +744,7 @@ class Biot(pp.Mpsa):
         # general combinations of specified cells, nodes and faces.
         tmp = g.cell_faces.transpose()
         tmp.data = np.abs(tmp.data)
-        af_vec = np.zeros(g.num_faces, dtype=np.bool)
+        af_vec = np.zeros(g.num_faces, dtype=bool)
         af_vec[active_faces] = 1
         update_cell_ind = np.where(tmp * af_vec)[0]
         eliminate_cells = np.setdiff1d(np.arange(g.num_cells), update_cell_ind)

--- a/src/porepy/numerics/fv/biot.py
+++ b/src/porepy/numerics/fv/biot.py
@@ -399,8 +399,8 @@ class Biot(pp.Mpsa):
         # is technical). If no updates, we short cut the method
         update_info = data["update_discretization"]
         # By default, neither cells nor faces have been updated
-        update_cells = update_info.get("modified_cells", np.array([], dtype=np.int))
-        update_faces = update_info.get("modified_faces", np.array([], dtype=np.int))
+        update_cells = update_info.get("modified_cells", np.array([], dtype=int))
+        update_faces = update_info.get("modified_faces", np.array([], dtype=int))
 
         if update_cells.size == 0 and update_faces.size == 0:
             return

--- a/src/porepy/numerics/fv/fvutils.py
+++ b/src/porepy/numerics/fv/fvutils.py
@@ -404,7 +404,7 @@ def subproblems(
             # To discretize with as little overlap as possible, we use the
             # keyword nodes to specify the update stencil. Find nodes of the
             # local cells.
-            cells_in_partition_boolean = np.zeros(g.num_cells, dtype=np.bool)
+            cells_in_partition_boolean = np.zeros(g.num_cells, dtype=bool)
             cells_in_partition_boolean[cells_in_partition] = 1
 
             nodes_in_partition: np.ndarray = np.squeeze(
@@ -1169,7 +1169,7 @@ class ExcludeBoundaries(object):
         col = np.argwhere([not it for it in ids])
         row = np.arange(col.size)
         return sps.coo_matrix(
-            (np.ones(row.size, dtype=np.bool), (row, col.ravel("C"))),
+            (np.ones(row.size, dtype=bool), (row, col.ravel("C"))),
             shape=(row.size, self.num_subfno),
         ).tocsr()
 
@@ -1581,7 +1581,7 @@ def cell_ind_for_partial_update(
 
     # Faces that are active, and should have their discretization stencil
     # updated / returned.
-    active_faces = np.zeros(g.num_faces, dtype=np.bool)
+    active_faces = np.zeros(g.num_faces, dtype=bool)
 
     # Index of cells to include in the subgrid.
     cell_ind = np.empty(0)
@@ -1619,10 +1619,10 @@ def cell_ind_for_partial_update(
 
         # The active faces (to be updated; (o-x and o-o above) are those that
         # share at least one vertex with cells in ind.
-        prim_cells = np.zeros(g.num_cells, dtype=np.bool)
+        prim_cells = np.zeros(g.num_cells, dtype=bool)
         prim_cells[cells] = 1
         # Vertexes of the cells
-        active_vertexes = np.zeros(g.num_nodes, dtype=np.bool)
+        active_vertexes = np.zeros(g.num_nodes, dtype=bool)
         active_vertexes[np.squeeze(np.where(cn * prim_cells > 0))] = 1
 
         # Faces of the vertexes, these will be the active faces.
@@ -1673,11 +1673,11 @@ def cell_ind_for_partial_update(
         data = np.ones_like(cf.data)
         cf = sps.csc_matrix((data, cf.indices, cf.indptr))
 
-        primary_faces = np.zeros(g.num_faces, dtype=np.bool)
+        primary_faces = np.zeros(g.num_faces, dtype=bool)
         primary_faces[faces] = 1
 
         # The active faces are those sharing a vertex with the primary faces
-        primary_vertex = np.zeros(g.num_nodes, dtype=np.bool)
+        primary_vertex = np.zeros(g.num_nodes, dtype=bool)
         primary_vertex[np.squeeze(np.where((g.face_nodes * primary_faces) > 0))] = 1
         active_face_ind = np.squeeze(
             np.where((g.face_nodes.transpose() * primary_vertex) > 0)
@@ -1685,7 +1685,7 @@ def cell_ind_for_partial_update(
         active_faces[active_face_ind] = 1
 
         # Find vertexes of the active faces
-        active_nodes = np.zeros(g.num_nodes, dtype=np.bool)
+        active_nodes = np.zeros(g.num_nodes, dtype=bool)
         active_nodes[np.squeeze(np.where((g.face_nodes * active_faces) > 0))] = 1
 
         cn = g.cell_nodes()
@@ -1694,7 +1694,7 @@ def cell_ind_for_partial_update(
         primary_cells = np.squeeze(np.where((cn.transpose() * active_nodes) > 0))
 
         # Get all nodes of the primary cells. These are the secondary_nodes
-        active_cells = np.zeros(g.num_cells, dtype=np.bool)
+        active_cells = np.zeros(g.num_cells, dtype=bool)
         active_cells[primary_cells] = 1
         secondary_nodes = np.where(cn * active_cells)[0]
         active_nodes[secondary_nodes] = 1

--- a/src/porepy/numerics/fv/fvutils.py
+++ b/src/porepy/numerics/fv/fvutils.py
@@ -381,7 +381,7 @@ def subproblems(
         loc2g_face = np.ones(g.num_faces, dtype=bool)
         yield g, loc_faces, loc_cells, loc2g_cells, loc2g_face
 
-    num_part: int = np.ceil(peak_memory_estimate / max_memory).astype(np.int)
+    num_part: int = np.ceil(peak_memory_estimate / max_memory).astype(int)
 
     if num_part == 1:
         yield g, np.arange(g.num_faces), np.arange(g.num_cells), np.arange(
@@ -1403,8 +1403,8 @@ def partial_update_discretization(
 
     update_info = data["update_discretization"]
     # By default, neither cells nor faces have been updated
-    update_cells = update_info.get("modified_cells", np.array([], dtype=np.int))
-    update_faces = update_info.get("modified_faces", np.array([], dtype=np.int))
+    update_cells = update_info.get("modified_cells", np.array([], dtype=int))
+    update_faces = update_info.get("modified_faces", np.array([], dtype=int))
 
     # Mappings of cells and faces. Default to identity maps
     cell_map = update_info.get("map_cells", sps.identity(g.num_cells))
@@ -1714,7 +1714,7 @@ def cell_ind_for_partial_update(
         # The data type of active_vertex is int (in contrast to similar cases
         # in other parts of this function), since we will use it to count the
         # number of active face_nodes below.
-        active_vertexes = np.zeros(g.num_nodes, dtype=np.int)
+        active_vertexes = np.zeros(g.num_nodes, dtype=int)
         active_vertexes[nodes] = 1
 
         # Find cells that share these nodes

--- a/src/porepy/numerics/fv/mpfa.py
+++ b/src/porepy/numerics/fv/mpfa.py
@@ -1353,9 +1353,9 @@ class Mpfa(pp.FVElliptic):
             data = scaled_sgn
         else:
             # Special handling when no elements are found.
-            rows = np.array([], dtype=np.int)
-            cols = np.array([], dtype=np.int)
-            data = np.array([], dtype=np.int)
+            rows = np.array([], dtype=int)
+            cols = np.array([], dtype=int)
+            data = np.array([], dtype=int)
 
         # Dirichlet boundary conditions
         dir_ind = np.argwhere(

--- a/src/porepy/numerics/fv/mpsa.py
+++ b/src/porepy/numerics/fv/mpsa.py
@@ -951,7 +951,7 @@ class Mpsa(Discretization):
         is_neu_nd = (
             bound_exclusion.keep_neumann(bound.is_neu.ravel("C"), transform=False)
             .ravel("F")
-            .astype(np.bool)
+            .astype(bool)
         )
 
         neu_ind = np.argsort(subfno_neu)
@@ -965,7 +965,7 @@ class Mpsa(Discretization):
         is_rob_nd = (
             bound_exclusion.keep_robin(bound.is_rob.ravel("C"), transform=False)
             .ravel("F")
-            .astype(np.bool)
+            .astype(bool)
         )
 
         rob_ind = np.argsort(subfno_rob)
@@ -981,7 +981,7 @@ class Mpsa(Discretization):
                 bound.is_dir.ravel("C"), transform=False
             )
             .ravel("F")
-            .astype(np.bool)
+            .astype(bool)
         )
 
         dir_ind = np.argsort(subfno_dir)

--- a/src/porepy/numerics/fv/mpsa.py
+++ b/src/porepy/numerics/fv/mpsa.py
@@ -1644,7 +1644,7 @@ class Mpsa(Discretization):
         num_eqs = csym.shape[0] / nd
         ind_single = np.tile(subcell_topology.unique_subfno, (nd, 1))
         increments = np.arange(nd) * num_eqs
-        ind_all = np.reshape(ind_single + increments[:, np.newaxis], -1).astype(np.int)
+        ind_all = np.reshape(ind_single + increments[:, np.newaxis], -1).astype(int)
 
         # Unique part of symmetric and asymmetric products
         hook_sym = csym[ind_all, ::]

--- a/src/porepy/numerics/interface_laws/abstract_interface_law.py
+++ b/src/porepy/numerics/interface_laws/abstract_interface_law.py
@@ -228,7 +228,7 @@ class AbstractInterfaceLaw(abc.ABC):
         discr_secondary: Discretization,
         mg: pp.MortarGrid,
         matrix: np.ndarray,
-    ) -> Union[np.ndarray, np.ndarray]:
+    ) -> Tuple[np.ndarray, np.ndarray]:
         """Initialize a block matrix and right hand side for the local linear
         system of the primary and secondary grid and the interface.
 
@@ -289,7 +289,7 @@ class AbstractInterfaceLaw(abc.ABC):
         cc = cc.reshape((3, 3))
 
         # The rhs is just zeros
-        rhs = np.empty(3, dtype=np.object)
+        rhs = np.empty(3, dtype=object)
         rhs[primary_ind] = np.zeros(dof_primary)
         rhs[secondary_ind] = np.zeros(dof_secondary)
         rhs[mortar_ind] = np.zeros(dof_mortar)
@@ -304,7 +304,7 @@ class AbstractInterfaceLaw(abc.ABC):
         mg_primary: pp.MortarGrid,
         mg_secondary: pp.MortarGrid,
         matrix: np.ndarray,
-    ) -> Union[np.ndarray, np.ndarray]:
+    ) -> Tuple[np.ndarray, np.ndarray]:
         """Initialize a block matrix and right hand side for the local linear
         system of the primary and secondary grid and the interface.
 
@@ -365,7 +365,7 @@ class AbstractInterfaceLaw(abc.ABC):
         cc = cc.reshape((3, 3))
 
         # The rhs is just zeros
-        rhs = np.empty(3, dtype=np.object)
+        rhs = np.empty(3, dtype=object)
         rhs[grid_ind] = np.zeros(dof_grid)
         rhs[primary_ind] = np.zeros(dof_mortar_primary)
         rhs[secondary_ind] = np.zeros(dof_mortar_secondary)

--- a/src/porepy/numerics/interface_laws/elliptic_interface_laws.py
+++ b/src/porepy/numerics/interface_laws/elliptic_interface_laws.py
@@ -150,7 +150,7 @@ class RobinCoupling(
 
         # The values in vals are sorted by the mortar cell index ordering (proj is a
         # csr matrix).
-        ci_mortar = np.arange(mg.num_cells, dtype=np.int)
+        ci_mortar = np.arange(mg.num_cells, dtype=int)
 
         # The mortar cell indices are expanded to account for the vector source
         # having multiple dimensions

--- a/src/porepy/numerics/interface_laws/elliptic_interface_laws.py
+++ b/src/porepy/numerics/interface_laws/elliptic_interface_laws.py
@@ -417,7 +417,7 @@ class FluxPressureContinuity(RobinCoupling):
         )
         # I got some problems with pointers when doing rhs_primary = rhs_secondary.copy()
         # so just reconstruct everything.
-        rhs_secondary = np.empty(3, dtype=np.object)
+        rhs_secondary = np.empty(3, dtype=object)
         rhs_secondary[primary_ind] = np.zeros_like(rhs_primary[primary_ind])
         rhs_secondary[secondary_ind] = np.zeros_like(rhs_primary[secondary_ind])
         rhs_secondary[2] = np.zeros_like(rhs_primary[2])
@@ -472,7 +472,7 @@ class FluxPressureContinuity(RobinCoupling):
 
         # I got some problems with pointers when doing rhs_primary = rhs_secondary.copy()
         # so just reconstruct everything.
-        rhs_secondary = np.empty(3, dtype=np.object)
+        rhs_secondary = np.empty(3, dtype=object)
         rhs_secondary[primary_ind] = np.zeros_like(rhs_primary[primary_ind])
         rhs_secondary[secondary_ind] = np.zeros_like(rhs_primary[secondary_ind])
         rhs_secondary[2] = np.zeros_like(rhs_primary[2])

--- a/src/porepy/numerics/mixed_dim/assembler.py
+++ b/src/porepy/numerics/mixed_dim/assembler.py
@@ -209,7 +209,7 @@ class Assembler:
         if add_matrices:
             size = np.sum(self.full_dof)
             full_matrix = sps_matrix((size, size))
-            full_rhs = np.zeros(size)
+            full_rhs = np.zeros(size)  # type: ignore
 
             for mat in matrix.values():
                 full_matrix += sps.bmat(mat, matrix_format)
@@ -1226,8 +1226,8 @@ class Assembler:
         for var in list(set(self.variable_combinations)):
 
             # Generate a block matrix
-            matrix_dict[var] = np.empty((num_blocks, num_blocks), dtype=np.object)
-            rhs_dict[var] = np.empty(num_blocks, dtype=np.object)
+            matrix_dict[var] = np.empty((num_blocks, num_blocks), dtype=object)
+            rhs_dict[var] = np.empty(num_blocks, dtype=object)
 
             # Loop over all blocks, initialize the diagonal block.
             # We could also initialize off-diagonal blocks, however, this turned
@@ -1250,8 +1250,8 @@ class Assembler:
     ) -> Tuple[np.ndarray, np.ndarray]:
         """ Assign a block matrix and vector with specified number of dofs per block"""
         num_blocks = dof.size
-        matrix = np.empty((num_blocks, num_blocks), dtype=np.object)
-        rhs = np.empty(num_blocks, dtype=np.object)
+        matrix = np.empty((num_blocks, num_blocks), dtype=object)
+        rhs = np.empty(num_blocks, dtype=object)
 
         for ri in range(num_blocks):
             rhs[ri] = np.zeros(dof[ri])
@@ -1419,7 +1419,7 @@ class Assembler:
         Returns:
             int: Number of unknowns. Size of solution vector.
         """
-        return self.full_dof.sum()
+        return self.full_dof.sum()  # type: ignore
 
     @pp.time_logger(sections=module_sections)
     def variables_of_grid(

--- a/src/porepy/numerics/vem/dual_elliptic.py
+++ b/src/porepy/numerics/vem/dual_elliptic.py
@@ -153,7 +153,7 @@ class DualElliptic(
     @pp.time_logger(sections=module_sections)
     def assemble_neumann_robin(
         self, g: pp.Grid, data: Dict, M, bc_weight: np.ndarray = None
-    ) -> Tuple[sps.csr_matrix, np.ndarray]:
+    ) -> Tuple[sps.csr_matrix, int]:
         """Impose Neumann and Robin boundary discretization on an already assembled
         system matrix.
         """
@@ -340,7 +340,7 @@ class DualElliptic(
         # is_dir.
         is_neu = np.logical_and(bc.is_neu, np.logical_not(bc.is_internal))
         if bc and np.any(is_neu):
-            is_neu = np.hstack((is_neu, np.zeros(g.num_cells, dtype=np.bool)))
+            is_neu = np.hstack((is_neu, np.zeros(g.num_cells, dtype=bool)))
             is_neu = np.where(is_neu)[0]
 
             # set in an efficient way the essential boundary conditions, by
@@ -672,7 +672,7 @@ class DualElliptic(
 
         hat_E_int = self._velocity_dof(g, mg, mg.mortar_to_primary_int())
 
-        dof = np.where(hat_E_int.sum(axis=1).A.astype(np.bool))[0]
+        dof = np.where(hat_E_int.sum(axis=1).A.astype(bool))[0]
         norm = np.linalg.norm(matrix[self_ind, self_ind].diagonal(), np.inf)
 
         for row in dof:

--- a/src/porepy/numerics/vem/hybrid.py
+++ b/src/porepy/numerics/vem/hybrid.py
@@ -122,8 +122,8 @@ class HybridDualVEM:
         # Allocate the data to store matrix entries, that's the most efficient
         # way to create a sparse matrix.
         size = np.sum(np.square(g.cell_faces.indptr[1:] - g.cell_faces.indptr[:-1]))
-        row = np.empty(size, dtype=np.int)
-        col = np.empty(size, dtype=np.int)
+        row = np.empty(size, dtype=int)
+        col = np.empty(size, dtype=int)
         data = np.empty(size)
         rhs = np.zeros(g.num_faces)
 

--- a/src/porepy/numerics/vem/mvem.py
+++ b/src/porepy/numerics/vem/mvem.py
@@ -110,15 +110,15 @@ class MVEM(pp.numerics.vem.dual_elliptic.DualElliptic):
         # Allocate the data to store matrix entries, that's the most efficient
         # way to create a sparse matrix.
         size_A = np.sum(np.square(g.cell_faces.indptr[1:] - g.cell_faces.indptr[:-1]))
-        rows_A = np.empty(size_A, dtype=np.int)
-        cols_A = np.empty(size_A, dtype=np.int)
+        rows_A = np.empty(size_A, dtype=int)
+        cols_A = np.empty(size_A, dtype=int)
         data_A = np.empty(size_A)
         idx_A = 0
 
         # Allocate the data to store matrix P entries
         size_P = 3 * np.sum(g.cell_faces.indptr[1:] - g.cell_faces.indptr[:-1])
-        rows_P = np.empty(size_P, dtype=np.int)
-        cols_P = np.empty(size_P, dtype=np.int)
+        rows_P = np.empty(size_P, dtype=int)
+        cols_P = np.empty(size_P, dtype=int)
         data_P = np.empty(size_P)
         idx_P = 0
         idx_row_P = 0

--- a/src/porepy/numerics/vem/vem_source.py
+++ b/src/porepy/numerics/vem/vem_source.py
@@ -96,7 +96,7 @@ class DualScalarSource(pp.numerics.discretization.Discretization):
         # The sources are assigned to the rows representing conservation.
         rhs = np.zeros(self.ndof(g))
         is_p = np.hstack(
-            (np.zeros(g.num_faces, dtype=np.bool), np.ones(g.num_cells, dtype=np.bool))
+            (np.zeros(g.num_faces, dtype=bool), np.ones(g.num_cells, dtype=bool))
         )
         # A minus sign is apparently needed here to be consistent with the user
         # side convention of the finite volume method

--- a/src/porepy/utils/interpolation_tables.py
+++ b/src/porepy/utils/interpolation_tables.py
@@ -217,7 +217,7 @@ class InterpolationTable:
         # Helper function to get the base (generalized lower-left) vertex of a
         # hypecube.
 
-        ind = np.zeros(coord.shape, dtype=np.int)
+        ind = np.zeros(coord.shape, dtype=int)
 
         # For each dimension, find the first index where coordinate in the
         # interpolation grid is higher than that of the point to be evaluated.

--- a/src/porepy/utils/matrix_compression.py
+++ b/src/porepy/utils/matrix_compression.py
@@ -33,8 +33,8 @@ def rldecode(A, n):
         n (int): Number of occurences for each element
     """
     r = n > 0
-    i = np.cumsum(np.hstack((np.zeros(1, dtype=np.int), n[r])), dtype=np.int)
-    j = np.zeros(i[-1], dtype=np.int)
+    i = np.cumsum(np.hstack((np.zeros(1, dtype=int), n[r])), dtype=int)
+    j = np.zeros(i[-1], dtype=int)
     j[i[1:-1:]] = 1
     B = A[np.cumsum(j)]
     return B

--- a/src/porepy/utils/mcolon.py
+++ b/src/porepy/utils/mcolon.py
@@ -42,9 +42,9 @@ def mcolon(lo, hi):
 
     """
     if lo.size == 1:
-        lo = lo * np.ones(hi.size, dtype="int64")
+        lo = lo * np.ones(hi.size, dtype=np.int64)
     if hi.size == 1:
-        hi = hi * np.ones(lo.size, dtype="int64")
+        hi = hi * np.ones(lo.size, dtype=np.int64)
     if lo.size != hi.size:
         raise ValueError(
             "Low and high should have same number of elements, " "or a single item "
@@ -54,12 +54,12 @@ def mcolon(lo, hi):
     if not any(i):
         return np.array([], dtype=np.int32)
 
-    lo = lo[i].astype(np.int)
-    hi = (hi[i] - 1).astype(np.int)
+    lo = lo[i].astype(int)
+    hi = (hi[i] - 1).astype(int)
     d = hi - lo + 1
     n = np.sum(d)
 
-    x = np.ones(n, dtype=np.int)
+    x = np.ones(n, dtype=int)
     x[0] = lo[0]
     x[np.cumsum(d[0:-1])] = lo[1:] - hi[0:-1]
     return np.cumsum(x)

--- a/src/porepy/utils/setmembership.py
+++ b/src/porepy/utils/setmembership.py
@@ -157,7 +157,7 @@ def unique_columns_tol(mat, tol=1e-8):
     num_cols = mat.shape[1]
 
     # By default, no columns are kept
-    keep = np.zeros(num_cols, dtype=np.bool)
+    keep = np.zeros(num_cols, dtype=bool)
 
     # We will however keep the first point
     keep[0] = True

--- a/src/porepy/utils/setmembership.py
+++ b/src/porepy/utils/setmembership.py
@@ -148,7 +148,7 @@ def unique_columns_tol(mat, tol=1e-8):
 
     # If the matrix is integers, and the tolerance less than 1/2, we can use
     # numpy's unique function
-    if issubclass(mat.dtype.type, np.integer) and tol < 0.5:
+    if issubclass(mat.dtype.type, np.int_) and tol < 0.5:
         un_ar, new_2_old, old_2_new = np.unique(
             mat, return_index=True, return_inverse=True, axis=1
         )

--- a/src/porepy/utils/sort_points.py
+++ b/src/porepy/utils/sort_points.py
@@ -47,7 +47,7 @@ def sort_point_pairs(
     sorted_lines = -np.ones(lines.shape, dtype=lines.dtype)
 
     # Keep track of which lines have been found, which are still candidates
-    found = np.zeros(num_lines, dtype=np.bool)
+    found = np.zeros(num_lines, dtype=bool)
 
     # Initialize array of sorting indices
     sort_ind = np.zeros(num_lines, dtype=int)
@@ -81,7 +81,7 @@ def sort_point_pairs(
     prev = sorted_lines[1, 0]
 
     # Order of the origin line list, store if they are flipped or not to form the chain
-    is_ordered = np.zeros(num_lines, dtype=np.bool)
+    is_ordered = np.zeros(num_lines, dtype=bool)
     is_ordered[0] = True
 
     # The sorting algorithm: Loop over all places in sorted_line to be filled,
@@ -120,7 +120,7 @@ def sort_point_plane(
     pts: np.ndarray,
     centre: np.ndarray,
     normal: Optional[np.ndarray] = None,
-    tol: Optional[float] = 1e-5,
+    tol: float = 1e-5,
 ) -> np.ndarray:
     """Sort the points which lie on a plane.
 
@@ -201,7 +201,7 @@ def sort_triangle_edges(t: np.ndarray) -> np.ndarray:
     num_iter = 0
 
     # Bookkeeping of already processed triangles. Not sure if this is needed.
-    is_ordered = np.zeros(nt, dtype=np.bool)
+    is_ordered = np.zeros(nt, dtype=bool)
     is_ordered[0] = 1
 
     while len(queue) > 0:

--- a/src/porepy/utils/sort_points.py
+++ b/src/porepy/utils/sort_points.py
@@ -50,7 +50,7 @@ def sort_point_pairs(
     found = np.zeros(num_lines, dtype=np.bool)
 
     # Initialize array of sorting indices
-    sort_ind = np.zeros(num_lines, dtype=np.int)
+    sort_ind = np.zeros(num_lines, dtype=int)
 
     # In the case of non-circular ordering ensure to start from the correct one
     if not is_circular:

--- a/src/porepy/utils/sparse_mat.py
+++ b/src/porepy/utils/sparse_mat.py
@@ -411,7 +411,7 @@ def _csx_matrix_from_blocks(
         )
         indices = base + block_increase
     else:
-        indices = np.arange(num_blocks, dytpe=np.int)
+        indices = np.arange(num_blocks, dytpe=int)
 
     mat = matrix_format(
         (data, indices, indptr),

--- a/src/porepy/utils/sparse_mat.py
+++ b/src/porepy/utils/sparse_mat.py
@@ -117,7 +117,7 @@ def merge_matrices(A, B, lines):
 
     indptr = indptr - num_rem
 
-    keep = np.ones(A.data.size, dtype=np.bool)
+    keep = np.ones(A.data.size, dtype=bool)
     keep[ind_ix] = False
     indices = indices[keep]
     data = data[keep]

--- a/src/porepy/viz/exporter.py
+++ b/src/porepy/viz/exporter.py
@@ -344,7 +344,7 @@ class Exporter:
         if len(data) > 0:
             fields.extend([Field(n, v) for n, v in data.items()])
 
-        grid_dim = self.grid.dim * np.ones(self.grid.num_cells, dtype=np.int)
+        grid_dim = self.grid.dim * np.ones(self.grid.num_cells, dtype=int)
 
         fields.extend(
             [
@@ -380,7 +380,7 @@ class Exporter:
         self.gb.add_node_props(extra_node_names)
         # fill the extra data
         for g, d in self.gb:
-            ones = np.ones(g.num_cells, dtype=np.int)
+            ones = np.ones(g.num_cells, dtype=int)
             d["grid_dim"] = g.dim * ones
             d["grid_node_number"] = d["node_number"] * ones
             d["is_mortar"] = 0 * ones
@@ -420,11 +420,11 @@ class Exporter:
             mg = d["mortar_grid"]
             mg_num_cells = 0
             for side, g in mg.side_grids.items():
-                ones = np.ones(g.num_cells, dtype=np.int)
+                ones = np.ones(g.num_cells, dtype=int)
                 d["grid_dim"][side] = g.dim * ones
                 d["is_mortar"][side] = ones
                 d["mortar_side"][side] = side.value * ones
-                d["cell_id"][side] = np.arange(g.num_cells, dtype=np.int) + mg_num_cells
+                d["cell_id"][side] = np.arange(g.num_cells, dtype=int) + mg_num_cells
                 mg_num_cells += g.num_cells
                 d["grid_edge_number"][side] = d["edge_number"] * ones
 
@@ -535,7 +535,7 @@ class Exporter:
         num_cells = np.sum([g.num_cells for g in gs])
         cell_to_nodes = {cell_type: np.empty((num_cells, 2))}
         # cell id map
-        cell_id = {cell_type: np.empty(num_cells, dtype=np.int)}
+        cell_id = {cell_type: np.empty(num_cells, dtype=int)}
         cell_pos = 0
 
         # points
@@ -571,7 +571,7 @@ class Exporter:
         meshio_cell_id = np.empty(num_block, dtype=np.object)
 
         for block, (cell_type, cell_block) in enumerate(cell_to_nodes.items()):
-            meshio_cells[block] = meshio.CellBlock(cell_type, cell_block.astype(np.int))
+            meshio_cells[block] = meshio.CellBlock(cell_type, cell_block.astype(int))
             meshio_cell_id[block] = np.array(cell_id[cell_type])
 
         return meshio_pts, meshio_cells, meshio_cell_id
@@ -652,7 +652,7 @@ class Exporter:
         meshio_cell_id = np.empty(num_block, dtype=np.object)
 
         for block, (cell_type, cell_block) in enumerate(cell_to_nodes.items()):
-            meshio_cells[block] = meshio.CellBlock(cell_type, cell_block.astype(np.int))
+            meshio_cells[block] = meshio.CellBlock(cell_type, cell_block.astype(int))
             meshio_cell_id[block] = np.array(cell_id[cell_type])
 
         return meshio_pts, meshio_cells, meshio_cell_id
@@ -755,7 +755,7 @@ class Exporter:
                     fc += 1
 
                 # collect all the nodes for the cell
-                nodes_loc = np.unique(faces_loc).astype(np.int)
+                nodes_loc = np.unique(faces_loc).astype(int)
 
                 # define the type of cell we are currently saving
                 cell_type = "polyhedron" + str(nodes_loc.size)
@@ -916,7 +916,7 @@ class Exporter:
         normals,
         num_cell_nodes,
     ):
-        cell_nodes = np.zeros(num_cell_nodes.sum(), dtype=np.int)
+        cell_nodes = np.zeros(num_cell_nodes.sum(), dtype=int)
         counter = 0
         for ci in range(cell_ptr.size - 1):
             loc_c = slice(cell_ptr[ci], cell_ptr[ci + 1])

--- a/test/integration/test_discretization_update.py
+++ b/test/integration/test_discretization_update.py
@@ -126,13 +126,13 @@ def test_propagation(geometry, method):
         # Transfer information on new faces and cells from the format used
         # by self.evaluate_propagation to the format needed for update of
         # discretizations (see Discretization.update_discretization()).
-        new_faces = data.get("new_faces", np.array([], dtype=np.int))
-        split_faces = data.get("split_faces", np.array([], dtype=np.int))
+        new_faces = data.get("new_faces", np.array([], dtype=int))
+        split_faces = data.get("split_faces", np.array([], dtype=int))
         modified_faces = np.hstack((new_faces, split_faces))
         update_info = {
             "map_cells": data["cell_index_map"],
             "map_faces": data["face_index_map"],
-            "modified_cells": data.get("new_cells", np.array([], dtype=np.int)),
+            "modified_cells": data.get("new_cells", np.array([], dtype=int)),
             "modified_faces": modified_faces,
         }
         data["update_discretization"] = update_info

--- a/test/integration/test_fracture_propagation.py
+++ b/test/integration/test_fracture_propagation.py
@@ -84,12 +84,12 @@ def _two_fractures_multiple_steps_3d():
     g2 = gb.grids_of_dimension(gb.dim_max() - 1)[1]
 
     targets = [
-        {g1: np.array([16, 6]), g2: np.array([], dtype=np.int)},
+        {g1: np.array([16, 6]), g2: np.array([], dtype=int)},
         {g1: np.array([1, 11, 26]), g2: np.array([8])},
     ]
 
     angles = [
-        {g1: np.array([0, 0]), g2: np.array([], dtype=np.int)},
+        {g1: np.array([0, 0]), g2: np.array([], dtype=int)},
         {g1: np.array([0, 0, 0]), g2: np.array([0])},
     ]
 

--- a/test/integration/test_mpfa_mpsa_partial_update.py
+++ b/test/integration/test_mpfa_mpsa_partial_update.py
@@ -766,7 +766,7 @@ class UpdateDiscretizations(unittest.TestCase):
         self.g_larger = pp.CartGrid([4, 4])
         self.g_larger.compute_geometry()
         cell_map_index = np.array(
-            [0, 1, 2, 4, 5, 6, 8, 9, 10, 12, 13, 14], dtype=np.int
+            [0, 1, 2, 4, 5, 6, 8, 9, 10, 12, 13, 14], dtype=int
         )
         self.cell_map = sps.coo_matrix(
             (np.ones(self.g.num_cells), (cell_map_index, np.arange(self.g.num_cells))),

--- a/test/unit/test_fvutils.py
+++ b/test/unit/test_fvutils.py
@@ -10,7 +10,7 @@ from porepy.numerics.fv import fvutils
 
 class TestFvutils(unittest.TestCase):
     def test_subcell_topology_2d_cart_1(self):
-        x = np.ones(2, dtype=np.int)
+        x = np.ones(2, dtype=int)
         g = structured.CartGrid(x)
 
         subcell_topology = fvutils.SubcellTopology(g)

--- a/test/unit/test_grid.py
+++ b/test/unit/test_grid.py
@@ -197,7 +197,7 @@ class TestCartGridGeometry2DPert(unittest.TestCase):
 
 class TestCartGridGeometryUnpert3D(unittest.TestCase):
     def setUp(self):
-        nc = 2 * np.ones(3, dtype=np.int)
+        nc = 2 * np.ones(3, dtype=int)
         g = structured.CartGrid(nc)
         g.compute_geometry()
         self.g = g
@@ -337,7 +337,7 @@ class TestCartGridGeometryUnpert3D(unittest.TestCase):
 
 class TestCartGridGeometry1CellPert3D(unittest.TestCase):
     def setUp(self):
-        nc = np.ones(3, dtype=np.int)
+        nc = np.ones(3, dtype=int)
         g = structured.CartGrid(nc)
         g.nodes[:, -1] = [2, 2, 2]
         g.compute_geometry()

--- a/test/unit/test_polygon_intersection.py
+++ b/test/unit/test_polygon_intersection.py
@@ -168,7 +168,7 @@ class TestIntersectionPolygonsEmbeddedIn3d(unittest.TestCase):
 
         self.assertTrue(seg_vert.size == 3)
 
-        counter = np.zeros(3, dtype=np.int)
+        counter = np.zeros(3, dtype=int)
 
         for p in pairs:
             if p[0] == 0 and p[1] == 1:
@@ -214,7 +214,7 @@ class TestIntersectionPolygonsEmbeddedIn3d(unittest.TestCase):
 
         self.assertTrue(seg_vert.size == 3)
 
-        counter = np.zeros(3, dtype=np.int)
+        counter = np.zeros(3, dtype=int)
 
         self.assertTrue(len(pairs) == 2)
 
@@ -267,7 +267,7 @@ class TestIntersectionPolygonsEmbeddedIn3d(unittest.TestCase):
 
         self.assertTrue(len(pairs) == 3)
 
-        counter = np.zeros(3, dtype=np.int)
+        counter = np.zeros(3, dtype=int)
 
         for p in pairs:
             if p[0] == 0 and p[1] == 1:
@@ -323,7 +323,7 @@ class TestIntersectionPolygonsEmbeddedIn3d(unittest.TestCase):
         ).T
         self.assertTrue(test_utils.compare_arrays(new_pt, known_points))
 
-        counter = np.zeros(3, dtype=np.int)
+        counter = np.zeros(3, dtype=int)
 
         for p in pairs:
             if p[0] == 0 and p[1] == 1:

--- a/test/unit/test_sparse_mat.py
+++ b/test/unit/test_sparse_mat.py
@@ -150,9 +150,9 @@ class TestSparseMath(unittest.TestCase):
         A0 = sparse_mat.slice_mat(A, np.array([1, 2], dtype=int))
         A1 = sparse_mat.slice_mat(A, np.array([0, 1]))
         A2 = sparse_mat.slice_mat(A, 2)
-        A3 = sparse_mat.slice_mat(A, np.array([], dtype=np.int))
-        A4 = sparse_mat.slice_mat(A, np.array([0, 2], dtype=np.int))
-        A5 = sparse_mat.slice_mat(A, np.array([1, 1], dtype=np.int))
+        A3 = sparse_mat.slice_mat(A, np.array([], dtype=int))
+        A4 = sparse_mat.slice_mat(A, np.array([0, 2], dtype=int))
+        A5 = sparse_mat.slice_mat(A, np.array([1, 1], dtype=int))
 
         self.assertTrue(np.sum(A0 != A0_t) == 0)
         self.assertTrue(np.sum(A1 != A1_t) == 0)
@@ -175,9 +175,9 @@ class TestSparseMath(unittest.TestCase):
         A0 = sparse_mat.slice_mat(A, np.array([1, 2], dtype=int))
         A1 = sparse_mat.slice_mat(A, np.array([0, 1]))
         A2 = sparse_mat.slice_mat(A, 2)
-        A3 = sparse_mat.slice_mat(A, np.array([], dtype=np.int))
-        A4 = sparse_mat.slice_mat(A, np.array([0, 2], dtype=np.int))
-        A5 = sparse_mat.slice_mat(A, np.array([1, 1], dtype=np.int))
+        A3 = sparse_mat.slice_mat(A, np.array([], dtype=int))
+        A4 = sparse_mat.slice_mat(A, np.array([0, 2], dtype=int))
+        A5 = sparse_mat.slice_mat(A, np.array([1, 1], dtype=int))
 
         self.assertTrue(np.sum(A0 != A0_t) == 0)
         self.assertTrue(np.sum(A1 != A1_t) == 0)
@@ -251,7 +251,7 @@ class TestSparseMath(unittest.TestCase):
 
         A_t = sps.csc_matrix(np.array([[0, 0, 2], [3, 0, 1], [1, 0, 0]]))
 
-        sparse_mat.merge_matrices(A, B, np.array([0, 2], dtype=np.int))
+        sparse_mat.merge_matrices(A, B, np.array([0, 2], dtype=int))
 
         self.assertTrue(np.sum(A != A_t) == 0)
 
@@ -263,7 +263,7 @@ class TestSparseMath(unittest.TestCase):
 
         A_t = sps.csc_matrix(np.array([[0, 0, 2], [1, 3, 1], [0, 1, 0]]))
 
-        sparse_mat.merge_matrices(A, B, np.array([1, 2], dtype=np.int))
+        sparse_mat.merge_matrices(A, B, np.array([1, 2], dtype=int))
 
         self.assertTrue(np.sum(A != A_t) == 0)
 
@@ -275,7 +275,7 @@ class TestSparseMath(unittest.TestCase):
 
         A_t = sps.csc_matrix(np.array([[2, 0, 0], [1, 0, 0], [0, 0, 3]]))
         try:
-            sparse_mat.merge_matrices(A, B, np.array([0, 0], dtype=np.int))
+            sparse_mat.merge_matrices(A, B, np.array([0, 0], dtype=int))
         except ValueError:
             pass
 
@@ -287,7 +287,7 @@ class TestSparseMath(unittest.TestCase):
 
         A_t = sps.csr_matrix(np.array([[0, 2, 2], [1, 0, 0], [3, 1, 3]]))
 
-        sparse_mat.merge_matrices(A, B, np.array([0, 2], dtype=np.int))
+        sparse_mat.merge_matrices(A, B, np.array([0, 2], dtype=int))
 
         self.assertTrue(np.sum(A != A_t) == 0)
 
@@ -299,7 +299,7 @@ class TestSparseMath(unittest.TestCase):
 
         A_t = sps.csr_matrix(np.array([[0, 2, 2], [3, 1, 3], [0, 0, 3]]))
 
-        sparse_mat.merge_matrices(A, B, np.array([0, 1], dtype=np.int))
+        sparse_mat.merge_matrices(A, B, np.array([0, 1], dtype=int))
 
         self.assertTrue(np.sum(A != A_t) == 0)
 


### PR DESCRIPTION
The upgrade to numpy 1.20 required several changes:
* np.int etc. is no longer permissible syntax, use int instead.
* Numpy introduced typing, which forced a lot of type specifications in PorePy.
* Python 3.6 is no longer supported.
* Numba version must be 0.52 to be compatible with the combination np 1.20 and python 3.7(.9?). So it goes.