### PR TITLE
Speed improvements for MPFA

### DIFF
--- a/src/porepy/geometry/geometry_property_checks.py
+++ b/src/porepy/geometry/geometry_property_checks.py
@@ -333,14 +333,15 @@ def points_are_planar(pts, normal=None, tol=1e-5):
     else:
         normal = normal.flatten() / np.linalg.norm(normal)
 
-    check_all = np.zeros(pts.shape[1] - 1, dtype=bool)
-
-    for idx, p in enumerate(pts[:, 1:].T):
-        den = np.linalg.norm(pts[:, 0] - p)
-        dotprod = np.dot(normal, (pts[:, 0] - p) / (den if den else 1))
-        check_all[idx] = np.isclose(dotprod, 0, atol=tol, rtol=0)
-
-    return np.all(check_all)
+    # Force normal vector to be a column vector
+    normal = normal.reshape((-1, 1))
+    # Mean point in the point cloud
+    cp = np.mean(pts, axis=1).reshape((-1, 1))
+    # Dot product between the normal vector and the vector from the center point to the
+    # individual points
+    dot_prod = np.linalg.norm(np.sum(normal * (pts - cp), axis=0))
+    # The points are planar if all the dot products are essentially zero.
+    return np.all(np.isclose(dot_prod, 0, atol=tol, rtol=0))
 
 
 def point_in_cell(poly, p, if_make_planar=True):

--- a/src/porepy/grids/partition.py
+++ b/src/porepy/grids/partition.py
@@ -43,6 +43,8 @@ def partition_metis(g: pp.Grid, num_part: int) -> np.ndarray:
 
     # Connection map between cells
     c2c = g.cell_connection_map()
+    # Enforce csr. This should be the case anyhow, but better safe than sorry.
+    c2c = c2c.tocsr()
 
     # Convert the cells into the format required by pymetis
     indptr = c2c.indptr

--- a/src/porepy/grids/partition.py
+++ b/src/porepy/grids/partition.py
@@ -45,7 +45,10 @@ def partition_metis(g: pp.Grid, num_part: int) -> np.ndarray:
     c2c = g.cell_connection_map()
 
     # Convert the cells into the format required by pymetis
-    adjacency_list = [list(c2c.getrow(i).indices) for i in range(c2c.shape[0])]
+    indptr = c2c.indptr
+    adjacency_list = [
+        c2c.indices[indptr[i] : indptr[i + 1]].tolist() for i in range(c2c.shape[0])
+    ]
     # Call pymetis
     # It seems it is important that num_part is an int, not an int.
     part = pymetis.part_graph(int(num_part), adjacency=adjacency_list)

