### PR TITLE
Allow empty lists of lower-dimensional grids and interfaces in Ad framework. Resolves #607

### DIFF
--- a/src/porepy/models/contact_mechanics_model.py
+++ b/src/porepy/models/contact_mechanics_model.py
@@ -57,7 +57,6 @@ class ContactMechanics(AbstractModel):
 
     """
 
-    @pp.time_logger(sections=module_sections)
     def __init__(self, params: Optional[Dict] = None):
 
         super().__init__(params)
@@ -73,7 +72,6 @@ class ContactMechanics(AbstractModel):
         # Terms of the equations
         self.friction_coupling_term: str = "fracture_force_balance"
 
-    @pp.time_logger(sections=module_sections)
     def before_newton_loop(self):
         """Will be run before entering a Newton loop.
         Discretize time-dependent quantities etc.
@@ -81,7 +79,6 @@ class ContactMechanics(AbstractModel):
         self.convergence_status = False
         self._nonlinear_iteration = 0
 
-    @pp.time_logger(sections=module_sections)
     def before_newton_iteration(self) -> None:
         # Re-discretize the nonlinear term
         if self._use_ad:
@@ -92,7 +89,6 @@ class ContactMechanics(AbstractModel):
             )
             self.assembler.discretize(filt=filt)
 
-    @pp.time_logger(sections=module_sections)
     def after_newton_iteration(self, solution_vector: np.ndarray) -> None:
         """
         Extract parts of the solution for current iterate.
@@ -110,7 +106,6 @@ class ContactMechanics(AbstractModel):
             values=solution_vector, additive=self._use_ad, to_iterate=True
         )
 
-    @pp.time_logger(sections=module_sections)
     def after_newton_convergence(
         self, solution: np.ndarray, errors: float, iteration_counter: int
     ) -> None:
@@ -221,7 +216,6 @@ class ContactMechanics(AbstractModel):
 
         return error_mech, converged, diverged
 
-    @pp.time_logger(sections=module_sections)
     def assemble_and_solve_linear_system(self, tol: float) -> np.ndarray:
 
         if self._use_ad:
@@ -238,7 +232,6 @@ class ContactMechanics(AbstractModel):
         else:
             raise NotImplementedError("Not that far yet")
 
-    @pp.time_logger(sections=module_sections)
     def reconstruct_local_displacement_jump(
         self,
         data_edge: Dict,
@@ -274,7 +267,6 @@ class ContactMechanics(AbstractModel):
         u_mortar_local = project_to_local * displacement_jump_global_coord
         return u_mortar_local.reshape((self._Nd, -1), order="F")
 
-    @pp.time_logger(sections=module_sections)
     def reconstruct_stress(self, previous_iterate: bool = False) -> None:
         """
         Compute the stress in the highest-dimensional grid based on the displacement
@@ -335,7 +327,6 @@ class ContactMechanics(AbstractModel):
 
         d[pp.STATE]["stress"] = stress
 
-    @pp.time_logger(sections=module_sections)
     def prepare_simulation(self) -> None:
         """Is run prior to a time-stepping scheme. Use this to initialize
         discretizations, export for visualization, linear solvers etc.
@@ -362,14 +353,12 @@ class ContactMechanics(AbstractModel):
             folder_name=self.params["folder_name"],
         )
 
-    @pp.time_logger(sections=module_sections)
     def after_simulation(self) -> None:
         """Called after a time-dependent problem"""
         pass
 
     # Methods for populating the model etc.
 
-    @pp.time_logger(sections=module_sections)
     def _set_parameters(self) -> None:
         """
         Set the parameters for the simulation.
@@ -415,12 +404,10 @@ class ContactMechanics(AbstractModel):
             mg = d["mortar_grid"]
             pp.initialize_data(mg, d, self.mechanics_parameter_key)
 
-    @pp.time_logger(sections=module_sections)
     def _nd_grid(self) -> pp.Grid:
         """Get the grid of the highest dimension. Assumes self.gb is set."""
         return self.gb.grids_of_dimension(self._Nd)[0]
 
