### PR TITLE
Fix errors related to mypy v0.99

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -6,15 +6,9 @@
 mypy_path = src/porepy
 
 
-# EK: It is not at all clear to me what to do with various libraries such as numpy etc.
+# EK: It is not at all clear to me what to do with various libraries such as scipy etc.
 # For the moment, ignore some of them (seems to be done as below), and hope my understanding
 # improves in the future.
-[mypy-numpy]
-ignore_missing_imports = True
-[mypy-numpy.matlib]
-ignore_missing_imports = True
-[mypy-numpy.linalg]
-ignore_missing_imports = True
 
 [mypy-scipy]
 ignore_missing_imports = True

--- a/src/porepy/fracs/fracture_importer.py
+++ b/src/porepy/fracs/fracture_importer.py
@@ -1,4 +1,5 @@
 import csv
+from typing import Optional
 
 import gmsh
 import numpy as np
@@ -403,7 +404,9 @@ def dfm_3d_from_fab(
         return mdg
 
 
-def network_3d_from_fab(f_name: str, return_all: bool = False, tol: float = None):
+def network_3d_from_fab(
+    f_name: str, return_all: bool = False, tol: Optional[float] = None
+):
     """Read fractures from a .fab file, as specified by FracMan.
 
     The filter is based on the .fab-files available at the time of writing, and

--- a/src/porepy/fracs/fracture_network_2d.py
+++ b/src/porepy/fracs/fracture_network_2d.py
@@ -1,6 +1,7 @@
 """
 Module contains class for representing a fracture network in a 2d domain.
 """
+from __future__ import annotations
 import copy
 import csv
 import logging

--- a/src/porepy/fracs/fracture_network_2d.py
+++ b/src/porepy/fracs/fracture_network_2d.py
@@ -2,6 +2,7 @@
 Module contains class for representing a fracture network in a 2d domain.
 """
 from __future__ import annotations
+
 import copy
 import csv
 import logging

--- a/src/porepy/fracs/fracture_network_3d.py
+++ b/src/porepy/fracs/fracture_network_3d.py
@@ -5,6 +5,7 @@ The model relies heavily on functions in the computational geometry library.
 
 """
 from __future__ import annotations
+
 import copy
 import csv
 import logging

--- a/src/porepy/fracs/fracture_network_3d.py
+++ b/src/porepy/fracs/fracture_network_3d.py
@@ -536,7 +536,7 @@ class FractureNetwork3d(object):
         polygon_tags: dict[int, GmshInterfaceTags] = dict()
 
         for fi, _ in enumerate(self._fractures):
-            # Translate to from numerical tags to the GmshInterfaceTags system.
+            # Translate from numerical tags to the GmshInterfaceTags system.
             if has_boundary and self.tags["boundary"][fi]:
                 physical_surfaces[fi] = GmshInterfaceTags.DOMAIN_BOUNDARY_SURFACE
                 polygon_tags[fi] = GmshInterfaceTags.DOMAIN_BOUNDARY_SURFACE

--- a/src/porepy/fracs/fracture_network_3d.py
+++ b/src/porepy/fracs/fracture_network_3d.py
@@ -4,6 +4,7 @@ A module for representation and manipulations of fractures and fracture sets.
 The model relies heavily on functions in the computational geometry library.
 
 """
+from __future__ import annotations
 import copy
 import csv
 import logging

--- a/src/porepy/fracs/gmsh_interface.py
+++ b/src/porepy/fracs/gmsh_interface.py
@@ -14,6 +14,7 @@ Content:
 
 """
 from __future__ import annotations
+
 from dataclasses import dataclass
 from enum import Enum
 from typing import Optional, Union

--- a/src/porepy/fracs/gmsh_interface.py
+++ b/src/porepy/fracs/gmsh_interface.py
@@ -15,7 +15,7 @@ Content:
 """
 from dataclasses import dataclass
 from enum import Enum
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Optional, Union
 
 import gmsh
 import numpy as np
@@ -145,10 +145,10 @@ class _GmshData:
     lines: np.ndarray
     # Mapping from indices of points (referring to the ordering in points) to
     # numerical tags for the points.
-    physical_points: Dict[int, Tags]
+    physical_points: dict[int, Tags]
     # Mapping from indices of lines (referring to the ordering in lines) to numerical tags
     # for the lines.
-    physical_lines: Dict[int, Tags]
+    physical_lines: dict[int, Tags]
 
 
 @dataclass
@@ -169,15 +169,15 @@ class GmshData3d(_GmshData):
 
     # Polygons (both boundary surfaces, fractures and auxiliary lines).
     # See FractureNetwork3d for examples of usage.
-    polygons: List[np.ndarray]
+    polygons: list[np.ndarray]
     # Tags used to identify the type of polygons.
-    polygon_tags: np.ndarray
+    polygon_tags: dict[int, Tags]
     # Physical name information for polygons. Used to set gmsh tags for objects to be
     # represented in hte output mesh.
-    physical_surfaces: Dict[int, Tags]
+    physical_surfaces: dict[int, Tags]
     # Lines to be embedded in surfaces. Outer list has one item per polygon, inner has
     # index of lines to embed.
-    lines_in_surface: List[List[int]]
+    lines_in_surface: list[list[int]]
 
     dim: int = 3
 
@@ -208,7 +208,7 @@ class GmshWriter:
 
         self.define_geometry()
 
-    def set_gmsh_options(self, options: Optional[Dict] = None) -> None:
+    def set_gmsh_options(self, options: Optional[dict] = None) -> None:
         """Set Gmsh options. See Gmsh documentation for choices available.
 
         Parameters:
@@ -350,7 +350,7 @@ class GmshWriter:
             gmsh.finalize()
             GmshWriter.gmsh_initialized = False
 
-    def _add_points(self) -> List[int]:
+    def _add_points(self) -> list[int]:
         """Add points to gmsh. Also set physical names for points if required."""
         point_tags = []
         for pi, sz in enumerate(self._data.mesh_size):
@@ -379,6 +379,8 @@ class GmshWriter:
         """Add all fracture lines to gmsh."""
         # Only add the lines that correspond to fractures or auxiliary lines.
         # Boundary lines are added elsewhere.
+        # NOTE: Here we operate on the numerical tagging of lines (the attribute edges
+        # in FractureNetwork2d), thus we must compare with the values of the Tags.
         inds = np.argwhere(
             np.logical_or.reduce(
                 (
@@ -389,19 +391,23 @@ class GmshWriter:
         ).ravel()
         self._frac_tags = self._add_lines(inds, embed_in_domain=True)
 
-    def _add_fractures_3d(self):
+    def _add_fractures_3d(self) -> None:
         """Add fracture polygons to gmsh"""
-        inds = np.argwhere(
-            np.logical_or.reduce(
-                (
-                    self._data.polygon_tags == Tags.FRACTURE.value,
-                    self._data.polygon_tags == Tags.AUXILIARY_PLANE.value,
-                )
-            )
-        ).ravel()
-        self._frac_tags = self._add_polygons_3d(inds, embed_in_domain=True)
 
-    def _add_polygons_3d(self, inds: np.ndarray, embed_in_domain: bool) -> List[int]:
+        if not isinstance(self._data, GmshData3d):
+            raise ValueError("Need 3d geometry to write fractures")
+
+        # Loop over the polygons, find those tagged as fractures or auxiliary planes
+        # (which could be constraints in the meshing). Add these to the information
+        # to be written.
+        indices_to_write = []
+        for ind, tag in self._data.polygon_tags.items():
+            if tag in (Tags.FRACTURE, Tags.AUXILIARY_PLANE):
+                indices_to_write.append(ind)
+
+        self._frac_tags = self._add_polygons_3d(indices_to_write, embed_in_domain=True)
+
+    def _add_polygons_3d(self, inds: list, embed_in_domain: bool) -> list[int]:
         """Generic method to add polygons to a 3d geometry"""
 
         if not isinstance(self._data, GmshData3d):
@@ -419,7 +425,7 @@ class GmshWriter:
 
         surf_tag = []
 
-        to_phys_tags: List[Tuple[int, str, List[int]]] = []
+        to_phys_tags: list[tuple[int, str, list[int]]] = []
 
         for pi in inds:
             line_tags = []
@@ -462,9 +468,9 @@ class GmshWriter:
 
         return surf_tag
 
-    def _add_lines(self, ind: np.ndarray, embed_in_domain: bool) -> List[int]:
+    def _add_lines(self, ind: np.ndarray, embed_in_domain: bool) -> list[int]:
         # Helper function to write lines.
-        line_tags: List[int] = []
+        line_tags: list[int] = []
 
         if ind.size == 0:
             return line_tags
@@ -483,7 +489,7 @@ class GmshWriter:
 
         # Temporary storage of the lines that are to be assigned physical
         # groups
-        to_physical_group: List[Tuple[int, str, List[int]]] = []
+        to_physical_group: list[tuple[int, str, list[int]]] = []
 
         for i in range_id:
             loc_tags = []
@@ -497,9 +503,9 @@ class GmshWriter:
             # Store local tags
             line_tags += loc_tags
 
-            # Add this line to the set of physical groups to be assigned
+            # Add this line to the set of physical groups to be assigned.
             # We do not assign physical groupings inside this for-loop, as this would
-            # require multiple costly synchronizations (gmsh style)
+            # require multiple costly synchronizations (gmsh style).
             if has_physical_lines and i in self._data.physical_lines:
                 to_physical_group.append((i, physical_name, loc_tags))
 
@@ -520,6 +526,9 @@ class GmshWriter:
 
     def _add_domain_2d(self) -> int:
         """Write boundary lines, and tie them together to a closed loop. Define domain."""
+
+        # Here we operate on ``FractureNetwork2d.edges``, thus we should use the
+        # numerical values of the tag for comparison.
         bound_line_ind = np.argwhere(
             self._data.lines[2] == Tags.DOMAIN_BOUNDARY_LINE.value
         ).ravel()
@@ -541,9 +550,10 @@ class GmshWriter:
         if not isinstance(self._data, GmshData3d):
             raise ValueError("Need 3d geometry to specify 3d domain")
 
-        inds = np.argwhere(
-            self._data.polygon_tags == Tags.DOMAIN_BOUNDARY_SURFACE.value
-        ).ravel()
+        inds = []
+        for i, tag in self._data.polygon_tags.items():
+            if tag == Tags.DOMAIN_BOUNDARY_SURFACE:
+                inds.append(i)
 
         bound_surf_tags = self._add_polygons_3d(inds, embed_in_domain=False)
 

--- a/src/porepy/fracs/gmsh_interface.py
+++ b/src/porepy/fracs/gmsh_interface.py
@@ -13,6 +13,7 @@ Content:
         gmsh model. Can also mesh.
 
 """
+from __future__ import annotations
 from dataclasses import dataclass
 from enum import Enum
 from typing import Optional, Union

--- a/src/porepy/fracs/meshing.py
+++ b/src/porepy/fracs/meshing.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import logging
 import time
+from typing import Optional
 
 import numpy as np
 import scipy.sparse as sps
@@ -28,7 +29,7 @@ mortar_sides = mortar_grid.MortarSides
 
 def subdomains_to_mdg(
     subdomains: list[list[pp.Grid]],
-    time_tot: float = None,
+    time_tot: Optional[float] = None,
     **kwargs,
 ) -> pp.MixedDimensionalGrid:
     """Convert a list of grids to a full MixedDimensionalGrid.

--- a/src/porepy/fracs/msh_2_grid.py
+++ b/src/porepy/fracs/msh_2_grid.py
@@ -1,7 +1,9 @@
 """
 Module for converting gmsh output file to our grid structure.
 """
-from typing import Dict, List, Tuple, Union
+from __future__ import annotations
+
+from typing import Optional, Union
 
 import numpy as np
 
@@ -10,7 +12,7 @@ import porepy as pp
 from .gmsh_interface import PhysicalNames
 
 
-def create_3d_grids(pts: np.ndarray, cells: Dict[str, np.ndarray]) -> List[pp.Grid]:
+def create_3d_grids(pts: np.ndarray, cells: dict[str, np.ndarray]) -> list[pp.Grid]:
     """Create a tetrahedral grid from a gmsh tessalation.
 
     Parameters:
@@ -37,13 +39,13 @@ def create_3d_grids(pts: np.ndarray, cells: Dict[str, np.ndarray]) -> List[pp.Gr
 
 def create_2d_grids(
     pts: np.ndarray,
-    cells: Dict[str, np.ndarray],
-    phys_names: Dict[str, str],
-    cell_info: Dict,
+    cells: dict[str, np.ndarray],
+    phys_names: dict[str, str],
+    cell_info: dict,
     is_embedded: bool = False,
-    surface_tag: str = None,
-    constraints: np.ndarray = None,
-) -> List[pp.Grid]:
+    surface_tag: Optional[str] = None,
+    constraints: Optional[np.ndarray] = None,
+) -> list[pp.Grid]:
     """Create 2d grids for lines of a specified type from a gmsh tessalation.
 
     Only surfaces that were defined as 'physical' in the gmsh sense may have a grid
@@ -85,7 +87,7 @@ def create_2d_grids(
 
     if is_embedded:
         # List of 2D grids, one for each surface
-        g_list: List[pp.Grid] = []
+        g_list: list[pp.Grid] = []
 
         # Special treatment of the case with no fractures
         if "triangle" not in cells:
@@ -199,14 +201,14 @@ def create_2d_grids(
 
 def create_1d_grids(
     pts: np.ndarray,
-    cells: Dict[str, np.ndarray],
-    phys_names: Dict,
-    cell_info: Dict,
-    line_tag: str = None,
+    cells: dict[str, np.ndarray],
+    phys_names: dict,
+    cell_info: dict,
+    line_tag: Optional[str] = None,
     tol: float = 1e-4,
-    constraints: np.ndarray = None,
+    constraints: Optional[np.ndarray] = None,
     return_fracture_tips: bool = True,
-) -> Union[List[pp.Grid], Tuple[List[pp.Grid], np.ndarray]]:
+) -> Union[list[pp.Grid], tuple[list[pp.Grid], np.ndarray]]:
     """Create 1d grids for lines of a specified type from a gmsh tessalation.
 
     Only lines that were defined as 'physical' in the gmsh sense may have a grid
@@ -253,7 +255,7 @@ def create_1d_grids(
     # fractures), fracture tips, and auxiliary lines (to be disregarded)
 
     # Data structure for the point grids
-    g_1d: List[pp.Grid] = []
+    g_1d: list[pp.Grid] = []
 
     # If there are no fracture intersections, we return empty lists
     if "line" not in cells:
@@ -318,11 +320,11 @@ def create_1d_grids(
 
 def create_0d_grids(
     pts: np.ndarray,
-    cells: Dict[str, np.ndarray],
-    phys_names: Dict[int, str],
-    cell_info: Dict[str, np.ndarray],
-    target_tag_stem: str = None,
-) -> List[pp.PointGrid]:
+    cells: dict[str, np.ndarray],
+    phys_names: dict[int, str],
+    cell_info: dict[str, np.ndarray],
+    target_tag_stem: Optional[str] = None,
+) -> list[pp.PointGrid]:
     """Create 0d grids for points of a specified type from a gmsh tessalation.
 
     Only points that were defined as 'physical' in the gmsh sense may have a grid

--- a/src/porepy/fracs/structured.py
+++ b/src/porepy/fracs/structured.py
@@ -3,7 +3,9 @@ Module for creating fractured cartesian grids in 2- and 3-dimensions.
 
 The functions in this module can be accessed through the meshing wrapper module.
 """
-from typing import List
+from __future__ import annotations
+
+from typing import Optional
 
 import numpy as np
 import scipy.sparse as sps
@@ -15,8 +17,8 @@ from .gmsh_interface import Tags
 
 
 def _cart_grid_3d(
-    fracs: List[np.ndarray], nx: np.ndarray, physdims: np.ndarray = None
-) -> List[pp.Grid]:
+    fracs: list[np.ndarray], nx: np.ndarray, physdims: Optional[np.ndarray] = None
+) -> list[pp.Grid]:
     """
     Create grids for a domain with possibly intersecting fractures in 3d.
 
@@ -61,8 +63,8 @@ def _cart_grid_3d(
 
 
 def _tensor_grid_3d(
-    fracs: List[np.ndarray], x: np.ndarray, y: np.ndarray, z: np.ndarray
-) -> List[List[pp.Grid]]:
+    fracs: list[np.ndarray], x: np.ndarray, y: np.ndarray, z: np.ndarray
+) -> list[list[pp.Grid]]:
     """
     Create a grids for a domain with possibly intersecting fractures in 3d.
 
@@ -140,8 +142,8 @@ def _cart_grid_2d(fracs, nx, physdims=None):
 
 
 def _tensor_grid_2d(
-    fracs: List[np.ndarray], x: np.ndarray, y: np.ndarray
-) -> List[List[pp.Grid]]:
+    fracs: list[np.ndarray], x: np.ndarray, y: np.ndarray
+) -> list[list[pp.Grid]]:
     """
     Create a grids for a domain with possibly intersecting fractures in 2d.
 

--- a/src/porepy/fracs/wells_3d.py
+++ b/src/porepy/fracs/wells_3d.py
@@ -9,8 +9,10 @@ by
     compute_well_fracture_intersections(well_network, fracture_network)
     well_network.mesh(mdg)
 """
