### PR TITLE
BUG: Use meshio's convention to define cell types.

### DIFF
--- a/src/porepy/viz/exporter.py
+++ b/src/porepy/viz/exporter.py
@@ -181,8 +181,7 @@ class Exporter:
         self._padding = 6
 
     def add_constant_data(
-        self,
-        data: Optional[Union[DataInput, list[DataInput]]] = None,
+        self, data: Optional[Union[DataInput, list[DataInput]]] = None
     ) -> None:
         """
         Collect user-defined constant-in-time data, associated with grids,
@@ -1363,18 +1362,18 @@ class Exporter:
             sl = slice(nodes_offset, nodes_offset + grid.num_nodes)
             meshio_pts[sl, :] = grid.nodes.T
 
-            # Determine cell types based on number of faces=nodes per cell.
-            num_faces_per_cell = grid.cell_faces.getnnz(axis=0)
+            # Determine cell types based on number of nodes.
+            num_nodes_per_cell = grid.cell_nodes().getnnz(axis=0)
 
             # Loop over all available cell types and group cells of one type.
             g_cell_map = dict()
-            for n in np.unique(num_faces_per_cell):
+            for n in np.unique(num_nodes_per_cell):
 
                 # Define cell type; check if it coincides with a predefined cell type
                 cell_type = polygon_map.get(f"polygon{n}", f"polygon{n}")
 
-                # Find all cells with n faces, and store for later use
-                cells = np.nonzero(num_faces_per_cell == n)[0]
+                # Find all cells with n nodes, and store for later use
+                cells = np.nonzero(num_nodes_per_cell == n)[0]
                 g_cell_map[cell_type] = cells
 
                 # Store cell ids in global container; init if entry not yet established
@@ -1387,7 +1386,7 @@ class Exporter:
             # Determine cell-node connectivity for each cell type and all cells.
             # Treat triangle, quad and polygonal cells differently
             # aiming for optimized performance.
-            for n in np.unique(num_faces_per_cell):
+            for n in np.unique(num_nodes_per_cell):
 
                 # Define the cell type
                 cell_type = polygon_map.get(f"polygon{n}", f"polygon{n}")
@@ -1826,20 +1825,19 @@ class Exporter:
             sl = slice(nodes_offset, nodes_offset + grid.num_nodes)
             meshio_pts[sl, :] = grid.nodes.T
 
-            # The number of faces per cell wil be later used to determining
-            # the cell types
-            num_faces_per_cell = grid.cell_faces.getnnz(axis=0)
-
-            # Categorize all polyhedron cells by their number of faces.
+            # Categorize all polyhedron cells by their number of nodes.
             # Each category will be treated separately allowing for using
             # fitting datastructures.
+            num_nodes_per_cell = grid.cell_nodes().getnnz(axis=0)
+
             g_cell_map = dict()
-            for n in np.unique(num_faces_per_cell):
+
+            for n in np.unique(num_nodes_per_cell):
 
                 cell_type = f"polyhedron{n}"
 
                 # Find all cells with n faces, and store for later use
-                cells = np.nonzero(num_faces_per_cell == n)[0]
+                cells = np.nonzero(num_nodes_per_cell == n)[0]
                 g_cell_map[cell_type] = cells
 
                 # Store cell ids in global container; init if entry not yet established
@@ -1903,10 +1901,7 @@ class Exporter:
         return Meshio_Geom(meshio_pts, meshio_cells, meshio_cell_id)
 
     def _write(
-        self,
-        fields: Iterable[Field],
-        file_name: str,
-        meshio_geom: Meshio_Geom,
+        self, fields: Iterable[Field], file_name: str, meshio_geom: Meshio_Geom
     ) -> None:
         """
         Interface to meshio for exporting cell data.


### PR DESCRIPTION
## Proposed changes

While working on an importer (via meshio), I noticed a bug in the exporter. Meshio defines cell types by the number of nodes and not number of faces per cell. The latter has been used in the current exporter (I believe I introduced this error - at some other location of the code in the exporter, still faces are used to distinguish tets, hex's and polyhedra, and in my opinion this is still OK, as this information does not propagate any further). 

Note, that `test_vtk.py` did not notice this inconsistency as meshio actually overwrites cell types, and the only critical case (for 3d polyhedra) is so easy that there has been never any trouble.

Now, a consistent use of cell types is suggested with this PR. 

## Types of changes

What types of changes does your code introduce to PorePy?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Testing (contribution related mainly to testing of existing functionality)
- [ ] Documentation update (if none of the other choices apply)
- [ ] Other: 

## Checklist

||Yes|No|NA|
|---|---|---|---|
|The update is covered by the  test suite |X|_|_|
|The documentation is up-to-date |X|_|_|
|I have not duplicated existing functionality |X|_|_|

