### PR TITLE
MAINT: Refactor of domain boundary sides

### DIFF
--- a/src/porepy/models/abstract_model.py
+++ b/src/porepy/models/abstract_model.py
@@ -18,7 +18,8 @@ import abc
 import logging
 import time
 import warnings
-from typing import Any, Dict, Optional, Tuple
+from collections import namedtuple
+from typing import Any, Dict, NamedTuple, Optional, Tuple
 
 import numpy as np
 import scipy.sparse as sps
@@ -345,49 +346,62 @@ class AbstractModel:
         """
         pass
 
-    def _domain_boundary_sides(
-        self,
-        sd: pp.Grid,
-        tol: float = 1e-10,
-    ) -> tuple[
-        np.ndarray,
-        np.ndarray,
-        np.ndarray,
-        np.ndarray,
-        np.ndarray,
-        np.ndarray,
-        np.ndarray,
-    ]:
+    def _domain_boundary_sides(self, sd: pp.Grid, tol: float = 1e-10) -> NamedTuple:
         """Obtain indices of the faces lying on the sides of the domain boundaries.
 
         The method is primarily intended for box-shaped domains. However, it can also be
         applied to non-box-shaped domains (e.g., domains with perturbed boundary nodes)
         provided `tol` is tuned accordingly.
 
-        Args:
+        Parameters:
             sd: Subdomain grid.
             tol: Tolerance used to determine whether a face center lies on a boundary side.
 
         Returns:
-            Tuple of boolean arrays, each one of size sd.num_faces. For a given array,
-                a True element indicates that the face lies on the side of the domain.
-                Otherwise, the element is set to False.
+            NamedTuple containing the domain boundary sides. Available attributes are:
+
+                - all_bf (np.ndarray of int): indices of the boundary faces.
+                - east (np.ndarray of bool): flags of the faces lying on the East side.
+                - west (np.ndarray of bool): flags of the faces lying on the West side.
+                - north (np.ndarray of bool): flags of the faces lying on the North side.
+                - south (np.ndarray of bool): flags of the faces lying on the South side.
+                - top (np.ndarray of bool): flags of the faces lying on the Top side.
+                - bottom (np.ndarray of bool): flags of the faces lying on Bottom side.
+
+        Examples:
+
+            .. code:: python
+
+                model = pp.IncompressibleFlow({})
+                model.prepare_simulation()
+                sd = model.mdg.subdomains()[0]
+                sides = model._domain_boundary_sides(sd)
+                print(sides.north)
 
         """
+
+        # Get domain boundary sides
         box = self.box
-        east = sd.face_centers[0] > box["xmax"] - tol
-        west = sd.face_centers[0] < box["xmin"] + tol
+        east = np.abs(box["xmax"] - sd.face_centers[0]) <= tol
+        west = np.abs(box["xmin"] - sd.face_centers[0]) <= tol
         if self.mdg.dim_max() == 1:
             north = np.zeros(sd.num_faces, dtype=bool)
             south = north.copy()
         else:
-            north = sd.face_centers[1] > box["ymax"] - tol
-            south = sd.face_centers[1] < box["ymin"] + tol
+            north = np.abs(box["ymax"] - sd.face_centers[1]) <= tol
+            south = np.abs(box["ymin"] - sd.face_centers[1]) <= tol
         if self.mdg.dim_max() < 3:
             top = np.zeros(sd.num_faces, dtype=bool)
             bottom = top.copy()
         else:
-            top = sd.face_centers[2] > box["zmax"] - tol
-            bottom = sd.face_centers[2] < box["zmin"] + tol
+            top = np.abs(box["zmax"] - sd.face_centers[2]) <= tol
+            bottom = np.abs(box["zmin"] - sd.face_centers[2]) <= tol
         all_bf = sd.get_boundary_faces()
-        return all_bf, east, west, north, south, top, bottom
+
+        # Create a namedtuple to store the arrays
+        DomainSides = namedtuple(
+            "DomainSides", "all_bf east west north south top bottom"
+        )
+        domain_sides = DomainSides(all_bf, east, west, north, south, top, bottom)
+
+        return domain_sides

--- a/src/porepy/models/abstract_model.py
+++ b/src/porepy/models/abstract_model.py
@@ -376,7 +376,10 @@ class AbstractModel:
                 model.prepare_simulation()
                 sd = model.mdg.subdomains()[0]
                 sides = model._domain_boundary_sides(sd)
-                print(sides.north)
+                # Access north faces using index or name is equivalent:
+                north_by_index = sides[3]
+                north_by_name = sides.north
+                assert all(north_by_index == north_by_name)
 
         """
 


### PR DESCRIPTION
## Proposed changes

This PR proposes a refactor of `domain_boundary_sides()` without changing its functionality. First, the output type was converted from a regular tuple to a namedtuple. This facilitates accessing the boundary sides as attributes (without having to check/remember its position in the returned tuple). The second change is related to the way the boundary sides are picked. Now, the distance between the face-centers and the box sides are computed such that it matches a given tolerance.

P.D.: A cool feature of named tuples is that they also behave as regular tuples. Another cool feature is that they can be transformed into dictionaries.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply_

- [ ] Minor change (e.g., dependency bumps, broken links, etc).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [x] Maintenance (e.g., improve logic and performance, remove obsolete code, etc).
- [ ] Other: 

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.	
- [x] Static typing is included in the update.
- [x] This PR does not duplicated existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).


