### PR TITLE
Partial integration of time-stepping control into models

### DIFF
--- a/src/porepy/__init__.py
+++ b/src/porepy/__init__.py
@@ -190,7 +190,7 @@ from porepy.models.slightly_compressible_flow_model import SlightlyCompressibleF
 from porepy.numerics import ad
 
 # Time stepping control
-from porepy.numerics.time_step_control import TimeSteppingControl
+from porepy.numerics.time_step_control import TimeManager
 
 # Visualization
 from porepy.viz.exporter import Exporter

--- a/src/porepy/models/contact_mechanics_biot_model.py
+++ b/src/porepy/models/contact_mechanics_biot_model.py
@@ -96,8 +96,8 @@ class ContactMechanicsBiot(pp.ContactMechanics):
         super().__init__(params)
 
         # Time manager
-        tsc = pp.TimeSteppingControl(schedule=[0, 1], dt_init=1, constant_dt=True)
-        self.tsc: pp.TimeSteppingControl = self.params.get("time_manager", tsc)
+        tsc = pp.TimeManager(schedule=[0, 1], dt_init=1, constant_dt=True)
+        self.tsc: pp.TimeManager = self.params.get("time_manager", tsc)
 
         # Temperature
         self.scalar_variable: str = "p"

--- a/src/porepy/models/contact_mechanics_biot_model.py
+++ b/src/porepy/models/contact_mechanics_biot_model.py
@@ -95,15 +95,9 @@ class ContactMechanicsBiot(pp.ContactMechanics):
     def __init__(self, params: Optional[Dict] = None) -> None:
         super().__init__(params)
 
-        # Time-step control
+        # Time manager
         tsc = pp.TimeSteppingControl(schedule=[0, 1], dt_init=1, constant_dt=True)
         self.tsc: pp.TimeSteppingControl = self.params.get("time_manager", tsc)
-
-        # Time
-        # self.time: float = 0
-        # self.time_step: float = self.params.get("time_step", 1.0)
-        # self.end_time: float = self.params.get("end_time", 1.0)
-        # self.time_index: int = 0
 
         # Temperature
         self.scalar_variable: str = "p"

--- a/src/porepy/models/contact_mechanics_biot_model.py
+++ b/src/porepy/models/contact_mechanics_biot_model.py
@@ -52,11 +52,7 @@ class ContactMechanicsBiot(pp.ContactMechanics):
     adjustment needed is to specify the method create_grid().
 
     Attributes:
-        time (float): Current time.
-        time_step (float): Size of an individual time step
-        time_index (int): Index of current time step. Used/updated in
-            run_time_dependent_model.
-        end_time (float): Time at which the simulation should stop.
+        tsc: Time-stepping control manager.
         displacement_variable (str): Name assigned to the displacement variable in the
             highest-dimensional subdomain. Will be used throughout the simulations,
             including in ParaView export.

--- a/src/porepy/models/contact_mechanics_biot_model.py
+++ b/src/porepy/models/contact_mechanics_biot_model.py
@@ -52,7 +52,7 @@ class ContactMechanicsBiot(pp.ContactMechanics):
     adjustment needed is to specify the method create_grid().
 
     Attributes:
-        tsc: Time-stepping control manager.
+        time_manager: Time-stepping control manager.
         displacement_variable (str): Name assigned to the displacement variable in the
             highest-dimensional subdomain. Will be used throughout the simulations,
             including in ParaView export.
@@ -96,8 +96,8 @@ class ContactMechanicsBiot(pp.ContactMechanics):
         super().__init__(params)
 
         # Time manager
-        tsc = pp.TimeManager(schedule=[0, 1], dt_init=1, constant_dt=True)
-        self.tsc: pp.TimeManager = self.params.get("time_manager", tsc)
+        time_manager = pp.TimeManager(schedule=[0, 1], dt_init=1, constant_dt=True)
+        self.time_manager: pp.TimeManager = self.params.get("time_manager", time_manager)
 
         # Temperature
         self.scalar_variable: str = "p"
@@ -190,7 +190,7 @@ class ContactMechanicsBiot(pp.ContactMechanics):
                     {
                         "bc": self._bc_type_mechanics(sd),
                         "bc_values": self._bc_values_mechanics(sd),
-                        "time_step": self.tsc.dt,
+                        "time_step": self.time_manager.dt,
                         "biot_alpha": self._biot_alpha(sd),
                         "p_reference": self._reference_scalar(sd),
                     },
@@ -232,7 +232,7 @@ class ContactMechanicsBiot(pp.ContactMechanics):
                     "biot_alpha": alpha,
                     "source": self._source_scalar(sd),
                     "second_order_tensor": diffusivity,
-                    "time_step": self.tsc.dt,
+                    "time_step": self.time_manager.dt,
                     "vector_source": self._vector_source(sd),
                     "ambient_dimension": self.mdg.dim_max(),
                 },
@@ -710,7 +710,7 @@ class ContactMechanicsBiot(pp.ContactMechanics):
         ad.local_fracture_coord_transformation_normal = normal_proj
         # Facilitate updates of dt. self.time_step_ad.time_step._value must be updated
         # if time steps are changed.
-        ad.time_step = pp.ad.Scalar(self.tsc.dt, "time step")
+        ad.time_step = pp.ad.Scalar(self.time_manager.dt, "time step")
 
     def _force_balance_equation(
         self,

--- a/src/porepy/models/contact_mechanics_biot_model.py
+++ b/src/porepy/models/contact_mechanics_biot_model.py
@@ -97,7 +97,9 @@ class ContactMechanicsBiot(pp.ContactMechanics):
 
         # Time manager
         time_manager = pp.TimeManager(schedule=[0, 1], dt_init=1, constant_dt=True)
-        self.time_manager: pp.TimeManager = self.params.get("time_manager", time_manager)
+        self.time_manager: pp.TimeManager = self.params.get(
+            "time_manager", time_manager
+        )
 
         # Temperature
         self.scalar_variable: str = "p"

--- a/src/porepy/models/contact_mechanics_biot_model.py
+++ b/src/porepy/models/contact_mechanics_biot_model.py
@@ -96,11 +96,7 @@ class ContactMechanicsBiot(pp.ContactMechanics):
         super().__init__(params)
 
         # Time-step control
-        tsc = pp.TimeSteppingControl(
-            schedule=[0, 1],
-            dt_init=1,
-            constant_dt=True
-        )
+        tsc = pp.TimeSteppingControl(schedule=[0, 1], dt_init=1, constant_dt=True)
         self.tsc: pp.TimeSteppingControl = self.params.get("time_manager", tsc)
 
         # Time

--- a/src/porepy/models/run_models.py
+++ b/src/porepy/models/run_models.py
@@ -1,6 +1,5 @@
-""" This module contains functions to run stationary and time-dependent models.
+""" This module contains functions to run stationary and time-dependent models."""
 
-"""
 import logging
 
 import porepy as pp
@@ -36,11 +35,13 @@ def run_time_dependent_model(model, params):
     if params.get("prepare_simulation", True):
         model.prepare_simulation()
 
-    # Prepare for the time loop
+    # Assign a solver
     if model._is_nonlinear_problem():
         solver = pp.NewtonSolver(params)
     else:
         solver = pp.LinearSolver(params)
+
+    # Time loop
     while model.tsc.time < model.tsc.time_final:
         model.tsc.increase_time()
         model.tsc.increase_time_index()
@@ -58,28 +59,29 @@ def run_time_dependent_model(model, params):
 def _run_iterative_model(model, params):
     """Intended use is for multi-step models with iterative couplings.
 
-    Only known instance so far is the combination of fracture deformation
-    and propagation.
+    Only known instance so far is the combination of fracture deformation and propagation.
+
     """
+
     # Assign parameters, variables and discretizations. Discretize time-indepedent terms
     if params.get("prepare_simulation", True):
         model.prepare_simulation()
 
-    # Prepare for the time loop
-    t_end = model.end_time
-    model.time_index = 0
+    # Assing a solver
     if model._is_nonlinear_problem():
         solver = pp.NewtonSolver(params)
     else:
         solver = pp.LinearSolver(params)
-    while model.time < t_end:
+
+    # Time loop
+    while model.tsc.time < model.tsc.time_final:
         model.propagation_index = 0
-        model.time += model.time_step
-        model.time_index += 1
+        model.tsc.increase_time()
+        model.tsc.increase_time_index()
         model.before_propagation_loop()
         logger.info(
             "\nTime step {} at time {:.1e} of {:.1e} with time step {:.1e}".format(
-                model.time_index, model.time, t_end, model.time_step
+                model.tsc.time_index, model.tsc.time, model.tsc.time_final, model.tsc.dt
             )
         )
         while model.keep_propagating():
@@ -87,4 +89,5 @@ def _run_iterative_model(model, params):
 
             solver.solve(model)
         model.after_propagation_loop()
+
     model.after_simulation()

--- a/src/porepy/models/run_models.py
+++ b/src/porepy/models/run_models.py
@@ -58,16 +58,16 @@ def run_time_dependent_model(model, params) -> None:
         solver = pp.LinearSolver(params)
 
     # Time loop
-    while model.tsc.time < model.tsc.time_final:
-        model.tsc.increase_time()
-        model.tsc.increase_time_index()
+    while model.time_manager.time < model.time_manager.time_final:
+        model.time_manager.increase_time()
+        model.time_manager.increase_time_index()
         logger.info(
             "\nTime step {} at time {:.1e} of {:.1e} with time step {:.1e}".format(
-                model.tsc.time_index, model.tsc.time, model.tsc.time_final, model.tsc.dt
+                model.time_manager.time_index, model.time_manager.time, model.time_manager.time_final, model.time_manager.dt
             )
         )
         solver.solve(model)
-        model.tsc.compute_time_step()
+        model.time_manager.compute_time_step()
 
     model.after_simulation()
 
@@ -100,14 +100,14 @@ def _run_iterative_model(model, params: dict) -> None:
         solver = pp.LinearSolver(params)
 
     # Time loop
-    while model.tsc.time < model.tsc.time_final:
+    while model.time_manager.time < model.time_manager.time_final:
         model.propagation_index = 0
-        model.tsc.increase_time()
-        model.tsc.increase_time_index()
+        model.time_manager.increase_time()
+        model.time_manager.increase_time_index()
         model.before_propagation_loop()
         logger.info(
             "\nTime step {} at time {:.1e} of {:.1e} with time step {:.1e}".format(
-                model.tsc.time_index, model.tsc.time, model.tsc.time_final, model.tsc.dt
+                model.time_manager.time_index, model.time_manager.time, model.time_manager.time_final, model.time_manager.dt
             )
         )
         while model.keep_propagating():

--- a/src/porepy/models/run_models.py
+++ b/src/porepy/models/run_models.py
@@ -63,7 +63,10 @@ def run_time_dependent_model(model, params) -> None:
         model.time_manager.increase_time_index()
         logger.info(
             "\nTime step {} at time {:.1e} of {:.1e} with time step {:.1e}".format(
-                model.time_manager.time_index, model.time_manager.time, model.time_manager.time_final, model.time_manager.dt
+                model.time_manager.time_index,
+                model.time_manager.time,
+                model.time_manager.time_final,
+                model.time_manager.dt,
             )
         )
         solver.solve(model)
@@ -107,7 +110,10 @@ def _run_iterative_model(model, params: dict) -> None:
         model.before_propagation_loop()
         logger.info(
             "\nTime step {} at time {:.1e} of {:.1e} with time step {:.1e}".format(
-                model.time_manager.time_index, model.time_manager.time, model.time_manager.time_final, model.time_manager.dt
+                model.time_manager.time_index,
+                model.time_manager.time,
+                model.time_manager.time_final,
+                model.time_manager.dt,
             )
         )
         while model.keep_propagating():

--- a/src/porepy/models/run_models.py
+++ b/src/porepy/models/run_models.py
@@ -1,15 +1,29 @@
 """ This module contains functions to run stationary and time-dependent models."""
 
 import logging
+from typing import Union
 
 import porepy as pp
 
 logger = logging.getLogger(__name__)
 
 
-def run_stationary_model(model, params) -> None:
+def run_stationary_model(model, params: dict) -> None:
+    """
+    Run a stationary model.
+
+    Args:
+        model: Model class containing all information on parameters, variables,
+            discretization, geometry. Various methods such as those relating to solving
+            the system, see the appropriate model for documentation.
+        params: Parameters related to the solution procedure. # Why not just set these
+            as e.g. model.solution_parameters.
+
+    """
+
     model.prepare_simulation()
 
+    solver: Union[pp.LinearSolver, pp.NewtonSolver]
     if model._is_nonlinear_problem():
         solver = pp.NewtonSolver(params)
     else:
@@ -22,7 +36,7 @@ def run_stationary_model(model, params) -> None:
 
 def run_time_dependent_model(model, params) -> None:
     """
-    Time loop for the model classes.
+    Run a time dependent model.
 
     Args:
         model: Model class containing all information on parameters, variables,
@@ -37,6 +51,7 @@ def run_time_dependent_model(model, params) -> None:
         model.prepare_simulation()
 
     # Assign a solver
+    solver: Union[pp.LinearSolver, pp.NewtonSolver]
     if model._is_nonlinear_problem():
         solver = pp.NewtonSolver(params)
     else:
@@ -57,10 +72,19 @@ def run_time_dependent_model(model, params) -> None:
     model.after_simulation()
 
 
-def _run_iterative_model(model, params) -> None:
-    """Intended use is for multi-step models with iterative couplings.
+def _run_iterative_model(model, params: dict) -> None:
+    """
+    Run an iterative model.
 
-    Only known instance so far is the combination of fracture deformation and propagation.
+    The intended use is for multi-step models with iterative couplings. Only known instance
+    so far is the combination of fracture deformation and propagation.
+
+    Args:
+        model: Model class containing all information on parameters, variables,
+            discretization, geometry. Various methods such as those relating to solving
+            the system, see the appropriate solver for documentation.
+        params: Parameters related to the solution procedure. # Why not just set these
+            as e.g. model.solution_parameters.
 
     """
 
@@ -68,7 +92,8 @@ def _run_iterative_model(model, params) -> None:
     if params.get("prepare_simulation", True):
         model.prepare_simulation()
 
-    # Assing a solver
+    # Assign a solver
+    solver: Union[pp.LinearSolver, pp.NewtonSolver]
     if model._is_nonlinear_problem():
         solver = pp.NewtonSolver(params)
     else:
@@ -87,7 +112,6 @@ def _run_iterative_model(model, params) -> None:
         )
         while model.keep_propagating():
             model.propagation_index += 1