+from __future__ import annotations
+
 import logging
-from typing import Dict, Iterator, List, Optional, Tuple
+from typing import Iterator, Optional
 
 import numpy as np
 import scipy.sparse as sps
@@ -40,7 +42,7 @@ class Well:
         self,
         points: np.ndarray,
         index: Optional[int] = None,
-        tags: Optional[Dict] = None,
+        tags: Optional[dict] = None,
     ) -> None:
         """Initialize fractures.
 
@@ -76,7 +78,7 @@ class Well:
         """
         self.index = i
 
-    def segments(self) -> Iterator[Tuple[List[int], np.ndarray]]:
+    def segments(self) -> Iterator[tuple[list[int], np.ndarray]]:
         """
         Iterate over the segments defined through segment indices and endpoints.
         """
@@ -91,7 +93,7 @@ class Well:
     def num_segments(self) -> int:
         return self.num_points() - 1
 
-    def add_point(self, point: np.ndarray, ind: int = None) -> None:
+    def add_point(self, point: np.ndarray, ind: Optional[int] = None) -> None:
         """Add new pts (3 x 1) to self.pts.
         If ind is not specified, the point is appended at the end of
         self.pts. Otherwise, it is inserted between the old points number ind
@@ -102,7 +104,7 @@ class Well:
         else:
             self.pts = np.hstack((self.pts[:, :ind], point, self.pts[:, ind:]))
 
-    def _mesh_size(self, segment_ind: Tuple[int] = None) -> Optional[float]:
+    def _mesh_size(self, segment_ind: Optional[tuple[int]] = None) -> Optional[float]:
         """Return the mesh size for a well or one of its segments.
 
         Args:
