### PR TITLE
BLD: Minor change to fetch_external_content.py; point_in_polyhedron test

### DIFF
--- a/fetch_content.py
+++ b/fetch_content.py
@@ -24,14 +24,20 @@ def fetch_polyhedron_file():
     finally:
         # Fetches local porepy installation directory (platform-independent via subprocess)
         command = "pip show porepy"
+        # To understand the logic in the lines below, run the command and have a look at
+        # the output.
         raw_ouput = subprocess.getoutput(command)
         # Drops 'Location: '
         begin = raw_ouput.find("Location:") + 10
-        # Drops end of line
-        end = raw_ouput.find("Requires:") - 1
+        # Drops end of line and also '/src', since we want the file located in the top
+        # directory of PorePy (this subtracting 1 + 4 characters).
+        end = raw_ouput.find("Requires:") - 5
         # Extracts porepy location
         site_packages_directory = raw_ouput[begin:end]
         print("Writing robust_point_in_polyhedron.py in :", site_packages_directory)
+        print(
+            f"If {site_packages_directory} is not in your PYTHONPATH, please move the file or append the PYTHONPATH."
+        )
 
         # Saves file data to local copy (platform-independent via pathlib)
         with open(


### PR DESCRIPTION
Implement the change suggested in #632: point_in_polyhedron file is fetched to the top directory in PorePy. Also, a reminder to check that this directory is in PYTHONPATH is given.

Resolves #632. Could also be a partial fix for #648.

## More information
The previous solution, fetching to `src` directory was unsatisfactory, in that this was unlikely to be (and should not be) in PYTHONPATH.

## Other changes possible
Another option is to place the file somewhere in PYTHONPATH (which we would need to fetch), or let the user choose which directory to use. This is however rather complex and potentially intrusive; in my opinion the suggested approach is better.



## Types of changes

What types of changes does your code introduce to PorePy?

- [x] Bugfix (not really, but closest we get)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Testing (contribution related mainly to testing of existing functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation 
- [x] I have checked that I have not duplicated existing functionality