-
             solver.solve(model)
         model.after_propagation_loop()
 

--- a/src/porepy/models/run_models.py
+++ b/src/porepy/models/run_models.py
@@ -7,7 +7,7 @@ import porepy as pp
 logger = logging.getLogger(__name__)
 
 
-def run_stationary_model(model, params):
+def run_stationary_model(model, params) -> None:
     model.prepare_simulation()
 
     if model._is_nonlinear_problem():
@@ -20,7 +20,7 @@ def run_stationary_model(model, params):
     model.after_simulation()
 
 
-def run_time_dependent_model(model, params):
+def run_time_dependent_model(model, params) -> None:
     """
     Time loop for the model classes.
 
@@ -30,6 +30,7 @@ def run_time_dependent_model(model, params):
             the system, see the appropriate solver for documentation.
         params: Parameters related to the solution procedure. # Why not just set these
             as e.g. model.solution_parameters.
+
     """
     # Assign parameters, variables and discretizations. Discretize time-indepedent terms
     if params.get("prepare_simulation", True):
@@ -56,7 +57,7 @@ def run_time_dependent_model(model, params):
     model.after_simulation()
 
 
-def _run_iterative_model(model, params):
+def _run_iterative_model(model, params) -> None:
     """Intended use is for multi-step models with iterative couplings.
 
     Only known instance so far is the combination of fracture deformation and propagation.

--- a/src/porepy/models/run_models.py
+++ b/src/porepy/models/run_models.py
@@ -37,21 +37,20 @@ def run_time_dependent_model(model, params):
         model.prepare_simulation()
 
     # Prepare for the time loop
-    t_end = model.end_time
-    model.time_index = 0
     if model._is_nonlinear_problem():
         solver = pp.NewtonSolver(params)
     else:
         solver = pp.LinearSolver(params)
-    while model.time < t_end:
-        model.time += model.time_step
-        model.time_index += 1
+    while model.tsc.time < model.tsc.time_final:
+        model.tsc.increase_time()
+        model.tsc.increase_time_index()
         logger.info(
             "\nTime step {} at time {:.1e} of {:.1e} with time step {:.1e}".format(
-                model.time_index, model.time, t_end, model.time_step
+                model.tsc.time_index, model.tsc.time, model.tsc.time_final, model.tsc.dt
             )
         )
         solver.solve(model)
+        model.tsc.next_time_step()
 
     model.after_simulation()
 

--- a/src/porepy/models/run_models.py
+++ b/src/porepy/models/run_models.py
@@ -67,7 +67,7 @@ def run_time_dependent_model(model, params) -> None:
             )
         )
         solver.solve(model)
-        model.tsc.next_time_step()
+        model.tsc.compute_time_step()
 
     model.after_simulation()
 

--- a/src/porepy/models/slightly_compressible_flow_model.py
+++ b/src/porepy/models/slightly_compressible_flow_model.py
@@ -34,7 +34,7 @@ class SlightlyCompressibleFlow(pp.models.incompressible_flow_model.Incompressibl
         1. _compressibility: constant compressibility per cell
 
     Attributes:
-        tsc: Time-stepping control manager.
+        time_manager: Time-stepping control manager.
 
     """
 
