### PR TITLE
fix plotting vector fields

### DIFF
--- a/src/porepy/viz/plot_grid.py
+++ b/src/porepy/viz/plot_grid.py
@@ -462,6 +462,11 @@ def _plot_sd_xd(
 
     # Add vector data
     if vector_value is not None:
+        # The further algorithm requires the vector_value array of shape (3 x n), but we have the 1D data array.
+        # Thus, we fill the remaining dimensions with zeros.
+        vector_value = vector_value.reshape(sd.dim, -1)
+        difference_dim = 3 - sd.dim
+        vector_value = np.vstack([vector_value, np.zeros((difference_dim, vector_value.shape[1]))])
         _quiver(sd, vector_value, ax, **kwargs)
 
 


### PR DESCRIPTION
## Proposed changes

The problem is in plotting the vector field. The function `plot_mdg` calls the inner function with 1D array vector_value. Inside the function quiver, the array of shape (3 x n) is required. I reshape the array to the shape (3 x n) and fill the redundant dimensions with zeros.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply_

- [ ] Minor change (e.g., dependency bumps, broken links, etc).
- [x] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code, etc).
- [ ] Other: 

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.	
- [ ] Static typing is included in the update.
- [x] This PR does not duplicated existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).


