### PR TITLE
BUG: Subtraction and addition of Ad arrays with numpy arrays did not commute

### DIFF
--- a/src/porepy/numerics/ad/discretizations.py
+++ b/src/porepy/numerics/ad/discretizations.py
@@ -70,7 +70,7 @@ class Discretization:
         Parameters:
             grid_discr (dict): Mapping between grids, or interfaces, where the
                 discretization is applied, and the actual Discretization objects.
-            name (str): Name of the wrapper.
+            _name (str): Name of the wrapper.
             mat_dict_key (str): Keyword used to access discretization matrices, if this
                 is not the same as the keyword of the discretization. The only known
                 case where this is necessary is for Mpfa applied to Biot's equations.
@@ -79,6 +79,7 @@ class Discretization:
         self.grids = grids
         self._discretization = discretization
         self.mat_dict_key = mat_dict_key
+        self.keyword = discretization.keyword
 
         # Get the name of this discretization.
         self._name = discretization.__class__.__name__
@@ -89,11 +90,14 @@ class Discretization:
         s = f"Ad discretization of type {self._name}. Defined on {len(self.grids)} grids"
         return s
 
+    def __str__(self) -> str:
+        return f"{self._name}({self.keyword})"
+
 
 ### Mechanics related discretizations
 
 
-class BiotAd:
+class BiotAd(Discretization):
     """Ad wrapper around the Biot discretization class.
 
     For description of the method, we refer to the standard Biot class.
@@ -128,12 +132,8 @@ class BiotAd:
             obj=self, discr=self._discretization, grids=grids, mat_dict_key=self.keyword
         )
 
-    def __repr__(self) -> str:
-        s = f"Ad discretization of type {self._name}. Defined on {len(self._grids)} grids"
-        return s
 
-
-class MpsaAd:
+class MpsaAd(Discretization):
     def __init__(self, keyword, grids):
         if isinstance(grids, list):
             self._grids = grids
@@ -154,12 +154,8 @@ class MpsaAd:
 
         _wrap_discretization(self, self._discretization, grids)
 
-    def __repr__(self) -> str:
-        s = f"Ad discretization of type {self._name}. Defined on {len(self._grids)} grids"
-        return s
 
-
-class GradPAd:
+class GradPAd(Discretization):
     def __init__(self, keyword, grids):
         if isinstance(grids, list):
             self._grids = grids
@@ -173,12 +169,8 @@ class GradPAd:
 
         _wrap_discretization(self, self._discretization, grids)
 
-    def __repr__(self) -> str:
-        s = f"Ad discretization of type {self._name}. Defined on {len(self._grids)} grids"
-        return s
 
-
-class DivUAd:
+class DivUAd(Discretization):
     def __init__(self, keyword, grids, mat_dict_keyword):
         if isinstance(grids, list):
             self._grids = grids
@@ -194,12 +186,8 @@ class DivUAd:
 
         _wrap_discretization(self, self._discretization, grids, mat_dict_keyword)
 
-    def __repr__(self) -> str:
-        s = f"Ad discretization of type {self._name}. Defined on {len(self._grids)} grids"
-        return s
 
-
-class BiotStabilizationAd:
+class BiotStabilizationAd(Discretization):
     def __init__(self, keyword, grids):
         if isinstance(grids, list):
             self._grids = grids
@@ -213,12 +201,8 @@ class BiotStabilizationAd:
 
         _wrap_discretization(self, self._discretization, grids)
 
-    def __repr__(self) -> str:
-        s = f"Ad discretization of type {self._name}. Defined on {len(self._grids)} grids"
-        return s
 
-
-class ColoumbContactAd:
+class ColoumbContactAd(Discretization):
     def __init__(self, keyword, grids):
 
         if isinstance(grids, list):
@@ -246,15 +230,11 @@ class ColoumbContactAd:
             self, self._discretization, grids, mat_dict_grids=low_dim_grids
         )
 
-    def __repr__(self) -> str:
-        s = f"Ad discretization of type {self._name}. Defined on {len(self._grids)} grids"
-        return s
-
 
 ## Flow related
 
 
-class MpfaAd:
+class MpfaAd(Discretization):
     def __init__(self, keyword, grids):
 
         if isinstance(grids, list):
@@ -274,12 +254,8 @@ class MpfaAd:
 
         _wrap_discretization(self, self._discretization, grids)
 
-    def __repr__(self) -> str:
-        s = f"Ad discretization of type {self._name}. Defined on {len(self._grids)} grids"
-        return s
 
-
-class TpfaAd:
+class TpfaAd(Discretization):
     def __init__(self, keyword, grids):
 
         if isinstance(grids, list):
@@ -304,7 +280,7 @@ class TpfaAd:
         return s
 
 
-class MassMatrixAd:
+class MassMatrixAd(Discretization):
     def __init__(self, keyword, grids):
         if isinstance(grids, list):
             self._grids = grids
@@ -317,12 +293,8 @@ class MassMatrixAd:
         self.mass: _MergedOperator
         _wrap_discretization(self, self._discretization, grids)
 
-    def __repr__(self) -> str:
-        s = f"Ad discretization of type {self._name}. Defined on {len(self._grids)} grids"
-        return s
 
-
-class UpwindAd:
+class UpwindAd(Discretization):
     def __init__(self, keyword, grids):
         if isinstance(grids, list):
             self._grids = grids
@@ -337,12 +309,8 @@ class UpwindAd:
         self.outflow_neumann: _MergedOperator
         _wrap_discretization(self, self._discretization, grids)
 
-    def __repr__(self) -> str:
-        s = f"Ad discretization of type {self._name}. Defined on {len(self._grids)} grids"
-        return s
 
-
-class WellCouplingAd:
+class WellCouplingAd(Discretization):
     def __init__(self, keyword, edges):
         if isinstance(edges, list):
             self._edges = edges
@@ -364,7 +332,7 @@ class WellCouplingAd:
         return s
 
 
-class RobinCouplingAd:
+class RobinCouplingAd(Discretization):
     def __init__(self, keyword, edges):
         if isinstance(edges, list):
             self._edges = edges
@@ -418,6 +386,7 @@ class _MergedOperator(Operator):
                 case where this is necessary is for Mpfa applied to Biot's equations.
 
         """
