### PR TITLE
Scaling_tests

### DIFF
--- a/src/porepy/models/constitutive_laws.py
+++ b/src/porepy/models/constitutive_laws.py
@@ -879,13 +879,19 @@ class DarcysLaw:
 
         # Gradient operator in the normal direction. The collapsed distance is
         # :math:`\frac{a}{2}` on either side of the fracture.
+        # We assume here that :meth:`apeture` is implemented to give a meaningful value
+        # also for subdomains of co-dimension > 1.
         normal_gradient = pp.ad.Scalar(2) * (
             projection.secondary_to_mortar_avg * self.aperture(subdomains) ** (-1)
         )
 
         # Project the two pressures to the interface and multiply with the normal
         # diffusivity.
-
+        # The cell volumes are scaled in two stages:
+        # The term cell_volumes carries the volume of the cells in the mortar grids,
+        # while the volume scaling from reduced dimensions is picked from the
+        # specific volumes of the higher dimension (variable `specific_volume`)
+        # and projected to the interface via a trace operator.
         eq = self.interface_darcy_flux(interfaces) - (
             cell_volumes
             * normal_gradient
@@ -1295,8 +1301,10 @@ class FouriersLaw:
         )
         normal_gradient.set_name("normal_gradient")
 
-        # Project the two pressures to the interface and multiply with the normal
-        # diffusivity.
+        # Project the two temperatures to the interface and multiply with the normal
+        # conductivity.
+        # See comments in :meth:`interface_darcy_flux_equation` for more information on
+        # the terms in the below equation.
         eq = self.interface_fourier_flux(interfaces) - (
             cell_volumes
             * normal_gradient

--- a/src/porepy/models/constitutive_laws.py
+++ b/src/porepy/models/constitutive_laws.py
@@ -787,6 +787,16 @@ class DarcysLaw:
     instance of :class:`~porepy.models.geometry.ModelGeometry`.
 
     """
+    specific_volume: Callable[[list[pp.Grid]], pp.ad.Operator]
+    """Specific volume. Normally defined in a mixin instance of
+    :class:`~porepy.models.constitutive_laws.DimensionReduction` or a subclass thereof.
+
+    """
+    aperture: Callable[[list[pp.Grid]], pp.ad.Operator]
+    """Aperture. Normally defined in a mixin instance of
+    :class:`~porepy.models.constitutive_laws.DimensionReduction` or a subclass thereof.
+
+    """
 
     def pressure_trace(self, subdomains: list[pp.Grid]) -> pp.ad.Operator:
         """Pressure on the subdomain boundaries.
@@ -1181,6 +1191,16 @@ class FouriersLaw:
     wrap_grid_attribute: Callable[[Sequence[pp.GridLike], str, int, bool], pp.ad.Matrix]
     """Wrap grid attributes as Ad operators. Normally set by a mixin instance of
     :class:`porepy.models.geometry.ModelGeometry`.
+
+    """
+    specific_volume: Callable[[list[pp.Grid]], pp.ad.Operator]
+    """Specific volume. Normally defined in a mixin instance of
+    :class:`~porepy.models.constitutive_laws.DimensionReduction` or a subclass thereof.
+
+    """
+    aperture: Callable[[list[pp.Grid]], pp.ad.Operator]
+    """Aperture. Normally defined in a mixin instance of
+    :class:`~porepy.models.constitutive_laws.DimensionReduction` or a subclass thereof.
 
     """
 

--- a/src/porepy/models/constitutive_laws.py
+++ b/src/porepy/models/constitutive_laws.py
@@ -100,6 +100,8 @@ class DimensionReduction:
             Specific volume for each cell.
 
         """
+        if len(subdomains) == 0:
+            return pp.wrap_as_ad_array(0, size=0)
         # Compute specific volume as the cross-sectional area/volume
         # of the cell, i.e. raise to the power nd-dim
         projection = pp.ad.SubdomainProjections(subdomains, dim=1)
@@ -813,6 +815,12 @@ class DarcysLaw:
     def darcy_flux(self, subdomains: list[pp.Grid]) -> pp.ad.Operator:
         """Discretization of Darcy's law.
 
+        Note:
+            The fluid mobility is not included in the Darcy flux. This is because we
+            discretize it with an upstream scheme. This means that the fluid mobility
+            may have to be included when using the flux in a transport equation.
+            The units of the Darcy flux are [m^2 Pa / s].
+
         Parameters:
             subdomains: List of subdomains where the Darcy flux is defined.
 
@@ -839,6 +847,8 @@ class DarcysLaw:
     def interface_darcy_flux_equation(self, interfaces: list[pp.MortarGrid]):
         """Darcy flux on interfaces.
 
+        The units of the Darcy flux are [m^2 Pa / s], see note in :meth:`darcy_flux`.
+
         Parameters:
             interfaces: List of interface grids.
 
@@ -854,14 +864,28 @@ class DarcysLaw:
         cell_volumes = self.wrap_grid_attribute(
             interfaces, "cell_volumes", dim=1, inverse=False  # type: ignore[call-arg]
         )
+        specific_volume = self.specific_volume(subdomains)
+        trace = pp.ad.Trace(subdomains, dim=1)
+
+        # Gradient operator in the normal direction. The collapsed distance is
+        # :math:`\frac{a}{2}` on either side of the fracture.
+        normal_gradient = pp.ad.Scalar(2) * (
+            projection.secondary_to_mortar_avg * self.aperture(subdomains) ** (-1)
+        )
+
         # Project the two pressures to the interface and multiply with the normal
-        # diffusivity
-        eq = self.interface_darcy_flux(
-            interfaces
-        ) - cell_volumes * self.normal_permeability(interfaces) * (
-            projection.primary_to_mortar_avg * self.pressure_trace(subdomains)
-            - projection.secondary_to_mortar_avg * self.pressure(subdomains)
-            + self.interface_vector_source(interfaces, material="fluid")
+        # diffusivity.
+
+        eq = self.interface_darcy_flux(interfaces) - (
+            cell_volumes
+            * normal_gradient
+            * self.normal_permeability(interfaces)
+            * (projection.primary_to_mortar_avg * trace.trace * specific_volume)
+            * (
+                projection.primary_to_mortar_avg * self.pressure_trace(subdomains)
+                - projection.secondary_to_mortar_avg * self.pressure(subdomains)
+                + self.interface_vector_source(interfaces, material="fluid")
+            )
         )
         eq.set_name("interface_darcy_flux_equation")
         return eq
@@ -1241,13 +1265,27 @@ class FouriersLaw:
         cell_volumes = self.wrap_grid_attribute(
             interfaces, "cell_volumes", dim=1, inverse=False  # type: ignore[call-arg]
         )
+        specific_volume = self.specific_volume(subdomains)
+        trace = pp.ad.Trace(subdomains, dim=1)
+
+        # Gradient operator in the normal direction. The collapsed distance is
+        # :math:`\frac{a}{2}` on either side of the fracture.
+        normal_gradient = pp.ad.Scalar(2) * (
+            projection.secondary_to_mortar_avg * self.aperture(subdomains) ** (-1)
+        )
+        normal_gradient.set_name("normal_gradient")
+
         # Project the two pressures to the interface and multiply with the normal
-        # diffusivity
-        eq = self.interface_fourier_flux(
-            interfaces
-        ) - cell_volumes * self.normal_thermal_conductivity(interfaces) * (
-            projection.primary_to_mortar_avg * self.temperature_trace(subdomains)
-            - projection.secondary_to_mortar_avg * self.temperature(subdomains)
+        # diffusivity.
+        eq = self.interface_fourier_flux(interfaces) - (
+            cell_volumes
+            * normal_gradient
+            * self.normal_thermal_conductivity(interfaces)
+            * (projection.primary_to_mortar_avg * trace.trace * specific_volume)
+            * (
+                projection.primary_to_mortar_avg * self.temperature_trace(subdomains)
+                - projection.secondary_to_mortar_avg * self.temperature(subdomains)
+            )
         )
         eq.set_name("interface_fourier_flux_equation")
         return eq

--- a/src/porepy/models/fluid_mass_balance.py
+++ b/src/porepy/models/fluid_mass_balance.py
@@ -174,7 +174,6 @@ class MassBalanceEquations(pp.BalanceEquation):
             Operator representing the cell-wise fluid mass.
 
         """
-
         mass_density = self.fluid_density(subdomains) * self.porosity(subdomains)
         mass = self.volume_integral(mass_density, subdomains, dim=1)
         mass.set_name("fluid_mass")

--- a/src/porepy/models/material_constants.py
+++ b/src/porepy/models/material_constants.py
@@ -68,8 +68,8 @@ class MaterialConstants:
         return self._constants
 
     def convert_units(
-        self, value: number | np.ndarray, units: str, to_si: Optional[bool] = False
-    ) -> number | np.ndarray:
+        self, value: number, units: str, to_si: Optional[bool] = False
+    ) -> number:
         """Convert value between SI and user specified units.
 
         The method divides the value by the units as defined by the user. As an example,

--- a/src/porepy/models/material_constants.py
+++ b/src/porepy/models/material_constants.py
@@ -13,8 +13,6 @@ from __future__ import annotations
 
 from typing import Optional
 
-import numpy as np
-
 import porepy as pp
 
 number = pp.number
@@ -93,6 +91,8 @@ class MaterialConstants:
 
         """
         # Make a copy of the value to avoid modifying the original.