-    @pp.time_logger(sections=module_sections)
     def _bc_type(self, g: pp.Grid) -> pp.BoundaryConditionVectorial:
         """Define type of boundary conditions: Dirichlet on all global boundaries,
         Dirichlet also on fracture faces.
@@ -435,7 +422,6 @@ class ContactMechanics(AbstractModel):
         bc.is_dir[:, frac_face] = True
         return bc
 
-    @pp.time_logger(sections=module_sections)
     def _bc_values(self, g: pp.Grid) -> np.ndarray:
         """Set homogeneous conditions on all boundary faces."""
         # Values for all Nd components, facewise
@@ -444,12 +430,10 @@ class ContactMechanics(AbstractModel):
         values = values.ravel("F")
         return values
 
-    @pp.time_logger(sections=module_sections)
     def _source(self, g: pp.Grid) -> np.ndarray:
         """"""
         return np.zeros(self._Nd * g.num_cells)
 
-    @pp.time_logger(sections=module_sections)
     def _assign_variables(self) -> None:
         """
         Assign variables to the nodes and edges of the grid bucket.
@@ -477,7 +461,6 @@ class ContactMechanics(AbstractModel):
             else:
                 d[pp.PRIMARY_VARIABLES] = {}
 
-    @pp.time_logger(sections=module_sections)
     def _assign_discretizations(self) -> None:
         """
         Assign discretizations to the nodes and edges of the grid bucket.
@@ -527,7 +510,7 @@ class ContactMechanics(AbstractModel):
 
             g_primary: pp.Grid = gb.grids_of_dimension(Nd)[0]
             g_frac: List[pp.Grid] = gb.grids_of_dimension(Nd - 1).tolist()
-            num_frac_cells = np.sum([g.num_cells for g in g_frac])
+            num_frac_cells = int(np.sum([g.num_cells for g in g_frac]))
 
             if len(gb.grids_of_dimension(Nd)) != 1:
                 raise NotImplementedError("This will require further work")
@@ -538,13 +521,17 @@ class ContactMechanics(AbstractModel):
                 grids=grid_list, edges=edge_list, gb=gb, nd=self._Nd
             )
             subdomain_proj = pp.ad.SubdomainProjections(grids=grid_list, nd=self._Nd)
-            tangential_proj_lists = [
-                gb.node_props(
-                    gf, "tangential_normal_projection"
-                ).project_tangential_normal(gf.num_cells)
-                for gf in g_frac
-            ]
-            tangential_proj = pp.ad.Matrix(sps.block_diag(tangential_proj_lists))
+
+            if len(g_frac) > 0:
+                tangential_proj_lists = [
+                    gb.node_props(
+                        gf, "tangential_normal_projection"
+                    ).project_tangential_normal(gf.num_cells)
+                    for gf in g_frac
+                ]
+                tangential_proj = pp.ad.Matrix(sps.block_diag(tangential_proj_lists))
+            else:
+                tangential_proj = pp.ad.Matrix(sps.csr_matrix((0, 0)))
 
             mpsa_ad = mpsa_ad = pp.ad.MpsaAd(self.mechanics_parameter_key, [g_primary])
             bc_ad = pp.ad.BoundaryCondition(
@@ -585,7 +572,6 @@ class ContactMechanics(AbstractModel):
                 * mortar_proj.mortar_to_secondary_avg
                 * mortar_proj.sign_of_mortar_sides
             )
-
             # Contact conditions
             jump_discr = coloumb_ad.displacement * jump_rotate * u_mortar
             tmp = np.ones(num_frac_cells * self._Nd)
@@ -602,19 +588,30 @@ class ContactMechanics(AbstractModel):
 
             # Force balance
             mat = None
-            for _, d in gb.edges():
-                mg: pp.MortarGrid = d["mortar_grid"]
-                if mg.dim < self._Nd - 1:
-                    continue
+            # Special handling of the case with no fractures
+            if len(edge_list) > 0:
+                for _, d in gb.edges():
+                    mg: pp.MortarGrid = d["mortar_grid"]
+                    if mg.dim < self._Nd - 1:
+                        continue
 
-                faces_on_fracture_surface = mg.primary_to_mortar_int().tocsr().indices
-                m = pp.grid_utils.switch_sign_if_inwards_normal(
-                    g_primary, self._Nd, faces_on_fracture_surface
+                    faces_on_fracture_surface = (
+                        mg.primary_to_mortar_int().tocsr().indices
+                    )
+                    m = pp.grid_utils.switch_sign_if_inwards_normal(
+                        g_primary, self._Nd, faces_on_fracture_surface
+                    )
+                    if mat is None:
+                        mat = m
+                    else:
+                        mat += m
+            else:
+                # If no fractures, make the sign switcher into an empty matrix
+                # of the right size (it will be multiplied by zeros at some point
+                # so we might as well kill it off).
+                mat = sps.csr_matrix(
+                    (g_primary.num_faces * self._Nd, g_primary.num_faces * self._Nd)
                 )
-                if mat is None:
-                    mat = m
-                else:
-                    mat += m
 
             sign_switcher = pp.ad.Matrix(mat)
 
@@ -644,13 +641,11 @@ class ContactMechanics(AbstractModel):
 
             self._eq_manager = eq_manager
 
-    @pp.time_logger(sections=module_sections)
     def _set_friction_coefficient(self, g: pp.Grid) -> np.ndarray:
         """The friction coefficient is uniform, and equal to 1."""
         return np.ones(g.num_cells)
 
     # Methods for discretization, numerical issues etc.
-    @pp.time_logger(sections=module_sections)
     def _discretize(self) -> None:
         """Discretize all terms"""
         tic = time.time()
@@ -661,7 +656,6 @@ class ContactMechanics(AbstractModel):
             self.assembler.discretize()
         logger.info("Done. Elapsed time {}".format(time.time() - tic))
 
-    @pp.time_logger(sections=module_sections)
     def _initialize_linear_solver(self) -> None:
         solver: str = self.params.get("linear_solver", "direct")
         if solver == "direct":
@@ -680,7 +674,6 @@ class ContactMechanics(AbstractModel):
         else:
             raise ValueError(f"Unknown linear solver {solver}")
 
-    @pp.time_logger(sections=module_sections)
     def _is_nonlinear_problem(self) -> bool:
         """
         If there is no fracture, the problem is usually linear.

