### PR TITLE
BLD: Pin version of python 3.10 to 3.10.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     # https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#specifying-a-python-version
     strategy:
       matrix:
-        python-version:  ["3.8", "3.9", "3.10.6"]
+        python-version:  ["3.8", "3.9", "3.10.6"]  # TODO: Change 3.10.6 to 3.10 when mypy error is fixed
       # Complete all versions in matrix even if one fails.
       fail-fast: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     # https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#specifying-a-python-version
     strategy:
       matrix:
-        python-version:  ["3.8", "3.9", "3.10"]
+        python-version:  ["3.8", "3.9", "3.10.6"]
       # Complete all versions in matrix even if one fails.
       fail-fast: false
 


### PR DESCRIPTION
## Proposed changes

Pinning of python 3.10 version to python 3.10.6  in the CI workflow to avoid failing of mypy during build. This a temporary workaround until (an already existing patch) that fixes the issue is included in a new version of mypy. This closes #728.

Python versions 3.8 and 3.9 are agnostic to this issue.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply_

- [ ] Minor change (e.g., dependency bumps, broken links, etc).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code, etc).
- [x] Other: Github Actions / Building / Mypy-related issue.

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] The documentation is up-to-date.	
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicated existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).

None of the items included in the checklist are relevant in this case.