@@ -146,10 +148,10 @@ class WellNetwork3d:
 
     def __init__(
         self,
-        wells: Optional[List[Well]] = None,
-        domain: Optional[Dict[str, float]] = None,
+        wells: Optional[list[Well]] = None,
+        domain: Optional[dict[str, float]] = None,
         tol: float = 1e-8,
-        parameters: Optional[Dict] = None,
+        parameters: Optional[dict] = None,
     ) -> None:
         """Initialize well network.
 
@@ -183,12 +185,12 @@ class WellNetwork3d:
             self.parameters = parameters
 
         if domain is None:
-            domain = {}
-        self.domain: Dict = domain
+            domain = dict()
+        self.domain: dict = domain
         self.tol = tol
 
         # Assign an empty tag dictionary
-        self.tags: Dict[str, List[bool]] = {}
+        self.tags: dict[str, list[bool]] = dict()
 
     def add(self, w: Well) -> None:
         """Add a well to the network.
@@ -208,7 +210,7 @@ class WellNetwork3d:
             w.set_index(0)
         self._wells.append(w)
 
-    def _mesh_size(self, w: Well, segment_ind: Tuple[int] = None) -> float:
+    def _mesh_size(self, w: Well, segment_ind: Optional[tuple[int]] = None) -> float:
         """Return the mesh size for a well or one of its segments.
 
         Args:
@@ -442,7 +444,7 @@ def compute_well_fracture_intersections(
 
 def compute_well_rock_matrix_intersections(
     mdg: pp.MixedDimensionalGrid,
-    cells: np.ndarray = None,
+    cells: Optional[np.ndarray] = None,
     min_length: float = 1e-10,
     tol: float = 1e-5,
 ) -> None:
@@ -470,7 +472,7 @@ def compute_well_rock_matrix_intersections(
     tree.from_grid(sd_max, cells)
 
     # Extract the grids of the wells of co-dimension 2
-    well_subdomains: List[pp.Grid] = [
+    well_subdomains: list[pp.Grid] = [
         g for g in mdg.subdomains(dim=dim_max - 2) if hasattr(g, "well_num")
     ]
 
@@ -562,7 +564,7 @@ def compute_well_rock_matrix_intersections(
 
 def _argsort_points_along_line_segment(
     seg: np.ndarray,
-) -> Tuple[np.ndarray, np.ndarray]:
+) -> tuple[np.ndarray, np.ndarray]:
     """Sort point lying along a segment.
 
     Args:
@@ -594,10 +596,10 @@ def _argsort_points_along_line_segment(
 def _intersection_segment_fracture(
     segment_points: np.ndarray,
     fracture: pp.PlaneFracture,
-    tags: List[np.ndarray],
+    tags: list[np.ndarray],
     ignore_endpoint_tag: bool,
     tol: float = 1e-8,
-) -> Tuple[np.ndarray, List[np.ndarray]]:
+) -> tuple[np.ndarray, list[np.ndarray]]:
     """Compute intersection between a single line segment and fracture.
 
     Computes intersection point. If no intersection exists (distance > 0), no updates are

--- a/src/porepy/grids/md_grid.py
+++ b/src/porepy/grids/md_grid.py
@@ -589,7 +589,7 @@ class MixedDimensionalGrid:
     # ---- Methods for getting information on the bucket, or its components ----
 
     def diameter(
-        self, cond: Callable[[Union[pp.Grid, pp.MortarGrid]], bool] = None
+        self, cond: Optional[Callable[[Union[pp.Grid, pp.MortarGrid]], bool]] = None
     ) -> float:
         """Compute the cell diameter (mesh size) of the mixed-dimensional grid.
 
@@ -632,7 +632,9 @@ class MixedDimensionalGrid:
         # lead to a recursion error.
         return np.max([sd.dim for sd in self._subdomain_data.keys()])
 
-    def num_subdomain_cells(self, cond: Callable[[pp.Grid], bool] = None) -> int:
+    def num_subdomain_cells(
+        self, cond: Optional[Callable[[pp.Grid], bool]] = None
+    ) -> int:
         """Compute the total number of cells of the mixed-dimensional grid.
 
         A function can be passed to filter subdomains and/or interfaces.
@@ -650,7 +652,9 @@ class MixedDimensionalGrid:
             [grid.num_cells for grid in self.subdomains() if cond(grid)], dtype=int
         )
 
-    def num_interface_cells(self, cond: Callable[[pp.MortarGrid], bool] = None) -> int:
+    def num_interface_cells(
+        self, cond: Optional[Callable[[pp.MortarGrid], bool]] = None
+    ) -> int:
         """
         Compute the total number of mortar cells of the mixed-dimensional grid.
 

--- a/src/porepy/grids/mortar_grid.py
+++ b/src/porepy/grids/mortar_grid.py
@@ -212,7 +212,7 @@ class MortarGrid:
     ### Methods to update the mortar grid, or the neighboring grids.
 
     def update_mortar(
-        self, new_side_grids: dict[MortarSides, pp.Grid], tol: float = None
+        self, new_side_grids: dict[MortarSides, pp.Grid], tol: Optional[float] = None
     ) -> None:
         """
         Update the low_to_mortar_int and high_to_mortar_int maps when the mortar grids
@@ -319,7 +319,7 @@ class MortarGrid:
 
         self._check_mappings()
 
-    def update_secondary(self, new_g: pp.Grid, tol: float = None) -> None:
+    def update_secondary(self, new_g: pp.Grid, tol: Optional[float] = None) -> None:
         """Update the mappings between Mortar and secondary grid when the latter is changed.
 
         NOTE: This function assumes that the secondary grid is only updated once: A change
@@ -395,7 +395,9 @@ class MortarGrid:
 
         self._check_mappings()
 
-    def update_primary(self, g_new: pp.Grid, g_old: pp.Grid, tol: float = None) -> None:
+    def update_primary(
+        self, g_new: pp.Grid, g_old: pp.Grid, tol: Optional[float] = None
+    ) -> None:
         """
 
         Update the _primary_to_mortar_int map when the primary (higher-dimensional) grid is

--- a/src/porepy/grids/partition.py
+++ b/src/porepy/grids/partition.py
@@ -7,6 +7,7 @@ Intended support is by Cartesian indexing, and METIS-based.
 from __future__ import annotations
 
 import warnings
+from typing import Optional
 
 import numpy as np
 import scipy.sparse as sps
@@ -62,7 +63,7 @@ def partition_metis(g: pp.Grid, num_part: int) -> np.ndarray:
 
 
 def partition_structured(
-    g: pp.TensorGrid, num_part: int = 1, coarse_dims: np.ndarray = None
+    g: pp.TensorGrid, num_part: int = 1, coarse_dims: Optional[np.ndarray] = None
 ) -> np.ndarray:
     """Define a partitioning of a grid based on logical Cartesian indexing.
 
