### PR TITLE
BUG: Correct addressing time steps for exported constant data (append…

### DIFF
--- a/src/porepy/viz/exporter.py
+++ b/src/porepy/viz/exporter.py
@@ -164,7 +164,7 @@ class Exporter:
         self._exported_timesteps: list[int] = []
 
         # Reference to the last time step used for exporting constant data.
-        self._latest_time_step_constant_data: Optional[int] = None
+        self._time_step_constant_data: Optional[int] = None
         # Storage for file name extensions for time steps, regarding constant data.
         self._exported_timesteps_constants: list[int] = list()
         # Identifier for whether constant data is up-to-date.
@@ -314,7 +314,11 @@ class Exporter:
 
                 # Store the time step counter for later reference
                 # (required for pvd files)
-                self._latest_time_step_constant_data = time_step
+                # NOTE: The counter is only updated if the constant
+                # data is outdated, so if the mesh has been updated
+                # or new constant data has been added in the course
+                # of the simulation.
+                self._time_step_constant_data = time_step
 
                 # Identify the constant data as fixed. Has the effect
                 # that the constant data won't be exported if not the
@@ -322,10 +326,10 @@ class Exporter:
                 self._exported_constant_data_up_to_date = True
 
             # Store the timestep referring to the origin of the constant data
-            if hasattr(self, "_latest_time_step_constant_data"):
-                if self._latest_time_step_constant_data is not None:
+            if hasattr(self, "_time_step_constant_data"):
+                if self._time_step_constant_data is not None:
                     self._exported_timesteps_constants.append(
-                        self._latest_time_step_constant_data
+                        self._time_step_constant_data
                     )
         else:
             # Append constant subdomain and interface data to the
@@ -1139,7 +1143,7 @@ class Exporter:
                         fm
                         % self._make_file_name(
                             self._file_name + "_constant",
-                            self._latest_time_step_constant_data,
+                            self._time_step_constant_data,
                             dim,
                         )
                     )
@@ -1154,7 +1158,7 @@ class Exporter:
                         fm
                         % self._make_file_name(
                             self._file_name + "_constant_mortar",
-                            self._latest_time_step_constant_data,
+                            self._time_step_constant_data,
                             dim,
                         )
                     )

--- a/src/porepy/viz/exporter.py
+++ b/src/porepy/viz/exporter.py
@@ -164,7 +164,7 @@ class Exporter:
         self._exported_timesteps: list[int] = []
 
         # Reference to the last time step used for exporting constant data.
-        self._time_step_constants: int = 0
+        self._latest_time_step_constant_data: Optional[int] = None
         # Storage for file name extensions for time steps, regarding constant data.
         self._exported_timesteps_constants: list[int] = list()
         # Identifier for whether constant data is up-to-date.
@@ -314,7 +314,7 @@ class Exporter:
 
                 # Store the time step counter for later reference
                 # (required for pvd files)
-                self._time_step_constant_data = time_step
+                self._latest_time_step_constant_data = time_step
 
                 # Identify the constant data as fixed. Has the effect
                 # that the constant data won't be exported if not the
@@ -322,10 +322,10 @@ class Exporter:
                 self._exported_constant_data_up_to_date = True
 
             # Store the timestep referring to the origin of the constant data
-            if hasattr(self, "_time_step_constant_data"):
-                if self._time_step_constant_data is not None:
+            if hasattr(self, "_latest_time_step_constant_data"):
+                if self._latest_time_step_constant_data is not None:
                     self._exported_timesteps_constants.append(
-                        self._time_step_constant_data
+                        self._latest_time_step_constant_data
                     )
         else:
             # Append constant subdomain and interface data to the
@@ -1139,7 +1139,7 @@ class Exporter:
                         fm
                         % self._make_file_name(
                             self._file_name + "_constant",
-                            self._time_step_constants,
+                            self._latest_time_step_constant_data,
                             dim,
                         )
                     )
@@ -1154,7 +1154,7 @@ class Exporter:
                         fm
                         % self._make_file_name(
                             self._file_name + "_constant_mortar",
-                            self._time_step_constants,
+                            self._latest_time_step_constant_data,
                             dim,
                         )
                     )


### PR DESCRIPTION
## Proposed changes

When exporting constant data to separate files, the automatically created pvd file addressed the corresponding vtu files wrongly. The reason was the wrong use of the appendix responsible for the latest time step for which the constant data was exported. This error most likely only appeared for time-indepent simulations, e.g., when running the tutorial `meshing_of_fractures.` This bug has been fixed with this PR.

## Types of changes

What types of changes does your code introduce to PorePy?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Testing (contribution related mainly to testing of existing functionality)
- [ ] Documentation update (if none of the other choices apply)
- [ ] Other: 

## Checklist

_Enter one &check; (`&check;`) in each row. The table can be updated after creating the PR._

||Yes|No|NA|
|---|---|---|---|
|The update is covered by the  test suite |X|_|_|
|The documentation is up-to-date |X|_|_|
|I have not duplicated existing functionality |X|_|_|
