### PR TITLE
Failing tests in test_vtk

### DIFF
--- a/tests/unit/test_vtk.py
+++ b/tests/unit/test_vtk.py
@@ -177,33 +177,33 @@ def subdomain(request):
     return subdomains[request.param]
 
 
-@pytest.mark.parametrize("subdomain", np.arange(7), indirect=True)
-def test_single_subdomains(setup, subdomain):
-    # Test of the Exporter for single subdomains of different dimensionality
-    # and different grid type. Exporting of scalar and vectorial data is tested.
-
-    # Define grid
-    sd = subdomain.grid
-    sd.compute_geometry()
-
-    # Define data
-    dummy_scalar = np.ones(sd.num_cells) * sd.dim
-    dummy_vector = np.ones((3, sd.num_cells)) * sd.dim
-
-    # Export data
-    save = pp.Exporter(
-        sd,
-        setup.file_name,
-        setup.folder,
-        export_constants_separately=False,
-    )
-    save.write_vtu([("dummy_scalar", dummy_scalar), ("dummy_vector", dummy_vector)])
-
-    # Check that exported vtu file and reference file are the same
-    assert _compare_vtu_files(
-        f"{setup.folder}/{setup.file_name}_{sd.dim}.vtu",
-        f"{subdomain.ref_vtu_file}",
-    )
+# @pytest.mark.parametrize("subdomain", np.arange(7), indirect=True)
+# def test_single_subdomains(setup, subdomain):
+#    # Test of the Exporter for single subdomains of different dimensionality
+#    # and different grid type. Exporting of scalar and vectorial data is tested.
+#
+#    # Define grid
+#    sd = subdomain.grid
+#    sd.compute_geometry()
+#
+#    # Define data
+#    dummy_scalar = np.ones(sd.num_cells) * sd.dim
+#    dummy_vector = np.ones((3, sd.num_cells)) * sd.dim
+#
+#    # Export data
+#    save = pp.Exporter(
+#        sd,
+#        setup.file_name,
+#        setup.folder,
+#        export_constants_separately=False,
+#    )
+#    save.write_vtu([("dummy_scalar", dummy_scalar), ("dummy_vector", dummy_vector)])
+#
+#    # Check that exported vtu file and reference file are the same
+#    assert _compare_vtu_files(
+#        f"{setup.folder}/{setup.file_name}_{sd.dim}.vtu",
+#        f"{subdomain.ref_vtu_file}",
+#    )
 
 
 def test_mdg(setup):

--- a/tests/unit/test_vtk.py
+++ b/tests/unit/test_vtk.py
@@ -21,7 +21,6 @@ import pytest
 from deepdiff import DeepDiff
 
 import porepy as pp
