### PR TITLE
BUG: Error while trying to access the previous iteration of a MergedVariable

### DIFF
--- a/src/porepy/numerics/ad/operators.py
+++ b/src/porepy/numerics/ad/operators.py
@@ -958,9 +958,9 @@ class Variable(Operator):
         """
         ndof = {"cells": self._cells, "faces": self._faces, "nodes": self._nodes}
         if self._is_edge_var:
-            return Variable(self._name, ndof, grids=self.grids, previous_iteration=True)
-        else:
             return Variable(self._name, ndof, edges=self.edges, previous_iteration=True)
+        else:
+            return Variable(self._name, ndof, grids=self.grids, previous_iteration=True)
 
     def __repr__(self) -> str:
         s = (


### PR DESCRIPTION
Small bug while returning the previous iteration state of a `MergedVariable`.  The returned `Variable` was created with the parameter `grids=self.grids` for `self._is_edge_var = True`, and vice versa. This was causing a critical error while trying to create a `merged_variable.previous_iteration()`.