@@ -767,7 +768,7 @@ def overlap(
 
 
 def grid_is_connected(
-    g: pp.Grid, cell_ind: np.ndarray = None
+    g: pp.Grid, cell_ind: Optional[np.ndarray] = None
 ) -> tuple[bool, list[np.ndarray]]:
     """
     Check if a grid is fully connected, as defined by its cell_connection_map().

--- a/src/porepy/grids/point_grid.py
+++ b/src/porepy/grids/point_grid.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import numpy as np
 import scipy.sparse as sps
 
@@ -5,7 +7,7 @@ from porepy.grids.grid import Grid
 
 
 class PointGrid(Grid):
-    def __init__(self, pt: np.ndarray, name: str = None) -> None:
+    def __init__(self, pt: np.ndarray, name: Optional[str] = None) -> None:
         """Constructor for 0D grid.
 
         Args:

--- a/src/porepy/grids/standard_grids/md_grids_2d.py
+++ b/src/porepy/grids/standard_grids/md_grids_2d.py
@@ -12,7 +12,7 @@ The provided geometries are:
 """
 from __future__ import annotations
 
-from typing import Union
+from typing import Optional, Union
 
 import numpy as np
 
@@ -31,7 +31,11 @@ def _n_cells(mesh_args: Union[np.ndarray, dict, None]) -> np.ndarray:
         return mesh_args
 
 
-def single_horizontal(mesh_args=None, x_endpoints=None, simplex=True):
+def single_horizontal(
+    mesh_args: Optional[dict | np.ndarray] = None,
+    x_endpoints: Optional[np.ndarray] = None,
+    simplex: bool = True,
+):
     """
     Create a grid bucket for a domain containing a single horizontal fracture at y=0.5.
 
@@ -39,7 +43,7 @@ def single_horizontal(mesh_args=None, x_endpoints=None, simplex=True):
         mesh_args:  For triangular grids: Dictionary containing at least "mesh_size_frac". If
                         the optional values of "mesh_size_bound" and "mesh_size_min" are
                         not provided, these are set by utils.set_mesh_sizes.
-                    For cartesian grids: List containing number of cells in x and y
+                    For cartesian grids: np.array containing number of cells in x and y
                         direction.
         x_endpoints (list): Contains the x coordinates of the two endpoints. If not
             provided, the endpoints will be set to [0, 1]
@@ -55,6 +59,11 @@ def single_horizontal(mesh_args=None, x_endpoints=None, simplex=True):
     if simplex:
         if mesh_args is None:
             mesh_args = {"mesh_size_frac": 0.2}
+
+        if not isinstance(mesh_args, dict):
+            # The numpy-array format for mesh_args should not be used for simplex grids
+            raise ValueError("Mesh arguments should be a dictionary for simplex grids")
+
         points = np.array([x_endpoints, [0.5, 0.5]])
         edges = np.array([[0], [1]])
         mdg = utils.make_mdg_2d_simplex(mesh_args, points, edges, domain)
@@ -66,9 +75,9 @@ def single_horizontal(mesh_args=None, x_endpoints=None, simplex=True):
 
 
 def single_vertical(
-    mesh_args: Union[np.ndarray, dict] = None,
-    y_endpoints: np.ndarray = None,
-    simplex: bool = True,
+    mesh_args: Optional[Union[np.ndarray, dict]] = None,
+    y_endpoints: Optional[np.ndarray] = None,
+    simplex: Optional[bool] = True,
 ):
     """
     Create a grid bucket for a domain containing a single vertical fracture at x=0.5.
@@ -97,7 +106,11 @@ def single_vertical(
     if simplex:
         if mesh_args is None:
             mesh_args = {"mesh_size_frac": 0.2}
-        assert type(mesh_args) == dict
+
+        if not isinstance(mesh_args, dict):
+            # The numpy-array format for mesh_args should not be used for simplex grids
+            raise ValueError("Mesh arguments should be a dictionary for simplex grids")
+
         points = np.array([[0.5, 0.5], y_endpoints])
         edges = np.array([[0], [1]])
         mdg = utils.make_mdg_2d_simplex(mesh_args, points, edges, domain)
@@ -108,7 +121,12 @@ def single_vertical(
     return mdg, domain
 
 
-def two_intersecting(mesh_args=None, x_endpoints=None, y_endpoints=None, simplex=True):
+def two_intersecting(
+    mesh_args: Optional[dict | np.ndarray] = None,
+    x_endpoints: Optional[list] = None,
+    y_endpoints: Optional[list] = None,
+    simplex: bool = True,
+):
     """
     Create a grid bucket for a domain containing fractures, one horizontal and one vertical
     at y=0.5 and x=0.5 respectively.
@@ -138,6 +156,11 @@ def two_intersecting(mesh_args=None, x_endpoints=None, y_endpoints=None, simplex
     if simplex:
         if mesh_args is None:
             mesh_args = {"mesh_size_frac": 0.2}
+
+        if not isinstance(mesh_args, dict):
+            # The numpy-array format for mesh_args should not be used for simplex grids
+            raise ValueError("Mesh arguments should be a dictionary for simplex grids")
+
         points = np.array(
             [
                 [x_endpoints[0], x_endpoints[1], 0.5, 0.5],
@@ -159,7 +182,7 @@ def two_intersecting(mesh_args=None, x_endpoints=None, y_endpoints=None, simplex
     return mdg, domain
 
 
-def seven_fractures_one_L_intersection(mesh_args=None):
+def seven_fractures_one_L_intersection(mesh_args: dict):
     """
     Create a grid bucket for a domain containing the network introduced as example 1 of
     Berge et al. 2019: Finite volume discretization for poroelastic media with fractures
@@ -197,7 +220,7 @@ def seven_fractures_one_L_intersection(mesh_args=None):
     return mdg, domain
 
 
-def benchmark_regular(mesh_args, is_coarse=False):
+def benchmark_regular(mesh_args: dict, is_coarse: bool = False):
     """
     Create a grid bucket for a domain containing the network introduced as example 2 of
     Berre et al. 2018: Benchmarks for single-phase flow in fractured porous media.

--- a/src/porepy/grids/standard_grids/utils.py
+++ b/src/porepy/grids/standard_grids/utils.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import numpy as np
 
 import porepy as pp

--- a/src/porepy/grids/standard_grids/utils.py
+++ b/src/porepy/grids/standard_grids/utils.py
@@ -1,5 +1,3 @@
-from typing import List
-
 import numpy as np
 
 import porepy as pp
@@ -65,7 +63,7 @@ def make_mdg_2d_simplex(
 
 
 def make_mdg_2d_cartesian(
-    n_cells: np.ndarray, fractures: List[np.ndarray], domain: dict
+    n_cells: np.ndarray, fractures: list[np.ndarray], domain: dict
 ):
     """
     Construct a grid bucket with Cartesian grid in the 2d domain.

--- a/src/porepy/grids/standard_grids/utils.py
+++ b/src/porepy/grids/standard_grids/utils.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import numpy as np
 
 import porepy as pp

--- a/src/porepy/numerics/ad/equation_manager.py
+++ b/src/porepy/numerics/ad/equation_manager.py
@@ -527,7 +527,9 @@ class EquationManager:
 
     def _variable_set_complement(
         self,
-        variables: Sequence[Union["pp.ad.Variable", "pp.ad.MergedVariable"]] = None,
+        variables: Optional[
+            Sequence[Union["pp.ad.Variable", "pp.ad.MergedVariable"]]
+        ] = None,
     ) -> List["pp.ad.Variable"]:
         """
         Take the complement of a set of variables, with respect to the full set of

--- a/src/porepy/numerics/ad/operator_functions.py
+++ b/src/porepy/numerics/ad/operator_functions.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import abc
 from functools import partial
-from typing import Callable, List, Type, Union
+from typing import Callable, List, Optional, Type, Union
 
 import numpy as np
 import scipy.sparse as sps
@@ -466,7 +466,7 @@ class ADmethod:
 
     def __init__(
         self,
-        func: Callable = None,
+        func: Optional[Callable] = None,
         ad_function_type: Type["AbstractFunction"] = Function,
         operator_kwargs: dict = {},
     ) -> None:

--- a/src/porepy/numerics/fv/fvutils.py
+++ b/src/porepy/numerics/fv/fvutils.py
@@ -6,7 +6,9 @@ for MPxA discertizations, however, due to the somewhat intricate inheritance rel
 between these methods, the current structure with multiple auxiliary methods emerged.
 
 """
-from typing import Any, Callable, Dict, Generator, List, Optional, Tuple
+from __future__ import annotations
+
+from typing import Any, Callable, Generator, Optional
 
 import numpy as np
 import scipy.sparse as sps
@@ -299,8 +301,8 @@ def determine_eta(sd: pp.Grid) -> float:
 
 
 def find_active_indices(
-    parameter_dictionary: Dict[str, Any], sd: pp.Grid
-) -> Tuple[np.ndarray, np.ndarray]:
+    parameter_dictionary: dict[str, Any], sd: pp.Grid
+) -> tuple[np.ndarray, np.ndarray]:
     """Process information in parameter dictionary on whether the discretization
     should consider a subgrid. Look for fields in the parameter dictionary called
     specified_cells, specified_faces or specified_nodes. These are then processed by
@@ -351,7 +353,7 @@ def find_active_indices(
 def subproblems(
     sd: pp.Grid, max_memory: int, peak_memory_estimate: int
 ) -> Generator[
-    Tuple[pp.Grid, np.ndarray, np.ndarray, np.ndarray, np.ndarray], None, None
+    tuple[pp.Grid, np.ndarray, np.ndarray, np.ndarray, np.ndarray], None, None
 ]:
 
     if sd.dim == 0:
@@ -614,7 +616,7 @@ def vector_divergence(sd: pp.Grid) -> sps.csr_matrix:
 
 def scalar_tensor_vector_prod(
     sd: pp.Grid, k: pp.SecondOrderTensor, subcell_topology: SubcellTopology
-) -> Tuple[sps.csr_matrix, np.ndarray, np.ndarray]:
+) -> tuple[sps.csr_matrix, np.ndarray, np.ndarray]:
     """
     Compute product of normal vectors and tensors on a sub-cell level.
     This is essentially defining Darcy's law for each sub-face in terms of
@@ -1002,18 +1004,18 @@ class ExcludeBoundaries:
 
 def partial_update_discretization(
     sd: pp.Grid,  # Grid
-    data: Dict,  # full data dictionary for this grid
+    data: dict,  # full data dictionary for this grid
     keyword: str,  # keyword for the target discretization
     discretize: Callable,  # Discretization operation
     dim: Optional[int] = None,  # dimension. Used to expand vector quantities
-    scalar_cell_right: Optional[List[str]] = None,  # See method documentation
-    vector_cell_right: Optional[List[str]] = None,
-    scalar_face_right: Optional[List[str]] = None,
-    vector_face_right: Optional[List[str]] = None,
-    scalar_cell_left: Optional[List[str]] = None,
-    vector_cell_left: Optional[List[str]] = None,
-    scalar_face_left: Optional[List[str]] = None,
-    vector_face_left: Optional[List[str]] = None,
+    scalar_cell_right: Optional[list[str]] = None,  # See method documentation
+    vector_cell_right: Optional[list[str]] = None,
+    scalar_face_right: Optional[list[str]] = None,
+    vector_face_right: Optional[list[str]] = None,
+    scalar_cell_left: Optional[list[str]] = None,
+    vector_cell_left: Optional[list[str]] = None,
+    scalar_face_left: Optional[list[str]] = None,
+    vector_face_left: Optional[list[str]] = None,
     second_keyword: Optional[str] = None,  # Used for biot discertization
 ) -> None:
     """Do partial update of discretization scheme.
@@ -1191,10 +1193,10 @@ def partial_update_discretization(
 
 def cell_ind_for_partial_update(
     sd: pp.Grid,
-    cells: np.ndarray = None,
-    faces: np.ndarray = None,
-    nodes: np.ndarray = None,
-) -> Tuple[np.ndarray, np.ndarray]:
+    cells: Optional[np.ndarray] = None,
+    faces: Optional[np.ndarray] = None,
+    nodes: Optional[np.ndarray] = None,
+) -> tuple[np.ndarray, np.ndarray]:
     """Obtain indices of cells and faces needed for a partial update of the
     discretization stencil.
 
@@ -1400,7 +1402,7 @@ def map_subgrid_to_grid(
     loc_cells: np.ndarray,
     is_vector: bool,
     nd: Optional[int] = None,
-) -> Tuple[np.ndarray, np.ndarray]:
+) -> tuple[np.ndarray, np.ndarray]:
     """Obtain mappings from the cells and faces of a subgrid back to a larger grid.
 
     Args:

--- a/src/porepy/numerics/fv/mpsa.py
+++ b/src/porepy/numerics/fv/mpsa.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import logging
 from time import time
-from typing import Any, Dict, Tuple
+from typing import Any, Optional
 
 import numpy as np
 import scipy.sparse as sps
@@ -84,7 +84,7 @@ class Mpsa(Discretization):
         return sd.dim * sd.num_cells
 
     def extract_displacement(
-        self, sd: pp.Grid, solution_array: np.ndarray, d: Dict
+        self, sd: pp.Grid, solution_array: np.ndarray, d: dict
     ) -> np.ndarray:
         """Extract the displacement part of a solution.
 
@@ -102,7 +102,7 @@ class Mpsa(Discretization):
         return solution_array
 
     def extract_stress(
-        self, sd: pp.Grid, solution_array: np.ndarray, d: Dict
+        self, sd: pp.Grid, solution_array: np.ndarray, d: dict
     ) -> np.ndarray:
         """Extract the stress corresponding to a solution
 
@@ -128,7 +128,7 @@ class Mpsa(Discretization):
 
         return stress * solution_array + bound_stress * bc_val
 
-    def discretize(self, sd: pp.Grid, data: Dict) -> None:
+    def discretize(self, sd: pp.Grid, data: dict) -> None:
         """
         Discretize the second order vector elliptic equation using multi-point
         stress approximation.
@@ -175,8 +175,8 @@ class Mpsa(Discretization):
         data (dict): For entries, see above.
 
         """
-        parameter_dictionary: Dict[str, Any] = data[pp.PARAMETERS][self.keyword]
-        matrix_dictionary: Dict[str, sps.spmatrix] = data[pp.DISCRETIZATION_MATRICES][
+        parameter_dictionary: dict[str, Any] = data[pp.PARAMETERS][self.keyword]
+        matrix_dictionary: dict[str, sps.spmatrix] = data[pp.DISCRETIZATION_MATRICES][
             self.keyword
         ]
         constit: pp.FourthOrderTensor = parameter_dictionary["fourth_order_tensor"]
@@ -415,8 +415,8 @@ class Mpsa(Discretization):
         )
 
     def assemble_matrix_rhs(
-        self, sd: pp.Grid, data: Dict
-    ) -> Tuple[sps.spmatrix, np.ndarray]:
+        self, sd: pp.Grid, data: dict
+    ) -> tuple[sps.spmatrix, np.ndarray]:
         """
         Return the matrix and right-hand side for a discretization of a second
         order elliptic equation using a FV method with a multi-point stress
@@ -441,7 +441,7 @@ class Mpsa(Discretization):
         """
         return self.assemble_matrix(sd, data), self.assemble_rhs(sd, data)
 
-    def assemble_matrix(self, sd: pp.Grid, data: Dict) -> sps.spmatrix:
+    def assemble_matrix(self, sd: pp.Grid, data: dict) -> sps.spmatrix:
         """
         Return the matrix for a discretization of a second order elliptic vector
         equation using a FV method.
@@ -470,7 +470,7 @@ class Mpsa(Discretization):
 
         return M
 
-    def assemble_rhs(self, sd: pp.Grid, data: Dict) -> np.ndarray:
+    def assemble_rhs(self, sd: pp.Grid, data: dict) -> np.ndarray:
         """Return the right-hand side for a discretization of a second
         order elliptic equation using a finite volume method.
 
@@ -506,11 +506,11 @@ class Mpsa(Discretization):
         sd: pp.Grid,
         constit: pp.FourthOrderTensor,
         bound: pp.BoundaryConditionVectorial,
-        eta: float = None,
+        eta: Optional[float] = None,
         inverter: str = "numba",
-        hf_disp: bool = False,
-        hf_eta: float = None,
-    ) -> Tuple[sps.spmatrix, sps.spmatrix, sps.spmatrix, sps.spmatrix]:
+        hf_disp: Optional[bool] = False,
+        hf_eta: Optional[float] = None,
+    ) -> tuple[sps.spmatrix, sps.spmatrix, sps.spmatrix, sps.spmatrix]:
         """
         Actual implementation of the MPSA W-method. To calculate the MPSA
         discretization on a grid, either call this method, or, to respect the
@@ -621,7 +621,7 @@ class Mpsa(Discretization):
             k = pp.SecondOrderTensor(2 * constit.mu + constit.lmbda)
             params["second_order_tensor"] = k
 
-            d: Dict = {
+            d: dict = {
                 pp.PARAMETERS: {tpfa_key: params},
                 pp.DISCRETIZATION_MATRICES: {tpfa_key: {}},
             }
@@ -728,7 +728,7 @@ class Mpsa(Discretization):
         bound_exclusion: pp.fvutils.ExcludeBoundaries,
         eta: float,
         inverter: str,
-    ) -> Tuple[sps.spmatrix, sps.spmatrix, np.ndarray]:
+    ) -> tuple[sps.spmatrix, sps.spmatrix, np.ndarray]:
         """
         This is the function where the real discretization takes place. It contains
         the parts that are common for elasticity and poro-elasticity, and was thus
@@ -1084,8 +1084,8 @@ class Mpsa(Discretization):
         self,
         sd: pp.Grid,
         subcell_topology: pp.fvutils.SubcellTopology,
-        eta: float = None,
-    ) -> Tuple[sps.csr_matrix, sps.csr_matrix]:
+        eta: Optional[float] = None,
+    ) -> tuple[sps.csr_matrix, sps.csr_matrix]:
         """
         Function for reconstructing the displacement at the half faces given the
         local gradients. For a subcell Ks associated with cell K and node s, the
@@ -1212,7 +1212,7 @@ class Mpsa(Discretization):
         eta: float,
         num_sub_cells: int,
         bound_exclusion: pp.fvutils.ExcludeBoundaries,
-    ) -> Tuple[sps.spmatrix, sps.spmatrix]:
+    ) -> tuple[sps.spmatrix, sps.spmatrix]:
         nd = sd.dim
         # Distance from cell centers to face centers, this will be the
         # contribution from gradient unknown to equations for displacement
@@ -1247,7 +1247,7 @@ class Mpsa(Discretization):
         eta: float,
         num_sub_cells: int,
         bound_exclusion: pp.fvutils.ExcludeBoundaries,
-    ) -> Tuple[sps.spmatrix, sps.spmatrix]:
+    ) -> tuple[sps.spmatrix, sps.spmatrix]:
         nd = sd.dim
         # Distance from cell centers to face centers, this will be the
         # contribution from gradient unknown to equations for displacement
@@ -1297,7 +1297,7 @@ class Mpsa(Discretization):
 
     def _split_stiffness_matrix(
         self, constit: pp.FourthOrderTensor
-    ) -> Tuple[np.ndarray, np.ndarray]:
+    ) -> tuple[np.ndarray, np.ndarray]:
         """
         Split the stiffness matrix into symmetric and asymetric part
 
@@ -1361,7 +1361,7 @@ class Mpsa(Discretization):
         sd: pp.Grid,
         constit: pp.FourthOrderTensor,
         subcell_topology: pp.fvutils.SubcellTopology,
-    ) -> Tuple[sps.spmatrix, sps.spmatrix, np.ndarray, np.ndarray]:
+    ) -> tuple[sps.spmatrix, sps.spmatrix, np.ndarray, np.ndarray]:
         """Compute product between stiffness tensor and face normals.
 
         The method splits the stiffness matrix into a symmetric and asymmetric
@@ -1540,7 +1540,7 @@ class Mpsa(Discretization):
         nno: np.ndarray,
         bound_exclusion: pp.fvutils.ExcludeBoundaries,
         nd: int,
-    ) -> Tuple[sps.spmatrix, sps.spmatrix, np.ndarray]:
+    ) -> tuple[sps.spmatrix, sps.spmatrix, np.ndarray]:
         """
         Define matrices to turn linear system into block-diagonal form.
 