+        self._name = discr.__class__.__name__
         self.grids = grids
         self.key = key
         self.discr = discr
@@ -430,6 +399,9 @@ class _MergedOperator(Operator):
 
     def __repr__(self) -> str:
         return f"Operator with key {self.key} defined on {len(self.grids)} grids"
+
+    def __str__(self) -> str:
+        return f"{self._name}.{self.key}"
 
     def parse(self, gb):
         """Convert a merged operator into a sparse matrix by concatenating

--- a/src/porepy/numerics/ad/discretizations.py
+++ b/src/porepy/numerics/ad/discretizations.py
@@ -401,7 +401,7 @@ class _MergedOperator(Operator):
         return f"Operator with key {self.key} defined on {len(self.grids)} grids"
 
     def __str__(self) -> str:
-        return f"{self._name}.{self.key}"
+        return f"{self._name}({self.mat_dict_key}).{self.key}"
 
     def parse(self, gb):
         """Convert a merged operator into a sparse matrix by concatenating

--- a/src/porepy/numerics/ad/equation_manager.py
+++ b/src/porepy/numerics/ad/equation_manager.py
@@ -438,6 +438,12 @@ class Expression:
             # Convert any vectors that mascarade as a nx1 (1xn) scipy matrix
             self._ravel_scipy_matrix(results)
 
+            if isinstance(results[0], np.ndarray):
+                # With the implementation of Ad arrays, addition does not
+                # commute for combinations with numpy arrays. Switch the order
+                # of results, and everything works.
+                results = results[::-1]
+
             try:
                 return results[0] + results[1]
             except ValueError:
@@ -450,6 +456,12 @@ class Expression:
 
             # Convert any vectors that mascarade as a nx1 (1xn) scipy matrix
             self._ravel_scipy_matrix(results)
+
+            if isinstance(results[0], np.ndarray):
+                # With the implementation of Ad arrays, subtraction does not
+                # commute for combinations with numpy arrays. Switch the order
+                # of results, and everything works.
+                results = results[::-1]
 
             try:
                 return results[0] - results[1]

--- a/src/porepy/numerics/ad/grid_operators.py
+++ b/src/porepy/numerics/ad/grid_operators.py
@@ -421,6 +421,7 @@ class Divergence(Operator):
         grids: Optional[List[pp.Grid]] = None,
         gb: Optional[pp.GridBucket] = None,
         dim: int = 1,
+        name: Optional[str] = None,
     ):
         """Construct divergence operators for a set of subdomains.
 
@@ -439,7 +440,7 @@ class Divergence(Operator):
             dim (int, optional): Dimension of vector field. Defaults to 1.
 
         """
-
+        super().__init__(name=name)
         self._g: List[pp.Grid] = _grid_list(grids, gb)
 
         self.dim: int = dim
@@ -459,6 +460,12 @@ class Divergence(Operator):
 
         s += f"The total size of the matrix is ({nc}, {nf})\n"
 
+        return s
+
+    def __str__(self) -> str:
+        s = "Divergence "
+        if self._name is not None:
+            s += f"named {self._name}"
         return s
 
     def parse(self, gb: pp.GridBucket) -> sps.spmatrix:
@@ -493,6 +500,7 @@ class BoundaryCondition(Operator):
         keyword: str,
         grids: Optional[List[pp.Grid]] = None,
         gb: Optional[pp.GridBucket] = None,
+        name: Optional[str] = None,
     ):
         """Construct a wrapper for boundary conditions for a set of subdomains.
 
@@ -515,7 +523,7 @@ class BoundaryCondition(Operator):
                 grids is set according to iteration over the GridBucket nodes.
 
         """
-
+        super().__init__(name=name)
         self.keyword = keyword
         self._g: List[pp.Grid] = _grid_list(grids, gb)
         self._set_tree()
@@ -532,6 +540,9 @@ class BoundaryCondition(Operator):
                 s += f"{dims[d]} grids of dimension {d}\n"
 
         return s
+
+    def __str__(self) -> str:
+        return f"BC({self.keyword})"
 
     def parse(self, gb: pp.GridBucket) -> np.ndarray:
         """Convert the Ad expression into numerical values for the boundary conditions,
@@ -562,7 +573,9 @@ class DirBC(Operator):
         bc,
         grids: Optional[List[pp.Grid]] = None,
         gb: Optional[pp.GridBucket] = None,
+        name: Optional[str] = None,
     ):
+        super().__init__(name)
         self._bc = bc
         self._g: List[pp.Grid] = _grid_list(grids, gb)
         if not (len(self._g) == 1):
@@ -606,6 +619,7 @@ class ParameterArray(Operator):
         array_keyword: str,
         grids: Optional[List[pp.Grid]] = None,
         edges: Optional[List[Tuple[pp.Grid, pp.Grid]]] = None,
+        name: Optional[str] = None,
     ):
         """Construct a wrapper for scalar sources for a set of subdomains.
 
@@ -632,6 +646,7 @@ class ParameterArray(Operator):
             and array_keyword='source'.
 
         """
+        super().__init__(name=name)
         if grids is None:
             grids = []
             if edges is None:
@@ -672,6 +687,9 @@ class ParameterArray(Operator):
                 of dimension {d}\n"""
 
         return s
