### PR TITLE
BLD: Separate GH static and dynamic test workflows

### DIFF
--- a/.github/workflows/run-pytest.yml
+++ b/.github/workflows/run-pytest.yml
@@ -1,6 +1,5 @@
-# Code Quality workflow for black, flake8, mypy
-
-name: Build Test
+# Run unit, integration, and functional tests.
+name: Pytest
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events for the main and develop branches
@@ -87,26 +86,16 @@ jobs:
         pip install .
         pip freeze       
 
-    - name: black
-      if: ${{ always() }}
-      run: black --check src
-
-    - name: isort
-      if: ${{always()}}
-      run: isort --check src
-
-    - name: flake8
-      if: ${{ always() }}
-      run: flake8 src 
-
     - name: unit tests
       if: ${{always()}}
       run: pytest tests/unit
 
-    - name: mypy
-      if: ${{ always() }}
-      run: mypy src --cache-dir mypy-cache-${{ matrix.python-version}}
-
     - name: integration tests
       if: ${{always()}}
       run: pytest tests/integration
+
+    - name: functional tests
+      if: ${{always()}}
+      run: pytest tests/functional
+
+

--- a/.github/workflows/run-static-checks.yml
+++ b/.github/workflows/run-static-checks.yml
@@ -1,0 +1,92 @@
+# Run static tests for code quality: Isort, black, flake8, mypy.
+
+name: Static tests
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events for the main and develop branches
+on:
+  push:
+    branches:
+      - develop
+      - main
+  pull_request:
+    branches: 
+      - develop
+      - main
+  schedule:
+    # Do a nightly run of the tests
+    - cron: '0 1 * * *'
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#specifying-a-python-version
+    strategy:
+      matrix:
+        # Run the tests on the latest supported Python version (currently 3.10), but
+        # also do early checks on newer versions (3.11).
+        python-version:  ["3.10", "3.11"]
+      # Complete all versions in matrix even if one fails.
+      fail-fast: false
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it.
+    - uses: actions/checkout@v3
+    
+    - name: Setup Python ${{ matrix.python-version}}
+      uses: actions/setup-python@v3
+      with:
+        # Version range or exact version of a Python version to use, using SemVer's version range syntax.
+        python-version: ${{ matrix.python-version}}
+        architecture: x64
+        cache: 'pip'
+
+    # Cache pip dependencies
+    # Source: https://github.com/actions/cache/blob/main/examples.md#python---pip
+    - name: Cache dependencies
+      uses: actions/cache@v3
+      id: cache
+      with:
+        # Cache the full python environment, this is more efficient than just caching pip
+        # https://blog.allenai.org/python-caching-in-github-actions-e9452698e98d
+        path: ${{ env.pythonLocation }}
+        # We will install only the development requirements, since we will not actually
+        # install PorePy (just analyze the source code).
+        key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ hashFiles('**/requirements-dev.txt') }}
+
+    - name: Cache mypy
+      uses: actions/cache@v3
+      id: cache-mypy
+      with:
+        path: mypy-cache-${{ matrix.python-version}}
+        key: ${{ runner.os }}-mypy
+
+    # Install the requirements needed for development. This will give access to black,
+    # isort, mypy, and flake8
+    - name: Install requirements-dev
+      run: |
+        pip install --upgrade --upgrade-strategy eager -r requirements-dev.txt          
+
+    # Run black, isort, flake8, and mypy.
+    # Note that since these are static checks, we have not installed PorePy, nor its
+    # dependencies (except the development ones).
+    - name: black
+      if: ${{ always() }}
+      run: black --check src
+
+    - name: isort
+      if: ${{always()}}
+      run: isort --check src
+
+    - name: flake8
+      if: ${{ always() }}
+      run: flake8 src 
+
+    - name: mypy
+      if: ${{ always() }}
+      run: mypy src --cache-dir mypy-cache-${{ matrix.python-version}}

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ description-file = Readme.md
 test=pytest
 
 [tool:pytest]
-python_files = tests/unit/*.py tests/integration/*.py 
+python_files = tests/unit/*.py tests/integration/*.py tests/functional/*.py
 addopts = --cov=src/porepy --cov-report term-missing -p no:warnings
 
 [flake8]


### PR DESCRIPTION
## Proposed changes
Split the GH actions into static (mypy, isort, black, flake8) and dynamic (pytest) tests. Run the static tests only on the latest python version. The hope is that this will speed up the testing.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply_

- [ ] Minor change (e.g., dependency bumps, broken links, etc).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code, etc).
- [x] Other: GH actions

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

None are relevant, the PR considers GH actions only.

- [ ] The documentation is up-to-date.	
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicated existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).