@@ -1681,7 +1681,7 @@ class Mpsa(Discretization):
         d_cont_cell: np.ndarray,
         num_sub_cells: int,
         nd: int,
-    ) -> Tuple[np.ndarray, np.ndarray]:
+    ) -> tuple[np.ndarray, np.ndarray]:
         """Transform columns of displacement balance from increasing cell
         ordering (first x-variables of all cells, then y) to increasing
         variables (first all variables of the first cells, then...)
@@ -1720,7 +1720,7 @@ class Mpsa(Discretization):
         d_cont_cell = d_cont_cell[:, d_cont_cell_map]
         return d_cont_grad, d_cont_cell
 
-    def _row_major_to_col_major(self, shape: Tuple, nd: int, axis: int) -> sps.spmatrix:
+    def _row_major_to_col_major(self, shape: tuple, nd: int, axis: int) -> sps.spmatrix:
         """Transform columns of displacement balance from increasing cell
         ordering (first x-variables of all cells, then y) to increasing
         variables (first all variables of the first cells, then...)
@@ -1821,7 +1821,7 @@ class Mpsa(Discretization):
 
     def _reduce_grid_constit_2d(
         self, sd: pp.Grid, constit: pp.FourthOrderTensor
-    ) -> Tuple[pp.Grid, pp.FourthOrderTensor]:
+    ) -> tuple[pp.Grid, pp.FourthOrderTensor]:
         sd = sd.copy()
 
         (

--- a/src/porepy/numerics/interface_laws/elliptic_interface_laws.py
+++ b/src/porepy/numerics/interface_laws/elliptic_interface_laws.py
@@ -1104,8 +1104,10 @@ class WellCoupling(AbstractInterfaceLaw):
         sd_data_secondary: Dict,
         intf_data: Dict,
         matrix: sps.spmatrix,
-    ) -> Tuple[np.ndarray, np.ndarray]:
-        pass
+    ) -> Tuple[np.ndarray, np.ndarray]:  # type:ignore
+        raise NotImplementedError(
+            "Wells are not compatible with the Assembler framework"
+        )
 
     def __repr__(self) -> str:
         return f"Interface coupling of Well type, with keyword {self.keyword}"

