### PR TITLE
BUG: Ad_array divide and power functions special cases.

### DIFF
--- a/tests/unit/test_ad.py
+++ b/tests/unit/test_ad.py
@@ -780,25 +780,29 @@ class AdArrays(unittest.TestCase):
 
     def test_power_advar_scalar(self):
         a = Ad_array(2, 3)
-        b = a ** 2
+        b = a**2
         self.assertTrue(b.val == 4 and b.jac == 12)
 
     def test_power_advar_advar(self):
         a = Ad_array(4, 4)
         b = Ad_array(-8, -12)
-        c = a ** b
+        c = a**b
         jac = -(2 + 3 * np.log(4)) / 16384
-        self.assertTrue(np.allclose(c.val, 4 ** -8) and np.allclose(c.jac, jac))
+        self.assertTrue(np.allclose(c.val, 4**-8) and np.allclose(c.jac, jac))
 
     def test_rpower_advar_scalar(self):
+        # Make an Ad_array with value 2 and derivative 3.
         a = Ad_array(2, 3)
-        b = 2 ** a
+        b = 2**a
         self.assertTrue(b.val == 4 and b.jac == 12 * np.log(2))
+
+        c = 2 ** (-a)
+        self.assertTrue(c.val == 1 / 4 and c.jac == 2 ** (-2) * np.log(2) * (-3))
 
     def test_rpower_advar_vector_scalar(self):
         J = sps.csc_matrix(np.array([[1, 2], [2, 3], [0, 1]]))
         a = Ad_array(np.array([1, 2, 3]), J)