@@ -50,7 +50,7 @@ class SlightlyCompressibleFlow(pp.models.incompressible_flow_model.Incompressibl
         super().__init__(params)
 
         # Time manager
-        self.tsc = params.get(
+        self.time_manager = params.get(
             "time_manager",
             pp.TimeManager(schedule=[0, 1], dt_init=1, constant_dt=True),
         )
@@ -90,7 +90,7 @@ class SlightlyCompressibleFlow(pp.models.incompressible_flow_model.Incompressibl
 
         # Access to pressure ad variable
         p = self._ad.pressure
-        self._ad.time_step = pp.ad.Scalar(self.tsc.dt, "time step")
+        self._ad.time_step = pp.ad.Scalar(self.time_manager.dt, "time step")
 
         accumulation_term = (
             accumulation_term.mass * (p - p.previous_timestep()) / self._ad.time_step

--- a/src/porepy/models/slightly_compressible_flow_model.py
+++ b/src/porepy/models/slightly_compressible_flow_model.py
@@ -52,7 +52,7 @@ class SlightlyCompressibleFlow(pp.models.incompressible_flow_model.Incompressibl
         # Time manager
         self.tsc = params.get(
             "time_manager",
-            pp.TimeSteppingControl(schedule=[0, 1], dt_init=1, constant_dt=True),
+            pp.TimeManager(schedule=[0, 1], dt_init=1, constant_dt=True),
         )
         self._ad = _AdVariables()
 

--- a/src/porepy/models/slightly_compressible_flow_model.py
+++ b/src/porepy/models/slightly_compressible_flow_model.py
@@ -49,16 +49,10 @@ class SlightlyCompressibleFlow(pp.models.incompressible_flow_model.Incompressibl
         """
         super().__init__(params)
 
-        # attributes
-        if isinstance(params, type(None)):
-            self.end_time = float(1)
-            self.time_step = float(1)
-        else:
-            self.end_time = self.params.get("end_time", float(1))
-            self.time_step = self.params.get("time_step", float(1))
+        # Time manager
+        tsc = pp.TimeSteppingControl(schedule=[0, 1], dt_init=1, constant_dt=True)
+        self.tsc = params.get("time_manager", tsc)
 
-        self.time = float(0)
-        self.time_index = 0
         self._ad = _AdVariables()
 
     def _set_parameters(self) -> None:
@@ -95,7 +89,7 @@ class SlightlyCompressibleFlow(pp.models.incompressible_flow_model.Incompressibl
 
         # Access to pressure ad variable
         p = self._ad.pressure
-        self._ad.time_step = pp.ad.Scalar(self.time_step, "time step")
+        self._ad.time_step = pp.ad.Scalar(self.tsc.dt, "time step")
 
         accumulation_term = (
             accumulation_term.mass * (p - p.previous_timestep()) / self._ad.time_step

--- a/src/porepy/models/slightly_compressible_flow_model.py
+++ b/src/porepy/models/slightly_compressible_flow_model.py
@@ -25,7 +25,7 @@ class SlightlyCompressibleFlow(pp.models.incompressible_flow_model.Incompressibl
 
     The simulation starts at time t=0.
 
-    Overwritten methods include:
+    Overridden methods include:
         1. _set_parameters: compressibility added
         2. _assign_discretizations: Upgrade incompressible flow equations
             to slightly compressible
@@ -34,10 +34,8 @@ class SlightlyCompressibleFlow(pp.models.incompressible_flow_model.Incompressibl
         1. _compressibility: constant compressibility per cell
 
     Attributes:
-        end_time (float): Upper limit of considered time interval
-        time_step (float): time step size
-        time (float): simulation time
-        time_index (int): number of time steps passed
+        tsc: Time-stepping control manager.
+
     """
 
     def __init__(self, params: Optional[Dict] = None) -> None:

--- a/src/porepy/models/slightly_compressible_flow_model.py
+++ b/src/porepy/models/slightly_compressible_flow_model.py
@@ -45,12 +45,15 @@ class SlightlyCompressibleFlow(pp.models.incompressible_flow_model.Incompressibl
                 Some frequently used entries are file and folder names for export,
                 mesh sizes...
         """
+        if params is None:
+            params = {}
         super().__init__(params)
 
         # Time manager
-        tsc = pp.TimeSteppingControl(schedule=[0, 1], dt_init=1, constant_dt=True)
-        self.tsc = params.get("time_manager", tsc)
-
+        self.tsc = params.get(
+            "time_manager",
+            pp.TimeSteppingControl(schedule=[0, 1], dt_init=1, constant_dt=True),
+        )
         self._ad = _AdVariables()
 
     def _set_parameters(self) -> None:

--- a/src/porepy/models/thm_model.py
+++ b/src/porepy/models/thm_model.py
@@ -60,7 +60,7 @@ class THM(pp.ContactMechanicsBiot):
     adjustment needed is to specify the method create_grid().
 
     Attributes:
-        tsc : Time-stepping control manager.
+        time_manager : Time-stepping control manager.
 
         displacement_variable (str): Name assigned to the displacement variable in the
             highest-dimensional subdomain. Will be used throughout the simulations,
@@ -240,7 +240,7 @@ class THM(pp.ContactMechanicsBiot):
                 sd,
                 data,
                 self.t2s_parameter_key,
-                {"mass_weight": t2s_coupling, "time_step": self.tsc.dt},
+                {"mass_weight": t2s_coupling, "time_step": self.time_manager.dt},
             )
 
     def _set_temperature_parameters(self) -> None:
@@ -289,14 +289,14 @@ class THM(pp.ContactMechanicsBiot):
                     "advection_weight": advection_weight,  # TODO: remove on ad purge
                     "advection_weight_boundary": advection_weight_faces,
                     "heat_capacity": heat_capacity,
-                    "time_step": self.tsc.dt,
+                    "time_step": self.time_manager.dt,
                 },
             )
             pp.initialize_data(
                 sd,
                 data,
                 self.s2t_parameter_key,
-                {"mass_weight": s2t_coupling, "time_step": self.tsc.dt},
+                {"mass_weight": s2t_coupling, "time_step": self.time_manager.dt},
             )
 
         # Assign diffusivity in the normal direction of the fractures.

--- a/src/porepy/models/thm_model.py
+++ b/src/porepy/models/thm_model.py
@@ -242,7 +242,7 @@ class THM(pp.ContactMechanicsBiot):
                 sd,
                 data,
                 self.t2s_parameter_key,
-                {"mass_weight": t2s_coupling, "time_step": self.time_step},
+                {"mass_weight": t2s_coupling, "time_step": self.tsc.dt},
             )
 
     def _set_temperature_parameters(self) -> None:
@@ -291,14 +291,14 @@ class THM(pp.ContactMechanicsBiot):
                     "advection_weight": advection_weight,  # TODO: remove on ad purge
                     "advection_weight_boundary": advection_weight_faces,
                     "heat_capacity": heat_capacity,
-                    "time_step": self.time_step,
+                    "time_step": self.tsc.dt,
                 },
             )
             pp.initialize_data(
                 sd,
                 data,
                 self.s2t_parameter_key,
-                {"mass_weight": s2t_coupling, "time_step": self.time_step},
+                {"mass_weight": s2t_coupling, "time_step": self.tsc.dt},
             )
 
         # Assign diffusivity in the normal direction of the fractures.

--- a/src/porepy/models/thm_model.py
+++ b/src/porepy/models/thm_model.py
@@ -60,9 +60,7 @@ class THM(pp.ContactMechanicsBiot):
     adjustment needed is to specify the method create_grid().
 
     Attributes:
-        time (float): Current time.
-        time_step (float): Size of an individual time step
-        end_time (float): Time at which the simulation should stop.
+        tsc : Time-stepping control manager.
 
         displacement_variable (str): Name assigned to the displacement variable in the
             highest-dimensional subdomain. Will be used throughout the simulations,

--- a/src/porepy/numerics/time_step_control.py
+++ b/src/porepy/numerics/time_step_control.py
@@ -439,7 +439,7 @@ class TimeSteppingControl:
 
         # Adapt time step
         if not self._recomp_sol:
-            self._adaptation_based_on_iterations(iterations=iterations)
+            self._adaptation_based_on_iterations(iterations=self._iters)
         else:
             self._adaptation_based_on_recomputation()
 
@@ -458,7 +458,7 @@ class TimeSteppingControl:
         """Increase time index counter by one."""
         self.time_index += 1
 
-    def _adaptation_based_on_iterations(self, iterations: int) -> None:
+    def _adaptation_based_on_iterations(self, iterations: Optional[int]) -> None:
         """Provided convergence, adapt time step based on the number of iterations.
 
         Parameters:

--- a/src/porepy/numerics/time_step_control.py
+++ b/src/porepy/numerics/time_step_control.py
@@ -429,14 +429,10 @@ class TimeSteppingControl:
         if self.is_constant:
             # Some sanity checks
             if self._iters is not None:
-                msg = (
-                    f"iterations '{self._iters}' has no effect if time step is constant."
-                )
+                msg = f"iterations '{self._iters}' has no effect if time step is constant."
                 warnings.warn(msg)
             if self._recomp_sol:
-                msg = (
-                    "recompute_solution=True has no effect if time step is constant."
-                )
+                msg = "recompute_solution=True has no effect if time step is constant."
                 warnings.warn(msg)
 
             # Update time and time index

--- a/src/porepy/numerics/time_step_control.py
+++ b/src/porepy/numerics/time_step_control.py
@@ -37,7 +37,7 @@ Algorithm Overview:
 Algorithm Workflow in Pseudocode:
 
     INPUT
-        tsc // time step control object properly initialized
+        time_manager // time step control object properly initialized
         iterations // number of non-linear iterations
         recompute_solution // boolean flag
 
@@ -158,7 +158,7 @@ class TimeManager:
 
     Example:
         # The following is an example on how to initialize a time-stepping object
-        tsc = pp.TimeManager(
+        time_manager = pp.TimeManager(
             schedule=[0, 10],
             dt_init=0.5,
             dt_min_max=(0.1, 2),
@@ -170,7 +170,7 @@ class TimeManager:
             print_info=True
         )
         # To inspect the attributes of the object
-        print(tsc)
+        print(time_manager)
 
     Attributes:
         dt (float): Time step.

--- a/src/porepy/numerics/time_step_control.py
+++ b/src/porepy/numerics/time_step_control.py
@@ -393,7 +393,7 @@ class TimeSteppingControl:
         return s
 
     def next_time_step(
-        self, iterations: int, recompute_solution: bool = False
+        self, iterations: Optional[int] = None, recompute_solution: bool = False
     ) -> Union[float, None]:
         """Determine next time step based on the previous number of iterations.
 
@@ -441,9 +441,16 @@ class TimeSteppingControl:
         Parameters:
             iterations: Number of non-linear iterations needed to achieve convergence.
 
-        Raises: Warning if `iterations` > `max_iter`.
+        Raises:
+            ValueError if `iterations` is None.
+            Warning if `iterations` > `max_iter`.
 
         """
+
+        # Sanity check: Make sure number of iterations is not None
+        if iterations is None:
+            msg = "Time step cannot be adapted without 'iterations'."
+            raise ValueError(msg)
 
         # Sanity check: Make sure the given number of iterations is less or equal than the
         # maximum number of iterations

--- a/src/porepy/numerics/time_step_control.py
+++ b/src/porepy/numerics/time_step_control.py
@@ -396,7 +396,7 @@ class TimeSteppingControl:
 
         return s
 
-    def next_time_step(
+    def compute_time_step(
         self, iterations: Optional[int] = None, recompute_solution: bool = False
     ) -> Union[float, None]:
         """Determine next time step based on the previous number of iterations.

--- a/src/porepy/numerics/time_step_control.py
+++ b/src/porepy/numerics/time_step_control.py
@@ -96,10 +96,10 @@ from typing import Optional, Union
 import numpy as np
 from numpy.typing import ArrayLike
 
-__all__ = ["TimeSteppingControl"]
+__all__ = ["TimeManager"]
 
 
-class TimeSteppingControl:
+class TimeManager:
     """Parent class for iteration-based time-stepping control routine.
 
     Parameters:
@@ -158,7 +158,7 @@ class TimeSteppingControl:
 
     Example:
         # The following is an example on how to initialize a time-stepping object
-        tsc = pp.TimeSteppingControl(
+        tsc = pp.TimeManager(
             schedule=[0, 10],
             dt_init=0.5,
             dt_min_max=(0.1, 2),

--- a/src/porepy/numerics/time_step_control.py
+++ b/src/porepy/numerics/time_step_control.py
@@ -435,10 +435,6 @@ class TimeSteppingControl:
                 msg = "recompute_solution=True has no effect if time step is constant."
                 warnings.warn(msg)
 
-            # Update time and time index
-            self.time += self.dt_init
-            self.time_index += 1
-
             return self.dt_init
 
         # Adapt time step
@@ -451,10 +447,6 @@ class TimeSteppingControl:
         self._correction_based_on_dt_min()
         self._correction_based_on_dt_max()
         self._correction_based_on_schedule()
-
-        # Update time and time index
-        self.time += self.dt
-        self.time_index += 1
 
         return self.dt
 
@@ -611,8 +603,6 @@ class TimeSteppingControl:
                     print(
                         f"Correcting time step to match final time. Final dt = {self.dt}."
                     )
-
-
 
     # Helpers
     @staticmethod

--- a/src/porepy/numerics/time_step_control.py
+++ b/src/porepy/numerics/time_step_control.py
@@ -458,6 +458,14 @@ class TimeSteppingControl:
 
         return self.dt
 
+    def increase_time(self) -> None:
+        """Increase simulation time by the current time step."""
+        self.time += self.dt
+
+    def increase_time_index(self) -> None:
+        """Increase time index counter by one."""
+        self.time_index += 1
+
     def _adaptation_based_on_iterations(self, iterations: int) -> None:
         """Provided convergence, adapt time step based on the number of iterations.
 
@@ -603,6 +611,8 @@ class TimeSteppingControl:
                     print(
                         f"Correcting time step to match final time. Final dt = {self.dt}."
                     )
+
+
 
     # Helpers
     @staticmethod

--- a/src/porepy/numerics/time_step_control.py
+++ b/src/porepy/numerics/time_step_control.py
@@ -470,7 +470,7 @@ class TimeSteppingControl:
 
         """
 
-        # Sanity check: Make sure iterations is give
+        # Sanity check: Make sure iterations is given
         if iterations is None:
             msg = "Time step cannot be adapted without 'iterations'."
             raise ValueError(msg)

--- a/src/porepy/numerics/time_step_control.py
+++ b/src/porepy/numerics/time_step_control.py
@@ -411,8 +411,9 @@ class TimeSteppingControl:
 
         """
 
-        # For bookkeeping reasons, save recomputation flag
+        # For bookkeeping reasons, save recomputation and iterations
         self._recomp_sol = recompute_solution
+        self._iters = iterations
 
         # First, check if we reach final simulation time
         if self.time >= self.time_final:
@@ -447,7 +448,7 @@ class TimeSteppingControl:
 
         """
 
-        # Sanity check: Make sure number of iterations is not None
+        # Sanity check: Make sure iterations is give
         if iterations is None:
             msg = "Time step cannot be adapted without 'iterations'."
             raise ValueError(msg)
@@ -491,11 +492,9 @@ class TimeSteppingControl:
         """Adapt (decrease) time step when `recompute_solution` = True.
 
         Raises:
-            ValueError if dt = dt_min, since any further recomputation attempt will be
-                pointless.
-            ValueError if recomp_attempts > max_recomp_attempts. That is, if the maximum
-                number of recomputation attempts has been exhausted.
-
+            ValueError if dt = dt_min, since any recomputation attempt will be pointless.
+            ValueError if recomp_attempts > max_recomp_attempts.
+            
         """
 
         if self._recomp_num < self.recomp_max:
@@ -510,6 +509,11 @@ class TimeSteppingControl:
                     f"minimum admissible value -> dt = dt_min = {self.dt}."
                 )
                 raise ValueError(msg)
+
+            # Raise a warning if iterations is not None
+            if self._iters is not None:
+                msg = "Number of iterations has no effect in recomputation."
+                warnings.warn(msg)
 
             # If the solution did not converge AND we are allowed to recompute it, then:
             #   (S1) Update simulation time since solution will be recomputed.

--- a/tests/common/contact_mechanics_examples.py
+++ b/tests/common/contact_mechanics_examples.py
@@ -146,10 +146,10 @@ class ProblemDataTime:
         _, _, _, north, south, _, _ = self._domain_boundary_sides(g)
         values = np.zeros((g.dim, g.num_faces))
 
-        values[0, south] = self.ux_south * (self.tsc.time > 0.1)
-        values[1, south] = self.uy_south * (self.tsc.time > 0.1)
-        values[0, north] = self.ux_north * (self.tsc.time > 0.1)
-        values[1, north] = self.uy_north * (self.tsc.time > 0.1)
+        values[0, south] = self.ux_south * (self.time_manager.time > 0.1)
+        values[1, south] = self.uy_south * (self.time_manager.time > 0.1)
+        values[0, north] = self.ux_north * (self.time_manager.time > 0.1)
+        values[1, north] = self.uy_north * (self.time_manager.time > 0.1)
         return values.ravel("F")
 
     def _compute_aperture(self, sd, from_iterate=True):

--- a/tests/common/contact_mechanics_examples.py
+++ b/tests/common/contact_mechanics_examples.py
@@ -146,10 +146,10 @@ class ProblemDataTime:
         _, _, _, north, south, _, _ = self._domain_boundary_sides(g)
         values = np.zeros((g.dim, g.num_faces))
 
-        values[0, south] = self.ux_south * (self.time > 0.1)
-        values[1, south] = self.uy_south * (self.time > 0.1)
-        values[0, north] = self.ux_north * (self.time > 0.1)
-        values[1, north] = self.uy_north * (self.time > 0.1)
+        values[0, south] = self.ux_south * (self.tsc.time > 0.1)
+        values[1, south] = self.uy_south * (self.tsc.time > 0.1)
+        values[0, north] = self.ux_north * (self.tsc.time > 0.1)
+        values[1, north] = self.uy_north * (self.tsc.time > 0.1)
         return values.ravel("F")
 
     def _compute_aperture(self, sd, from_iterate=True):

--- a/tests/integration/test_ad_equations.py
+++ b/tests/integration/test_ad_equations.py
@@ -437,10 +437,6 @@ def _timestep_stepwise_newton_with_comparison(model_as, model_ad):
     model_ad.prepare_simulation()
     model_ad.before_newton_loop()
 
-    #model_as.time_index = 0
-    #model_ad.time_index = 0
-    #t_end = model_as.end_time
-
     while model_as.tsc.time < model_as.tsc.time_final:
         for model in (model_as, model_ad):
             model.tsc.increase_time()

--- a/tests/integration/test_ad_equations.py
+++ b/tests/integration/test_ad_equations.py
@@ -350,7 +350,7 @@ def _compare_solutions(m0, m1, tol=1e-7) -> None:
                     ):
                         # Reformulation; the advective flux is time integrated in
                         # non-ad but not in ad.
-                        sol1 = intf_data[pp.STATE][var] * m1.tsc.dt
+                        sol1 = intf_data[pp.STATE][var] * m1.time_manager.dt
                     else:
                         sol1 = intf_data[pp.STATE][var]
                     break
@@ -437,10 +437,10 @@ def _timestep_stepwise_newton_with_comparison(model_as, model_ad):
     model_ad.prepare_simulation()
     model_ad.before_newton_loop()
 
-    while model_as.tsc.time < model_as.tsc.time_final:
+    while model_as.time_manager.time < model_as.time_manager.time_final:
         for model in (model_as, model_ad):
-            model.tsc.increase_time()
-            model.tsc.increase_time_index()
+            model.time_manager.increase_time()
+            model.time_manager.increase_time_index()
             #model.time += model.time_step
             #model.time_index += 1
         _stepwise_newton_with_comparison(model_as, model_ad, prepare=False)
@@ -479,9 +479,9 @@ def test_contact_mechanics(grid_method):
     ],
 )
 def test_contact_mechanics_biot(grid_method):
-    tsc = pp.TimeManager(schedule=[0, 1], dt_init=0.5, constant_dt=True)
+    time_manager = pp.TimeManager(schedule=[0, 1], dt_init=0.5, constant_dt=True)
     # params = {"time_step": 0.5, "end_time": 1}
-    params = {"time_manager": tsc}
+    params = {"time_manager": time_manager}
     model_as = BiotContactModel(params.copy(), grid_method)
 
     model_ad = BiotContactModel(params, grid_method)
@@ -503,8 +503,8 @@ def test_contact_mechanics_biot(grid_method):
     ],
 )
 def test_thm(grid_method):
-    tsc = pp.TimeManager(schedule=[0, 1], dt_init=0.5, constant_dt=True)
-    params = {"time_manager": tsc}
+    time_manager = pp.TimeManager(schedule=[0, 1], dt_init=0.5, constant_dt=True)
+    params = {"time_manager": time_manager}
     # params = {"time_step": 0.5e-0, "end_time": 1.0e-0}
     model_as = THMModel(params.copy(), grid_method)
 

--- a/tests/integration/test_ad_equations.py
+++ b/tests/integration/test_ad_equations.py
@@ -479,7 +479,7 @@ def test_contact_mechanics(grid_method):
     ],
 )
 def test_contact_mechanics_biot(grid_method):
-    tsc = pp.TimeSteppingControl(schedule=[0, 1], dt_init=0.5, constant_dt=True)
+    tsc = pp.TimeManager(schedule=[0, 1], dt_init=0.5, constant_dt=True)
     # params = {"time_step": 0.5, "end_time": 1}
     params = {"time_manager": tsc}
     model_as = BiotContactModel(params.copy(), grid_method)
@@ -503,7 +503,7 @@ def test_contact_mechanics_biot(grid_method):
     ],
 )
 def test_thm(grid_method):
-    tsc = pp.TimeSteppingControl(schedule=[0, 1], dt_init=0.5, constant_dt=True)
+    tsc = pp.TimeManager(schedule=[0, 1], dt_init=0.5, constant_dt=True)
     params = {"time_manager": tsc}
     # params = {"time_step": 0.5e-0, "end_time": 1.0e-0}
     model_as = THMModel(params.copy(), grid_method)

--- a/tests/integration/test_ad_equations.py
+++ b/tests/integration/test_ad_equations.py
@@ -441,8 +441,6 @@ def _timestep_stepwise_newton_with_comparison(model_as, model_ad):
         for model in (model_as, model_ad):
             model.time_manager.increase_time()
             model.time_manager.increase_time_index()
-            #model.time += model.time_step
-            #model.time_index += 1
         _stepwise_newton_with_comparison(model_as, model_ad, prepare=False)
 
 
@@ -480,7 +478,6 @@ def test_contact_mechanics(grid_method):
 )
 def test_contact_mechanics_biot(grid_method):
     time_manager = pp.TimeManager(schedule=[0, 1], dt_init=0.5, constant_dt=True)
