### PR TITLE
Remove write vtk

### DIFF
--- a/tutorials/grid_structure.ipynb
+++ b/tutorials/grid_structure.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this tutorial we investigate the PorePy grid structure, and exlain how to access information stored in the grid. "
+    "In this tutorial we investigate the PorePy grid structure, and explain how to access information stored in the grid. "
    ]
   },
   {

--- a/tutorials/grid_structure.ipynb
+++ b/tutorials/grid_structure.ipynb
@@ -374,7 +374,7 @@
    "outputs": [],
    "source": [
     "e = pp.Exporter(g, 'grid')\n",
-    "e.write_vtk()"
+    "e.write_vtu()"
    ]
   },
   {

--- a/tutorials/grid_structure.ipynb
+++ b/tutorials/grid_structure.ipynb
@@ -381,7 +381,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This file can then be accessed by e.g. paraview. Again, see `export_vtk()` for further documentation."
+    "This file can then be accessed by e.g. paraview."
    ]
   },
   {


### PR DESCRIPTION
This PR is intended to improve the tutorial "grid_structure.ipynb" 

* It eliminates a remaining recurrence of  'write_vtk'. Since the 'Exporter' object has no such attribute, it was changed to write_vtu;  
* Since there is no 'export_vtk()' in the source, the comment "Again, see export_vtk() for further documentation." was deleted;
* A typo 'exlain' was fixed.