### PR TITLE
Include setuptools to requirements.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ numba >= 0.53.0, < 0.56.3
 numpy
 requests
 scipy
+setuptools
 shapely
 shapely[vectorized]
 six


### PR DESCRIPTION
## Proposed changes
Build for Python 3.10 fails due to lack of explicit mentioning of setuptools in the requirements. This requirement is now added to fix this issue. 

## Types of changes

What types of changes does your code introduce to PorePy?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Testing (contribution related mainly to testing of existing functionality)
- [ ] Documentation update (if none of the other choices apply)
- [ ] Other: 