+        # This is not strictly necessary for scalars, but is done in case the method is
+        # used for arrays.
         value = value.copy() if hasattr(value, "copy") else value
         # Trim any spaces
         units = units.replace(" ", "")
@@ -154,11 +154,6 @@ class FluidConstants(MaterialConstants):
             "viscosity": 1,
         }
         if constants is not None:
-            if "s" in constants:
-                if not np.isclose(constants["s"], 1):
-                    raise NotImplementedError(
-                        "Non-unitary time scaling is not implemented."
-                    )
             default_constants.update(constants)
         super().__init__(default_constants)
 

--- a/src/porepy/models/solution_strategy.py
+++ b/src/porepy/models/solution_strategy.py
@@ -119,6 +119,12 @@ class SolutionStrategy(abc.ABC):
         self.units: pp.Units = params.get("units", pp.Units())
         """Units of the model. See also :meth:`set_units`."""
 
+        self.fluid: pp.FluidConstants
+        """Fluid constants. See also :meth:`set_materials`."""
+
+        self.solid: pp.SolidConstants
+        """Solid constants. See also :meth:`set_materials`."""
+
         self.time_manager = params.get(
             "time_manager",
             pp.TimeManager(schedule=[0, 1], dt_init=1, constant_dt=True),
@@ -321,7 +327,7 @@ class SolutionStrategy(abc.ABC):
                 solver.
         """
         if self._is_nonlinear_problem():
-            raise ValueError("Newton iterations did not converge")
+            raise ValueError("Newton iterations did not converge.")
         else:
             raise ValueError("Tried solving singular matrix for the linear problem.")
 

--- a/src/porepy/models/units.py
+++ b/src/porepy/models/units.py
@@ -88,6 +88,9 @@ class Units:
         """Length unit in meters."""
         self.s: number = kwargs.get("s", 1)
         """Time unit in seconds."""
+        if not np.isclose(self.s, 1):
+            raise NotImplementedError("Non-unitary time scaling is not implemented.")
+
         self.kg: number = kwargs.get("kg", 1)
         """Mass unit in kilograms."""
         self.K: number = kwargs.get("K", 1)

--- a/src/porepy/models/verification_setups/manu_flow_comp_frac.py
+++ b/src/porepy/models/verification_setups/manu_flow_comp_frac.py
@@ -779,9 +779,13 @@ class ModifiedSolutionStrategy(pp.fluid_mass_balance.SolutionStrategySinglePhase
     def __init__(self, params: dict):
 
         # Parameters associated with the verification setup. The below parameters
-        # cannot be changed since they're associated with the exact solution
+        # cannot be changed since they're associated with the exact solution.
+        # Normal permeability of 1/2 counteracts division by a/2 in the normal Darcy
+        # equation.
         fluid = pp.FluidConstants({"compressibility": 0.2})
-        solid = pp.SolidConstants({"porosity": 0.1, "residual_aperture": 1})
+        solid = pp.SolidConstants(
+            {"porosity": 0.1, "residual_aperture": 1, "normal_permeability": 1 / 2}
+        )
         material_constants = {"fluid": fluid, "solid": solid}
         required_params = {"material_constants": material_constants}
         params.update(required_params)

--- a/src/porepy/models/verification_setups/manu_flow_incomp_frac.py
+++ b/src/porepy/models/verification_setups/manu_flow_incomp_frac.py
@@ -466,7 +466,7 @@ class ModifiedGeometry(pp.ModelGeometry):
         # FractureNetwork2d class.
         if isinstance(domain, np.ndarray):
             assert domain.shape == (2, 2)
-            self.domain: dict[str, float] = {
+            self.domain_bounds: dict[str, float] = {
                 "xmin": domain[0, 0],
                 "xmax": domain[1, 0],
                 "ymin": domain[0, 1],
@@ -474,7 +474,7 @@ class ModifiedGeometry(pp.ModelGeometry):
             }
         else:
             assert isinstance(domain, dict)
-            self.domain = domain
+            self.domain_bounds = domain
 
 
 class ModifiedBoundaryConditions:
@@ -547,9 +547,13 @@ class ModifiedSolutionStrategy(pp.fluid_mass_balance.SolutionStrategySinglePhase
     def __init__(self, params: dict):
 
         # Parameters associated with the verification setup. The below parameters
-        # cannot be changed since they're associated with the exact solution
+        # cannot be changed since they're associated with the exact solution.
+        # Normal permeability of 1/2 counteracts division by a/2 in the normal Darcy
+        # equation.
         fluid = pp.FluidConstants({"compressibility": 0})
-        solid = pp.SolidConstants({"porosity": 0, "residual_aperture": 1})
+        solid = pp.SolidConstants(
+            {"porosity": 0, "residual_aperture": 1, "normal_permeability": 1 / 2}
+        )
         material_constants = {"fluid": fluid, "solid": solid}
         required_params = {"material_constants": material_constants}
         params.update(required_params)

--- a/src/porepy/models/verification_setups/manu_poromech_nofrac.py
+++ b/src/porepy/models/verification_setups/manu_poromech_nofrac.py
@@ -536,7 +536,7 @@ class UnitSquare(pp.ModelGeometry):
         domain = self.fracture_network.domain
         if isinstance(domain, np.ndarray):
             assert domain.shape == (2, 2)
-            self.domain: dict[str, float] = {
+            self.domain_bounds: dict[str, float] = {
                 "xmin": domain[0, 0],
                 "xmax": domain[1, 0],
                 "ymin": domain[0, 1],
@@ -544,7 +544,7 @@ class UnitSquare(pp.ModelGeometry):
             }
         else:
             assert isinstance(domain, dict)
-            self.domain = domain
+            self.domain_bounds = domain
 
 
 # --------> Equations

--- a/src/porepy/viz/data_saving_model_mixin.py
+++ b/src/porepy/viz/data_saving_model_mixin.py
@@ -51,6 +51,7 @@ class DataSavingMixin:
 
         Returns:
             List containing all variable names.
+
         """
         var_names = [var.name for var in self.equation_system.variables]
         return var_names
@@ -61,6 +62,7 @@ class DataSavingMixin:
         This method is called by :meth:`prepare_simulation` to initialize the exporter,
         and any other data saving functionality (e.g., empty data containers to be
         appended in :meth:`save_data_time_step`).
+
         """
         self.exporter = pp.Exporter(
             self.mdg,

--- a/tests/integration/models/setup_utils.py
+++ b/tests/integration/models/setup_utils.py
@@ -37,7 +37,7 @@ class RectangularDomainOrthogonalFractures2d(pp.ModelGeometry):
             e = np.array([[0, 2], [1, 3]])
         elif num_fracs == 3:
             if self.params.get("cartesian", False):
-                raise ValueError("Only up to 2 fractures supported in cartesian mode.")
+                raise ValueError("Only up to 2 fractures supported in Cartesian mode.")
             p = np.array([[0, 2, 0.5, 0.5, 0.3, 0.7], [0.5, 0.5, 0, 1, 0.3, 0.7]]) * ls
             e = np.array([[0, 2, 4], [1, 3, 5]])
         else:
@@ -539,7 +539,7 @@ def compare_scaled_model_quantities(
     setup_1: pp.SolutionStrategy,
     method_names: list[str],
     method_units: list[str],
-    dimensions: list[int | None],
+    domain_dimensions: list[int | None],
     cell_wise: bool = True,
 ):
     """Compare the solution of two simulations.
@@ -552,11 +552,15 @@ def compare_scaled_model_quantities(
         setup_1: Second simulation.
         method_names: Names of the methods to be compared.
         method_units: Units of the methods to be compared.
+        domain_dimensions: Dimensions of the domains to be tested. If None, the method
+            will be tested for all dimensions.
         cell_wise: If True, the values are compared cell-wise. If False, the values are
             compared globally.
 
     """
-    for method_name, method_unit, dim in zip(method_names, method_units, dimensions):
+    for method_name, method_unit, dim in zip(
+        method_names, method_units, domain_dimensions
+    ):
         values = []
         for setup in [setup_0, setup_1]:
             # Obtain scaled values.

--- a/tests/integration/models/test_constitutive_laws.py
+++ b/tests/integration/models/test_constitutive_laws.py
@@ -10,6 +10,7 @@ the classes are refactored.
 
 """
 from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/tests/integration/models/test_energy_balance.py
+++ b/tests/integration/models/test_energy_balance.py
@@ -227,8 +227,9 @@ def test_unit_conversion(units):
         setup.temperature_variable,
         setup.pressure_variable,
         setup.interface_darcy_flux_variable,
+        setup.interface_enthalpy_flux_variable,
     ]
-    variable_units = ["K", "Pa", "m^2 * s^-1 * Pa"]
+    variable_units = ["K", "Pa", "m^2 * s^-1 * Pa", "m^-1 * s^-1 * J"]
     secondary_variables = ["darcy_flux", "enthalpy_flux", "fourier_flux"]
     secondary_units = ["m^2 * s^-1 * Pa", "m^-1 * s^-1 * J", "m^-1 * s^-1 * J"]
     # No domain restrictions.

--- a/tests/integration/models/test_materials_and_units.py
+++ b/tests/integration/models/test_materials_and_units.py
@@ -82,7 +82,7 @@ def test_default_units(base_units, derived_units):
 # Two sets of units to be used in the tests below. All basic units are modified in at
 # least one of the two sets, except the radian, which is not expected to be rescaled
 # in a manner similar to the other units.
-modification_dictionaries = [dict(m=2, kg=3.7, s=4), dict(m=3, mol=2.5)]
+modification_dictionaries = [dict(m=2, kg=3.7, s=1), dict(m=3, mol=2.5)]
 
 
 @pytest.mark.parametrize("modify_dict", modification_dictionaries)

--- a/tests/integration/models/test_materials_and_units.py
+++ b/tests/integration/models/test_materials_and_units.py
@@ -9,6 +9,7 @@ Constitutive library tests.
         - Setting modified values TODO
 """
 from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/tests/integration/models/test_momentum_balance.py
+++ b/tests/integration/models/test_momentum_balance.py
@@ -115,11 +115,10 @@ def test_2d_single_fracture(solid_vals, north_displacement):
 def test_unit_conversion(units, uy_north):
     """Test that solution is independent of units.
 
-    We avoid the value uy
-
     Parameters:
         units (dict): Dictionary with keys as those in
             :class:`~pp.models.material_constants.MaterialConstants`.
+        uy_north (float): Value of displacement on the north boundary.
 
     """
 

--- a/tests/integration/models/test_poromechanics.py
+++ b/tests/integration/models/test_poromechanics.py
@@ -6,6 +6,9 @@ This is needed to avoid degenerate mass balance equation in fracture.
 TODO: Clean up.
 """
 from __future__ import annotations
+
+import copy
+
 import numpy as np
 import pytest
 
@@ -15,6 +18,8 @@ from .setup_utils import (
     BoundaryConditionsMassAndEnergyDirNorthSouth,
     Poromechanics,
     TimeDependentMechanicalBCsDirNorthSouth,
+    compare_scaled_model_quantities,
+    compare_scaled_primary_variables,
 )
 
 
@@ -47,7 +52,7 @@ class NonzeroFractureGapPoromechanics:
 
             top_cells = sd.cell_centers[1] > 0.5
             vals = np.zeros((self.nd, sd.num_cells))
-            vals[1, top_cells] = 0.042
+            vals[1, top_cells] = self.fluid.convert_units(0.042, "m")
             self.equation_system.set_variable_values(
                 vals.ravel("F"),
                 [self.displacement_variable],
@@ -72,7 +77,7 @@ class NonzeroFractureGapPoromechanics:
 
             # Set mortar displacement to zero on bottom and 0.042 on top
             vals = np.zeros((self.nd, intf.num_cells))
-            vals[1, top_cells] = 0.042
+            vals[1, top_cells] = self.fluid.convert_units(0.042, "m")
             self.equation_system.set_variable_values(
                 vals.ravel("F"),
                 [self.interface_displacement_variable],
@@ -126,9 +131,10 @@ class NonzeroFractureGapPoromechanics:
             if sd.dim == self.nd:
                 vals.append(np.zeros(sd.num_cells))
             else:
-                vals.append(
-                    np.ones(sd.num_cells) * self.params["fracture_source_value"]
+                val = self.fluid.convert_units(
+                    self.params["fracture_source_value"], "kg * s ^ -1"
                 )
+                vals.append(val * np.ones(sd.num_cells))
         fracture_source = pp.wrap_as_ad_array(
             np.hstack(vals), name="fracture_fluid_source"
         )
@@ -301,9 +307,9 @@ def test_2d_single_fracture(solid_vals, north_displacement):
 
 
 def test_poromechanics_model_no_modification():
-    """Test that the raw contact poromechanics model with no modifications can be run with
-    no error messages. Failure of this test would signify rather fundamental problems
-    in the model.
+    """Test that the poromechanics model with no modifications runs with no errors.
+
+    Failure of this test would signify rather fundamental problems in the model.
     """
     mod = pp.poromechanics.Poromechanics({})
     pp.run_stationary_model(mod, {})
@@ -347,9 +353,10 @@ def test_without_fracture(biot_coefficient):
 
 
 def test_pull_north_positive_opening():
+    """Check solution for a pull on the north side with one horizontal fracture."""
     setup = create_fractured_setup({}, {}, 0.001)
     pp.run_time_dependent_model(setup, {})
-    u_vals, p_vals, p_frac, jump, traction = get_variables(setup)
+    _, _s, p_frac, jump, traction = get_variables(setup)
 
     # All components should be open in the normal direction
     assert np.all(jump[1] > 0)
@@ -368,6 +375,7 @@ def test_pull_north_positive_opening():
 
 
 def test_pull_south_positive_opening():
+    """Check solution for a pull on the south side with one horizontal fracture."""
 
     setup = create_fractured_setup({}, {}, 0)
     setup.params["uy_south"] = -0.001
@@ -411,7 +419,7 @@ def test_positive_p_frac_positive_opening():
     setup = create_fractured_setup({}, {}, 0)
     setup.params["fracture_source_value"] = 0.001
     pp.run_time_dependent_model(setup, {})
-    u_vals, p_vals, p_frac, jump, traction = get_variables(setup)
+    _, _, p_frac, jump, traction = get_variables(setup)
 
     # All components should be open in the normal direction
     assert np.all(jump[1] > 0.042)
@@ -426,7 +434,8 @@ def test_positive_p_frac_positive_opening():
     assert np.all(np.abs(traction) < 1e-7)
 
     # Fracture pressure is positive
-    assert np.all(p_frac > 1e-3)
+    assert np.all(p_frac > 4.7e-4)
+    assert np.all(p_frac < 4.9e-4)
 
 
 def test_pull_south_positive_reference_pressure():
@@ -450,3 +459,51 @@ def test_pull_south_positive_reference_pressure():
     assert np.allclose(traction, traction_ref)
     assert np.allclose(p_frac, p_frac_ref + 1)
     assert np.allclose(p_vals, p_vals_ref + 1)
+
+
+@pytest.mark.parametrize(
+    "units",
+    [
+        {"m": 0.2, "kg": 0.3, "K": 42},
+    ],
+)
+def test_unit_conversion(units):
+    """Test that solution is independent of units.
+
+    Parameters:
+        units (dict): Dictionary with keys as those in
+            :class:`~pp.models.material_constants.MaterialConstants`.
+
+    """
+
+    params = {
+        "suppress_export": True,  # Suppress output for tests
+        "num_fracs": 1,
+        "cartesian": True,
+        "uy_north": 0.1,
+    }
+    reference_params = copy.deepcopy(params)
+    reference_params["file_name"] = "unit_conversion_reference"
+
+    # Create model and run simulation
+    setup_0 = TailoredPoromechanics(reference_params)
+    pp.run_time_dependent_model(setup_0, reference_params)
+
+    params["units"] = pp.Units(**units)
+    setup_1 = TailoredPoromechanics(params)
+
+    pp.run_time_dependent_model(setup_1, params)
+    variables = [
+        setup_1.pressure_variable,
+        setup_1.interface_darcy_flux_variable,
+        setup_1.displacement_variable,
+        setup_1.interface_displacement_variable,
+    ]
+    variable_units = ["Pa", "Pa * m^2 * s^-1", "m", "m"]
+    compare_scaled_primary_variables(setup_0, setup_1, variables, variable_units)
+    flux_names = ["darcy_flux", "fluid_flux", "stress", "fracture_stress"]
+    flux_units = ["Pa * m^2 * s^-1", "kg * m^-1 * s^-1", "Pa * m", "Pa"]
+    domain_dimensions = [None, None, 2, 1]
+    compare_scaled_model_quantities(
+        setup_0, setup_1, flux_names, flux_units, domain_dimensions
+    )

--- a/tests/integration/models/test_variables.py
+++ b/tests/integration/models/test_variables.py
@@ -2,6 +2,7 @@
 
 """
 from __future__ import annotations
+
 from inspect import signature
 
 import pytest


### PR DESCRIPTION
## Proposed changes

1. Introduces testing for scaling. The functionality is still somewhat experimental, but way better covered than previously. The tests are of integration type, checking that simulations results are identical with and without scaling for all provided model classes. 
2. Fixes some bugs caught by the new tests. 
3. We decided to include the normal gradient in the diffusive interface laws, i.e. division through a/2. Consequently, the normal permeability and thermal conductivity now have the same units as their tangential counterparts (m^2 and W/m/s, respectively).

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply_

- [ ] Minor change (e.g., dependency bumps, broken links, etc).
- [x] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code, etc).
- [ ] Other: 

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.	
- [x] Static typing is included in the update.
- [x] This PR does not duplicated existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).