### PR TITLE
Use optimized storage format for projection matrices

### DIFF
--- a/src/porepy/grids/mortar_grid.py
+++ b/src/porepy/grids/mortar_grid.py
@@ -9,8 +9,6 @@ from scipy import sparse as sps
 
 import porepy as pp
 
-module_sections = ["grids", "gridding"]
-
 
 class MortarSides(Enum):
     # Enum of constants used to identify the grids on each side of the mortar
@@ -54,7 +52,6 @@ class MortarGrid:
 
     """
 
-    @pp.time_logger(sections=module_sections)
     def __init__(
         self,
         dim: int,
@@ -123,7 +120,6 @@ class MortarGrid:
             self._init_projections(primary_secondary, face_duplicate_ind)
             self._set_projections()
 
-    @pp.time_logger(sections=module_sections)
     def __repr__(self) -> str:
         """
         Implementation of __repr__
@@ -151,7 +147,6 @@ class MortarGrid:
 
         return s
 
-    @pp.time_logger(sections=module_sections)
     def __str__(self) -> str:
         """Implementation of __str__"""
         s = (
@@ -163,7 +158,6 @@ class MortarGrid:
         )
         return s
 
-    @pp.time_logger(sections=module_sections)
     def compute_geometry(self) -> None:
         """
         Compute the geometry of the mortar grids.
@@ -186,7 +180,6 @@ class MortarGrid:
 
     ### Methods to update the mortar grid, or the neighboring grids.
 
-    @pp.time_logger(sections=module_sections)
     def update_mortar(
         self, new_side_grids: Dict[MortarSides, pp.Grid], tol: float = None
     ) -> None:
@@ -265,7 +258,6 @@ class MortarGrid:
 
         self._check_mappings()
 
-    @pp.time_logger(sections=module_sections)
     def update_secondary(self, new_g: pp.Grid, tol: float = None) -> None:
         """
         Update the _secondary_to_mortar_int map when the lower dimensional grid is changed.
@@ -320,7 +312,6 @@ class MortarGrid:
 
         self._check_mappings()
 
-    @pp.time_logger(sections=module_sections)
     def update_primary(self, g_new: pp.Grid, g_old: pp.Grid, tol: float = None):
         """
 
@@ -382,7 +373,6 @@ class MortarGrid:
         self._set_projections(secondary=False)
         self._check_mappings()
 
-    @pp.time_logger(sections=module_sections)
     def num_sides(self) -> int:
         """
         Shortcut to compute the number of sides, it has to be 2 or 1.
@@ -392,7 +382,6 @@ class MortarGrid:
         """
         return len(self.side_grids)
 
-    @pp.time_logger(sections=module_sections)
     def project_to_side_grids(
         self,
     ) -> Generator[Tuple[sps.spmatrix, pp.Grid], None, None]:
@@ -420,7 +409,6 @@ class MortarGrid:
             yield proj, grid
 
     ## Methods to construct projection matrices
-    @pp.time_logger(sections=module_sections)
     def primary_to_mortar_int(self, nd: int = 1) -> sps.spmatrix:
         """Project values from faces of primary to the mortar, by summing quantities
         from the primary side.
@@ -442,7 +430,6 @@ class MortarGrid:
         """
         return self._convert_to_vector_variable(self._primary_to_mortar_int, nd)
 
-    @pp.time_logger(sections=module_sections)
     def secondary_to_mortar_int(self, nd: int = 1) -> sps.spmatrix:
         """Project values from cells on the secondary side to the mortar, by
         summing quantities from the secondary side.
@@ -464,7 +451,6 @@ class MortarGrid:
         """
         return self._convert_to_vector_variable(self._secondary_to_mortar_int, nd)
 
-    @pp.time_logger(sections=module_sections)
     def primary_to_mortar_avg(self, nd: int = 1) -> sps.spmatrix:
         """Project values from faces of primary to the mortar, by averaging quantities
         from the primary side.
