### PR TITLE
BUG: Minor fix of __repr__ in Ad divergence

### DIFF
--- a/src/porepy/numerics/ad/grid_operators.py
+++ b/src/porepy/numerics/ad/grid_operators.py
@@ -584,8 +584,8 @@ class Divergence(Operator):
         nf = 0
         nc = 0
         for g in self.grids:
-            nf += g.num_faces * g.dim
-            nc += g.num_cells * g.dim
+            nf += g.num_faces * self.dim
+            nc += g.num_cells * self.dim
         s += f"The total size of the matrix is ({nc}, {nf})\n"
 
         return s


### PR DESCRIPTION
The reported dimension should refer to the dimension of the divergence, not of the grid.

## Proposed changes
Fix an issue where the old version of the code made the `__repr__` method report wrong matrix sizes for the discrete divergence.

## Types of changes

What types of changes does your code introduce to PorePy?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Testing (contribution related mainly to testing of existing functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._
- [ ] I have added tests that prove my fix is effective or that my feature works - not relevant
- [ ] I have added necessary documentation - not relevant 
- [x] I have checked that I have not duplicated existing functionality

