### PR TITLE
fix the exporter for the polygon

### DIFF
--- a/src/porepy/viz/exporter.py
+++ b/src/porepy/viz/exporter.py
@@ -628,9 +628,8 @@ class Exporter:
                 # define the type of cell we are currently saving
                 cell_type_raw = "polygon" + str(nodes_loc.shape[1])
 
-                default_type = "polygon"
                 # Map to triangle/quad if relevant, or simple polygon for general cells.
-                cell_type = polygon_map.get(cell_type_raw, default_type)
+                cell_type = polygon_map.get(cell_type_raw, cell_type_raw)
                 # if the cell type is not present, then add it
                 if cell_type not in cell_to_nodes:
                     cell_to_nodes[cell_type] = np.atleast_2d(nodes_loc[0] + pts_pos)
@@ -639,6 +638,7 @@ class Exporter:
                     cell_to_nodes[cell_type] = np.vstack(
                         (cell_to_nodes[cell_type], nodes_loc[0] + pts_pos)
                     )
+
                     cell_id[cell_type] += [cell_pos]
                 cell_pos += 1
 
@@ -650,7 +650,8 @@ class Exporter:
         meshio_cell_id = np.empty(num_block, dtype=object)
 
         for block, (cell_type, cell_block) in enumerate(cell_to_nodes.items()):
-            meshio_cells[block] = meshio.CellBlock(cell_type, cell_block.astype(int))
+            cell_type_ = "polygon" if "polygon" in cell_type else cell_type
+            meshio_cells[block] = meshio.CellBlock(cell_type_, cell_block.astype(int))
             meshio_cell_id[block] = np.array(cell_id[cell_type])
 
         return meshio_pts, meshio_cells, meshio_cell_id

--- a/src/porepy/viz/exporter.py
+++ b/src/porepy/viz/exporter.py
@@ -650,6 +650,8 @@ class Exporter:
         meshio_cell_id = np.empty(num_block, dtype=object)
 
         for block, (cell_type, cell_block) in enumerate(cell_to_nodes.items()):
+            # remove the number of nodes associated to the polygon since meshio requires only
+            # the keyword "polygon" for polygons
             cell_type_ = "polygon" if "polygon" in cell_type else cell_type
             meshio_cells[block] = meshio.CellBlock(cell_type_, cell_block.astype(int))
             meshio_cell_id[block] = np.array(cell_id[cell_type])


### PR DESCRIPTION
## Proposed changes

Bug fix, the current version of pp fails the exporting to vtk in presence of polygonal 2d cells with different number of cell to node relation.

## Types of changes

What types of changes does your code introduce to PorePy?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Testing (contribution related mainly to testing of existing functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation 
- [X] I have checked that I have not duplicated existing functionality

## Further comments

Not sure if the exporter is really tested in pp, which is the reason why I didn't put the first X in the checklist