--- a/src/porepy/numerics/ad/_ad_utils.py
+++ b/src/porepy/numerics/ad/_ad_utils.py
@@ -250,6 +250,12 @@ class MergedOperator(operators.Operator):
         # Data structure for matrices
         mat = []
 
+        if len(self.mat_dict_grids) == 0:
+            # The underlying discretization is constructed on an empty grid list, quite
+            # likely on a mixed-dimensional grid containing no mortar grids.
+            # We can return an empty matrix.
+            return sps.csc_matrix((0, 0))
+
         # Loop over all grid-discretization combinations, get hold of the discretization
         # matrix for this grid quantity
         for g in self.mat_dict_grids:

--- a/src/porepy/numerics/ad/discretizations.py
+++ b/src/porepy/numerics/ad/discretizations.py
@@ -182,11 +182,22 @@ class ColoumbContactAd(Discretization):
     def __init__(self, keyword: str, edges: List[Edge]) -> None:
         self.edges = edges
 
-        dim = np.unique([e[0].dim for e in edges])
+        # Special treatment is needed to cover the case when the edge list happens to
+        # be empty.
+        if len(edges) > 0:
+            dim = np.unique([e[0].dim for e in edges])
 
-        low_dim_grids = [e[1] for e in edges]
-        if not dim.size == 1:
-            raise ValueError("Expected unique dimension of grids with contact problems")
+            low_dim_grids = [e[1] for e in edges]
+            if not dim.size == 1:
+                raise ValueError(
+                    "Expected unique dimension of grids with contact problems"
+                )
+        else:
+            # The assigned dimension value should never be used for anything, so we
+            # set a negative value to indicate this (not sure how the parameter is used)
+            # in the real contact discretization.
+            dim = [-1]
+            low_dim_grids = []
 
         self._discretization = pp.ColoumbContact(
             keyword, ambient_dimension=dim[0], discr_h=pp.Mpsa(keyword)

--- a/src/porepy/numerics/ad/forward_mode.py
+++ b/src/porepy/numerics/ad/forward_mode.py
@@ -1,14 +1,9 @@
 import numpy as np
 import scipy.sparse as sps
 
-import porepy as pp
-
 __all__ = ["initAdArrays", "Ad_array"]
 
-module_sections = ["assembly", "numerics"]
 
-
-@pp.time_logger(sections=module_sections)
 def initAdArrays(variables):
     if not isinstance(variables, list):
         try:
@@ -16,7 +11,6 @@ def initAdArrays(variables):
         except AttributeError:
             num_val = 1
         return Ad_array(variables, sps.diags(np.ones(num_val)).tocsc())
-
     num_val = [v.size for v in variables]
     ad_arrays = []
     for i, val in enumerate(variables):
@@ -28,12 +22,10 @@ def initAdArrays(variables):
         # initiate Ad_array
         jac = sps.bmat([jac])
         ad_arrays.append(Ad_array(val, jac))
-
     return ad_arrays
 
 
 class Ad_array:
-    @pp.time_logger(sections=module_sections)
     def __init__(self, val=1.0, jac=0.0):
         self.val = val
         self.jac = jac
@@ -43,7 +35,6 @@ class Ad_array:
         s += f"Jacobian is of size {self.jac.shape} and has {self.jac.data.size} elements"
         return s
 
-    @pp.time_logger(sections=module_sections)
     def __add__(self, other):
         b = _cast(other)
         c = Ad_array()
@@ -51,42 +42,33 @@ class Ad_array:
         c.jac = self.jac + b.jac
         return c
 
-    @pp.time_logger(sections=module_sections)
     def __radd__(self, other):
         return self.__add__(other)
 
-    @pp.time_logger(sections=module_sections)
     def __sub__(self, other):
         b = _cast(other).copy()
         b.val = -b.val
         b.jac = -b.jac
         return self + b
 
-    @pp.time_logger(sections=module_sections)
     def __rsub__(self, other):
         return -self.__sub__(other)
 
-    @pp.time_logger(sections=module_sections)
     def __lt__(self, other):
         return self.val < _cast(other).val
 
-    @pp.time_logger(sections=module_sections)
     def __le__(self, other):
         return self.val <= _cast(other).val
 
-    @pp.time_logger(sections=module_sections)
     def __gt__(self, other):
         return self.val > _cast(other).val
 
-    @pp.time_logger(sections=module_sections)
     def __ge__(self, other):
         return self.val >= _cast(other).val
 
-    @pp.time_logger(sections=module_sections)
     def __eq__(self, other):
         return self.val == _cast(other).val
 
-    @pp.time_logger(sections=module_sections)
     def __mul__(self, other):
         if not isinstance(other, Ad_array):  # other is scalar
             val = self.val * other
@@ -99,7 +81,6 @@ class Ad_array:
             jac = self.diagvec_mul_jac(other.val) + other.diagvec_mul_jac(self.val)
         return Ad_array(val, jac)
 
-    @pp.time_logger(sections=module_sections)
     def __rmul__(self, other):
         if isinstance(other, Ad_array):
             # other is Ad_var, so should have called __mul__
@@ -108,7 +89,6 @@ class Ad_array:
         jac = self._other_mul_jac(other)
         return Ad_array(val, jac)
 
-    @pp.time_logger(sections=module_sections)
     def __pow__(self, other):
         if not isinstance(other, Ad_array):
             val = self.val ** other
@@ -120,33 +100,27 @@ class Ad_array:
             ) + other.diagvec_mul_jac(self.val ** other.val * np.log(self.val))
         return Ad_array(val, jac)
 
