### PR TITLE
ENH: Linear solver

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ from os.path import basename, splitext
 
 from setuptools import find_packages, setup
 
+
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 

--- a/src/porepy/models/abstract_model.py
+++ b/src/porepy/models/abstract_model.py
@@ -260,7 +260,7 @@ class AbstractModel:
             {np.min(np.sum(np.abs(A), axis=1)):.2e} A sum."""
         )
 
-        solver = self.params["linear_solver"]
+        solver = self.linear_solver
         if solver == "pypardiso":
             # This is the default option which is invoked unless explicitly overriden by the
             # user. We need to check if the pypardiso package is available.
@@ -290,7 +290,7 @@ class AbstractModel:
             f"Assembled and solved in {t_1-t_0:.2e} and {t_2-t_1:.2e} seconds, respectively."
         )
 
-        return x
+        return np.atleast_1d(x)
 
     @abc.abstractmethod
     def _is_nonlinear_problem(self) -> bool:

--- a/src/porepy/models/incompressible_flow_model.py
+++ b/src/porepy/models/incompressible_flow_model.py
@@ -8,7 +8,6 @@ import time
 from typing import Dict, List, Optional, Union
 
 import numpy as np
-import scipy.sparse as sps
 
 import porepy as pp
 
@@ -84,6 +83,7 @@ class IncompressibleFlow(pp.models.abstract_model.AbstractModel):
 
         self._export()
         self._discretize()
+        self._initialize_linear_solver()
 
     def _set_parameters(self) -> None:
         """Set default (unitary/zero) parameters for the flow problem.
@@ -399,19 +399,6 @@ class IncompressibleFlow(pp.models.abstract_model.AbstractModel):
         )
         flux.set_name("Fluid flux")
         return flux
-
-    def assemble_and_solve_linear_system(self, tol: float) -> np.ndarray:
-        """Use a direct solver for the linear system."""
-        A, b = self._eq_manager.assemble()
-        logger.debug(f"Max element in A {np.max(np.abs(A)):.2e}")
-        logger.debug(
-            f"Max {np.max(np.sum(np.abs(A), axis=1)):.2e} and min"
-            + f" {np.min(np.sum(np.abs(A), axis=1)):.2e} A sum."
-        )
-        tic = time.time()
-        x = sps.linalg.spsolve(A, b)
-        logger.info("Solved linear system in {} seconds".format(time.time() - tic))
-        return x
 
     def _discretize(self) -> None:
         """Discretize all terms"""

--- a/tests/unit/test_tag.py
+++ b/tests/unit/test_tag.py
@@ -854,7 +854,7 @@ class BasicsTest(unittest.TestCase):
                 self.assertTrue(np.array_equal(computed, known))
                 known = [10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
                 computed = np.where(sd.tags["fracture_nodes"])[0]
-                
+
                 self.assertTrue(np.array_equal(computed, known))
                 self.assertTrue(
                     np.array_equal(sd.tags["tip_faces"], [False] * sd.num_faces)


### PR DESCRIPTION

## Proposed changes

* Make IncompressibleFlowModel use AbstractModel's assemble and solve method instead of overwriting. 
* In assemble_and_solve, we use attribute self.linear_solver to identify the linear solver instead of self.params["linear_solver"]. The attribute is set in _initilaize_linear_solver.


## Types of changes

What types of changes does your code introduce to PorePy?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Testing (contribution related mainly to testing of existing functionality)
- [ ] Documentation update (if none of the other choices apply)
- [ ] Other: 

## Checklist

_Enter one &check; (`&check;`) in each row. The table can be updated after creating the PR._

||Yes|No|NA|
|---|---|---|---|
|The update is covered by the  test suite |&check;|_|_|
|The documentation is up-to-date |&check;|_|_|
|I have not duplicated existing functionality (on the contrary!) |&check;|_|_|

