### PR TITLE
BLD: GH action runs on Python 3.10,*, not fixed to 3.10.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     # https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#specifying-a-python-version
     strategy:
       matrix:
-        python-version:  ["3.8", "3.9", "3.10.6"]  # TODO: Change 3.10.6 to 3.10 when mypy error is fixed
+        python-version:  ["3.8", "3.9", "3.10"]  # TODO: Change 3.10.6 to 3.10 when mypy error is fixed
       # Complete all versions in matrix even if one fails.
       fail-fast: false
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ black == 22.*
 deepdiff
 flake8
 isort
-mypy
+mypy >= 0.981
 pytest >= 4.6
 pytest-cov
 pytest-runner


### PR DESCRIPTION
This fixes a temporary requirement that actions were run on Python > 3.10.7, relating to an issue in mypy.

Resolves #733. 

## Proposed changes

Contributions to PorePy are highly appreciated. Clearly explain to the maintainers why this pull request (PR) is needed and why it should be accepted. If this PR solves an issue, explain how it is done. Please, also summarise the changes to the code. 

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply_

- [ ] Minor change (e.g., dependency bumps, broken links, etc).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code, etc).
- [x] Other: Github actions.

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] The documentation is up-to-date: Not relevarnt, only GH actions are updated.
- [ ] Static typing is included in the update: Not relevarnt, only GH actions are updated.
- [ ] This PR does not duplicated existing functionality: Not relevarnt, only GH actions are updated.
- [ ] The update is covered by the test suite (including tests added in the PR): Not relevarnt, only GH actions are updated.