-    @pp.time_logger(sections=module_sections)
     def __rpow__(self, other):
         if isinstance(other, Ad_array):
             raise ValueError(
                 "Somthing went horrible wrong, should" "have called __pow__"
             )
-
         val = other ** self.val
         jac = self.diagvec_mul_jac(other ** self.val * np.log(other))
         return Ad_array(val, jac)
 
-    @pp.time_logger(sections=module_sections)
     def __truediv__(self, other):
         return self * other ** -1
 
-    @pp.time_logger(sections=module_sections)
     def __neg__(self):
         b = self.copy()
         b.val = -b.val
         b.jac = -b.jac
         return b
 
-    @pp.time_logger(sections=module_sections)
     def __len__(self):
         return len(self.val)
 
-    @pp.time_logger(sections=module_sections)
     def copy(self):
         b = Ad_array()
         try:
@@ -159,19 +133,16 @@ class Ad_array:
             b.jac = self.jac
         return b
 
-    @pp.time_logger(sections=module_sections)
     def diagvec_mul_jac(self, a):
         try:
             A = sps.diags(a)
         except TypeError:
             A = a
-
         if isinstance(self.jac, np.ndarray):
             return np.array([A * J for J in self.jac])
         else:
             return A * self.jac
 
-    @pp.time_logger(sections=module_sections)
     def jac_mul_diagvec(self, a):
         try:
             A = sps.diags(a)