--- a/src/porepy/numerics/fv/fvutils.py
+++ b/src/porepy/numerics/fv/fvutils.py
@@ -847,7 +847,7 @@ class ExcludeBoundaries(object):
             [[0, 1, 0, 0],
               [0, 0, 0, 1]]
         """
-        col = np.argwhere([not it for it in ids])
+        col = np.argwhere(np.logical_not(ids))
         row = np.arange(col.size)
         return sps.coo_matrix(
             (np.ones(row.size, dtype=bool), (row, col.ravel("C"))),

--- a/src/porepy/numerics/linalg/matrix_operations.py
+++ b/src/porepy/numerics/linalg/matrix_operations.py
@@ -7,7 +7,6 @@ import numpy as np
 import scipy.sparse as sps
 from typing_extensions import Literal
 
-import porepy as pp
 from porepy.utils.mcolon import mcolon
 
 

--- a/src/porepy/numerics/linalg/matrix_operations.py
+++ b/src/porepy/numerics/linalg/matrix_operations.py
@@ -621,7 +621,7 @@ def invert_diagonal_blocks(
             matrix is formed, the inverse is computed using numpy (which again will
             invoke LAPACK), and the inverse is stored in an (raveled) array. The most
             complex part of the code is the formation of the local matrix: Since the
-            original matrix is be sparse, there may be zero elements in the blocks
+            original matrix is sparse, there may be zero elements in the blocks
             which may not be explicitly represented in the data, and the order of the
             columns in the sparse format may not be linear. To deal with this, we do a
             double loop to fill in the local matrix.

--- a/src/porepy/numerics/linalg/matrix_operations.py
+++ b/src/porepy/numerics/linalg/matrix_operations.py
@@ -4,10 +4,10 @@ module for operations on sparse matrices
 from typing import Optional, Tuple, Union
 
 import numpy as np
-import porepy as pp
 import scipy.sparse as sps
 from typing_extensions import Literal
 
+import porepy as pp
 from porepy.utils.mcolon import mcolon
 
 

--- a/src/porepy/numerics/linalg/matrix_operations.py
+++ b/src/porepy/numerics/linalg/matrix_operations.py
@@ -4,6 +4,7 @@ module for operations on sparse matrices
 from typing import Optional, Tuple, Union
 
 import numpy as np
+import porepy as pp
 import scipy.sparse as sps
 from typing_extensions import Literal
 
@@ -580,7 +581,7 @@ def invert_diagonal_blocks(
             p2 = p2 + n2
         return v
 
-    def invert_diagonal_blocks_numba(a: sps.spmatrix, size: np.ndarray) -> np.ndarray:
+    def invert_diagonal_blocks_numba(a: sps.csr_matrix, size: np.ndarray) -> np.ndarray:
         """
         Invert block diagonal matrix by invoking numba acceleration of a simple
         for-loop based algorithm.