-    # params = {"time_step": 0.5, "end_time": 1}
     params = {"time_manager": time_manager}
     model_as = BiotContactModel(params.copy(), grid_method)
 
@@ -505,7 +502,6 @@ def test_contact_mechanics_biot(grid_method):
 def test_thm(grid_method):
     time_manager = pp.TimeManager(schedule=[0, 1], dt_init=0.5, constant_dt=True)
     params = {"time_manager": time_manager}
-    # params = {"time_step": 0.5e-0, "end_time": 1.0e-0}
     model_as = THMModel(params.copy(), grid_method)
 
     model_ad = THMModel(params, grid_method)

--- a/tests/integration/test_contact_mechanics_biot.py
+++ b/tests/integration/test_contact_mechanics_biot.py
@@ -280,7 +280,7 @@ class TestContactMechanicsBiot(unittest.TestCase):
         """
         setup = SetupContactMechanicsBiot()
         setup.uy_north = 0.001
-        setup.tsc.time_final *= 3
+        setup.time_manager.time_final *= 3
         setup.mesh_args = [2, 2]
         setup.simplex = False
         # setup.subtract_fracture_pressure = False

--- a/tests/integration/test_contact_mechanics_biot.py
+++ b/tests/integration/test_contact_mechanics_biot.py
@@ -280,7 +280,7 @@ class TestContactMechanicsBiot(unittest.TestCase):
         """
         setup = SetupContactMechanicsBiot()
         setup.uy_north = 0.001
-        setup.end_time *= 3
+        setup.tsc.time_final *= 3
         setup.mesh_args = [2, 2]
         setup.simplex = False
         # setup.subtract_fracture_pressure = False

--- a/tests/integration/test_dilation.py
+++ b/tests/integration/test_dilation.py
@@ -179,7 +179,9 @@ class TestDilation(unittest.TestCase):
         self.assertTrue(np.all(np.isclose(u_mortar_0[0], 0)))
 
         # Second step
-        setup.time_manager.time_final = 1  # increase final time to enter time loop again
+        setup.time_manager.time_final = (
+            1  # increase final time to enter time loop again
+        )
         u_mortar_1, contact_force_1 = self._solve(setup)
         # Should be in contact (u_x > u_y on boundary):
         self.assertTrue(np.all(contact_force_1[1] < setup.zero_tol))
