### PR TITLE
DEP: Remove the k_inv_scaling option from RobinCoupling

### DIFF
--- a/src/porepy/models/contact_mechanics_biot_model.py
+++ b/src/porepy/models/contact_mechanics_biot_model.py
@@ -780,19 +780,28 @@ class ContactMechanicsBiot(pp.ContactMechanics):
                 * accumulation_primary
                 + subdomain_proj_scalar.cell_prolongation(g_frac) * accumulation_fracs
             )
-
-            interface_flow_eq = robin_ad.mortar_scaling * (
-                mortar_proj_scalar.primary_to_mortar_avg
+            # Interface equation: \lambda = -\kappa (p_l - p_h)
+            # Robin_ad.mortar_discr represents -\kappa. The involved term is
+            # reconstruction of p_h on internal boundary, which has contributions
+            # from cell center pressure, external boundary and interface flux
+            # on internal boundaries (including those corresponding to "other"
+            # fractures).
+            interface_flow_eq = (
+                robin_ad.mortar_discr
+                * mortar_proj_scalar.primary_to_mortar_avg
                 * mpfa_ad.bound_pressure_cell
                 * p
-                + mortar_proj_scalar.primary_to_mortar_avg
+                + robin_ad.mortar_discr
+                * mortar_proj_scalar.primary_to_mortar_avg
                 * mpfa_ad.bound_pressure_face
-                * (
-                    mortar_proj_scalar.mortar_to_primary_int * mortar_flux
-                    + bc_val_scalar
-                )
-                - mortar_proj_scalar.secondary_to_mortar_avg * p
-                + robin_ad.mortar_discr * mortar_flux
+                * mortar_proj_scalar.mortar_to_primary_int
+                * mortar_flux
+                + robin_ad.mortar_discr
+                * mortar_proj_scalar.primary_to_mortar_avg
+                * mpfa_ad.bound_pressure_face
+                * bc_val_scalar
+                - robin_ad.mortar_discr * mortar_proj_scalar.secondary_to_mortar_avg * p
+                + mortar_flux
             )
 
             eq_manager.equations += [

--- a/src/porepy/models/contact_mechanics_biot_model.py
+++ b/src/porepy/models/contact_mechanics_biot_model.py
@@ -786,21 +786,20 @@ class ContactMechanicsBiot(pp.ContactMechanics):
             # from cell center pressure, external boundary and interface flux
             # on internal boundaries (including those corresponding to "other"
             # fractures).
-            interface_flow_eq = (
-                robin_ad.mortar_discr
-                * mortar_proj_scalar.primary_to_mortar_avg
-                * mpfa_ad.bound_pressure_cell
-                * p
-                + robin_ad.mortar_discr
-                * mortar_proj_scalar.primary_to_mortar_avg
-                * mpfa_ad.bound_pressure_face
+            p_primary = (
+                mpfa_ad.bound_pressure_cell * p
+                + mpfa_ad.bound_pressure_face
                 * mortar_proj_scalar.mortar_to_primary_int
                 * mortar_flux
-                + robin_ad.mortar_discr
-                * mortar_proj_scalar.primary_to_mortar_avg
-                * mpfa_ad.bound_pressure_face
-                * bc_val_scalar
-                - robin_ad.mortar_discr * mortar_proj_scalar.secondary_to_mortar_avg * p
+                + mpfa_ad.bound_pressure_face * bc_val_scalar
+            )
+            # Project the two pressures to the interface and equate with \lambda
+            interface_flow_eq = (
+                robin_ad.mortar_discr
+                * (
+                    mortar_proj_scalar.primary_to_mortar_avg * p_primary
+                    - mortar_proj_scalar.secondary_to_mortar_avg * p
+                )
                 + mortar_flux
             )
 

--- a/src/porepy/numerics/ad/discretizations.py
+++ b/src/porepy/numerics/ad/discretizations.py
@@ -288,7 +288,6 @@ class RobinCouplingAd(Discretization):
         self._name = "Robin interface coupling"
         self.keyword = keyword
 
-        self.mortar_scaling: MergedOperator
         self.mortar_discr: MergedOperator
         self.mortar_vector_source: MergedOperator
         wrap_discretization(self, self._discretization, edges=edges)

--- a/src/porepy/numerics/interface_laws/elliptic_interface_laws.py
+++ b/src/porepy/numerics/interface_laws/elliptic_interface_laws.py
@@ -320,7 +320,9 @@ class RobinCoupling(
     ):
         """Actual implementation of assembly. May skip matrix and rhs if specified."""
 
-        matrix_dictionary_edge: Dict[str, sps.spmatrix] = data_edge[pp.DISCRETIZATION_MATRICES][self.keyword]
+        matrix_dictionary_edge: Dict[str, sps.spmatrix] = data_edge[
+            pp.DISCRETIZATION_MATRICES
+        ][self.keyword]
         diffusivity_discr = matrix_dictionary_edge[self.mortar_discr_matrix_key]
         parameter_dictionary_edge = data_edge[pp.PARAMETERS][self.keyword]
         mg = data_edge["mortar_grid"]

--- a/src/porepy/numerics/interface_laws/elliptic_interface_laws.py
+++ b/src/porepy/numerics/interface_laws/elliptic_interface_laws.py
@@ -509,7 +509,9 @@ class RobinCoupling(
             # Scale the equations (this will modify from K^-1 to K scaling if relevant)
 
             for block in range(3):
-                # Scale the pressure blocks in the row of the primary mortar problem.
+                # Scale the pressure blocks in the row of the primary mortar problem,
+                # i.e. the row corresponding to the mortar variable to which the
+                # contributions from the flux of block 2 is being added.
                 # The secondary mortar will be treated somewhere else (handled by the
                 # assembler).
                 cc[1, block] = (

--- a/src/porepy/numerics/interface_laws/elliptic_interface_laws.py
+++ b/src/porepy/numerics/interface_laws/elliptic_interface_laws.py
@@ -22,7 +22,10 @@ class RobinCoupling(
 ):
     """A condition with resistance to flow between subdomains. Implementation
     of the model studied (though not originally proposed) by Martin et
-    al 2005.
+    al 2005. The equation reads
+        \lambda = -\int{\kappa_n [p_l - p_h +  a/2 g \cdot n]} dV,
+    where the last gravity type term is zero by default (controlled by the vector_source
+    parameter).
 
     The class can be used either as pure discretization, or also to do assembly of
     the local (to the interface / mortar grid) linear system. The latter case will
@@ -82,21 +85,6 @@ class RobinCoupling(
         # Keys used to identify the discretization matrices of this discretization
         self.mortar_discr_matrix_key = "robin_mortar_discr"
         self.mortar_vector_source_matrix_key = "robin_vector_source_discr"
-        self.mortar_scaling_matrix_key = "mortar_scaling"
-
-        # Decide on whether to scale the mortar flux with K^-1 or not.
-        # This is the scaling of Darcy's law in mixed methods, and should be used in the
-        # interface law if the full system is on mixed form.
-        # We decide on this based on whether both neigboring discretizations are mixed
-        # or not. This leaves the case when one neighbor is mixed, the other is FV; in
-        # this case, we use a K-scaling, but it is not clear what is best.
-        if isinstance(
-            discr_primary, pp.numerics.vem.dual_elliptic.DualElliptic
-        ) and isinstance(discr_secondary, pp.numerics.vem.dual_elliptic.DualElliptic):
-            self.kinv_scaling = True
-        else:
-            # At least one of the neighboring discretizations is FV.
-            self.kinv_scaling = False
 
     def ndof(self, mg: pp.MortarGrid):
         return mg.num_cells
@@ -129,10 +117,8 @@ class RobinCoupling(
         if not isinstance(kn, np.ndarray):
             kn *= np.ones(mg.num_cells)
 
-        inv_M = sps.diags(1.0 / mg.cell_volumes)
-        inv_k = 1.0 / kn
-        Eta = sps.diags(inv_k)
-        matrix_dictionary_edge[self.mortar_discr_matrix_key] = -inv_M * Eta
+        val: np.ndarray = mg.cell_volumes * kn
+        matrix_dictionary_edge[self.mortar_discr_matrix_key] = -sps.diags(val)
 
         ## Vector source.
         # This contribution is last term of
@@ -206,21 +192,6 @@ class RobinCoupling(
         # On assembly, the outwards normals on the mortars will be multiplied by the
         # interface vector source.
         matrix_dictionary_edge[self.mortar_vector_source_matrix_key] = mortar_normals
-        if self.kinv_scaling:
-            # Use a discretization fit for mixed methods, with a K^-1 scaling of the
-            # mortar flux
-            # In this case, the scaling of the pressure blocks on the mortar rows is
-            # simple.
-            matrix_dictionary_edge[self.mortar_scaling_matrix_key] = sps.diags(
-                np.ones(mg.num_cells)
-            )
-
-        else:
-            # Scale the the mortar equations with K, so that the this becomes a
-            # Darcy-type equation on standard form.
-            matrix_dictionary_edge[self.mortar_scaling_matrix_key] = sps.diags(
-                mg.cell_volumes * kn
-            )
 
     def assemble_matrix(
         self, g_primary, g_secondary, data_primary, data_secondary, data_edge, matrix
@@ -241,9 +212,10 @@ class RobinCoupling(
                     g[ambient_dimension]= -G * rho.
             matrix: original discretization
 
-            The discretization matrices must be included since they will be
-            changed by the imposition of Neumann boundary conditions on the
-            internal boundary in some numerical methods (Read: VEM, RT0)
+        The discretization matrices must be included since they will be changed
+        by the imposition of Neumann boundary conditions on the internal boundary
+        in some numerical methods (Read: VEM, RT0)
+
 
         """
 
@@ -317,9 +289,14 @@ class RobinCoupling(
                     g[ambient_dimension]= -G * rho.
             matrix: original discretization
 
-            The discretization matrices must be included since they will be
-            changed by the imposition of Neumann boundary conditions on the
-            internal boundary in some numerical methods (Read: VEM, RT0)
+        The discretization matrices must be included since they will be changed
+        by the imposition of Neumann boundary conditions on the internal boundary
+        in some numerical methods (Read: VEM, RT0).
+
+        The overall strategy is to first assemble the pressure contributions,
+        then multiply by the mortar discretization (corresponding to -\kappa) and
+        finally add the identity matrix for the interface flux (see equation
+        description above).
         """
         return self._assemble(
             g_primary,
@@ -344,6 +321,7 @@ class RobinCoupling(
         """Actual implementation of assembly. May skip matrix and rhs if specified."""
 
         matrix_dictionary_edge = data_edge[pp.DISCRETIZATION_MATRICES][self.keyword]
+        diffusivity_discr = matrix_dictionary_edge[self.mortar_discr_matrix_key]
         parameter_dictionary_edge = data_edge[pp.PARAMETERS][self.keyword]
         mg = data_edge["mortar_grid"]
 
@@ -376,8 +354,6 @@ class RobinCoupling(
         # The convention, for now, is to put the higher dimensional information
         # in the first column and row in matrix, lower-dimensional in the second
         # and mortar variables in the third
-        if assemble_matrix:
-            cc[2, 2] = matrix_dictionary_edge[self.mortar_discr_matrix_key]
 
         # Assembly of contribution from boundary pressure must be called even if only
         # matrix or rhs must be assembled.
@@ -392,7 +368,6 @@ class RobinCoupling(
             assemble_matrix=assemble_matrix,
             assemble_rhs=assemble_rhs,
         )
-
         if assemble_matrix:
             # Calls only for matrix assembly
             self.discr_primary.assemble_int_bound_flux(
@@ -429,15 +404,16 @@ class RobinCoupling(
 
                 rhs[2] = rhs[2] - vector_source_discr * vector_source
 
-            rhs[2] = matrix_dictionary_edge[self.mortar_scaling_matrix_key] * rhs[2]
+            rhs[2] = diffusivity_discr * rhs[2]
 
         if assemble_matrix:
-            for block in range(cc.shape[1]):
-                # Scale the pressure blocks in the mortar problem
-                cc[2, block] = (
-                    matrix_dictionary_edge[self.mortar_scaling_matrix_key]
-                    * cc[2, block]
-                )
+            for block in range(3):
+                # Scale the pressure contributions in the mortar equation by
+                # normal diffusivity.
+                cc[2, block] = diffusivity_discr * cc[2, block]
+            # Add mortar flux to the interface equation
+            cc[2, 2] += sps.diags(np.ones(data_edge["mortar_grid"].num_cells))
+
             matrix += cc
 
             self.discr_primary.enforce_neumann_int_bound(
@@ -525,23 +501,25 @@ class RobinCoupling(
             ):
                 proj_flux = mg_secondary.mortar_to_secondary_int()
             # Assemble contribution between higher dimensions.
+            # import pdb
+            # pdb.set_trace()
             self.discr_primary.assemble_int_bound_pressure_trace_between_interfaces(
                 g, data_grid, proj_pressure, proj_flux, cc, matrix, rhs
             )
             # Scale the equations (this will modify from K^-1 to K scaling if relevant)
-            for block in range(cc.shape[1]):
+
+            for block in range(3):
                 # Scale the pressure blocks in the row of the primary mortar problem.
                 # The secondary mortar will be treated somewhere else (handled by the
                 # assembler).
                 cc[1, block] = (
-                    matrix_dictionary_edge[self.mortar_scaling_matrix_key]
-                    * cc[1, block]
+                    matrix_dictionary_edge[self.mortar_discr_matrix_key] * cc[1, block]
                 )
         else:
             cc = None
 
         if assemble_rhs:
-            rhs[1] = matrix_dictionary_edge[self.mortar_scaling_matrix_key] * rhs[1]
+            rhs[1] = matrix_dictionary_edge[self.mortar_discr_matrix_key] * rhs[1]
 
         return cc, rhs
 
@@ -920,7 +898,7 @@ class WellCoupling(
 
         # Keys used to identify the discretization matrices of this discretization
         self.well_discr_matrix_key = "well_mortar_discr"
-        self.mortar_vector_source_matrix_key = "well_vector_source_discr"
+        self.well_vector_source_matrix_key = "well_vector_source_discr"
 
     def ndof(self, mg: pp.MortarGrid) -> int:
         return mg.num_cells
@@ -1027,7 +1005,7 @@ class WellCoupling(
 
         # On assembly, the outwards normals on the mortars will be multiplied by the
         # interface vector source.
-        matrix_dictionary_edge[self.mortar_vector_source_matrix_key] = expanded_vectors
+        matrix_dictionary_edge[self.well_vector_source_matrix_key] = expanded_vectors
 
     def assemble_matrix_rhs(
         self,

--- a/src/porepy/numerics/interface_laws/elliptic_interface_laws.py
+++ b/src/porepy/numerics/interface_laws/elliptic_interface_laws.py
@@ -25,7 +25,7 @@ class RobinCoupling(
     al 2005. The equation reads
         \lambda = -\int{\kappa_n [p_l - p_h +  a/2 g \cdot n]} dV,
     where the last gravity type term is zero by default (controlled by the vector_source
-    parameter).
+    parameter). That is, \lambda is an extensive quantity.
 
     The class can be used either as pure discretization, or also to do assembly of
     the local (to the interface / mortar grid) linear system. The latter case will
@@ -214,7 +214,7 @@ class RobinCoupling(
 
         The discretization matrices must be included since they will be changed
         by the imposition of Neumann boundary conditions on the internal boundary
-        in some numerical methods (Read: VEM, RT0)
+        in some numerical methods (Read: VEM, RT0).
 
 
         """
@@ -320,7 +320,7 @@ class RobinCoupling(
     ):
         """Actual implementation of assembly. May skip matrix and rhs if specified."""
 
-        matrix_dictionary_edge = data_edge[pp.DISCRETIZATION_MATRICES][self.keyword]
+        matrix_dictionary_edge: Dict[str, sps.spmatrix] = data_edge[pp.DISCRETIZATION_MATRICES][self.keyword]
         diffusivity_discr = matrix_dictionary_edge[self.mortar_discr_matrix_key]
         parameter_dictionary_edge = data_edge[pp.PARAMETERS][self.keyword]
         mg = data_edge["mortar_grid"]
@@ -501,8 +501,6 @@ class RobinCoupling(
             ):
                 proj_flux = mg_secondary.mortar_to_secondary_int()
             # Assemble contribution between higher dimensions.
-            # import pdb
-            # pdb.set_trace()
             self.discr_primary.assemble_int_bound_pressure_trace_between_interfaces(
                 g, data_grid, proj_pressure, proj_flux, cc, matrix, rhs
             )
@@ -899,8 +897,8 @@ class WellCoupling(
         self.discr_secondary = discr_secondary
 
         # Keys used to identify the discretization matrices of this discretization
-        self.well_discr_matrix_key = "well_mortar_discr"
-        self.well_vector_source_matrix_key = "well_vector_source_discr"
+        self.well_discr_matrix_key: str = "well_mortar_discr"
+        self.well_vector_source_matrix_key: str = "well_vector_source_discr"
 
     def ndof(self, mg: pp.MortarGrid) -> int:
         return mg.num_cells

--- a/test/integration/test_ad_equations.py
+++ b/test/integration/test_ad_equations.py
@@ -109,14 +109,18 @@ def test_md_flow():
     )
     flow_eq = div * flux - projections.mortar_to_secondary_int * lmbda - source
 
-    interface_flux = edge_discr.mortar_scaling * (
-        projections.primary_to_mortar_avg * node_discr.bound_pressure_cell * p
-        + projections.primary_to_mortar_avg
+    interface_flux = (
+        edge_discr.mortar_discr
+        * projections.primary_to_mortar_avg
+        * node_discr.bound_pressure_cell
+        * p
+        + edge_discr.mortar_discr
+        * projections.primary_to_mortar_avg
         * node_discr.bound_pressure_face
         * projections.mortar_to_primary_int
         * lmbda
-        - projections.secondary_to_mortar_avg * p
-        + edge_discr.mortar_discr * lmbda
+        - edge_discr.mortar_discr * projections.secondary_to_mortar_avg * p
+        + lmbda
     )
 
     flow_eq.discretize(gb)

--- a/tutorials/AdFramework.ipynb
+++ b/tutorials/AdFramework.ipynb
@@ -632,9 +632,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "interface_flux_eq = (robin.mortar_scaling * (pressure_trace_from_high - \n",
+    "interface_flux_eq = (robin.mortar_discr * (pressure_trace_from_high - \n",
     "                                                    mortar_proj.secondary_to_mortar_avg * p)\n",
-    "                     + robin.mortar_discr * lmbda)"
+    "                     +  lmbda)"
    ]
   },
   {


### PR DESCRIPTION
The PR removes the k-inv scaling option, which was deemed to cause more confusion than it was worth. 

Now, the Robin condition \lambda = - \kappa * (p_l - p_h) is discretized in the standard FV way by multiplying the pressure contributions by a matrix with diagonal entries -\kappa * mg.cell_volumes.