-        b = 3 ** a
+        b = 3**a
         bJac = np.array(
             [
                 [3 * np.log(3) * 1, 3 * np.log(3) * 2],

--- a/tests/unit/test_ad_init.py
+++ b/tests/unit/test_ad_init.py
@@ -1,3 +1,10 @@
+"""Module contains tests of arithmetic operations on forward Ad arrays.
+
+The tests cover initiation of Ad_array (both of single arrays and joint initiation of
+multiple dependent variables). The test also partly cover the arithmetic operations
+implemented for Ad_arrays, e.g., __add__, __sub__, etc., however, coverage of these
+is only partial at the moment.
+"""
 import unittest
 import warnings
 
@@ -11,6 +18,10 @@ warnings.simplefilter("ignore", sps.SparseEfficiencyWarning)
 
 
 class AdInitTest(unittest.TestCase):
+    def _compare(self, arr, known_val, known_jac):
+        self.assertTrue(np.allclose(arr.val, known_val))
+        self.assertTrue(np.allclose(arr.jac.A, known_jac))
+
     def test_add_two_ad_variables_init(self):
         a, b = initAdArrays([np.array(1), np.array(-10)])
         c = a + b
@@ -97,15 +108,6 @@ class AdInitTest(unittest.TestCase):
         self.assertTrue(np.all(z.val == [-1, 20]))
         self.assertTrue(np.all((z.jac == J).A))
 
-    def test_power_advar_advar_init(self):
-        a, b = initAdArrays([np.array(4.0), np.array(-8)])
-
-        c = a ** b
-        jac = np.array([-8 * (4 ** -9), 4 ** -8 * np.log(4)])
-
-        self.assertTrue(np.allclose(c.val, 4 ** -8))
-        self.assertTrue(np.all(np.abs(c.jac.A - jac) < 1e-6))
-
     def test_exp_scalar_times_ad_var(self):
         val = np.array([1, 2, 3])
         J = sps.diags(np.array([1, 1, 1]))
@@ -120,3 +122,117 @@ class AdInitTest(unittest.TestCase):
             np.allclose(b.val, np.exp(c * val)) and np.allclose(b.jac.A, jac.A)
         )
         self.assertTrue(np.all(a.val == [1, 2, 3]) and np.all(a.jac.A == jac_a.A))
+
+    def test_pow(self):
+        # Tests of Ad_array.__pow__()
+
+        # First run an initial test that covers the basic arithmetics of powers.
+        # This is sort of a legacy test.
+        a, b = initAdArrays([np.array(4.0), np.array(-8)])
+
+        c = a**b
+        jac = np.array([-8 * (4**-9), 4**-8 * np.log(4)])
+
+        self.assertTrue(np.allclose(c.val, 4**-8))
+        self.assertTrue(np.all(np.abs(c.jac.A - jac) < 1e-6))
+
+        # Now, systematic tests of arrays with different data formats.
+        # The tests raises Ad arrays to powers of Ad_arrays, numpy arrays and scalars.
+        # Both ints and floats are considered, since the former requires some special
+        # treatment in the implementation of __pow__() (it seems this can be traced back
+        # to the underlying implementation in numpy).
+
+        # Numpy arrays, int and float versions of the same numbers
+        array_int = np.array([2, 3])
+        array_float = np.array([2, 3], dtype=float)
+        # Ad_array versions of the numpy arrays
+        ad_int = initAdArrays(array_int)
+        ad_float = initAdArrays(array_float)
+        # Also some scalars
+        scalar_int = 2
+        scalar_float = 2.0
+
+        # First, raise arrays to the power of positive scalars
+        known_val = np.array([4, 9])
+        # The derivatives will be (x**2)' = 2x
+        known_jac = np.array([[4, 0], [0, 6]])
+        self._compare(ad_int**scalar_int, known_val, known_jac)
+        self._compare(ad_int**scalar_float, known_val, known_jac)
+        self._compare(ad_float**scalar_int, known_val, known_jac)
+        self._compare(ad_float**scalar_float, known_val, known_jac)
+
+        # Raise arrays to the power of negative scalars. This will trigger some special
+        # handling in __pow__().
+        known_val = np.array([1 / 4, 1 / 9])
+        # The derivatives will be (x^-2)' = -2/x^3
+        known_jac = np.array([[-1 / 4, 0], [0, -2 / 27]])
+        self._compare(ad_int ** (-scalar_int), known_val, known_jac)
+        self._compare(ad_int ** (-scalar_float), known_val, known_jac)
+        self._compare(ad_float ** (-scalar_int), known_val, known_jac)
+        self._compare(ad_float ** (-scalar_float), known_val, known_jac)
+
+        # Next raise the Ad arrays to other arrays of positive integers
+        known_val = np.array([4, 27])
+        # The derivatives are of the form n x ^(n-1)
+        known_jac = np.array([[4, 0], [0, 27]])
+        self._compare(ad_int**array_int, known_val, known_jac)
+        self._compare(ad_int**array_float, known_val, known_jac)
+        self._compare(ad_float**array_int, known_val, known_jac)
+        self._compare(ad_float**array_float, known_val, known_jac)
+
+        # Raise an Ad_array to the negative power of numpy arrays
+        # Next raise the Ad arrays to other arrays of positive integers
+        known_val = np.array([1 / 4, 1 / 27])
+        # The derivatives of x^-n = -nx^(-n-1)
+        known_jac = np.array([[-1 / 4, 0], [0, -1 / 27]])
+        self._compare(ad_int ** (-array_int), known_val, known_jac)
+        self._compare(ad_int ** (-array_float), known_val, known_jac)
+        self._compare(ad_float ** (-array_int), known_val, known_jac)
+        self._compare(ad_float ** (-array_float), known_val, known_jac)
+
+        # Finally, raise an array to the power of another array.
+        # For this, create new arrays with coupled derivatives.
+        # Also, test only int-int and float-float combinations (the expected problem
+        # is powers that are negative integers, which is well covered).
+        a_int, b_int = initAdArrays([np.array([2]), np.array([3])])
+        a_float, b_float = initAdArrays([np.array([2]), np.array([3])])
+
+        # First positive powers
+        known_val = np.array([2**3])
+        known_jac = np.array([[3 * 2 ** (3 - 1), 2**3 * np.log(2)]])
+        self._compare(a_int**b_int, known_val, known_jac)
+        self._compare(a_float**b_float, known_val, known_jac)
+
+        # Then negative
+        known_val = np.array([2 ** (-3)])
+        known_jac = np.array([[-3 * 2 ** (-3 - 1), 2 ** (-3) * np.log(2) * (-1)]])
+        self._compare(a_int ** (-b_int), known_val, known_jac)
+        self._compare(a_float ** (-b_float), known_val, known_jac)
+
+    def test_truediv(self):
+        # Tests of Ad_array.__truediv__().
+        # Division, a/b, is implemented as a* (b**-1), and, since numpy has some rules
+        # for not taking negative integer powers, we need to check that various special
+        # cases have beed correctly dealt with.
+
+        val_int = np.array([2])
+        val_float = np.array([4]).astype(float)
+
+        a_int, a_float = initAdArrays([val_int, val_float])
+
+        scalar_int = 2
+        scalar_float = 2.0
+
+        # First combine Ad arrays with scalars
+        self._compare(a_int / scalar_int, np.array([1]), np.array([[1 / 2, 0]]))
+        self._compare(a_int / scalar_float, np.array([1]), np.array([[1 / 2, 0]]))
+
+        # Divide Ad arrays by numpy arrays
+        self._compare(a_int / val_int, np.array([1]), np.array([[1 / 2, 0]]))
+        self._compare(a_int / val_float, np.array([1 / 2]), np.array([[1 / 4, 0]]))
+        self._compare(a_float / val_int, np.array([2]), np.array([[0, 1 / 2]]))
+        self._compare(a_float / val_float, np.array([1]), np.array([[0, 1 / 4]]))
+
+        # Finally, divide two Ad_arrays
+        self._compare(a_int / a_float, np.array([1 / 2]), np.array([[1 / 4, -1 / 8]]))
+        self._compare(a_float / a_int, np.array([2]), np.array([[-1, 1 / 2]]))


### PR DESCRIPTION
Fix issues related to taking `Ad_array`s to negative integer powers. 

## Proposed changes
Raising numpy arrays to negative integer powers is not allowed (no idea why). Fixed this by selective casting to floats when needed.

Also significantly improved test coverage for the relevant functions. As an observation, it took some effort to realize which special cases must be covered etc., indicating that fully dealing with #645 will be a major undertaking just to cover the forward ad part.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Testing (contribution related mainly to testing of existing functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation 
- [x] I have checked that I have not duplicated existing functionality
