### PR TITLE
Fixed missing type transformation in subtraction operator overload of ad.Operator superclass

### DIFF
--- a/src/porepy/numerics/ad/operators.py
+++ b/src/porepy/numerics/ad/operators.py
@@ -536,7 +536,7 @@ class Operator:
         return Operator(tree=Tree(Operation.add, children), name="Addition operator")
 
     def __sub__(self, other):
-        children = [self, other]
+        children = self._parse_other(other)
         return Operator(tree=Tree(Operation.sub, children), name="Subtraction operator")
 
     def __rmul__(self, other):


### PR DESCRIPTION
The subtraction of np.ndarrays and ad.Operator child instances should work now without having to transform them explicitely to ad.Array.

The changed line is now same as in all other operator overloads. Seems like it was simply overlooked earlier.