@@ -608,22 +609,33 @@ def invert_diagonal_blocks(
         dat = a.data
 
         # Just in time compilation
-        @numba.jit("f8[:](i4[:],i4[:],f8[:],i8[:])", nopython=True, cache=True)
+        @numba.njit("f8[:](i4[:],i4[:],f8[:],i8[:])", cache=True, parallel=True)
         def inv_python(indptr, ind, data, sz):
             """
             Invert block matrices by explicitly forming local matrices. The code
             in itself is not efficient, but it is hopefully well suited for
             speeding up with numba.
 
-            It may be possible to restructure the code to further help numba,
-            this has not been investigated.
+            IMPLEMENTATION NOTES BELOW
 
-            The computation can easily be parallelized, consider this later.
+            The code consists of a loop over the blocks. For each block, a local square
+            matrix is formed, the inverse is computed using numpy (which again will
+            invoke LAPACK), and the inverse is stored in an (raveled) array. The most
+            complex part of the code is the formation of the local matrix: Since the
+            original matrix is be sparse, there may be zero elements in the blocks
+            which may not be explicitly represented in the data, and the order of the
+            columns in the sparse format may not be linear. To deal with this, we do a
+            double loop to fill in the local matrix.
+
+            Profiling (June 2022) showed that the overhead in filling in the local
+            matrix by for-loops was minimal; specifically, attempts at speeding up the
+            computations by forcing a full block structure of the matrices (with
+            explicit zeros and linear ordering of columns), so that the local matrix
+            could be formed by a reshape, failed.
+
             """
 
             # Index of where the rows start for each block.
-            # block_row_starts_ind = np.hstack((np.array([0]),
-            #                                   np.cumsum(sz[:-1])))
             block_row_starts_ind = np.zeros(sz.size, dtype=np.int32)
             block_row_starts_ind[1:] = np.cumsum(sz[:-1])
 
@@ -631,25 +643,27 @@ def invert_diagonal_blocks(
             # next
             num_cols_per_row = indptr[1:] - indptr[0:-1]
             # Index to where the columns start for each row (NOT blocks)
-            # row_cols_start_ind = np.hstack((np.zeros(1),
-            #                                 np.cumsum(num_cols_per_row)))
             row_cols_start_ind = np.zeros(num_cols_per_row.size + 1, dtype=np.int32)
             row_cols_start_ind[1:] = np.cumsum(num_cols_per_row)
 
             # Index to where the (full) data starts. Needed, since the
             # inverse matrix will generally be full
-            # full_block_starts_ind = np.hstack((np.array([0]),
-            #                                    np.cumsum(np.square(sz))))
             full_block_starts_ind = np.zeros(sz.size + 1, dtype=np.int32)
             full_block_starts_ind[1:] = np.cumsum(np.square(sz))
             # Structure to store the solution
             inv_vals = np.zeros(np.sum(np.square(sz)))
 
-            # Loop over all blocks
-            for iter1 in range(sz.size):
+            # Loop over all blocks. Do this in parallel, this has shown significant
+            # speedups by numba.
+            for iter1 in numba.prange(sz.size):
                 n = sz[iter1]
+
                 loc_mat = np.zeros((n, n))
                 # Fill in non-zero elements in local matrix
+                # This requires some work, since not all elements in the local matrix
+                # are represented in the data array (elements may be zero). Also, the
+                # ordering of the data may not correspond to a linear ordering of the
+                # columns.
                 for iter2 in range(n):  # Local rows
                     global_row = block_row_starts_ind[iter1] + iter2
                     data_counter = row_cols_start_ind[global_row]
@@ -662,16 +676,16 @@ def invert_diagonal_blocks(
                         loc_col = ind[data_counter] - block_row_starts_ind[iter1]
                         loc_mat[iter2, loc_col] = data[data_counter]
                         data_counter += 1
-                # Compute inverse. np.linalg.inv is supported by numba (May
-                # 2016), it is not clear if this is the best option. To be
-                # revised
+                # Compute inverse using np.linalg.inv, which will again invoke an
+                # appropriate lapack function.
                 inv_mat = np.ravel(np.linalg.inv(loc_mat))
 
+                # Store data in the output
                 loc_ind = np.arange(
                     full_block_starts_ind[iter1], full_block_starts_ind[iter1 + 1]
                 )
                 inv_vals[loc_ind] = inv_mat
-                # Update fields
+
             return inv_vals
 
         v = inv_python(ptr, indices, dat, size)


### PR DESCRIPTION
## Proposed changes
This PR contains several improvements that speed up MPFA discretization (will have a positive effect on MPSA as well). There are no changes to code functionality. 

To summarize:
* Inversion of block matrices, at the core of MPXA discretizations, now uses parallelized numba. This leads to significant speedup of discretization.
* In Mpfa, slight reorganizations of the code (mainly, avoiding to compute the same matrix-matrix products over again) lead to further savings. NOTE: Similar changes have already been done in MPSA, but we might want to revisit that code and see if there are more easy pickings.
* In grid partitioning, a bottleneck in preprocessing before calling metis was essentially removed.
* Improved and modernized other parts of the code that gave minor performance enhancements.

To quantify the changes, anecdotally, I see a >50% reduction of discretization time on the 3d flow benchmark with a regular geometry on my system (this is likely dependent on a host of other factors, but the gains are real and substantial). My expectation is that quite a bit of this will carry over to MPSA.

## Types of changes

What types of changes does your code introduce to PorePy?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] General maintenance / improvements of the code
- [ ] Testing (contribution related mainly to testing of existing functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._
- [ ] I have added tests that prove my fix is effective or that my feature works : NOT RELEVANT
- [x] I have added necessary documentation 
- [x] I have checked that I have not duplicated existing functionality

## Further comments
* A significant part of the remaining MPFA cost (~30%) relates to the vector source discretization. We should consider to make it possible to opt out of this.
* I also tested various ways of further speeding up the block inversion, but got no gains. It seems this code is as efficient as we can get it now, the main cost is in the actual inversion as implemented by lapack, which essentially is irreducible.
* Under testing, I observed that the block inversion can speed up significantly (again >50%, perhaps much more) by using numpy compiled with MKL, rather than the precompiled version from pip (conda install may be much better here, since it is already compiled with MKL).