@@ -487,7 +473,6 @@ class MortarGrid:
         """
         return self._convert_to_vector_variable(self._primary_to_mortar_avg, nd)
 
-    @pp.time_logger(sections=module_sections)
     def secondary_to_mortar_avg(self, nd: int = 1) -> sps.spmatrix:
         """Project values from cells at the secondary to the mortar, by averaging
         quantities from the secondary side.
@@ -509,7 +494,6 @@ class MortarGrid:
         """
         return self._convert_to_vector_variable(self._secondary_to_mortar_avg, nd)
 
-    @pp.time_logger(sections=module_sections)
     def _row_sum_scaling_matrix(self, mat):
         # Helper method to construct projection matrices.
         row_sum = mat.sum(axis=1).A.ravel()
@@ -530,7 +514,6 @@ class MortarGrid:
     # found by taking transposes, and switching average and integration (since we are
     # changing which side we are taking the area relative to.
 
-    @pp.time_logger(sections=module_sections)
     def mortar_to_primary_int(self, nd: int = 1) -> sps.spmatrix:
         """Project values from the mortar to faces of primary, by summing quantities
         from the mortar side.
@@ -552,7 +535,6 @@ class MortarGrid:
         """
         return self._convert_to_vector_variable(self._mortar_to_primary_int, nd)
 
-    @pp.time_logger(sections=module_sections)
     def mortar_to_secondary_int(self, nd: int = 1) -> sps.spmatrix:
         """Project values from the mortar to cells at the secondary, by summing quantities
         from the mortar side.
@@ -575,7 +557,6 @@ class MortarGrid:
         """
         return self._convert_to_vector_variable(self._mortar_to_secondary_int, nd)
 
-    @pp.time_logger(sections=module_sections)
     def mortar_to_primary_avg(self, nd: int = 1) -> sps.spmatrix:
         """Project values from the mortar to faces of primary, by averaging
         quantities from the mortar side.
@@ -598,7 +579,6 @@ class MortarGrid:
         """
         return self._convert_to_vector_variable(self._mortar_to_primary_avg, nd)
 
-    @pp.time_logger(sections=module_sections)
     def mortar_to_secondary_avg(self, nd: int = 1) -> sps.spmatrix:
         """Project values from the mortar to secondary, by averaging quantities from the
         mortar side.
@@ -621,7 +601,6 @@ class MortarGrid:
         """
         return self._convert_to_vector_variable(self._mortar_to_secondary_avg, nd)
 
-    @pp.time_logger(sections=module_sections)
     def _convert_to_vector_variable(
         self, matrix: sps.spmatrix, nd: int
     ) -> sps.spmatrix:
@@ -635,7 +614,6 @@ class MortarGrid:
         else:
             return sps.kron(matrix, sps.eye(nd)).tocsc()
 
-    @pp.time_logger(sections=module_sections)
     def sign_of_mortar_sides(self, nd: int = 1) -> sps.spmatrix:
         """Assign positive or negative weight to the two sides of a mortar grid.
 
@@ -683,14 +661,12 @@ class MortarGrid:
             )
             return sps.dia_matrix((data, 0), shape=(nd * nc, nd * nc))
 
-    @pp.time_logger(sections=module_sections)
     def cell_diameters(self) -> np.ndarray:
         diams = np.empty(self.num_sides(), dtype=object)
         for pos, (_, g) in enumerate(self.side_grids.items()):
             diams[pos] = g.cell_diameters()
         return np.concatenate(diams).ravel()
 
-    @pp.time_logger(sections=module_sections)
     def _check_mappings(self, tol=1e-4) -> None:
         row_sum = self._primary_to_mortar_int.sum(axis=1)
         if not (row_sum.min() > tol):
@@ -700,7 +676,6 @@ class MortarGrid:
         if not (row_sum.min() > tol):
             raise ValueError("Check not satisfied for the secondary grid")
 
-    @pp.time_logger(sections=module_sections)
     def _init_projections(
         self,
         primary_secondary: sps.spmatrix,
@@ -840,7 +815,6 @@ class MortarGrid:
             )
 
 
