### PR TITLE
Fix bug when using multiple active Ad variables

### DIFF
--- a/src/porepy/numerics/ad/equation_manager.py
+++ b/src/porepy/numerics/ad/equation_manager.py
@@ -10,9 +10,8 @@
 from typing import Dict, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
-import scipy.sparse as sps
-
 import porepy as pp
+import scipy.sparse as sps
 
 from . import operators
 from .discretizations import _MergedOperator

--- a/src/porepy/numerics/ad/equation_manager.py
+++ b/src/porepy/numerics/ad/equation_manager.py
@@ -126,9 +126,11 @@ class Expression:
             dofs = np.hstack([d for d in self._variable_dofs])
         else:
             active_variable_ids = [v.id for v in active_variables]
-            assert all([i in self._variable_ids for i in active_variable_ids])
+            present_active_variable_ids = list(
+                set(self._variable_ids).intersection(active_variable_ids)
+            )
             active_variable_local_ids = [
-                self._variable_ids.index(i) for i in active_variable_ids
+                self._variable_ids.index(i) for i in present_active_variable_ids
             ]
             ad_variable_dofs = [
                 self._variable_dofs[i] for i in active_variable_local_ids
@@ -299,12 +301,11 @@ class Expression:
             self._ad = {var_id: ad for (var_id, ad) in zip(self._variable_ids, ad_vars)}
         else:
             active_variable_ids = [v.id for v in active_variables]
-            active_variable_ids = list(
+            present_active_variable_ids = list(
                 set(self._variable_ids).intersection(active_variable_ids)
             )
-            assert all([i in self._variable_ids for i in active_variable_ids])
             active_variable_local_ids = [
-                self._variable_ids.index(i) for i in active_variable_ids
+                self._variable_ids.index(i) for i in present_active_variable_ids
             ]
             active_variable_dofs = [
                 self._variable_dofs[i] for i in active_variable_local_ids

--- a/src/porepy/numerics/ad/equation_manager.py
+++ b/src/porepy/numerics/ad/equation_manager.py
@@ -130,7 +130,9 @@ class Expression:
             active_variable_local_ids = [
                 self._variable_ids.index(i) for i in active_variable_ids
             ]
-            ad_variable_dofs = [self._variable_dofs[i] for i in active_variable_local_ids]
+            ad_variable_dofs = [
+                self._variable_dofs[i] for i in active_variable_local_ids
+            ]
             dofs = np.hstack([d for d in ad_variable_dofs])
         return dofs
 
@@ -304,9 +306,13 @@ class Expression:
             active_variable_local_ids = [
                 self._variable_ids.index(i) for i in active_variable_ids
             ]
-            active_variable_dofs = [self._variable_dofs[i] for i in active_variable_local_ids]
+            active_variable_dofs = [
+                self._variable_dofs[i] for i in active_variable_local_ids
+            ]
             ad_vars = initAdArrays([state[ind] for ind in active_variable_dofs])
-            self._ad = {var_id: ad for (var_id, ad) in zip(active_variable_ids, ad_vars)}
+            self._ad = {
+                var_id: ad for (var_id, ad) in zip(active_variable_ids, ad_vars)
+            }
 
         # Also make mappings from the previous iteration.
         if active_variables is None:
@@ -318,7 +324,9 @@ class Expression:
         else:
             # FIXME: This needs explanations
             prev_iter_vals_list = [state[ind] for ind in self._prev_iter_dofs]
-            inactive_variable_ids = list(set(self._variable_ids) - set(active_variable_ids))
+            inactive_variable_ids = list(
+                set(self._variable_ids) - set(active_variable_ids)
+            )
             inactive_variable_local_ids = [
                 self._variable_ids.index(i) for i in inactive_variable_ids
             ]

--- a/src/porepy/numerics/ad/equation_manager.py
+++ b/src/porepy/numerics/ad/equation_manager.py
@@ -300,12 +300,12 @@ class Expression:
             ad_vars = initAdArrays([state[ind] for ind in self._variable_dofs])
             self._ad = {var_id: ad for (var_id, ad) in zip(self._variable_ids, ad_vars)}
         else:
-            active_variable_ids = [v.id for v in active_variables]
-            present_active_variable_ids = list(
-                set(self._variable_ids).intersection(active_variable_ids)
+            potential_active_variable_ids = [v.id for v in active_variables]
+            active_variable_ids = list(
+                set(self._variable_ids).intersection(potential_active_variable_ids)
             )
             active_variable_local_ids = [
-                self._variable_ids.index(i) for i in present_active_variable_ids
+                self._variable_ids.index(i) for i in active_variable_ids
             ]
             active_variable_dofs = [
                 self._variable_dofs[i] for i in active_variable_local_ids

--- a/src/porepy/numerics/mixed_dim/dof_manager.py
+++ b/src/porepy/numerics/mixed_dim/dof_manager.py
@@ -211,11 +211,11 @@ class DofManager:
             var = [var]
 
         # Mark input dofs among all global dofs
-        is_dofs = np.full((total_dofs, 1), False)
+        is_dofs = np.full((total_dofs, 1), False, dtype=bool)
         is_dofs[dofs] = True
 
         # Mark dofs associated to var (on all grids)
-        is_var = np.full((total_dofs, 1), False)
+        is_var = np.full((total_dofs, 1), False, dtype=bool)
         for grid, variable in self.block_dof:
             if variable in var:
                 var_dofs = self.dof_ind(grid, variable)

--- a/src/porepy/numerics/mixed_dim/dof_manager.py
+++ b/src/porepy/numerics/mixed_dim/dof_manager.py
@@ -3,8 +3,6 @@
 from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
-import scipy.sparse as sps
-
 import porepy as pp
 
 

--- a/src/porepy/numerics/mixed_dim/dof_manager.py
+++ b/src/porepy/numerics/mixed_dim/dof_manager.py
@@ -211,11 +211,11 @@ class DofManager:
             var = [var]
 
         # Mark input dofs among all global dofs
-        is_dofs = np.full(total_dofs, False)
+        is_dofs = np.full((total_dofs, 1), False)
         is_dofs[dofs] = True
 
         # Mark dofs associated to var (on all grids)
-        is_var = np.full(total_dofs, False)
+        is_var = np.full((total_dofs, 1), False)
         for grid, variable in self.block_dof:
             if variable in var:
                 var_dofs = self.dof_ind(grid, variable)

--- a/src/porepy/numerics/mixed_dim/dof_manager.py
+++ b/src/porepy/numerics/mixed_dim/dof_manager.py
@@ -198,7 +198,7 @@ class DofManager:
 
                     data[pp.STATE][var_name] = vals
                 else:
-                    # If no values exist, there is othing to add to
+                    # If no values exist, there is nothing to add to
                     data[pp.STATE] = {var_name: values[dof[bi] : dof[bi + 1]]}
 
     def transform_dofs(self, dofs: np.ndarray, var: Optional[list]) -> np.ndarray:


### PR DESCRIPTION
The previous capability for solving for subsystems did only allow solving for a single field. The update allows for combining solution for multiple fields, e.g., given pressure, and two saturations, the current approach ultimately allows for solving for both saturations simultaneously.

Note: This PR is basis for the PR "Provide variant of distribute_variable of DofManager.".