### PR TITLE
ENH: DFN's in 2d does not need auxillary points

### DIFF
--- a/src/porepy/fracs/fractures_2d.py
+++ b/src/porepy/fracs/fractures_2d.py
@@ -545,7 +545,7 @@ class FractureNetwork2d(object):
         mesh_size_frac: Optional[float] = None,
         mesh_size_bound: Optional[float] = None,
         mesh_size_min: Optional[float] = None,
-    ):
+    ): -> None
         """
         Set the "Vailla" mesh size to points. No attemts at automatically
         determine the mesh size is done and no auxillary points are inserted.

--- a/src/porepy/fracs/fractures_2d.py
+++ b/src/porepy/fracs/fractures_2d.py
@@ -349,8 +349,16 @@ class FractureNetwork2d(object):
             self._snap_to_boundary()
 
         self._find_and_split_intersections(constraints)
-        self._insert_auxiliary_points(**mesh_args)
 
+        # Insert auxiliary points and determine mesh size.
+        # _insert_auxiliary_points(..) does both.
+        # _set_mesh_size_withouth_auxiliary_points() sets the mesh size
+        # to the existing points. This is only done for DFNs, but could
+        # also be used for any grid if that is desired.
+        if not dfn:
+            self._insert_auxiliary_points(**mesh_args)
+        else:
+            self._set_mesh_size_withouth_auxiliary_points(**mesh_args)
         # Transfer data to the format expected by the gmsh interface
         decomp = self._decomposition
 
@@ -530,6 +538,37 @@ class FractureNetwork2d(object):
         self._decomposition["points"] = pts_split
         self._decomposition["edges"] = lines
         self._decomposition["mesh_size"] = mesh_size
+
+    @pp.time_logger(sections=module_sections)
+    def _set_mesh_size_withouth_auxiliary_points(
+        self,
+        mesh_size_frac: Optional[float]=None,
+        mesh_size_bound: Optional[float]=None,
+        mesh_size_min: Optional[float]=None,
+    ):
+        """
+        Set the "Vailla" mesh size to points. No attemts at automatically
+        determine the mesh size is done and no auxillary points are inserted.
+        Fracture points are given the mesh_size_frac mesh size and the domain
+        boundary is given the mesh_size_bound mesh size. mesh_size_min is unused.
+        """
+        # Gridding size
+        # Tag points at the domain corners
+        logger.info("Determine mesh size")
+        tm = time.time()
+
+        boundary_pt_ind = self._decomposition["domain_boundary_points"]
+        num_pts = self._decomposition["points"].shape[1]
+
+        val = 1
+        if mesh_size_frac is not None:
+            val = mesh_size_frac
+        # One value for each point to distinguish betwee val and val_bound.
+        vals = val * np.ones(num_pts)
+        if mesh_size_bound is not None:
+            vals[boundary_pt_ind] = mesh_size_bound
+        logger.info("Done. Elapsed time " + str(time.time() - tm))
+        self._decomposition["mesh_size"] = vals
 
     @pp.time_logger(sections=module_sections)
     def impose_external_boundary(

--- a/src/porepy/fracs/fractures_2d.py
+++ b/src/porepy/fracs/fractures_2d.py
@@ -545,7 +545,7 @@ class FractureNetwork2d(object):
         mesh_size_frac: Optional[float] = None,
         mesh_size_bound: Optional[float] = None,
         mesh_size_min: Optional[float] = None,
-    ): -> None
+    ) -> None:
         """
         Set the "Vailla" mesh size to points. No attemts at automatically
         determine the mesh size is done and no auxillary points are inserted.

--- a/src/porepy/fracs/fractures_2d.py
+++ b/src/porepy/fracs/fractures_2d.py
@@ -358,7 +358,7 @@ class FractureNetwork2d(object):
         if not dfn:
             self._insert_auxiliary_points(**mesh_args)
         else:
-            self._set_mesh_size_withouth_auxiliary_points(**mesh_args)
+            self._set_mesh_size_without_auxiliary_points(**mesh_args)
         # Transfer data to the format expected by the gmsh interface
         decomp = self._decomposition
 
@@ -540,11 +540,11 @@ class FractureNetwork2d(object):
         self._decomposition["mesh_size"] = mesh_size
 
     @pp.time_logger(sections=module_sections)
-    def _set_mesh_size_withouth_auxiliary_points(
+    def _set_mesh_size_without_auxiliary_points(
         self,
-        mesh_size_frac: Optional[float]=None,
-        mesh_size_bound: Optional[float]=None,
-        mesh_size_min: Optional[float]=None,
+        mesh_size_frac: Optional[float] = None,
+        mesh_size_bound: Optional[float] = None,
+        mesh_size_min: Optional[float] = None,
     ):
         """
         Set the "Vailla" mesh size to points. No attemts at automatically
@@ -560,7 +560,7 @@ class FractureNetwork2d(object):
         boundary_pt_ind = self._decomposition["domain_boundary_points"]
         num_pts = self._decomposition["points"].shape[1]
 
-        val = 1
+        val = 1.0
         if mesh_size_frac is not None:
             val = mesh_size_frac
         # One value for each point to distinguish betwee val and val_bound.


### PR DESCRIPTION
When a fracture tip is almost touching another fracture an auxiliary point is inserted. For DFN's these auxillary points does not have
a purpose as there is no need to refine the mesh in these areas. 

This Pullrequest therefore make the FractureNetwork2D.prepare_for_gmsh( mesh_args, dfn=True) skip the insertion of auxillary points. As far as I understand this should be OK for DFN's, can you confirm @keileg ?

Note for the future: The pp.fracs.tools.determine_mesh_size(...) should probably change name (it does much more than determining the mesh size).
