### PR TITLE
Update polygon constraint algorithm to work with shapely v2

### DIFF
--- a/src/porepy/geometry/constrain_geometry.py
+++ b/src/porepy/geometry/constrain_geometry.py
@@ -73,9 +73,22 @@ def lines_by_polygon(
                 int_pts = np.c_[int_pts, np.array(int_lines.xy)]
                 edges_kept_aslist.append(ei)
         elif type(int_lines) is shapely_geometry.MultiLineString:
-            # consider the case of multiple intersections by avoiding considering
-            # lines on the boundary of the polygon
-            for int_line in int_lines:
+            # Consider the case of multiple intersections by avoiding considering
+            # lines on the boundary of the polygon.
+
+            # NOTE: After updating to shapely 2.0, iteration over the components
+            # of a multiline should call the geoms attribute.
+            # We could have enforced an update for all users, but instead do a
+            # gentler version which should accommodate v1 and v2.
+            import shapely
+
+            if shapely.__version__[0] > "1":
+                lines_for_iteration = [line for line in int_lines.geoms]
+            else:
+                # shapely v1
+                lines_for_iteration = [line for line in int_lines]
+
+            for int_line in lines_for_iteration:
                 if not int_line.touches(poly) and int_line.length > 0:
                     int_pts = np.c_[int_pts, np.array(int_line.xy)]
                     edges_kept_aslist.append(ei)


### PR DESCRIPTION
## Proposed changes
This is a minor update of the function `geometry.constrain_geometry.lines_by_polygon()`, which uses the dependency `shapely` to find the intersection between line segments and non-convex polygons. After a major upgrade to `shapely`, one of the functions we use changed, and this PR updates the code accordingly. 

The new code is compatible with both the old and new version of Shapely, instead of forcing users to update. The consequences of such an update would likely have been minor to none, but it can be hard to tell. The workaround is properly documented locally in the code.


## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply_

- [ ] Minor change (e.g., dependency bumps, broken links, etc).
- [x] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code, etc).
- [ ] Other: 

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.	
- [x] Static typing is included in the update: No changes needed
- [x] This PR does not duplicated existing functionality. Bugfix only
- [x] The update is covered by the test suite (including tests added in the PR). Bugfix only.