--- a/src/porepy/numerics/linear_solvers.py
+++ b/src/porepy/numerics/linear_solvers.py
@@ -5,7 +5,9 @@ setup object has its own system to assemble and solve the system; this
 is just a wrapper around that, mostly for compliance with the nonlinear
 case, see numerics.nonlinear.nonlinear_solvers.
 """
-from typing import Dict, Tuple
+from __future__ import annotations
+
+from typing import Optional
 
 from porepy.models.abstract_model import AbstractModel
 
@@ -15,7 +17,7 @@ class LinearSolver:
     model class before and after solving the problem.
     """
 
-    def __init__(self, params: Dict = None) -> None:
+    def __init__(self, params: Optional[dict] = None) -> None:
         """Define linear solver.
 
         Parameters:
@@ -29,7 +31,7 @@ class LinearSolver:
         # default_options.update(params)
         self.params = params  # default_options
 
-    def solve(self, setup: AbstractModel) -> Tuple[float, bool]:
+    def solve(self, setup: AbstractModel) -> tuple[float, bool]:
         """Solve a linear problem defined by the current state of the model.
 
         Parameters:

--- a/src/porepy/numerics/mixed_dim/assembler.py
+++ b/src/porepy/numerics/mixed_dim/assembler.py
@@ -88,14 +88,16 @@ class Assembler:
         self._identify_variable_combinations()
 
     @staticmethod
