### PR TITLE
BUG: Compatibility check between scheduled and simulated times

### DIFF
--- a/tests/unit/test_time_step_control.py
+++ b/tests/unit/test_time_step_control.py
@@ -94,14 +94,36 @@ class TestParameterInputs:
     @pytest.mark.parametrize(
         "schedule, dt_init",
         [
+            ([0, 1], 1),
+            ([0, 1], 1.0),
+            ([0, 1, 2], 1),
+            ([0, 0.05, 2.0, 4.0, 10.0], 0.05),
+            ([5.0, 10.0, 60.0, 62.5, 70.0], 2.5),
+        ]
+    )
+    def test_constant_dt_compatibility_with_schedule(self, schedule, dt_init):
+        """No error should be raised if dt and schedule are compatible"""
+        try:
+            Ts(schedule=schedule, dt_init=dt_init, constant_dt=True)
+        except Exception as exc:
+            assert False, f"The following exception was raised: {exc}"
+
+    @pytest.mark.parametrize(
+        "schedule, dt_init",
+        [
             ([0, 1], 0.4),
             ([0, 1], 0.3333),
             ([0, 0.4, 0.5, 0.8, 1], 0.2),
+            ([13.1, 13.2, 13.3], 0.2)
         ],
     )
-    def test_schedule_matches_constant_time_step(self, schedule, dt_init):
-        """An error should be raised if the schedule does not match the constant time step."""
-        msg = "Mismatch between the time step and scheduled time."
+    def test_raise_error_incompatible_dt_and_schedule(self, schedule, dt_init):
+        """An error should be raised if the schedule is incompatible with the constant time
+        step."""
+        msg = (
+            "Mismatch between the time step and scheduled time. Make sure the two are "
+            "compatible, or consider adjusting the tolerances of the sanity check."
+        )
         with pytest.raises(ValueError) as excinfo:
             Ts(schedule=schedule, dt_init=dt_init, constant_dt=True)
         assert msg in str(excinfo.value)


### PR DESCRIPTION
## Proposed changes

Improved sanity check for testing compatibility between scheduled and simulated times when constant dt is used. The sanity check is now outsourced to a static method `is_schedule_in_simulated_times()`. A previous unit test was improved and a new unit test was added. This PR solves #736.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply_

- [ ] Minor change (e.g., dependency bumps, broken links, etc).
- [x] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code, etc).
- [ ] Other: 

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.	
- [x] Static typing is included in the update.
- [x] This PR does not duplicated existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).