@@ -204,7 +206,9 @@ class SetupContactMechanics(
         self.ux_north = ux_north
         self.uy_north = uy_north
         self.zero_tol = 1e-8
-        self.time_manager = pp.TimeManager(schedule=[0, 0.5], dt_init=0.5, constant_dt=True)
+        self.time_manager = pp.TimeManager(
+            schedule=[0, 0.5], dt_init=0.5, constant_dt=True
+        )
 
     def create_grid(self):
         """
@@ -235,7 +239,9 @@ class SetupContactMechanics(
         _, _, _, north, south, _, _ = self._domain_boundary_sides(g)
         values = np.zeros((g.dim, g.num_faces))
         # Dirty hack for the two-stage test. All other tests have time > 0
-        if hasattr(self, "ux_south_initial") and self.time_manager.time < (1 - self.zero_tol):
+        if hasattr(self, "ux_south_initial") and self.time_manager.time < (
+            1 - self.zero_tol
+        ):
             values[0, south] = self.ux_south_initial
         else:
             values[0, south] = self.ux_south

--- a/tests/integration/test_dilation.py
+++ b/tests/integration/test_dilation.py
@@ -204,7 +204,7 @@ class SetupContactMechanics(
         self.ux_north = ux_north
         self.uy_north = uy_north
         self.zero_tol = 1e-8
-        self.tsc = pp.TimeSteppingControl(schedule=[0, 0.5], dt_init=0.5, constant_dt=True)
+        self.tsc = pp.TimeManager(schedule=[0, 0.5], dt_init=0.5, constant_dt=True)
 
     def create_grid(self):
         """

--- a/tests/integration/test_dilation.py
+++ b/tests/integration/test_dilation.py
@@ -11,7 +11,7 @@ import porepy as pp
 
 class TestDilation(unittest.TestCase):
     def _solve(self, setup):
-        if hasattr(setup, "tsc"):
+        if hasattr(setup, "time_manager"):
             pp.run_time_dependent_model(setup, {"convergence_tol": 1e-10})
         else:
             pp.run_stationary_model(setup, {"convergence_tol": 1e-10})
@@ -179,7 +179,7 @@ class TestDilation(unittest.TestCase):
         self.assertTrue(np.all(np.isclose(u_mortar_0[0], 0)))
 
         # Second step
-        setup.tsc.time_final = 1  # increase final time to enter time loop again
+        setup.time_manager.time_final = 1  # increase final time to enter time loop again
         u_mortar_1, contact_force_1 = self._solve(setup)
         # Should be in contact (u_x > u_y on boundary):
         self.assertTrue(np.all(contact_force_1[1] < setup.zero_tol))
@@ -204,7 +204,7 @@ class SetupContactMechanics(
         self.ux_north = ux_north
         self.uy_north = uy_north
         self.zero_tol = 1e-8
-        self.tsc = pp.TimeManager(schedule=[0, 0.5], dt_init=0.5, constant_dt=True)
+        self.time_manager = pp.TimeManager(schedule=[0, 0.5], dt_init=0.5, constant_dt=True)
 
     def create_grid(self):
         """
@@ -235,7 +235,7 @@ class SetupContactMechanics(
         _, _, _, north, south, _, _ = self._domain_boundary_sides(g)
         values = np.zeros((g.dim, g.num_faces))
         # Dirty hack for the two-stage test. All other tests have time > 0
-        if hasattr(self, "ux_south_initial") and self.tsc.time < (1 - self.zero_tol):
+        if hasattr(self, "ux_south_initial") and self.time_manager.time < (1 - self.zero_tol):
             values[0, south] = self.ux_south_initial
         else:
             values[0, south] = self.ux_south

--- a/tests/integration/test_thm.py
+++ b/tests/integration/test_thm.py
@@ -202,7 +202,7 @@ class TestContactMechanicsTHM(unittest.TestCase):
     def test_time_dependent_pull_north_positive_opening(self):
 
         setup = SetupTHM(ux_south=0, uy_south=0, ux_north=0, uy_north=0.001)
-        setup.tsc.time_final *= 3
+        setup.time_manager.time_final *= 3
         setup.mesh_args = [2, 2]
         setup.simplex = False
         setup.gamma = -1e-2
@@ -241,7 +241,7 @@ class TestContactMechanicsTHM(unittest.TestCase):
         """
         setup = SetupTHM(ux_south=0, uy_south=0, ux_north=0, uy_north=0.001)
         setup.beta, setup.gamma = 1e-12, 1e-12
-        setup.tsc.time_final *= 3
+        setup.time_manager.time_final *= 3
         setup.mesh_args = [2, 2]
         setup.simplex = False
         #
@@ -263,7 +263,7 @@ class TestContactMechanicsTHM(unittest.TestCase):
         to slightly more opening).
         """
         setup = SetupTHM(ux_south=0, uy_south=0, ux_north=0, uy_north=0.001)
-        setup.tsc.time_final *= 3
+        setup.time_manager.time_final *= 3
         setup.mesh_args = [2, 2]
         setup.simplex = False
         setup.T_0_Kelvin = 1

--- a/tests/integration/test_thm.py
+++ b/tests/integration/test_thm.py
@@ -202,7 +202,7 @@ class TestContactMechanicsTHM(unittest.TestCase):
     def test_time_dependent_pull_north_positive_opening(self):
 
         setup = SetupTHM(ux_south=0, uy_south=0, ux_north=0, uy_north=0.001)
-        setup.end_time *= 3
+        setup.tsc.time_final *= 3
         setup.mesh_args = [2, 2]
         setup.simplex = False
         setup.gamma = -1e-2
@@ -241,7 +241,7 @@ class TestContactMechanicsTHM(unittest.TestCase):
         """
         setup = SetupTHM(ux_south=0, uy_south=0, ux_north=0, uy_north=0.001)
         setup.beta, setup.gamma = 1e-12, 1e-12
-        setup.end_time *= 3
+        setup.tsc.time_final *= 3
         setup.mesh_args = [2, 2]
         setup.simplex = False
         #
@@ -263,7 +263,7 @@ class TestContactMechanicsTHM(unittest.TestCase):
         to slightly more opening).
         """
         setup = SetupTHM(ux_south=0, uy_south=0, ux_north=0, uy_north=0.001)
-        setup.end_time *= 3
+        setup.tsc.time_final *= 3
         setup.mesh_args = [2, 2]
         setup.simplex = False
         setup.T_0_Kelvin = 1

--- a/tests/unit/test_time_step_control.py
+++ b/tests/unit/test_time_step_control.py
@@ -151,18 +151,30 @@ class TestParameterInputs:
 
     def test_initial_time_step_larger_than_minimum_time_step(self):
         """An error should be raised if initial time step is less than minimum time step."""
-        msg = "Initial time step cannot be smaller than minimum time step."
+        msg_dtmin = "Initial time step cannot be smaller than minimum time step. "
+        msg_unset = (
+            "This error was raised since `dt_min_max` was not set on "
+            "initialization. Thus, values of dt_min and dt_max were assigned "
+            "based on the final simulation time. If you still want to use this "
+            "initial time step, consider passing `dt_min_max` explicitly."
+        )
         with pytest.raises(ValueError) as excinfo:
             Ts(schedule=[0, 1], dt_init=0.0009)
-        assert msg in str(excinfo.value)
+        assert (msg_dtmin + msg_unset) in str(excinfo.value)
 
     def test_initial_time_step_smaller_than_maximum_time_step(self):
         """An error should be raised if initial time step is larger than the maximum time
         step."""
-        msg = "Initial time step cannot be larger than maximum time step."
+        msg_dtmax = "Initial time step cannot be larger than maximum time step. "
+        msg_unset = (
+            "This error was raised since `dt_min_max` was not set on "
+            "initialization. Thus, values of dt_min and dt_max were assigned "
+            "based on the final simulation time. If you still want to use this "
+            "initial time step, consider passing `dt_min_max` explicitly."
+        )
         with pytest.raises(ValueError) as excinfo:
             Ts(schedule=[0, 1], dt_init=0.11)
-        assert msg in str(excinfo.value)
+        assert (msg_dtmax + msg_unset) in str(excinfo.value)
 
     @pytest.mark.parametrize("iter_max", [0, -1])
     def test_max_number_of_iterations_positive(self, iter_max):

--- a/tests/unit/test_time_step_control.py
+++ b/tests/unit/test_time_step_control.py
@@ -1,5 +1,5 @@
 """
-This module contains a collection of unit tests for the `TimeSteppingControl` class. The
+This module contains a collection of unit tests for the `TimeManager` class. The
 module contains two test classes, namely: `TestParameterInputs` and `TestTimeControl`.
 
 `TestParameterInputs` contains test methods that check the sanity of the input parameters.
@@ -16,7 +16,7 @@ import numpy as np
 import pytest
 
 import porepy as pp
-from porepy.numerics.time_step_control import TimeSteppingControl as Ts
+from porepy.numerics.time_step_control import TimeManager as Ts
 
 
 class TestParameterInputs:

--- a/tests/unit/test_time_step_control.py
+++ b/tests/unit/test_time_step_control.py
@@ -437,6 +437,16 @@ class TestTimeControl:
             tsc.next_time_step(iterations=5, recompute_solution=True)
         assert tsc._recomp_sol and (msg in str(excinfo.value))
 
