### PR TITLE
BLD: separate reqs and reqs-dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,7 @@ jobs:
         pip install -U pip
         # Install requirements, using eager updates to avoid stalled dependencies due to caching
         # https://blog.allenai.org/python-caching-in-github-actions-e9452698e98d
+        pip install --upgrade --upgrade-strategy eager -r requirements.txt
         pip install --upgrade --upgrade-strategy eager -r requirements-dev.txt
         pip install .
         pip freeze

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,15 +69,21 @@ jobs:
         sudo apt-get install libglu1-mesa libgeos-dev
         export LD_LIBRARY_PATH=/usr/local/lib64/:$LD_LIBRARY_PATH
 
-    - name: Install PorePy
+    - name: Install requirements
       run: |
         pip install -U pip
         # Install requirements, using eager updates to avoid stalled dependencies due to caching
         # https://blog.allenai.org/python-caching-in-github-actions-e9452698e98d
         pip install --upgrade --upgrade-strategy eager -r requirements.txt
-        pip install --upgrade --upgrade-strategy eager -r requirements-dev.txt
+
+    - name: Install requirements-dev
+      run: |
+        pip install --upgrade --upgrade-strategy eager -r requirements-dev.txt        
+
+    - name: Install PorePy
+      run: |
         pip install .
-        pip freeze
+        pip freeze       
 
     - name: black
       if: ${{ always() }}

--- a/dockerfiles/base/Dockerfile
+++ b/dockerfiles/base/Dockerfile
@@ -86,7 +86,8 @@ RUN conda config --add channels conda-forge
 # is not too big)
 ENV TMP_DIR /tmp
 WORKDIR ${TMP_DIR}
-RUN wget https://raw.githubusercontent.com/pmgbergen/porepy/develop/requirements-dev.txt
+RUN wget https://raw.githubusercontent.com/pmgbergen/porepy/develop/requirements.txt && \
+    wget https://raw.githubusercontent.com/pmgbergen/porepy/develop/requirements-dev.txt
 
 # For some reason, which is completely incomprehenible to EK, the conda install
 # of gmsh fails: Conda will list it as being installed, but 'import gmsh' in python
@@ -94,7 +95,7 @@ RUN wget https://raw.githubusercontent.com/pmgbergen/porepy/develop/requirements
 # since updates like 'conda update --all' will not update all packages, likely contrary
 # to the user's expectation, but it will have to do.
 # Remove gmsh from the list of requirements for PorePy.
-RUN sed -i '/gmsh/d' requirements-dev.txt 
+RUN sed -i '/gmsh/d' requirements.txt 
 
 # Activating the conda environment inside the Docker container is
 # not straightforward, since every RUN command is executed in a separate
@@ -104,7 +105,7 @@ SHELL ["conda", "run", "-n", "pp_env", "/bin/bash", "-c"]
 RUN conda env list
 
 # Install all requirements
-RUN conda install -c conda-forge --file requirements-dev.txt
+RUN conda install -c conda-forge --file requirements.txt --file requirements-dev.txt
 
 # Pip install gmsh, since we skipped it from the conda install
 RUN pip install gmsh

--- a/dockerfiles/base/Dockerfile
+++ b/dockerfiles/base/Dockerfile
@@ -2,7 +2,7 @@
 # instead, use the stable or development versions.
 # To build:
 #
-#    docker build . --tag porepy
+#    docker build  --tag porepy --file dockerfiles/base/Dockerfile .
 #
 # To run (sharing the current directory with the container)
 #
@@ -105,7 +105,8 @@ SHELL ["conda", "run", "-n", "pp_env", "/bin/bash", "-c"]
 RUN conda env list
 
 # Install all requirements
-RUN conda install -c conda-forge --file requirements.txt --file requirements-dev.txt
+RUN conda install -c conda-forge --file requirements.txt && \
+    conda install -c conda-forge --file requirements-dev.txt
 
 # Pip install gmsh, since we skipped it from the conda install
 RUN pip install gmsh

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,22 +1,8 @@
-meshio >= 5.0
-networkx
-numpy
-scipy
-sympy
-matplotlib
-future
-six
-shapely
-shapely[vectorized]
+deepdiff
 pytest >= 4.6
 pytest-cov
 pytest-runner
-numba >= 0.53.0, < 0.56.1
-gmsh
 flake8
 mypy
-black == 22.8.0
+black
 isort
-typing_extensions
-requests
-deepdiff

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,5 +4,5 @@ pytest-cov
 pytest-runner
 flake8
 mypy
-black
+black == 22.8.0
 isort

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,5 +4,5 @@ pytest-cov
 pytest-runner
 flake8
 mypy
-black == 22.8.0
+black == 22.*
 isort

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,8 @@
+black == 22.*
 deepdiff
+flake8
+isort
+mypy
 pytest >= 4.6
 pytest-cov
 pytest-runner
-flake8
-mypy
-black == 22.*
-isort

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-meshio>=5.0
+meshio >= 5.0
 networkx
 numpy
 scipy
@@ -10,4 +10,4 @@ shapely
 shapely[vectorized]
 numba >= 0.53.0, < 0.56.1
 gmsh
-requests
+typing_extensions

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ shapely[vectorized]
 numba >= 0.53.0, < 0.56.1
 gmsh
 typing_extensions
+requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,14 @@
+future
+gmsh
+matplotlib
 meshio >= 5.0
 networkx
+numba >= 0.53.0, < 0.56.1
 numpy
+requests
 scipy
-sympy
-matplotlib
-future
-six
 shapely
 shapely[vectorized]
-numba >= 0.53.0, < 0.56.1
-gmsh
+six
+sympy
 typing_extensions
-requests


### PR DESCRIPTION
## Proposed changes

By separating production and development requirements, this PR avoids duplicate entries in those files. As a result, the workflow "ci.yml" checks requirements.txt and requirements-dev.txt separately.

## Types of changes

What types of changes does your code introduce to PorePy?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Testing (contribution related mainly to testing of existing functionality)
- [ ] Documentation update (if none of the other choices apply)
- [x] Other: Minor refactor on PorePy building

## Checklist

_Enter one &check; (`&check;`) in each row. The table can be updated after creating the PR._

||Yes|No|NA|
|---|---|---|---|
|The update is covered by the test suite |&check;|_|_|
|The documentation is up-to-date |_|_|&check;|
|I have not duplicated existing functionality |&check;|_|_|

## Further comments

Pip installation is performed as in https://github.com/pmgbergen/porepy/blob/develop/Readme.md

Conda installation can be performed for:
Production: conda install --file requirements.txt 
Development: conda install --file requirements.txt  --file requirements-dev.txt 

