### PR TITLE
Make it possible to export cells with different number of faces/nodes

### DIFF
--- a/src/porepy/viz/exporter.py
+++ b/src/porepy/viz/exporter.py
@@ -755,7 +755,7 @@ class Exporter:
                     f_counter += 1
 
                 # collect all the nodes for the cell
-                nodes_loc = np.unique(faces_loc).astype(int)
+                nodes_loc = np.unique(np.hstack(faces_loc)).astype(int)
 
                 # define the type of cell we are currently saving
                 cell_type = "polyhedron" + str(nodes_loc.size)


### PR DESCRIPTION
If you have a mix of cell types (e.g., tetrahedrons and cubes) the entries in the faces_loc will have a different sizes.
numpy tires to vstack the list. Instead we hstack the list before calling unique.

 