+    def test_raise_error_when_adapting_based_on_iterations_with_iterations_none(self):
+        """An error should be raised if adaptation based on iteration is intended but
+        iterations is None.
+        """
+        tsc = Ts(schedule=[0, 100], dt_init=1)
+        with pytest.raises(ValueError) as excinfo:
+            msg = "Time step cannot be adapted without 'iterations'."
+            tsc.next_time_step()
+        assert not tsc._recomp_sol and (msg in str(excinfo.value))
+
     @pytest.mark.parametrize("iterations", [11, 100])
     def test_warning_iteration_is_greater_than_max_iter(self, iterations):
         """Test if a warning is raised when the number of iterations passed to the method is

--- a/tests/unit/test_time_step_control.py
+++ b/tests/unit/test_time_step_control.py
@@ -379,6 +379,28 @@ class TestTimeControl:
         dt = tsc.next_time_step(1, False)
         assert dt == 0.1
 
+    def test_raise_warning_iteration_not_none_for_constant_time_step(self):
+        """A warning should be raised if iterations is given and time step is constant"""
+        tsc = Ts([0, 1], 0.1, iter_max=10, constant_dt=True)
+        iterations = 1
+        msg = (
+            f"iterations '{iterations}' has no effect if time step is constant."
+        )
+        with pytest.warns() as record:
+            tsc.next_time_step(iterations=iterations)
+        assert str(record[0].message) == msg
+
+    def test_raise_warning_recompute_solution_true_for_constant_time_step(self):
+        """A warning should be raised if recompute_solution is True and time step is
+        constant"""
+        tsc = Ts([0, 1], 0.1, iter_max=10, constant_dt=True)
+        msg = (
+            "recompute_solution=True has no effect if time step is constant."
+        )
+        with pytest.warns() as record:
+            tsc.next_time_step(recompute_solution=True)
+        assert str(record[0].message) == msg
+
     def test_non_recomputed_solution_conditions(self):
         """Test behaviour of the algorithm when the solution should NOT be recomputed"""
         # Check if internal flag _recomp_sol remains unchanged when recompute_solution=False

--- a/tests/unit/test_time_step_control.py
+++ b/tests/unit/test_time_step_control.py
@@ -597,3 +597,32 @@ class TestTimeControl:
             tsc.dt = tsc.dt_min_max[1]
             tsc.next_time_step(iterations=4)
             assert time == tsc.time + tsc.dt
+
+    @pytest.mark.parametrize(
+        "schedule, dt_init, is_constant, time, dt",
+        [
+            ([0, 1], 0.1, False, 0.3, 0.2),
+            ([0, 1], 0.1, True, 0.3, 0.2),
+        ]
+    )
+    def test_update_time(self, schedule, dt_init, is_constant, time, dt):
+        """Checks if time is correctly updated"""
+        tsc = Ts(schedule=schedule, dt_init=dt_init, constant_dt=is_constant)
+        tsc.time = time
+        tsc.dt = dt
+        tsc.increase_time()
+        assert tsc.time == time + dt
+
+    @pytest.mark.parametrize(
+        "schedule, dt_init, is_constant, time_index",
+        [
+            ([0, 1], 0.1, False, 13),
+            ([0, 1], 0.1, True, 13),
+        ]
+    )
+    def test_update_time_index(self, schedule, dt_init, is_constant, time_index):
+        """Checks if time index is correctly updated"""
+        tsc = Ts(schedule=schedule, dt_init=dt_init, constant_dt=is_constant)
+        tsc.time_index = time_index
+        tsc.increase_time_index()
+        assert tsc.time_index == (time_index + 1)

--- a/tests/unit/test_time_step_control.py
+++ b/tests/unit/test_time_step_control.py
@@ -16,7 +16,6 @@ import numpy as np
 import pytest
 
 import porepy as pp
-from porepy.numerics.time_step_control import TimeManager as Ts
 
 
 class TestParameterInputs:
@@ -24,7 +23,7 @@ class TestParameterInputs:
 
     def test_default_parameters_and_attribute_initialization(self):
         """Test the default parameters and initialization of attributes."""
-        time_manager = Ts(schedule=[0, 1], dt_init=0.1)
+        time_manager = pp.TimeManager(schedule=[0, 1], dt_init=0.1)
         np.testing.assert_equal(time_manager.schedule, np.array([0, 1]))
         assert time_manager.time_init == 0
         assert time_manager.time_final == 1
@@ -43,7 +42,7 @@ class TestParameterInputs:
     )
     def test_schedule_argument_type_compatibility(self, schedule):
         """The 'schedule' object is supposed to take any array-like object."""
-        time_manager = Ts(schedule=schedule, dt_init=0.01)
+        time_manager = pp.TimeManager(schedule=schedule, dt_init=0.01)
         assert isinstance(time_manager.schedule, np.ndarray)
         assert (time_manager.schedule == np.array([0.0, 0.5, 1.0])).all()
 
@@ -58,7 +57,7 @@ class TestParameterInputs:
         """An error should be raised if len(schedule) < 2."""
         msg = "Expected schedule with at least two elements."
         with pytest.raises(ValueError) as excinfo:
-            Ts(schedule=schedule, dt_init=dt_init)
+            pp.TimeManager(schedule=schedule, dt_init=dt_init)
         assert msg in str(excinfo.value)
 
     @pytest.mark.parametrize(
@@ -73,7 +72,7 @@ class TestParameterInputs:
         """An error should be raised if a negative time is encountered in the schedule."""
         msg = "Encountered at least one negative time in schedule."
         with pytest.raises(ValueError) as excinfo:
-            Ts(schedule=schedule, dt_init=dt_init)
+            pp.TimeManager(schedule=schedule, dt_init=dt_init)
         assert msg in str(excinfo.value)
 
     @pytest.mark.parametrize(
@@ -88,7 +87,7 @@ class TestParameterInputs:
         """An error should be raised if times in schedule are not strictly increasing."""
         msg = "Schedule must contain strictly increasing times."
         with pytest.raises(ValueError) as excinfo:
-            Ts(schedule=schedule, dt_init=dt_init)
+            pp.TimeManager(schedule=schedule, dt_init=dt_init)
         assert msg in str(excinfo.value)
 
     @pytest.mark.parametrize(
@@ -104,7 +103,7 @@ class TestParameterInputs:
     def test_constant_dt_compatibility_with_schedule(self, schedule, dt_init):
         """No error should be raised if dt and schedule are compatible"""
         try:
-            Ts(schedule=schedule, dt_init=dt_init, constant_dt=True)
+            pp.TimeManager(schedule=schedule, dt_init=dt_init, constant_dt=True)
         except Exception as exc:
             assert False, f"The following exception was raised: {exc}"
 
@@ -125,7 +124,7 @@ class TestParameterInputs:
             "compatible, or consider adjusting the tolerances of the sanity check."
         )
         with pytest.raises(ValueError) as excinfo:
-            Ts(schedule=schedule, dt_init=dt_init, constant_dt=True)
+            pp.TimeManager(schedule=schedule, dt_init=dt_init, constant_dt=True)
         assert msg in str(excinfo.value)
 
     @pytest.mark.parametrize(
@@ -139,14 +138,14 @@ class TestParameterInputs:
         """An error should be raised if initial time step is non-positive."""
         msg = "Initial time step must be positive."
         with pytest.raises(ValueError) as excinfo:
-            Ts(schedule=schedule, dt_init=dt_init)
+            pp.TimeManager(schedule=schedule, dt_init=dt_init)
         assert msg in str(excinfo.value)
 
     def test_initial_time_step_smaller_than_final_time(self):
         """An error should be raised if initial time step is larger than final time."""
         msg = "Initial time step cannot be larger than final simulation time."
         with pytest.raises(ValueError) as excinfo:
-            Ts(schedule=[0, 1], dt_init=1.0001)
+            pp.TimeManager(schedule=[0, 1], dt_init=1.0001)
         assert msg in str(excinfo.value)
 
     def test_initial_time_step_larger_than_minimum_time_step(self):
@@ -159,7 +158,7 @@ class TestParameterInputs:
             "initial time step, consider passing `dt_min_max` explicitly."
         )
         with pytest.raises(ValueError) as excinfo:
-            Ts(schedule=[0, 1], dt_init=0.0009)
+            pp.TimeManager(schedule=[0, 1], dt_init=0.0009)
         assert (msg_dtmin + msg_unset) in str(excinfo.value)
 
     def test_initial_time_step_smaller_than_maximum_time_step(self):
@@ -173,7 +172,7 @@ class TestParameterInputs:
             "initial time step, consider passing `dt_min_max` explicitly."
         )
         with pytest.raises(ValueError) as excinfo:
-            Ts(schedule=[0, 1], dt_init=0.11)
+            pp.TimeManager(schedule=[0, 1], dt_init=0.11)
         assert (msg_dtmax + msg_unset) in str(excinfo.value)
 
     @pytest.mark.parametrize("iter_max", [0, -1])
@@ -181,7 +180,7 @@ class TestParameterInputs:
         """An error should be raised if the maximum number of iterations is not positive."""
         msg = "Maximum number of iterations must be positive."
         with pytest.raises(ValueError) as excinfo:
-            Ts(schedule=[0, 1], dt_init=0.1, iter_max=iter_max)
+            pp.TimeManager(schedule=[0, 1], dt_init=0.1, iter_max=iter_max)
         assert msg in str(excinfo.value)
 
     def test_lower_iter_endpoint_smaller_than_upper_iter_endpoint(self):
@@ -193,7 +192,7 @@ class TestParameterInputs:
             f"cannot be larger than upper endpoint '{iter_optimal_range[1]}'."
         )
         with pytest.raises(ValueError) as excinfo:
-            Ts(
+            pp.TimeManager(
                 schedule=[0, 1],
                 dt_init=0.1,
                 iter_max=5,
@@ -211,7 +210,7 @@ class TestParameterInputs:
             f"cannot be larger than maximum number of iterations '{iter_max}'."
         )
         with pytest.raises(ValueError) as excinfo:
-            Ts(
+            pp.TimeManager(
                 schedule=[0, 1],
                 dt_init=0.1,
                 iter_max=iter_max,
@@ -227,7 +226,7 @@ class TestParameterInputs:
             "cannot be negative."
         )
         with pytest.raises(ValueError) as excinfo:
-            Ts(
+            pp.TimeManager(
                 schedule=[0, 1],
                 dt_init=0.1,
                 iter_max=5,
@@ -248,7 +247,7 @@ class TestParameterInputs:
         """An error should be raised if under-relaxation factor >= 1"""
         msg = "Expected under-relaxation factor < 1."
         with pytest.raises(ValueError) as excinfo:
-            Ts(
+            pp.TimeManager(
                 schedule,
                 dt_init,
                 iter_relax_factors=iter_relax_factors,
@@ -268,7 +267,7 @@ class TestParameterInputs:
         """An error should be raised if over-relaxation factor <= 1"""
         msg = "Expected over-relaxation factor > 1."
         with pytest.raises(ValueError) as excinfo:
-            Ts(
+            pp.TimeManager(
                 schedule,
                 dt_init,
                 iter_relax_factors=iter_relax_factors,
@@ -284,7 +283,7 @@ class TestParameterInputs:
         )
         msg = msg_dtmin_over + msg_osc
         with pytest.raises(ValueError) as excinfo:
-            Ts(
+            pp.TimeManager(
                 schedule=[0, 1],
                 dt_init=0.1,
                 iter_relax_factors=(0.9, 101),
@@ -300,7 +299,7 @@ class TestParameterInputs:
         )
         msg = msg_dtmax_under + msg_osc
         with pytest.raises(ValueError) as excinfo:
-            Ts(
+            pp.TimeManager(
                 schedule=[0, 1],
                 dt_init=0.1,
                 iter_relax_factors=(0.009, 1.3),
@@ -318,7 +317,7 @@ class TestParameterInputs:
         """An error should be raised if the recomputation factor is greater or equal to one."""
         msg = "Expected recomputation factor < 1."
         with pytest.raises(ValueError) as excinfo:
-            Ts(
+            pp.TimeManager(
                 schedule=schedule,
                 dt_init=dt_init,
                 recomp_factor=recomp_factor,
@@ -339,7 +338,7 @@ class TestParameterInputs:
         negative."""
         msg = "Number of recomputation attempts must be > 0."
         with pytest.raises(ValueError) as excinfo:
-            Ts(
+            pp.TimeManager(
                 schedule=schedule,
                 dt_init=dt_init,
                 recomp_max=recomp_max,
@@ -355,12 +354,12 @@ class TestTimeControl:
         """Test if final simulation time returns None, irrespectively of parameters
         passed in next_time_step()."""
         # Assume we reach the final time
-        time_manager = Ts(schedule=[0, 1], dt_init=0.1)
+        time_manager = pp.TimeManager(schedule=[0, 1], dt_init=0.1)
         time_manager.time = 1
         dt = time_manager.compute_time_step(iterations=1000, recompute_solution=True)
         assert dt is None
         # Now, assume we are above the final time
-        time_manager = Ts(schedule=[0, 1], dt_init=0.1)
+        time_manager = pp.TimeManager(schedule=[0, 1], dt_init=0.1)
         time_manager.time = 2
         dt = time_manager.compute_time_step(iterations=0, recompute_solution=False)
         assert dt is None
@@ -378,7 +377,9 @@ class TestTimeControl:
         self, schedule, dt_init, time, time_index, iters, recomp_sol
     ):
         """Test if a constant dt is returned, independent of any configuration or input."""
-        time_manager = Ts(schedule=schedule, dt_init=dt_init, constant_dt=True)
+        time_manager = pp.TimeManager(
+            schedule=schedule, dt_init=dt_init, constant_dt=True
+        )
         time_manager.time = time
         time_manager.time_index = time_index
 
@@ -391,7 +392,7 @@ class TestTimeControl:
 
     def test_raise_warning_iteration_not_none_for_constant_time_step(self):
         """A warning should be raised if iterations is given and time step is constant"""
-        time_manager = Ts([0, 1], 0.1, iter_max=10, constant_dt=True)
+        time_manager = pp.TimeManager([0, 1], 0.1, iter_max=10, constant_dt=True)
         iterations = 1
         msg = f"iterations '{iterations}' has no effect if time step is constant."
         with pytest.warns() as record:
@@ -401,7 +402,7 @@ class TestTimeControl:
     def test_raise_warning_recompute_solution_true_for_constant_time_step(self):
         """A warning should be raised if recompute_solution is True and time step is
         constant"""
-        time_manager = Ts([0, 1], 0.1, iter_max=10, constant_dt=True)
+        time_manager = pp.TimeManager([0, 1], 0.1, iter_max=10, constant_dt=True)
         msg = "recompute_solution=True has no effect if time step is constant."
         with pytest.warns() as record:
             time_manager.compute_time_step(recompute_solution=True)
@@ -411,18 +412,18 @@ class TestTimeControl:
         """Test behaviour of the algorithm when the solution should NOT be recomputed"""
         # Check if internal flag _recomp_sol remains unchanged when recompute_solution=False
         # regardless of the number of iterations provided by the user
-        time_manager = Ts([0, 1], 0.1)
+        time_manager = pp.TimeManager([0, 1], 0.1)
         time_manager.compute_time_step(iterations=5)
         assert not time_manager._recomp_sol
         time_manager.compute_time_step(iterations=1000)
         assert not time_manager._recomp_sol
         # Check if _recomp_num resets to zero when solution is NOT recomputed
-        time_manager = Ts([0, 1], 0.1)
+        time_manager = pp.TimeManager([0, 1], 0.1)
         time_manager._recomp_num = 3  # manually change recomputation attempts
         time_manager.compute_time_step(iterations=5)
         assert time_manager._recomp_num == 0
         # Assume recompute_solution=True, but we reach or exceeded maximum number of attempts
-        time_manager = Ts([0, 1], 0.1, recomp_max=5)
+        time_manager = pp.TimeManager([0, 1], 0.1, recomp_max=5)
         time_manager._recomp_num = 5
         with pytest.raises(ValueError) as excinfo:
             msg = (
@@ -434,14 +435,14 @@ class TestTimeControl:
 
     def test_recompute_solution_false_by_default(self):
         """ "Checks if recompute solution is False by default"""
-        time_manager = Ts([0, 1], 0.1)
+        time_manager = pp.TimeManager([0, 1], 0.1)
         time_manager.compute_time_step(iterations=3)
         assert not time_manager._recomp_sol
 
     def test_recomputed_solutions(self):
         """Test behaviour of the algorithm when the solution should be recomputed. Note
         that this should be independent of the number of iterations that the user passes"""
-        time_manager = Ts([0, 100], 2, recomp_factor=0.5)
+        time_manager = pp.TimeManager([0, 100], 2, recomp_factor=0.5)
         time_manager.time = 5
         time_manager.time_index = 13
         time_manager.dt = 1
@@ -462,7 +463,7 @@ class TestTimeControl:
     def test_recomputed_solution_with_calculated_dt_less_than_dt_min(self):
         """Test when a solution is recomputed and the calculated time step is less than
         the minimum allowable time step, the time step is indeed the minimum time step"""
-        time_manager = Ts([0, 100], 0.15, recomp_factor=0.5)
+        time_manager = pp.TimeManager([0, 100], 0.15, recomp_factor=0.5)
         # Emulate the scenario where the solution must be recomputed
         time_manager.time = 5
         time_manager.compute_time_step(iterations=1000, recompute_solution=True)
@@ -473,7 +474,7 @@ class TestTimeControl:
     def test_warning_when_iterations_is_given_and_recomputation_is_true(self):
         """A warning should be raised when iterations is not None and the recomputation flag
         is True"""
-        time_manager = Ts([0, 1], 0.1, iter_max=10)
+        time_manager = pp.TimeManager([0, 1], 0.1, iter_max=10)
         msg = "Number of iterations has no effect in recomputation."
         with pytest.warns() as record:
             time_manager.compute_time_step(iterations=1, recompute_solution=True)
@@ -484,7 +485,7 @@ class TestTimeControl:
     ):
         """An error should be raised when adaption based on recomputation is attempted with
         dt = dt_min"""
-        time_manager = Ts(schedule=[0, 100], dt_init=1, dt_min_max=(1, 10))
+        time_manager = pp.TimeManager(schedule=[0, 100], dt_init=1, dt_min_max=(1, 10))
         # For these parameters, we have time_manager.dt = time_manager.dt_init = time_manager.dt_min_max[0]
         # Attempting a recomputation should raise an error
         with pytest.raises(ValueError) as excinfo:
@@ -499,7 +500,7 @@ class TestTimeControl:
         """An error should be raised if adaptation based on iteration is intended but
         iterations is None.
         """
-        time_manager = Ts(schedule=[0, 100], dt_init=1)
+        time_manager = pp.TimeManager(schedule=[0, 100], dt_init=1)
         with pytest.raises(ValueError) as excinfo:
             msg = "Time step cannot be adapted without 'iterations'."
             time_manager.compute_time_step()
@@ -509,7 +510,7 @@ class TestTimeControl:
     def test_warning_iteration_is_greater_than_max_iter(self, iterations):
         """Test if a warning is raised when the number of iterations passed to the method is
         greater than max_iter and the solution is not recomputed"""
-        time_manager = Ts([0, 1], 0.1, iter_max=10)
+        time_manager = pp.TimeManager([0, 1], 0.1, iter_max=10)
         warn_msg = (
             f"The given number of iterations '{iterations}' is larger than the maximum "
             f"number of iterations '{time_manager.iter_max}'. This usually means that the solver "
@@ -526,7 +527,7 @@ class TestTimeControl:
     def test_decreasing_time_step(self, iterations):
         """Test if the time step decreases after the number of iterations is less or equal
         than the lower endpoint of the optimal iteration range by its corresponding factor"""
-        time_manager = Ts(
+        time_manager = pp.TimeManager(
             [0, 100],
             2,
             iter_optimal_range=(5, 9),
@@ -541,7 +542,7 @@ class TestTimeControl:
         """Test if the time step is restricted after the number of iterations is greater or
         equal than the upper endpoint of the optimal iteration range by its corresponding
         factor"""
-        time_manager = Ts(
+        time_manager = pp.TimeManager(
             [0, 100],
             2,
             iter_optimal_range=(5, 9),
@@ -555,7 +556,7 @@ class TestTimeControl:
     def test_time_step_within_optimal_iteration_range(self, iterations):
         """Test if the time step remains unchanged when the number of iterations lies
         between the optimal iteration range"""
-        time_manager = Ts(
+        time_manager = pp.TimeManager(
             [0, 100],
             2,
             iter_optimal_range=(5, 9),
@@ -568,7 +569,7 @@ class TestTimeControl:
     @pytest.mark.parametrize("dt", [0.13, 0.1, 0.075])
     def test_time_step_less_than_dt_min(self, dt):
         """Test if the algorithm passes dt_min when the calculated dt is less than dt_min"""
-        time_manager = Ts([0, 100], 2, iter_optimal_range=(4, 7))
+        time_manager = pp.TimeManager([0, 100], 2, iter_optimal_range=(4, 7))
         time_manager.dt = dt
         time_manager.compute_time_step(iterations=7)
         assert time_manager.dt == time_manager.dt_min_max[0]
@@ -576,7 +577,7 @@ class TestTimeControl:
     @pytest.mark.parametrize("dt", [9, 10, 15])
     def test_time_step_greater_than_dt_max(self, dt):
         """Test if the algorithm passes dt_max when the calculated dt is greater than dt_max"""
-        time_manager = Ts([0, 100], 2, iter_optimal_range=(4, 7))
+        time_manager = pp.TimeManager([0, 100], 2, iter_optimal_range=(4, 7))
         time_manager.dt = dt
         time_manager.compute_time_step(iterations=4)
         assert time_manager.dt == time_manager.dt_min_max[1]
@@ -595,7 +596,7 @@ class TestTimeControl:
     )
     def test_hitting_schedule_times(self, schedule, dt_init):
         """Test if algorithm respects the passed target times from the schedule"""
-        time_manager = Ts(schedule, dt_init)
+        time_manager = pp.TimeManager(schedule, dt_init)
         for time in schedule[1:]:
             time_manager.time = 0.99 * time
             time_manager.dt = time_manager.dt_min_max[1]
@@ -611,7 +612,9 @@ class TestTimeControl:
     )
     def test_update_time(self, schedule, dt_init, is_constant, time, dt):
         """Checks if time is correctly updated"""
-        time_manager = Ts(schedule=schedule, dt_init=dt_init, constant_dt=is_constant)
+        time_manager = pp.TimeManager(
+            schedule=schedule, dt_init=dt_init, constant_dt=is_constant
+        )
         time_manager.time = time
         time_manager.dt = dt
         time_manager.increase_time()
@@ -626,7 +629,9 @@ class TestTimeControl:
     )
     def test_update_time_index(self, schedule, dt_init, is_constant, time_index):
         """Checks if time index is correctly updated"""
-        time_manager = Ts(schedule=schedule, dt_init=dt_init, constant_dt=is_constant)
+        time_manager = pp.TimeManager(
+            schedule=schedule, dt_init=dt_init, constant_dt=is_constant
+        )
         time_manager.time_index = time_index
         time_manager.increase_time_index()
         assert time_manager.time_index == (time_index + 1)

--- a/tests/unit/test_time_step_control.py
+++ b/tests/unit/test_time_step_control.py
@@ -377,16 +377,15 @@ class TestTimeControl:
     def test_constant_time_step(
         self, schedule, dt_init, time, time_index, iters, recomp_sol
     ):
-        """Test if a constant time step is returned, independent of any configuration or
-        input. We also test that the time and the time index are updated accordingly"""
+        """Test if a constant dt is returned, independent of any configuration or input."""
         tsc = Ts(schedule=schedule, dt_init=dt_init, constant_dt=True)
         tsc.time = time
         tsc.time_index = time_index
 
         dt = tsc.next_time_step(iterations=iters, recompute_solution=recomp_sol)
         assert tsc.dt == dt
-        assert tsc.time == time + dt
-        assert tsc.time_index == time_index + 1
+        assert tsc.time == time
+        assert tsc.time_index == time_index
 
     def test_raise_warning_iteration_not_none_for_constant_time_step(self):
         """A warning should be raised if iterations is given and time step is constant"""
@@ -452,10 +451,8 @@ class TestTimeControl:
         #     new dt to be half of the old one (dt = 1 * 0.5 = 0.5)
         #     recomputation flag set to True (_recomp_flag = True)
         #     recomputation counter to increase by 1 (_recomp_num = 6 + 1 = 7)
-        #     time to be added increased by new dt (time = 4 + 0.5 = 4.5)
-        #     time index to be increased by one (time_index = 12 + 1 = 13)
-        assert tsc.time == 4.5
-        assert tsc.time_index == 13
+        assert tsc.time == 4.0
+        assert tsc.time_index == 12
         assert tsc.dt == 0.5
         assert tsc._recomp_sol
         assert tsc._recomp_num == 7
@@ -599,4 +596,4 @@ class TestTimeControl:
             tsc.time = 0.99 * time
             tsc.dt = tsc.dt_min_max[1]
             tsc.next_time_step(iterations=4)
-            assert time == tsc.time
+            assert time == tsc.time + tsc.dt

--- a/tests/unit/test_time_step_control.py
+++ b/tests/unit/test_time_step_control.py
@@ -382,7 +382,9 @@ class TestTimeControl:
         time_manager.time = time
         time_manager.time_index = time_index
 
-        dt = time_manager.compute_time_step(iterations=iters, recompute_solution=recomp_sol)
+        dt = time_manager.compute_time_step(
+            iterations=iters, recompute_solution=recomp_sol
+        )
         assert time_manager.dt == dt
         assert time_manager.time == time
         assert time_manager.time_index == time_index
@@ -515,7 +517,9 @@ class TestTimeControl:
             f"algorithm will adapt the time step anyways."
         )
         with pytest.warns() as record:
-            time_manager.compute_time_step(iterations=iterations, recompute_solution=False)
+            time_manager.compute_time_step(
+                iterations=iterations, recompute_solution=False
+            )
         assert str(record[0].message) == warn_msg
 
     @pytest.mark.parametrize("iterations", [1, 3, 5])
@@ -603,7 +607,7 @@ class TestTimeControl:
         [
             ([0, 1], 0.1, False, 0.3, 0.2),
             ([0, 1], 0.1, True, 0.3, 0.2),
-        ]
+        ],
     )
     def test_update_time(self, schedule, dt_init, is_constant, time, dt):
         """Checks if time is correctly updated"""
@@ -618,7 +622,7 @@ class TestTimeControl:
         [
             ([0, 1], 0.1, False, 13),
             ([0, 1], 0.1, True, 13),
-        ]
+        ],
     )
     def test_update_time_index(self, schedule, dt_init, is_constant, time_index):
         """Checks if time index is correctly updated"""

