### PR TITLE
Pypardiso default

### DIFF
--- a/src/porepy/models/abstract_model.py
+++ b/src/porepy/models/abstract_model.py
@@ -255,18 +255,18 @@ class AbstractModel:
         t_1 = time.time()
         logger.debug(f"Max element in A {np.max(np.abs(A)):.2e}")
         logger.debug(
-            f"Max {np.max(np.sum(np.abs(A), axis=1)):.2e} and min"
-            + f" {np.min(np.sum(np.abs(A), axis=1)):.2e} A sum."
+            f"""Max {np.max(np.sum(np.abs(A), axis=1)):.2e} and min
+            {np.min(np.sum(np.abs(A), axis=1)):.2e} A sum."""
         )
 
         solver = self.params["linear_solver"]
         if solver == "pypardiso":
             try:
-                from pypardiso import spsolve as sparse_solver
+                from pypardiso import spsolve as sparse_solver  # type: ignore
             except ImportError:
                 sparse_solver = sps.linalg.spsolve
                 warnings.warn(
-                    """Pypardiso could not be imported, 
+                    """PyPardiso could not be imported, 
                     falling back on scipy.sparse.linalg.spsolve"""
                 )
             x = sparse_solver(A, b)

--- a/src/porepy/models/abstract_model.py
+++ b/src/porepy/models/abstract_model.py
@@ -221,8 +221,8 @@ class AbstractModel:
         Raises:
             ValueError if the chosen solver is not among the three currently
             supported, see assemble_and_solve_linear_system.
-            
-            To use a custom solver in a model, override this method (and 
+
+            To use a custom solver in a model, override this method (and
             assemble_and_solve_linear_system).
 
         """
@@ -236,7 +236,7 @@ class AbstractModel:
         """Assemble the linearized system, solve and return the new solution vector.
 
         The linear system is defined by the current state of the model.
-        
+
         The linear solver is set according to the parameter 'linear_solver' set under
         initialization of this model.
 

--- a/src/porepy/models/abstract_model.py
+++ b/src/porepy/models/abstract_model.py
@@ -266,7 +266,7 @@ class AbstractModel:
             except ImportError:
                 sparse_solver = sps.linalg.spsolve
                 warnings.warn(
-                    """PyPardiso could not be imported, 
+                    """PyPardiso could not be imported,
                     falling back on scipy.sparse.linalg.spsolve"""
                 )
             x = sparse_solver(A, b)

--- a/src/porepy/models/contact_mechanics_model.py
+++ b/src/porepy/models/contact_mechanics_model.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import logging
 import time
-import warnings
 from functools import partial
 from typing import Any, Dict, List, Optional, Tuple
 


### PR DESCRIPTION
## Proposed changes

The default linear solver in the models is now PyPardiso's sparse solver. 
The methods _initialize_linear_solver and assemble_and_solve were moved from ContactMechanics to AbstractModel (which is more of a base than abstract class).

## Types of changes

What types of changes does your code introduce to PorePy?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Testing (contribution related mainly to testing of existing functionality)
- [ ] Documentation update (if none of the other choices apply)
- [x] Other: Change default

## Checklist

_Enter one &check; (`&check;`) in each row. The table can be updated after creating the PR._

||Yes|No|NA|
|---|---|---|---|
|The update is covered by the  test suite |&check;|_|_|
|The documentation is up-to-date |&check;|_|_|
|I have not duplicated existing functionality |&check;|_|_|

