### PR TITLE
Fix plotting vector fields

### DIFF
--- a/src/porepy/viz/plot_grid.py
+++ b/src/porepy/viz/plot_grid.py
@@ -279,11 +279,19 @@ def plot_mdg(
 
         vector_value_array = sd_data.get(pp.STATE, {}).get(vector_value, None)
         if vector_value_array is not None:
-            # The further algorithm requires the vector_value array of shape (3 x n). But
-            # we have a 1D data array. Thus, we first reshape and then fill the remaining dimensions with zeros.
-            vector_value_array = vector_value_array.reshape(sd.dim, -1, order="F")
+            # The further algorithm requires the vector_value array of shape (3 x n).
+            # Now, we have a 1D array.
+            # Thus, we first reshape and then fill the remaining dimensions with zeros.
+            vector_value_array = vector_value_array.reshape(
+                (mdg.dim_max(), -1), order="F"
+            )
             vector_value_array = np.vstack(
-                [vector_value_array, np.zeros((3 - sd.dim, vector_value_array.shape[1]))]
+                [
+                    vector_value_array,
+                    np.zeros(
+                        (3 - vector_value_array.shape[0], vector_value_array.shape[1])
+                    ),
+                ]
             )
         _plot_sd_xd(
             sd,

--- a/src/porepy/viz/plot_grid.py
+++ b/src/porepy/viz/plot_grid.py
@@ -377,7 +377,7 @@ class _Arrow3D(FancyArrowPatch):
         """
         # Render the 3d coordinates of the arrows as preparation for plotting in the 2d plane.
         xs3d, ys3d, zs3d = self._verts3d
-        xs, ys, zs = proj3d.proj_transform(xs3d, ys3d, zs3d, renderer.M)
+        xs, ys, zs = proj3d.proj_transform(xs3d, ys3d, zs3d, self.axes.M)
         # Extract the rendered positions in the 2d plotting plane
         self.set_positions((xs[0], ys[0]), (xs[1], ys[1]))
         # Draw the arrows

--- a/src/porepy/viz/plot_grid.py
+++ b/src/porepy/viz/plot_grid.py
@@ -276,10 +276,19 @@ def plot_mdg(
         # Adjust rgb colors depending on the subdomain ordering
         kwargs["rgb"] = np.divide(kwargs.get("rgb", [1, 0, 0]), sd.id + 1)
         # Plot the subdomain and data
+
+        vector_value = sd_data.get(pp.STATE, {}).get(vector_value, None)
+        if vector_value is not None:
+            # The further algorithm requires the vector_value array of shape (3 x n). but
+            # We have the 1D data array. Thus, we fill the remaining dimensions with zeros.
+            vector_value = vector_value.reshape(sd.dim, -1)
+            vector_value = np.vstack(
+                [vector_value, np.zeros((3 - sd.dim, vector_value.shape[1]))]
+            )
         _plot_sd_xd(
             sd,
             sd_data.get(pp.STATE, {}).get(cell_value, None),
-            sd_data.get(pp.STATE, {}).get(vector_value, None),
+            vector_value,
             ax,
             **kwargs,
         )

--- a/src/porepy/viz/plot_grid.py
+++ b/src/porepy/viz/plot_grid.py
@@ -279,8 +279,8 @@ def plot_mdg(
 
         vector_value_array = sd_data.get(pp.STATE, {}).get(vector_value, None)
         if vector_value_array is not None:
-            # The further algorithm requires the vector_value array of shape (3 x n). but
-            # We have the 1D data array. Thus, we fill the remaining dimensions with zeros.
+            # The further algorithm requires the vector_value array of shape (3 x n). But
+            # we have a 1D data array. Thus, we first reshape and then fill the remaining dimensions with zeros.
             vector_value_array = vector_value_array.reshape(sd.dim, -1, order="F")
             vector_value_array = np.vstack(
                 [vector_value_array, np.zeros((3 - sd.dim, vector_value_array.shape[1]))]

--- a/src/porepy/viz/plot_grid.py
+++ b/src/porepy/viz/plot_grid.py
@@ -277,18 +277,18 @@ def plot_mdg(
         kwargs["rgb"] = np.divide(kwargs.get("rgb", [1, 0, 0]), sd.id + 1)
         # Plot the subdomain and data
 
-        vector_value = sd_data.get(pp.STATE, {}).get(vector_value, None)
-        if vector_value is not None:
+        vector_value_array = sd_data.get(pp.STATE, {}).get(vector_value, None)
+        if vector_value_array is not None:
             # The further algorithm requires the vector_value array of shape (3 x n). but
             # We have the 1D data array. Thus, we fill the remaining dimensions with zeros.
-            vector_value = vector_value.reshape(sd.dim, -1)
-            vector_value = np.vstack(
-                [vector_value, np.zeros((3 - sd.dim, vector_value.shape[1]))]
+            vector_value_array = vector_value_array.reshape(sd.dim, -1, order="F")
+            vector_value_array = np.vstack(
+                [vector_value_array, np.zeros((3 - sd.dim, vector_value_array.shape[1]))]
             )
         _plot_sd_xd(
             sd,
             sd_data.get(pp.STATE, {}).get(cell_value, None),
-            vector_value,
+            vector_value_array,
             ax,
             **kwargs,
         )

--- a/tests/unit/test_plotting.py
+++ b/tests/unit/test_plotting.py
@@ -40,7 +40,7 @@ def test_plot_grid_mdg(mdg):
 
 
 def test_plot_grid_simple_grid(mdg):
-    """Tests that no error is risen if we plot the single and provide variable arrays.
+    """Tests that no error is raised if we plot a single dimension grid and provide variable arrays.
     This use case requires the user to reshape the vector array to the shape (3 x n).
     The redundant dimensions are filled with zeros."""
     grid, data = mdg.subdomains(return_data=True)[0]

--- a/tests/unit/test_plotting.py
+++ b/tests/unit/test_plotting.py
@@ -29,7 +29,7 @@ def mdg(request):
 
 
 def test_plot_grid_mdg(mdg):
-    """Tests that no error is risen if we plot mdg and provide variable names."""
+    """Tests that no error is raised if we plot mdg and provide variable names."""
     pp.plot_grid(
         mdg,
         cell_value=SCALAR_VARIABLE,

--- a/tests/unit/test_plotting.py
+++ b/tests/unit/test_plotting.py
@@ -1,0 +1,99 @@
+""" Tests of methods from porepy.vis.plot_grid.
+"""
+
+import os
+import pytest
+
+import numpy as np
+
+import porepy as pp
+from porepy.grids.standard_grids import md_grids_2d, md_grids_3d
+
+
+SCALAR_VARIABLE = "scalar"
+VECTOR_VARIABLE = "vector_cell"
+
+
+@pytest.fixture(
+    params=[
+        md_grids_2d.single_horizontal(mesh_args=[5, 5], simplex=False),
+        md_grids_2d.single_vertical(simplex=True),
+        md_grids_3d.single_horizontal(mesh_args=[3, 3, 3], simplex=False),
+    ],
+)
+def mdg(request):
+    """Helper for initialization of the parametrized mdgs"""
+    mdg_ = request.param[0]
+    _initialize_mdg(mdg_)
+    return mdg_
+
+
+def test_plot_grid_mdg(mdg):
+    """Tests that no error is risen if we plot mdg and provide variable names."""
+    pp.plot_grid(
+        mdg,
+        cell_value=SCALAR_VARIABLE,
+        vector_variable=VECTOR_VARIABLE,
+        vector_scale=10,
+        info="CNFO",
+    )
+
+
+def test_plot_grid_simple_grid(mdg):
+    """Tests that no error is risen if we plot the single and provide variable arrays.
+    This use case requires the user to reshape the vector array to the shape (3 x n).
+    The redundant dimensions are filled with zeros."""
+    grid, data = mdg.subdomains(return_data=True)[0]
+    scalar_data = data[pp.STATE][SCALAR_VARIABLE]
+    vector_data = data[pp.STATE][VECTOR_VARIABLE].reshape((mdg.dim_max(), -1), order="F")
+    vector_data = np.vstack([vector_data, np.zeros((3 - mdg.dim_max(), vector_data.shape[1]))])
+    pp.plot_grid(
+        grid,
+        cell_value=scalar_data,
+        vector_variable=vector_data,
+        vector_scale=10,
+        info="CNFO",
+    )
+
+
+def test_save_img():
+    """Tests that `save_img` saves some image."""
+
+    mdg_ = md_grids_2d.single_horizontal(mesh_args=[5, 5], simplex=False)[0]
+    _initialize_mdg(mdg_)
+
+    image_name = "test_save_img.png"
+    assert not os.path.exists(image_name)
+
+    pp.save_img(
+        image_name,
+        mdg,
+        cell_value=SCALAR_VARIABLE,
+        vector_variable=VECTOR_VARIABLE,
+    )
+
+    assert os.path.exists(image_name)
+    os.remove(image_name)
+
+
+def _initialize_mdg(mdg_):
+    """Initializes mdg with an arbitrary state.
+    The state contains one scalar and one vector variable at cell centres."""
+
+    for sd, data in mdg_.subdomains(return_data=True):
+        if sd.dim in (mdg_.dim_max(), mdg_.dim_max() - 1):
+            data[pp.STATE] = {
+                SCALAR_VARIABLE: np.ones(sd.num_cells),
+                VECTOR_VARIABLE: np.ones((sd.dim, sd.num_cells)).ravel(order="F"),
+            }
+        else:
+            data[pp.PRIMARY_VARIABLES] = {}
+
+    for intf, data in mdg_.interfaces(return_data=True):
+        if intf.dim == mdg_.dim_max() - 1:
+            data[pp.STATE] = {
+                SCALAR_VARIABLE: np.ones(intf.num_cells),
+                VECTOR_VARIABLE: np.ones((intf.dim, intf.num_cells)).ravel(order="F"),
+            }
+        else:
+            data[pp.PRIMARY_VARIABLES] = {}


### PR DESCRIPTION
## Proposed changes

The function `pp.plot_grid` now doesn't work if you pass `mdg` and `vector_value: str`. The internal function `_quiver` expects the array of shape (3 x n), but the state contains 1D arrays. However, this visualization works if you pass not `mdg`, but `grid`, and `vector_value: ndarray`. In this case, the user ensures that he provides the array of shape (3 x n). So we have 2 cases of behaviour:

1. `mdg` and `vector_value: str` - fails due to an error. `mdg` and `vector_value: ndarray` is not allowed according to the docstring.
2. `grid` and `vector_value: ndarray` - works.

All the examples use the second case. I made a minor fix so the first case is not failing, and verified that it doesn't break the second case.

I provided the tests for both cases. Also, I provided a test for the function `save_img` as @jhabriel suggested. The tests cover three setups: simplex 2D grid, cartesian 2D grid and cartesian 3D grid. The vector variable is stored at the cell centres everywhere, but I hope it must not affect the behaviour of the plotting function significantly.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply_

- [ ] Minor change (e.g., dependency bumps, broken links, etc).
- [x] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code, etc).
- [ ] Other: 

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.	
- [ ] Static typing is included in the update.
- [x] This PR does not duplicated existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).


