### PR TITLE
BUG: Update needed for networkx v3

### DIFF
--- a/src/porepy/grids/partition.py
+++ b/src/porepy/grids/partition.py
@@ -819,7 +819,7 @@ def grid_is_connected(
     c2c = c2c.tocsr()[cell_ind, :].tocsc()[:, cell_ind]
 
     # Represent the connections as a networkx graph and check for connectivity
-    graph = networkx.from_scipy_sparse_matrix(c2c)
+    graph = networkx.from_scipy_sparse_array(c2c)
     is_connected = networkx.is_connected(graph)
 
     # Get the connected components of the network.


### PR DESCRIPTION
In the update of networkx to v3, the name of the function to create graphs from sparse matrices was changed. This PR updates PorePy to work with the newest version. On local testing, the update also works with older versions of networkx.

## Proposed changes

Contributions to PorePy are highly appreciated. Clearly explain to the maintainers why this pull request (PR) is needed and why it should be accepted. If this PR solves an issue, explain how it is done. Please, also summarise the changes to the code. 

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply_

- [ ] Minor change (e.g., dependency bumps, broken links, etc).
- [x] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code, etc).
- [ ] Other: 

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.	
- [ ] Static typing is included in the update. NOT RELEVANT
- [x] This PR does not duplicated existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).


