### PR TITLE
BUG: self.Nd to self._Nd in propagation models

### DIFF
--- a/src/porepy/numerics/fracture_deformation/propagation_model.py
+++ b/src/porepy/numerics/fracture_deformation/propagation_model.py
@@ -59,7 +59,7 @@ class FracturePropagation(abc.ABC):
         # come from combining this class with a mechanical model.
         self.assembler = assembler
         self.gb = self.assembler.gb
-        self.Nd = self.gb.dim_max()
+        self._Nd = self.gb.dim_max()
 
     @abc.abstractmethod
     @pp.time_logger(sections=module_sections)

--- a/test/integration/test_fracture_propagation.py
+++ b/test/integration/test_fracture_propagation.py
@@ -135,7 +135,7 @@ def test_pick_propagation_face_conforming_propagation(generate):
     # Propagation model; assign this some necessary fields.
     model = pp.ConformingFracturePropagation({})
     model.mechanics_parameter_key = mech_key
-    model.Nd = gb.dim_max()
+    model._Nd = gb.dim_max()
 
     # Loop over all propagation steps
     for step_target, step_angle in zip(targets, angles):
@@ -675,7 +675,7 @@ class PropagationCriteria(unittest.TestCase):
         pp.contact_conditions.set_projections(gb)
 
         # Model needs to know dimension
-        self.model.Nd = dim
+        self.model._Nd = dim
         # Set for convenient access without passing around:
         self.nd = dim
         self.gb = gb


### PR DESCRIPTION
When the model methods and attributes were renamed, the .Nd attribute of the propagation models were not updated. This PR simply updates to self._Nd in FracturePropagation, ConformingFracturePropagation and the test.