### PR TITLE
FEAT: Split assemble_and_solve_linear_system

### DIFF
--- a/src/porepy/models/abstract_model.py
+++ b/src/porepy/models/abstract_model.py
@@ -235,14 +235,10 @@ class AbstractModel:
         if solver not in ["scipy_sparse", "pypardiso", "umfpack"]:
             raise ValueError(f"Unknown linear solver {solver}")
 
-    def assemble_linear_system(self):
+    def assemble_linear_system(self) -> None:
         """Assemble the linearized system.
 
         The linear system is defined by the current state of the model.
-
-
-
-
 
         Attributes:
             linear_system is assigned.
@@ -256,7 +252,7 @@ class AbstractModel:
         self.linear_system = (A, b)
         logger.debug(f"Assembled linear system in {t_0-time.time():.2e} seconds.")
 
-    def linear_solve(self) -> np.ndarray:
+    def solve_linear_system(self) -> np.ndarray:
         """Solve linear system.
 
         Default method is a direct solver. The linear solver is chosen in the

--- a/src/porepy/models/abstract_model.py
+++ b/src/porepy/models/abstract_model.py
@@ -256,7 +256,7 @@ class AbstractModel:
         self.linear_system = (A, b)
         logger.debug(f"Assembled linear system in {t_0-time.time():.2e} seconds.")
 
-    def linear_solve(self):
+    def linear_solve(self) -> np.ndarray:
         """Solve linear system.
 
         Default method is a direct solver. The linear solver is chosen in the

--- a/src/porepy/models/abstract_model.py
+++ b/src/porepy/models/abstract_model.py
@@ -12,6 +12,8 @@ after_newton_convergence/after_newton_divergence, (only NewtonSolver:) before_ne
 after_newton_iteration. The name "newton" is there for legacy reasons, a more fitting
 and general name would be something like "equation_solve".
 """
+from __future__ import annotations
+
 import abc
 import logging
 import time

--- a/src/porepy/models/abstract_model.py
+++ b/src/porepy/models/abstract_model.py
@@ -236,7 +236,7 @@ class AbstractModel:
             raise ValueError(f"Unknown linear solver {solver}")
 
     def assemble_linear_system(self):
-        """Assemble the linearized system, solve and return the new solution vector.
+        """Assemble the linearized system.
 
         The linear system is defined by the current state of the model.
 

--- a/src/porepy/numerics/linear_solvers.py
+++ b/src/porepy/numerics/linear_solvers.py
@@ -48,7 +48,9 @@ class LinearSolver:
         # FIXME: This assumes a direct solver is applied, but it may also be that parameters
         # for linear solvers should be a property of the model, not the solver. This
         # needs clarification at some point.
-        sol = setup.assemble_and_solve_linear_system(tol=0)
+        setup.assemble_linear_system()
+        sol = setup.linear_solve()
+
         error_norm, is_converged, _ = setup.check_convergence(
             sol, prev_sol, prev_sol, self.params
         )
@@ -61,7 +63,7 @@ class LinearSolver:
             # Since the setup's after_newton_convergence may expect that the converged
             # solution is already stored as an iterate (this may happen if a model is
             # implemented to be valid for both linear and non-linear problems, as is
-            # the case for ContactMechanics and possibly others). Thus we first call
+            # the case for ContactMechanics and possibly others). Thus, we first call
             # after_newton_iteration(), and then after_newton_convergence()
             setup.after_newton_iteration(sol)
             setup.after_newton_convergence(sol, error_norm, iteration_counter=1)

--- a/src/porepy/numerics/linear_solvers.py
+++ b/src/porepy/numerics/linear_solvers.py
@@ -49,7 +49,7 @@ class LinearSolver:
         # for linear solvers should be a property of the model, not the solver. This
         # needs clarification at some point.
         setup.assemble_linear_system()