-@pp.time_logger(sections=module_sections)
 def _split_matrix_1d(g_old: pp.Grid, g_new: pp.Grid, tol: float) -> sps.spmatrix:
     """
     By calling matching grid the function compute the cell mapping between two
@@ -864,7 +838,6 @@ def _split_matrix_1d(g_old: pp.Grid, g_new: pp.Grid, tol: float) -> sps.spmatrix
     return sps.csr_matrix((weights, (new_cells, old_cells)), shape=shape)
 
 
-@pp.time_logger(sections=module_sections)
 def _split_matrix_2d(g_old: pp.Grid, g_new: pp.Grid, tol: float) -> sps.spmatrix:
     """
     By calling matching grid the function compute the cell mapping between two

--- a/src/porepy/numerics/ad/grid_operators.py
+++ b/src/porepy/numerics/ad/grid_operators.py
@@ -87,7 +87,7 @@ class SubdomainProjections(Operator):
             if len(grids) > 0:
                 # A key error will be raised if a grid in g is not known to
                 # self._cell_projection
-                # IMPLEMENTATION NOTE: Use csc format, since the number of rows can
+                # IMPLEMENTATION NOTE: Use csr format, since the number of rows can
                 # be much less than the number of columns.
                 mat = sps.bmat([[self._cell_projection[g].T] for g in grids]).tocsr()
             else:
@@ -153,7 +153,7 @@ class SubdomainProjections(Operator):
             if len(grids) > 0:
                 # A key error will be raised if a grid in grids is not known to
                 # self._face_projection
-                # IMPLEMENTATION NOTE: Use csc format, since the number of rows can
+                # IMPLEMENTATION NOTE: Use csr format, since the number of rows can
                 # be much less than the number of columns.
                 mat = sps.bmat([[self._face_projection[g].T] for g in grids]).tocsr()
             else:

--- a/src/porepy/numerics/ad/grid_operators.py
+++ b/src/porepy/numerics/ad/grid_operators.py
@@ -87,6 +87,8 @@ class SubdomainProjections(Operator):
             if len(grids) > 0:
                 # A key error will be raised if a grid in g is not known to
                 # self._cell_projection
+                # IMPLEMENTATION NOTE: Use csc format, since the number of rows can
+                # be much less than the number of columns.
                 mat = sps.bmat([[self._cell_projection[g].T] for g in grids]).tocsr()
             else:
                 # If the grid list is empty, we project from the full set of cells to
@@ -117,11 +119,13 @@ class SubdomainProjections(Operator):
             if len(grids) > 0:
                 # A key error will be raised if a grid in g is not known to
                 # self._cell_projection
-                mat = sps.bmat([[self._cell_projection[g] for g in grids]]).tocsr()
+                # IMPLEMENTATION NOTE: Use csc format, since the number of columns can
+                # be much less than the number of rows.
+                mat = sps.bmat([[self._cell_projection[g] for g in grids]]).tocsc()
             else:
                 # If the grid list is empty, we project from nothing to the full set of
                 # cells
-                mat = sps.csr_matrix((self._tot_num_cells * self._nd, 0))
+                mat = sps.csc_matrix((self._tot_num_cells * self._nd, 0))
             return pp.ad.Matrix(
                 mat,
                 name="CellProlongation",
@@ -149,6 +153,8 @@ class SubdomainProjections(Operator):
             if len(grids) > 0:
                 # A key error will be raised if a grid in grids is not known to
                 # self._face_projection
+                # IMPLEMENTATION NOTE: Use csc format, since the number of rows can
+                # be much less than the number of columns.
                 mat = sps.bmat([[self._face_projection[g].T] for g in grids]).tocsr()
             else:
                 # If the grid list is empty, we project from the full set of faces to
@@ -179,11 +185,13 @@ class SubdomainProjections(Operator):
             if len(grids) > 0:
                 # A key error will be raised if a grid in grids is not known to
                 # self._face_projection
-                mat = sps.bmat([[self._face_projection[g] for g in grids]]).tocsr()
+                # IMPLEMENTATION NOTE: Use csc format, since the number of columns can
+                # be much less than the number of rows.
+                mat = sps.bmat([[self._face_projection[g] for g in grids]]).tocsc()
             else:
                 # If the grid list is empty, we project from nothing to the full set of
                 # faces
-                mat = sps.csr_matrix((self._tot_num_faces * self._nd, 0))
+                mat = sps.csc_matrix((self._tot_num_faces * self._nd, 0))
             return pp.ad.Matrix(
                 mat,
                 name="FaceProlongation",

--- a/tests/unit/test_grid_refinement.py
+++ b/tests/unit/test_grid_refinement.py
@@ -915,56 +915,12 @@ class TestRefinementMortarGrid(unittest.TestCase):
         for e, d in gb.edges():
 
             mg = d["mortar_grid"]
-            indices_known = np.array([0, 1, 2, 3, 4, 5, 6, 7])
+            indices_known = np.array([28, 29, 30, 31, 36, 37, 38, 39])
             self.assertTrue(
                 np.array_equal(mg.primary_to_mortar_int().indices, indices_known)
             )
 
-            indptr_known = np.array(
-                [
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    1,
-                    2,
-                    3,
-                    4,
-                    4,
-                    4,
-                    4,
-                    4,
-                    5,
-                    6,
-                    7,
-                    8,
-                ]
-            )
+            indptr_known = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8])
             self.assertTrue(
                 np.array_equal(mg.primary_to_mortar_int().indptr, indptr_known)
             )

