### PR TITLE
Safer distribute_variable method

### DIFF
--- a/src/porepy/numerics/mixed_dim/dof_manager.py
+++ b/src/porepy/numerics/mixed_dim/dof_manager.py
@@ -428,9 +428,11 @@ class DofManager:
             vals = values[dof_ind]
             if additive:
                 if to_iterate:
-                    data[pp.STATE][pp.ITERATE][var] += vals
+                    data[pp.STATE][pp.ITERATE][var] = (
+                        data[pp.STATE][pp.ITERATE][var] + vals
+                    )
                 else:
-                    data[pp.STATE][var] += vals
+                    data[pp.STATE][var] = data[pp.STATE][var] + vals
             else:
                 if to_iterate:
                     # Make a copy of the array to avoid nasty bugs


### PR DESCRIPTION
While pythonic, the += version of additive STATE/ITERATE updating has proven to lead to errors (related to initialization of the values without using deep copies). This PR changes to the slightly uglier and less efficient but far safer d[pp.STATE] = d[pp.STATE] + vals.