-        sol = setup.linear_solve()
+        sol = setup.solve_linear_system()
 
         error_norm, is_converged, _ = setup.check_convergence(
             sol, prev_sol, prev_sol, self.params

--- a/src/porepy/numerics/nonlinear/nonlinear_solvers.py
+++ b/src/porepy/numerics/nonlinear/nonlinear_solvers.py
@@ -75,6 +75,6 @@ class NewtonSolver:
 
         # Assemble and solve
         model.assemble_linear_system()
-        sol = model.linear_solve()
+        sol = model.solve_linear_system()
 
         return sol

--- a/src/porepy/numerics/nonlinear/nonlinear_solvers.py
+++ b/src/porepy/numerics/nonlinear/nonlinear_solvers.py
@@ -1,13 +1,9 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 """
-Created on Fri Sep  6 11:21:54 2019
-
-@author: eke001
+Nonlinear solvers to be used with model classes.
+Implemented classes
+    NewtonSolver
 """
 import logging
-
-import numpy as np
 
 # Module-wide logger
 logger = logging.getLogger(__name__)
@@ -48,8 +44,7 @@ class NewtonSolver:
             # Re-discretize the nonlinear term
             model.before_newton_iteration()
 
-            lin_tol = np.minimum(1e-4, error_norm)
-            sol = self.iteration(model, lin_tol)
+            sol = self.iteration(model)
 
             model.after_newton_iteration(sol)
 
@@ -71,7 +66,7 @@ class NewtonSolver:
 
         return error_norm, is_converged, iteration_counter
 
-    def iteration(self, model, lin_tol):
+    def iteration(self, model):
         """A single Newton iteration.
 
         Right now, this is a single line, however, we keep it as a separate function
@@ -79,6 +74,7 @@ class NewtonSolver:
         """
 
         # Assemble and solve
-        sol = model.assemble_and_solve_linear_system(lin_tol)
+        model.assemble_linear_system()
+        sol = model.linear_solve()
 
         return sol

--- a/src/porepy/numerics/nonlinear/nonlinear_solvers.py
+++ b/src/porepy/numerics/nonlinear/nonlinear_solvers.py
@@ -66,7 +66,7 @@ class NewtonSolver:
 
         return error_norm, is_converged, iteration_counter
 
-    def iteration(self, model):
+    def iteration(self, model) -> np.ndarray:
         """A single Newton iteration.
 
         Right now, this is a single line, however, we keep it as a separate function

--- a/src/porepy/numerics/nonlinear/nonlinear_solvers.py
+++ b/src/porepy/numerics/nonlinear/nonlinear_solvers.py
@@ -5,6 +5,8 @@ Implemented classes
 """
 import logging
 
+import numpy as np
+
 # Module-wide logger
 logger = logging.getLogger(__name__)
 

--- a/tests/integration/test_ad_equations.py
+++ b/tests/integration/test_ad_equations.py
@@ -404,8 +404,11 @@ def _stepwise_newton_with_comparison(model_as, model_ad, prepare=True) -> None:
         model_ad.before_newton_iteration()
 
         # Solve linear system
-        sol_as = model_as.assemble_and_solve_linear_system(tol)
-        sol_ad = model_ad.assemble_and_solve_linear_system(tol)
+        model_as.assemble_linear_system()
+        sol_as = model_as.linear_solve()
+        model_ad.assemble_linear_system()
+        sol_ad = model_ad.linear_solve()
+
         model_as.after_newton_iteration(sol_as)
         model_ad.after_newton_iteration(sol_ad)
 

--- a/tests/integration/test_ad_equations.py
+++ b/tests/integration/test_ad_equations.py
@@ -405,9 +405,9 @@ def _stepwise_newton_with_comparison(model_as, model_ad, prepare=True) -> None:
 
         # Solve linear system
         model_as.assemble_linear_system()
-        sol_as = model_as.linear_solve()
+        sol_as = model_as.solve_linear_system()
         model_ad.assemble_linear_system()
-        sol_ad = model_ad.linear_solve()
+        sol_ad = model_ad.solve_linear_system()
 
         model_as.after_newton_iteration(sol_as)
         model_ad.after_newton_iteration(sol_ad)

--- a/tutorials/simulation_exporting.ipynb
+++ b/tutorials/simulation_exporting.ipynb
@@ -148,7 +148,6 @@
     "        vals = self._displacement_jump(fractures).evaluate(self.dof_manager).val\n",
     "        # The jump values are defined on all fractures. We need to access the values\n",
     "        # corresponding to individual subdomains, which corresponds to a restriction:\n",
-    "        # FIXME: EK, should we rather use the dof manager for this?\n",
     "        projection = pp.ad.SubdomainProjections(\n",
     "            subdomains=fractures, nd=self.nd\n",
     "        )\n",


### PR DESCRIPTION
## Proposed changes

I have split assemble_and_solve_linear_system into assemble_linear_system and linear_solve. The system is stored as a model attribute as `self.linear_system = (A, b)` in the former method. I removed the unused tolerance parameter and suggest to use something like `self.params["linear_solve_tolerance"]` if the need arises.

Solves #715 

## Types of changes

What types of changes does your code introduce to PorePy?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Testing (contribution related mainly to testing of existing functionality)
- [ ] Documentation update (if none of the other choices apply)
- [ ] Other: 

## Checklist

_Enter one &check; (`&check;`) in each row. The table can be updated after creating the PR._

||Yes|No|NA|
|---|---|---|---|
|The update is covered by the  test suite |&check;|_|_|
|The documentation is up-to-date |&check;|_|_|
|I have not duplicated existing functionality |&check;|_|_|