--- a/tests/unit/test_matrix_operations.py
+++ b/tests/unit/test_matrix_operations.py
@@ -1,4 +1,5 @@
 import unittest
+import pytest
 
 import numpy as np
 import scipy.sparse as sps
@@ -377,6 +378,26 @@ class TestSparseMath(unittest.TestCase):
         value = pp.matrix_operations.csc_matrix_from_blocks(arr, block_size, num_blocks)
 
         self.assertTrue(np.allclose(known, value.toarray()))
+
+
+@pytest.mark.parametrize(
+    "mat", [np.arange(6).reshape((3, 2)), np.arange(6).reshape((2, 3))]
+)
+def test_optimized_storage(mat):
+    # Check that the optimized sparse storage chooses format according to whether the
+    # matrix has more columns or rows or oposite.
+
+    # Convert input matrix to sparse storage. For the moment, the matrix format is chosen
+    # according to the number of rows and columns only, thus the lack of true sparsity
+    # does not matter.
+    A = sps.csc_matrix(mat)
+
+    optimized = pp.matrix_operations.optimized_compressed_storage(A)
+
+    if A.shape[0] > A.shape[1]:
+        assert optimized.getformat() == "csc"
+    else:
+        assert optimized.getformat() == "csr"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Summary
This PR takes care of two issues that were detected while using the Ad framework to solve single phase flow on the field case in the 3d flow benchmark (though using different grid parameters than in the official benchmark setup):

1. The memory consumption in the Ad representation of mortar projections was unexpectedly heavy on memory (several GB).
2. Construction of the same projections took much longer than expected (34s on a reasonably fast computer, for reference the grid has 52 grids, and the 3d grid ended up with ~450K cells).

# Diagnostics
The problem turned out to be the storage format used for the matrix representation of the projections: Depending on the direction of the projection, these can have many more columns than rows (or vice versa) and should be assigned CSC storage (or oposite). 

# Solution
I ended up making a method, `pp.matrix_operations.optimized_compressed_storage()`, that converts a sparse matrix to CSC or CSR, depending on the number of rows and columns. I then used this to force the storage format for all projection matrices in the `MortarGrid` class and the `MortarProjections` in Ad. These changes reduced the construction time to 4s (which is still unexpectedly high, but at least it is better), and essentially removed the memory bottleneck.

I also ensure that the projection matrices in pp.ad.SubdomainProjections use the most suitable storage formate.

# Extended usage?
The storage for sparse matrices is generally not optimized in PorePy, and there sure are cases where a different format would be preferrable. The main impact is however expected for matrices with few elements and substantial differences in the number of rows and columns, while for the moment, there is no reason to reformat matrices that do not fit with this description. As an illustration that these are non-trivial matters, see https://github.com/pmgbergen/porepy/blob/c6e4504f56c09565334de003a5c05e097e33bce9/src/porepy/numerics/ad/grid_operators.py#L346