-from itertools import count
 
 # Globally store location of reference files
 folder_reference = (
@@ -32,6 +31,7 @@ folder_reference = (
 class ExporterTestSetup:
     """Class to define where to store vtu files, and test the export functionality
     of the Exporter, FractureNetwork2d, and FractureNetwork3d.
+
     """
 
     def __init__(self):
@@ -41,26 +41,15 @@ class ExporterTestSetup:
         self.folder_reference = folder_reference
 
 
-def setup_module():
-    """Run before any tests in this file.
-
-    Reset the counter to 0 to ensure that "subdomain/interface_id" is the same every
-    time the tests in the module are run. Changing the counter is strongly discouraged in
-    general.
-    """
-    pp.Grid._counter = count(0)
-    pp.MortarGrid._counter = count(0)
-
-
 @pytest.fixture
 def setup():
-    # Method to deliver a setup to all tests, and remove any temporary directory
+    """Method to deliver a setup to all tests, and remove any temporary directory."""
 
     # Setup
     setup = ExporterTestSetup()
     yield setup
 
-    # Teardown: remove temporary directory for vtu files
+    # Teardown: remove temporary directory for vtu files.
     full_path = Path.cwd() / Path.resolve(Path(setup.folder)).name
     shutil.rmtree(full_path)
 
@@ -76,19 +65,21 @@ def _compare_vtu_files(
     down below whether the Exporter produces identical outputs as stored
     reference files.
 
-    NOTE: It is implicitly assumed that Gmsh returns the same grid as
-    for the reference grid; thus, if this test fails, it should be
-    rerun with an older version of Gmsh to test for failure due to
-    external reasons.
+    .. note:
+        It is implicitly assumed that Gmsh returns the same grid as
+        for the reference grid; thus, if this test fails, it should be
+        rerun with an older version of Gmsh to test for failure due to
+        external reasons.
 
-    Args:
+    Parameters:
         test_file: Name of the test file.
         reference_file: Name of the reference file
-        overwrite: Whether to overwrite the reference file with the test file. This should
-            ONLY ever be done if you are changing the "truth" of the test.
+        overwrite: Whether to overwrite the reference file with the test file. This
+            should only ever be done if you are changing the "truth" of the test.
 
     Returns:
         Boolean. True iff files are identical.
+
     """
     if overwrite:
         shutil.copy(test_file, reference_file)
@@ -99,16 +90,23 @@ def _compare_vtu_files(
     reference_data = meshio.read(reference_file)
 
     # Determine the difference between the two meshio objects.
-    # Ignore differences in the data type if values are close.
-    # To judge whether values are close, only consider certain
-    # number of significant digits and base the comparison in
-    # exponential form.
+    # Ignore differences in the data type if values are close. To judge whether values
+    # are close, only consider certain number of significant digits and base the
+    # comparison in exponential form.
+    # Also ignore differences in the subdomain_id and interface_id, as these are
+    # very sensitive to the order of grid creation, which may depend on pytest assembly
+    # and number of tests run.
+    excludePaths = [
+        "root['cell_data']['subdomain_id']",
+        "root['cell_data']['interface_id']",
+    ]
     diff = DeepDiff(
         reference_data.__dict__,
         test_data.__dict__,
         significant_digits=8,
         number_format_notation="e",
         ignore_numeric_type_changes=True,
+        exclude_paths=excludePaths,
     )
 
     # If the difference is empty, the meshio objects are identified as identical.
@@ -117,9 +115,12 @@ def _compare_vtu_files(
 
 @pytest.fixture(scope="function")
 def subdomain(request):
-    # Helper for parametrization of test_single_subdomains. Define collection of
-    # single subdomains incl. 1d, 2d, 3d grids, of simplicial, Cartesian and
-    # polytopal element type.
+    """Helper for parametrization of test_single_subdomains.
+
+    Define collection of single subdomains incl. 1d, 2d, 3d grids, of simplicial,
+    Cartesian and polytopal element type.
+
+    """
 
     # Construct 2d polytopal grid
     sd_polytop_2d = pp.StructuredTriangleGrid([2] * 2, [1] * 2)
@@ -177,39 +178,44 @@ def subdomain(request):
     return subdomains[request.param]
 
 
-# @pytest.mark.parametrize("subdomain", np.arange(7), indirect=True)
-# def test_single_subdomains(setup, subdomain):
-#    # Test of the Exporter for single subdomains of different dimensionality
-#    # and different grid type. Exporting of scalar and vectorial data is tested.
-#
-#    # Define grid
-#    sd = subdomain.grid
-#    sd.compute_geometry()
-#
-#    # Define data
-#    dummy_scalar = np.ones(sd.num_cells) * sd.dim
-#    dummy_vector = np.ones((3, sd.num_cells)) * sd.dim
-#
-#    # Export data
-#    save = pp.Exporter(
-#        sd,
-#        setup.file_name,
-#        setup.folder,
-#        export_constants_separately=False,
-#    )
-#    save.write_vtu([("dummy_scalar", dummy_scalar), ("dummy_vector", dummy_vector)])
-#
-#    # Check that exported vtu file and reference file are the same
-#    assert _compare_vtu_files(
-#        f"{setup.folder}/{setup.file_name}_{sd.dim}.vtu",
-#        f"{subdomain.ref_vtu_file}",
-#    )
+@pytest.mark.parametrize("subdomain", np.arange(7), indirect=True)
+def test_single_subdomains(setup, subdomain):
+    """Test of the Exporter for single subdomains of different dimensionality
+    and different grid type. Exporting of scalar and vectorial data is tested.
+
+    """
+
+    # Define grid
+    sd = subdomain.grid
+    sd.compute_geometry()
+
+    # Define data
+    dummy_scalar = np.ones(sd.num_cells) * sd.dim
+    dummy_vector = np.ones((3, sd.num_cells)) * sd.dim
+
+    # Export data
+    save = pp.Exporter(
+        sd,
+        setup.file_name,
+        setup.folder,
+        export_constants_separately=False,
+    )
+    save.write_vtu([("dummy_scalar", dummy_scalar), ("dummy_vector", dummy_vector)])
+
+    # Check that exported vtu file and reference file are the same
+    assert _compare_vtu_files(
+        f"{setup.folder}/{setup.file_name}_{sd.dim}.vtu",
+        f"{subdomain.ref_vtu_file}",
+    )
 
 
 def test_mdg(setup):
-    # Test of the Exporter for 2d mixed-dimensional grids, here based on a doubly
-    # fractured domain. Exporting of scalar and vectorial data, separately defined
-    # on both subdomains and interfaces.
+    """Test Exporter for 2d mixed-dimensional grids for a two-fracture domain.
+
+    Exporting of scalar and vectorial data, separately defined on both subdomains and
+    interfaces.
+
+    """
 
     # Define grid
     mdg, _ = pp.md_grids_2d.two_intersecting(
@@ -253,12 +259,14 @@ def test_mdg(setup):
 
 
 def test_mdg_data_selection(setup):
-    # Test of the Exporter for 2d mixed-dimensional grids, here based on a doubly
-    # fractured domain. Exporting of scalar and vectorial data, separately defined
-    # on both subdomains and interfaces. Furthermore, the different possibilities
-    # of how to export data are tested: addressing selected data associated to all
-    # subdomains and interfaces, single ones, or defining external data (here simply
-    # cell centers).
+    """Test Exporter for 2d mixed-dimensional grids for a two-fracture domain.
+
+    Exporting of scalar and vectorial data, separately defined on both subdomains and
+    interfaces. Furthermore, the different possibilities of how to export data are
+    tested: addressing selected data associated to all subdomains and interfaces, single
+    ones, or defining external data (here simply cell centers).
+
+    """
 
     # Define grid
     mdg, _ = pp.md_grids_2d.two_intersecting(
@@ -305,7 +313,7 @@ def test_mdg_data_selection(setup):
         ]
     )
 
-    # Check that exported vtu files and reference files are the same
+    # Check that exported vtu files and reference files are the same.
     for appendix in ["1", "2", "mortar_1"]:
         assert _compare_vtu_files(
             f"{setup.folder}/{setup.file_name}_{appendix}.vtu",
@@ -314,8 +322,10 @@ def test_mdg_data_selection(setup):
 
 
 def test_constant_data(setup):
-    # Test of the Exporter functionality to distinguish between constant and non-constant
-    # data during exporting.
+    """Test Exporter functionality to distinguish between constant and non-constant
+    data during exporting.
+
+    """
 
     # Define grid
     g = pp.StructuredTriangleGrid([3] * 2, [1] * 2)
@@ -344,7 +354,7 @@ def test_constant_data(setup):
 
 
 def test_fracture_network_2d(setup):
-    # Test of the export functionality of FractureNetwork2d.
+    """Test of the export functionality of FractureNetwork2d."""
 
     # Define network
     p = np.array([[0, 2, 1, 2, 1], [0, 0, 0, 1, 2]])
@@ -367,7 +377,7 @@ def test_fracture_network_2d(setup):
         data=data,
     )
 
-    # Check that exported vtu file and reference file are the same
+    # Check that exported vtu file and reference file are the same.
     assert _compare_vtu_files(
         f"{setup.folder}/{setup.file_name}.vtu",
         f"{setup.folder_reference}/fractures_2d.vtu",
@@ -375,7 +385,7 @@ def test_fracture_network_2d(setup):
 
 
 def test_fracture_network_3d(setup):
-    # Test of the export functionality of FractureNetwork3d.
+    """Test of the export functionality of FractureNetwork3d."""
 
     # Define network
     f_1 = pp.PlaneFracture(np.array([[0, 1, 2, 0], [0, 0, 1, 1], [0, 0, 1, 1]]))
@@ -391,7 +401,7 @@ def test_fracture_network_3d(setup):
     dummy_vector = [[np.ones(3)] for _ in range(num_frac)]
     data = {"dummy_scalar": dummy_scalar, "dummy_vector": dummy_vector}
 
-    # Make directory if not existent
+    # Make directory if not existent.
     if not os.path.exists(setup.folder):
         os.makedirs(setup.folder)
 
@@ -401,7 +411,7 @@ def test_fracture_network_3d(setup):
         data=data,
     )
 
-    # Check that exported vtu file and reference file are the same
+    # Check that exported vtu file and reference file are the same.
     assert _compare_vtu_files(
         f"{setup.folder}/{setup.file_name}.vtu",
         f"{setup.folder_reference}/fractures_3d.vtu",


### PR DESCRIPTION
## Proposed changes

In the current develop branch failing tests in test_vtk are strangely buried and seem to suceed. By commenting out a single test, the failure however uncovered. Two issues are identified:

- 3 tests fail due to wrong reference test vtk files introduced in #746 
- The recently introduced parametrization of `test_single_subdomains` seems to be the reason why the tests are not run properly.

Currently this PR does not offer a solution. Though githubs tracking of succeeding and failing tests will be used in the development to track the progress. The boxes below will have to be updated in the process of fixing the bugs.

## Types of changes

- [ ] Minor change (e.g., dependency bumps, broken links, etc).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code, etc).
- [ ] Other: 

## Checklist

- [ ] The documentation is up-to-date.	
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicated existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).


