### PR TITLE
Revert dependabot commit changing requirements for numba

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ gmsh
 matplotlib
 meshio >= 5.0
 networkx
-numba >= 0.53.0, < 0.56.3
+numba >= 0.53.0, < 0.56.1
 numpy
 requests
 scipy


### PR DESCRIPTION
## Proposed changes

The latest dependabot commit leads to a failing build of PorePy on Python 3.10. Therefore the reversion of this commit is suggested. See explanation in #704.
 
## Types of changes

What types of changes does your code introduce to PorePy?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Testing (contribution related mainly to testing of existing functionality)
- [ ] Documentation update (if none of the other choices apply)
- [ ] Other: 
