### PR TITLE
Fix definition of box in AbstractModel

### DIFF
--- a/src/porepy/models/abstract_model.py
+++ b/src/porepy/models/abstract_model.py
@@ -76,7 +76,7 @@ class AbstractModel:
         phys_dims = [1, 1]
         n_cells = [1, 1]
         self.box: Dict = pp.geometry.bounding_box.from_points(
-            np.array([[0, 1], [0, 1]])
+            np.array([[0, 0], phys_dims]).T
         )
         g: pp.Grid = pp.CartGrid(n_cells, phys_dims)
         g.compute_geometry()

--- a/src/porepy/models/abstract_model.py
+++ b/src/porepy/models/abstract_model.py
@@ -76,7 +76,7 @@ class AbstractModel:
         phys_dims = [1, 1]
         n_cells = [1, 1]
         self.box: Dict = pp.geometry.bounding_box.from_points(
-            np.array([[0, 0], phys_dims])
+            np.array([[0, 1], [0, 1]])
         )
         g: pp.Grid = pp.CartGrid(n_cells, phys_dims)
         g.compute_geometry()


### PR DESCRIPTION
In `create_grid` of `AbstractModel`, `box` is defined as bounding box of a point cloud. The point cloud however contained merely the point (0,1) twice. By transposing the definition of the points, or as here, hardcoding the two corner points (0,0) and (1,1), this is fixed, and the box indeed represents the unit sqaure.