--- a/tests/unit/test_time_step_control.py
+++ b/tests/unit/test_time_step_control.py
@@ -45,7 +45,7 @@ class TestParameterInputs:
         """The 'schedule' object is supposed to take any array-like object."""
         tsc = Ts(schedule=schedule, dt_init=0.01)
         assert isinstance(tsc.schedule, np.ndarray)
-        assert (tsc.schedule == np.array([0., 0.5, 1.])).all()
+        assert (tsc.schedule == np.array([0.0, 0.5, 1.0])).all()
 
     @pytest.mark.parametrize(
         "schedule, dt_init",
@@ -99,7 +99,7 @@ class TestParameterInputs:
             ([0, 1, 2], 1),
             ([0, 0.05, 2.0, 4.0, 10.0], 0.05),
             ([5.0, 10.0, 60.0, 62.5, 70.0], 2.5),
-        ]
+        ],
     )
     def test_constant_dt_compatibility_with_schedule(self, schedule, dt_init):
         """No error should be raised if dt and schedule are compatible"""
@@ -114,7 +114,7 @@ class TestParameterInputs:
             ([0, 1], 0.4),
             ([0, 1], 0.3333),
             ([0, 0.4, 0.5, 0.8, 1], 0.2),
-            ([13.1, 13.2, 13.3], 0.2)
+            ([13.1, 13.2, 13.3], 0.2),
         ],
     )
     def test_raise_error_incompatible_dt_and_schedule(self, schedule, dt_init):
@@ -370,11 +370,13 @@ class TestTimeControl:
         [
             ([0, 1], 0.1, 0.3, 3, 1000, True),
             ([0, 10], 1, 2, 0, None, False),
-            ([0, pp.HOUR, 3*pp.HOUR], 0.5*pp.HOUR, 0, 0, None, False),
-            ([0, pp.HOUR, 3 * pp.HOUR], 0.5 * pp.HOUR, 1.5*pp.HOUR, 678, 342, True),
-        ]
+            ([0, pp.HOUR, 3 * pp.HOUR], 0.5 * pp.HOUR, 0, 0, None, False),
+            ([0, pp.HOUR, 3 * pp.HOUR], 0.5 * pp.HOUR, 1.5 * pp.HOUR, 678, 342, True),
+        ],
     )
-    def test_constant_time_step(self, schedule, dt_init, time, time_index, iters, recomp_sol):
+    def test_constant_time_step(
+        self, schedule, dt_init, time, time_index, iters, recomp_sol
+    ):
         """Test if a constant time step is returned, independent of any configuration or
         input. We also test that the time and the time index are updated accordingly"""
         tsc = Ts(schedule=schedule, dt_init=dt_init, constant_dt=True)
@@ -390,9 +392,7 @@ class TestTimeControl:
         """A warning should be raised if iterations is given and time step is constant"""
         tsc = Ts([0, 1], 0.1, iter_max=10, constant_dt=True)
         iterations = 1
-        msg = (
-            f"iterations '{iterations}' has no effect if time step is constant."
-        )
+        msg = f"iterations '{iterations}' has no effect if time step is constant."
         with pytest.warns() as record:
             tsc.next_time_step(iterations=iterations)
         assert str(record[0].message) == msg
@@ -401,9 +401,7 @@ class TestTimeControl:
         """A warning should be raised if recompute_solution is True and time step is
         constant"""
         tsc = Ts([0, 1], 0.1, iter_max=10, constant_dt=True)
-        msg = (
-            "recompute_solution=True has no effect if time step is constant."
-        )
+        msg = "recompute_solution=True has no effect if time step is constant."
         with pytest.warns() as record:
             tsc.next_time_step(recompute_solution=True)
         assert str(record[0].message) == msg
@@ -434,7 +432,7 @@ class TestTimeControl:
         assert tsc._recomp_sol and (msg in str(excinfo.value))
 
     def test_recompute_solution_false_by_default(self):
-        """"Checks if recompute solution is False by default"""
+        """ "Checks if recompute solution is False by default"""
         tsc = Ts([0, 1], 0.1)
         tsc.next_time_step(iterations=3)
         assert not tsc._recomp_sol
@@ -482,7 +480,9 @@ class TestTimeControl:
             tsc.next_time_step(iterations=1, recompute_solution=True)
         assert str(record[0].message) == msg
 
-    def test_raise_error_when_adapting_based_on_recomputation_with_dt_equal_to_dt_min(self):
+    def test_raise_error_when_adapting_based_on_recomputation_with_dt_equal_to_dt_min(
+        self,
+    ):
         """An error should be raised when adaption based on recomputation is attempted with
         dt = dt_min"""
         tsc = Ts(schedule=[0, 100], dt_init=1, dt_min_max=(1, 10))

--- a/tests/unit/test_time_step_control.py
+++ b/tests/unit/test_time_step_control.py
@@ -435,6 +435,15 @@ class TestTimeControl:
         # dt_min. Hence, dt_min should be set.
         assert tsc.dt == tsc.dt_min_max[0]
 
+    def test_warning_when_iterations_is_given_and_recomputation_is_true(self):
+        """A warning should be raised when iterations is not None and the recomputation flag
+        is True"""
+        tsc = Ts([0, 1], 0.1, iter_max=10)
+        msg = "Number of iterations has no effect in recomputation."
+        with pytest.warns() as record:
+            tsc.next_time_step(iterations=1, recompute_solution=True)
+        assert str(record[0].message) == msg
+
     def test_raise_error_when_adapting_based_on_recomputation_with_dt_equal_to_dt_min(self):
         """An error should be raised when adaption based on recomputation is attempted with
         dt = dt_min"""


### PR DESCRIPTION
## Proposed changes

This PR proposes a non-breaking integration of the `TimeSteppingControl` class into time-dependent models. The PR preserves all previous functionality of the models, including natural values of initial time, final time, and time step when the `params` dictionary does not contain the key `"time_manager"` with value `tsc: pp.TimeSteppingControl`. 

Note that this PR does not incorporate any time adaptation into the models (thus the name partial). This will be the natural next step. This PR solves #735, where more information about the integration can be found.

Two main changes have been introduced:
1. Models no longer have time attributes. Instead, all time-related variables are centralised in `model.tsc`.
2.  `run_time_dependent_model()` and `_run_iterative_model()` from `run_models.py` now use `model.tsc` in the time loops. 

After code review, the following naming-related changes were incorporated to the PR:

- The class `TimeSteppingControl` was renamed to `TimeManager`
- The method `next_time_step()` was renamed to `compute_time_step()`
- The object `tsc` was renamed to `time_manager`

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply_

- [ ] Minor change (e.g., dependency bumps, broken links, etc).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Testing (contribution related to testing of existing or new functionality).
- [x] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code, etc).
- [ ] Other: 

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.	
- [x] Static typing is included in the update.
- [x] This PR does not duplicated existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).