+
+    def __str__(self) -> str:
+        return f"ParameterArray({self.param_keyword})({self.array_keyword})"
 
     def parse(self, gb: pp.GridBucket) -> np.ndarray:
         """Convert the Ad expression into numerical values for the scalar sources,

--- a/src/porepy/numerics/ad/operators.py
+++ b/src/porepy/numerics/ad/operators.py
@@ -44,8 +44,7 @@ class Operator:
         grid: Optional[Union[pp.Grid, Tuple[pp.Grid, pp.Grid]]] = None,
         tree: Optional["Tree"] = None,
     ) -> None:
-        if name is not None:
-            self._name = name
+        self._name = name
         if grid is not None:
             self.g = grid
         self._set_tree(tree)
@@ -65,6 +64,9 @@ class Operator:
         """
         return len(self.tree.children) == 0
 
+    def set_name(self, name: str) -> None:
+        self._name = name
+
     def parse(self, gb) -> Any:
         """Translate the operator into a numerical expression.
 
@@ -82,6 +84,9 @@ class Operator:
         return (
             f"Operator formed by {self.tree.op} with {len(self.tree.children)} children"
         )
+
+    def __str__(self) -> str:
+        return self._name if self._name is not None else ""
 
     def viz(self):
         """Give a visualization of the operator tree that has this operator at the top."""
@@ -153,19 +158,26 @@ class Matrix(Operator):
 
     """
 
-    def __init__(self, mat: sps.spmatrix) -> None:
+    def __init__(self, mat: sps.spmatrix, name: Optional[str] = None) -> None:
         """Construct an Ad representation of a matrix.
 
         Parameters:
             mat (sps.spmatrix): Sparse matrix to be represented.
 
         """
+        super().__init__(name=name)
         self._mat = mat
         self._set_tree()
         self.shape = mat.shape
 
     def __repr__(self) -> str:
         return f"Matrix with shape {self._mat.shape} and {self._mat.data.size} elements"
+
+    def __str__(self) -> str:
+        s = "Matrix "
+        if self._name is not None:
+            s += self._name
+        return s
 
     def parse(self, gb) -> sps.spmatrix:
         """Convert the Ad matrix into an actual matrix.
@@ -194,18 +206,25 @@ class Array(Operator):
 
     """
 
-    def __init__(self, values):
+    def __init__(self, values, name: Optional[str] = None) -> None:
         """Construct an Ad representation of a numpy array.
 
         Parameters:
             values (np.ndarray): Numpy array to be represented.
 
         """
+        super().__init__(name=name)
         self._values = values
         self._set_tree()
 
     def __repr__(self) -> str:
         return f"Wrapped numpy array of size {self._values.size}"
+
+    def __str__(self) -> str:
+        s = "Array"
+        if self._name is not None:
+            s += f"({self._name})"
+        return s
 
     def parse(self, gb: pp.GridBucket) -> np.ndarray:
         """Convert the Ad Array into an actual array.
@@ -229,18 +248,25 @@ class Scalar(Operator):
 
     """
 
-    def __init__(self, value):
+    def __init__(self, value, name: Optional[str] = None) -> None:
         """Construct an Ad representation of a numpy array.
 
         Parameters:
             values (float): Number to be represented
 
         """
+        super().__init__(name=name)
         self._value = value
         self._set_tree()
 
     def __repr__(self) -> str:
         return f"Wrapped scalar with value {self._value}"
+
+    def __str__(self) -> str:
+        s = "Scalar"
+        if self._name is not None:
+            s += f"({self._name})"
+        return s
 
     def parse(self, gb: pp.GridBucket) -> float:
         """Convert the Ad Scalar into an actual number.
@@ -362,6 +388,7 @@ class MergedVariable(Variable):
                 same name.
 
         """
+        self._name = variables[0]._name
         self.sub_vars = variables
 
         # Use counter from superclass to ensure unique Variable ids


### PR DESCRIPTION
Problem: For a `pp.Ad_array` a and a numpy array `b` (wrapped as a `pp.ad.Array`), `a+b` and `b+a `gave different results; specifically `b+a` was parsed wrongly. This PR is a minor fix to resolve the issue.