-    def _discretization_key(row: str, col: str = None) -> str:
+    def _discretization_key(row: str, col: Optional[str] = None) -> str:
         if col is None or row == col:
             return row
         else:
             return row + "_" + col
 
     @staticmethod
-    def _variable_term_key(term: str, key_1: str, key_2: str, key_3: str = None) -> str:
+    def _variable_term_key(
+        term: str, key_1: str, key_2: str, key_3: Optional[str] = None
+    ) -> str:
         """Get the key-variable combination used to identify a specific term in the
         equation.
 

--- a/src/porepy/numerics/vem/dual_elliptic.py
+++ b/src/porepy/numerics/vem/dual_elliptic.py
@@ -322,7 +322,7 @@ class DualElliptic(EllipticDiscretization):
         data: dict,
         M: sps.csr_matrix,
         mass: sps.csr_matrix,
-        bc_weight: float = None,
+        bc_weight: Optional[float] = None,
     ) -> tuple[sps.csr_matrix, np.ndarray]:
         """Impose Neumann boundary discretization on an already assembled
         system matrix.

--- a/src/porepy/params/data.py
+++ b/src/porepy/params/data.py
@@ -91,7 +91,7 @@ class Parameters(Dict):
     def __init__(
         self,
         grid: Optional[Union[pp.Grid, pp.MortarGrid]] = None,
-        keywords: list[str] = None,
+        keywords: Optional[list[str]] = None,
         dictionaries: Optional[list[dict]] = None,
     ):
         """Initialize Data object.


### PR DESCRIPTION
## Proposed changes
After an update, mypy (to v0.99) gave error mesasges at function and method parameters that had the default argument `None`, but were not marked as optional (e.g., `def foo(bar: list = None)` instead of `def(foo: Optional[list] = None)`. This PR resolves all such conflicts.

In addition, the tagging system in the interface between the `FractureNetwork` classes and `Gmsh` (the tags themselves are defined as an enum in the module `GmshInterface`) is used in a more principled manner: We now use numerical tags under geometry processing (this is very convenient when the geometry is defined as numpy arrays, for instance, fractures defined as an array of point indices that are connected), while Gmsh interface mainly uses the Enum form, which is closer to Gmsh, easier to read etc. There are some exceptions to the latter, where the Gmsh interface has to work with numerical tags, but this is now explicitly noted and should be less incomprehensible.

I also tried to introduce some spot-wise improvements in the documentation of how tagging works in `FractureNetwork2d`. I am fully aware that much more comments really are necessary, together with a refactoring of the code (the same applies even more to `FractureNetwork3d`), but do not have the capacity to take this on now.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply_

- [ ] Minor change (e.g., dependency bumps, broken links, etc).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [x] Documentation (contribution related to adding, improving, or fixing documentation).
- [x] Maintenance (e.g., improve logic and performance, remove obsolete code, etc).
- [ ] Other: 

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.	
- [x] Static typing is included in the update.
- [ ] This PR does not duplicated existing functionality: No new functionality introduced.
- [ ] The update is covered by the test suite (including tests added in the PR). No new functionality introduced.