@@ -182,27 +153,16 @@ class Ad_array:
         else:
             return self.jac * A
 
-    @pp.time_logger(sections=module_sections)
     def full_jac(self):
         return self.jac
 
-    #        return sps.hstack(self.jac[:])
-
-    @pp.time_logger(sections=module_sections)
     def _other_mul_jac(self, other):
         return other * self.jac
 
-    #        return np.array([other * J for J in self.jac])
-
-    @pp.time_logger(sections=module_sections)
     def _jac_mul_other(self, other):
         return self.jac * other
 
 
-#        return np.array([J * other for J in self.jac])
-
-
-@pp.time_logger(sections=module_sections)
 def _cast(variables):
     if isinstance(variables, list):
         out_var = []

--- a/tests/integration/test_contact_mechanics.py
+++ b/tests/integration/test_contact_mechanics.py
@@ -9,6 +9,15 @@ import numpy as np
 import porepy as pp
 
 
+def test_contact_mechanics_model_no_modification():
+    """Test that the raw contact mechanics model with no modifications can be run with
+    no error messages. Failure of this test would signify rather fundamental problems
+    in the model.
+    """
+    model = pp.ContactMechanics({"use_ad": True})
+    pp.run_stationary_model(model, {})
+
+
 class TestContactMechanics(unittest.TestCase):
     def _solve(self, setup):
         pp.run_stationary_model(setup, {"convergence_tol": 1e-10})

--- a/tests/integration/test_contact_mechanics_biot.py
+++ b/tests/integration/test_contact_mechanics_biot.py
@@ -14,6 +14,15 @@ import porepy as pp
 import porepy.models.contact_mechanics_biot_model as model
 
 
+def test_contact_mechanics_model_no_modification():
+    """Test that the raw contact poromechanics model with no modifications can be run with
+    no error messages. Failure of this test would signify rather fundamental problems
+    in the model.
+    """
+    mod = pp.ContactMechanicsBiot({"use_ad": True})
+    pp.run_stationary_model(mod, {})
+
+
 class TestBiot(unittest.TestCase):
     def _solve(self, setup):
         pp.run_time_dependent_model(setup, {})


### PR DESCRIPTION
This PR resolves the issue of the Ad framework dealing with variables, and some other operators, defined on empty lists of grids or interfaces. This also led to several other corrections being needed throughout the Ad framework, mainly of a rather technical sort.

After this PR, the model classes ContactMechanics and ContactMechanicsBiot can be run in Ad modus without modifications (this used not to be the case). Tests are added to verify this.

Also some minor improvements and maintenance along the way.