### PR TITLE
Advective_flux_no_interfaces

### DIFF
--- a/src/porepy/grids/standard_grids/utils.py
+++ b/src/porepy/grids/standard_grids/utils.py
@@ -9,10 +9,11 @@ def unit_domain(dimension: int):
     """Return a domain of unitary size extending from 0 to 1 in all dimensions.
 
     Parameters:
-        dimension (int): the dimension of the domain.
+        dimension: the dimension of the domain.
 
     Returns:
-        dict: specification of max and min in all dimensions
+        dict: specification of max and min in all dimensions.
+
     """
     assert dimension in np.arange(1, 4)
     domain = {"xmin": 0, "xmax": 1}
@@ -27,6 +28,7 @@ def set_mesh_sizes(mesh_args: dict):
     """
     Checks whether mesh_size_min and mesh_size_bound are present in the mesh_args dictionary.
     If not, they are set to 1/5 and 2 of the mesh_size_frac value, respectively.
+
     """
     if "mesh_size_frac" not in mesh_args:
         raise ValueError("Mesh size parameters should be specified via mesh_size_frac")
@@ -39,23 +41,20 @@ def set_mesh_sizes(mesh_args: dict):
 def make_mdg_2d_simplex(
     mesh_args: dict, points: np.ndarray, fractures: np.ndarray, domain: dict
 ):
-    """
-    Construct a grid bucket with triangle grid in the 2d domain.
+    """Construct a mixed-dimensional simplex grid in the 2d domain.
 
-    Args:
-        mesh_args:
-            Contains at least "mesh_size_frac". If the optional values of
+    Parameters:
+        mesh_args: Contains at least "mesh_size_frac". If the optional values of
             "mesh_size_bound" and "mesh_size_min" are not provided, these are set by
             set_mesh_sizes.
-        points:
-            Fracture endpoints.
-        fractures:
-            Connectivity list of the fractures, pointing to the provided
+        points: Fracture endpoints.
+        fractures: Connectivity list of the fractures, pointing to the provided
             endpoint list.
-        domain:
-            Defines the size of the rectangular domain.
+        domain: Defines the size of the rectangular domain.
 
-    Returns: Grid bucket with geometry computation and node ordering performed.
+    Returns:
+        Mixed-dimensional grid with geometry computation and node ordering performed.
+
     """
     set_mesh_sizes(mesh_args)
     network = pp.FractureNetwork2d(points, fractures, domain)
@@ -68,18 +67,16 @@ def make_mdg_2d_cartesian(
     n_cells: np.ndarray, fractures: list[np.ndarray], domain: dict
 ):
     """
-    Construct a grid bucket with Cartesian grid in the 2d domain.
+    Construct a Cartesian mixed-dimensional grid in the 2d domain.
 
-    Args:
-        n_cells:
-            Contains number of cells in x and y direction.
-        fractures:
-            Each element is an np.array([[x0, x1],[y0,y1]])
-        domain:
-            Defines the size of the rectangular domain.
+    Parameters:
+        n_cells: Contains number of cells in x and y direction.
+        fractures: Each element is an np.array([[x0, x1],[y0,y1]])
+        domain: Defines the size of the rectangular domain.
 
     Returns:
-        Grid bucket with geometry computation and node ordering performed.
+        Mixed-dimensional grid with geometry computation and node ordering performed.
+
     """
     mdg: pp.MixedDimensionalGrid = pp.meshing.cart_grid(
         fractures, n_cells, physdims=[domain["xmax"], domain["ymax"]]

--- a/src/porepy/models/constitutive_laws.py
+++ b/src/porepy/models/constitutive_laws.py
@@ -1360,18 +1360,23 @@ class AdvectiveFlux:
         ] = None,
     ) -> pp.ad.Operator:
         """An operator represetning the advective flux on subdomains.
+
         .. note::
             The implementation assumes that the advective flux is discretized using a
             standard upwind discretization. Other discretizations may be possible, but
             this has not been considered.
+
         Parameters:
             subdomains: List of subdomains.
             advected_entity: Operator representing the advected entity.
             discr: Discretization of the advective flux.
             bc_values: Boundary conditions for the advective flux.
-            interface_flux: Interface flux operator/variable.
+            interface_flux: Interface flux operator/variable. If subdomains have no
+                neighboring interfaces, this argument can be omitted.
+
         Returns:
             Operator representing the advective flux.
+
         """
         darcy_flux = self.darcy_flux(subdomains)
         interfaces = self.subdomains_to_interfaces(subdomains, [1])

--- a/src/porepy/models/constitutive_laws.py
+++ b/src/porepy/models/constitutive_laws.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import Callable, Literal, Sequence, Union
+from typing import Callable, Literal, Optional, Sequence, Union
 
 import numpy as np
 
@@ -1355,7 +1355,9 @@ class AdvectiveFlux:
         advected_entity: pp.ad.Operator,
         discr: pp.ad.UpwindAd,
         bc_values: pp.ad.Operator,
-        interface_flux: Callable[[list[pp.MortarGrid]], pp.ad.Operator],
+        interface_flux: Optional[
+            Callable[[list[pp.MortarGrid]], pp.ad.Operator]
+        ] = None,
     ) -> pp.ad.Operator:
         """An operator represetning the advective flux on subdomains.
         .. note::
@@ -1376,16 +1378,21 @@ class AdvectiveFlux:
         mortar_projection = pp.ad.MortarProjections(
             self.mdg, subdomains, interfaces, dim=1
         )
+
         flux: pp.ad.Operator = (
             darcy_flux * (discr.upwind * advected_entity)
             - discr.bound_transport_dir * darcy_flux * bc_values
             # Advective flux coming from lower-dimensional subdomains
-            - discr.bound_transport_neu
-            * (
-                mortar_projection.mortar_to_primary_int * interface_flux(interfaces)
-                + bc_values
-            )
+            - discr.bound_transport_neu * bc_values
         )
+        if interface_flux is not None:
+            flux -= (
+                discr.bound_transport_neu
+                * mortar_projection.mortar_to_primary_int
+                * interface_flux(interfaces)
+            )
+        else:
+            assert len(interfaces) == 0
         return flux
 
     def interface_advective_flux(

--- a/tests/functional/test_terzaghi_biot.py
+++ b/tests/functional/test_terzaghi_biot.py
@@ -29,7 +29,7 @@ from porepy.models.verification_setups.terzaghi_biot import (
     SetupUtilities,
     ModifiedPoromechanicsBoundaryConditions,
     ModifiedSolutionStrategy,
-    ModifiedDataSavingMixin
+    ModifiedDataSavingMixin,
 )
 
 
@@ -40,7 +40,7 @@ class TerzaghiSetupPoromechanics(
     SetupUtilities,
     Poromechanics,
     VerificationUtils,
-    ModifiedDataSavingMixin
+    ModifiedDataSavingMixin,
 ):
     """Terzaghi mixer class based on the full poromechanics class."""
 
@@ -54,7 +54,7 @@ def test_biot_equal_to_incompressible_poromechanics():
             "solid": pp.SolidConstants(terzaghi_solid_constants),
             "fluid": pp.FluidConstants(terzaghi_fluid_constants),
         },
-        "num_cells": 10
+        "num_cells": 10,
     }
     setup_poromech = TerzaghiSetupPoromechanics(params_poromech)
     pp.run_time_dependent_model(setup_poromech, params_poromech)
@@ -63,11 +63,11 @@ def test_biot_equal_to_incompressible_poromechanics():
 
     # Run Terzaghi setup with Biot model
     params_biot = {
-          "material_constants": {
-              "solid": pp.SolidConstants(terzaghi_solid_constants),
-              "fluid": pp.FluidConstants(terzaghi_fluid_constants),
-          },
-          "num_cells": 10,
+        "material_constants": {
+            "solid": pp.SolidConstants(terzaghi_solid_constants),
+            "fluid": pp.FluidConstants(terzaghi_fluid_constants),
+        },
+        "num_cells": 10,
     }
     setup_biot = TerzaghiSetup(params_biot)
     pp.run_time_dependent_model(setup_biot, params_biot)
@@ -118,11 +118,7 @@ def test_pressure_and_consolidation_degree_errors():
     pp.run_time_dependent_model(setup, params)
 
     # Check pressure error
-    desired_error_p = [
-        0.06884857957987067,
-        0.0455347877406611,
-        0.022391576732172767
-    ]
+    desired_error_p = [0.06884857957987067, 0.0455347877406611, 0.022391576732172767]
     actual_error_p = [result.pressure_error for result in setup.results]
     np.testing.assert_allclose(actual_error_p, desired_error_p, rtol=1e-3, atol=1e-5)
 
@@ -130,7 +126,7 @@ def test_pressure_and_consolidation_degree_errors():
     desired_error_consol = [
         0.0270053052913328,
         0.018839104164792175,
-        0.010927390550216687
+        0.010927390550216687,
     ]
     actual_error_consol = [
         result.consolidation_degree_error for result in setup.results

--- a/tests/integration/test_DFN.py
+++ b/tests/integration/test_DFN.py
@@ -464,7 +464,7 @@ class TestDFN(unittest.TestCase):
 
 
 def setup_data(mdg, key="flow"):
-    """Setup the data"""
+    """Setup the data."""
     for sd, data in mdg.subdomains(return_data=True):
         param = {}
         kxx = np.ones(sd.num_cells)
@@ -544,16 +544,12 @@ def setup_discr_tpfa(mdg, key="flow"):
 
 
 def create_dfn(mdg, dim):
-    """given a MixedDimensionalGrid remove the higher dimensional node and
-    fix the internal mapping."""
-    # remove the +1 and -2 dimensional grids with respect to the
-    # considered dfn, and re-write the node number
+    """Remove the higher-dimensional subdomain and fix the internal mapping."""
+    # Remove the +1 and -2 dimensional grids with respect to the
+    # considered dfn, and re-write the node number.
     subdomains = [sd for sd in mdg.subdomains(dim=dim + 1)] + [
         sd for sd in mdg.subdomains(dim=dim - 2)
     ]
 
     for sd in subdomains:
         mdg.remove_subdomain(sd)
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/integration/test_TpfaMonoCoupling.py
+++ b/tests/integration/test_TpfaMonoCoupling.py
@@ -370,7 +370,6 @@ class TestTpfaCouplingPeriodicBc(unittest.TestCase):
                     if np.sum(face_faces) == 0:
                         continue
 
-
                     if gi.id < gj.id:
                         # gj is left
                         g_m, _, _ = pp.partition.extract_subgrid(

--- a/tests/unit/ad/test_forward_ad.py
+++ b/tests/unit/ad/test_forward_ad.py
@@ -18,6 +18,7 @@ from porepy.numerics.ad import Ad_array, initAdArrays
 
 warnings.simplefilter("ignore", sps.SparseEfficiencyWarning)
 
+
 class AdInitTest(unittest.TestCase):
     """
     The tests cover initiation of Ad_array (both of single arrays and joint initiation of
@@ -25,6 +26,7 @@ class AdInitTest(unittest.TestCase):
     implemented for Ad_arrays, e.g., __add__, __sub__, etc., however, coverage of these
     is only partial at the moment.
     """
+
     def _compare(self, arr, known_val, known_jac):
         self.assertTrue(np.allclose(arr.val, known_val))
         self.assertTrue(np.allclose(arr.jac.A, known_jac))
@@ -243,6 +245,7 @@ class AdInitTest(unittest.TestCase):
         # Finally, divide two Ad_arrays
         self._compare(a_int / a_float, np.array([1 / 2]), np.array([[1 / 4, -1 / 8]]))
         self._compare(a_float / a_int, np.array([2]), np.array([[-1, 1 / 2]]))
+
 
 class AdArrays(unittest.TestCase):
     """Tests for the implementation of the main Ad array class,
@@ -503,6 +506,7 @@ class AdArrays(unittest.TestCase):
         a.jac[2] = 4
         self.assertTrue(np.allclose(b.val, np.ones((3, 1))))
         self.assertTrue(np.allclose(b.jac, np.ones((3, 1))))
+
 
 class AdFunctionTest(unittest.TestCase):
 

--- a/tests/unit/test_array_operations.py
+++ b/tests/unit/test_array_operations.py
@@ -44,9 +44,12 @@ coord_3 = [
     ],
 ]
 # An array with 2d values.
-coord_2d_values = [[[np.array([0]), np.array([1]), np.array([0])], np.array([[42, 2, 3], [4, 43, 7]])]]
+coord_2d_values = [
+    [[np.array([0]), np.array([1]), np.array([0])], np.array([[42, 2, 3], [4, 43, 7]])]
+]
 
 coordinates = coord_1 + coord_2 + coord_3 + coord_2d_values
+
 
 @pytest.mark.parametrize("coords_values", coordinates)
 def test_sparse_nd_array(coords_values: list[np.ndarray]):
@@ -68,13 +71,13 @@ def test_sparse_nd_array(coords_values: list[np.ndarray]):
     # Split the data and values, infer dimension from the coordinates.
     coords, values = coords_values
     dim = coords[0].size
-    
+
     # Force all values to be 2d (this will be done inside the array as data is added,
     # doing it here simplifies comparison and indexing).
     values = np.atleast_2d(values)
-    # Dimension of the values to be represented    
+    # Dimension of the values to be represented
     value_dim = values.shape[0]
-    
+
     all_coords = np.vstack(coords).T
 
     _, all_2_unique, unique_2_all = np.unique(
@@ -121,15 +124,21 @@ def test_sparse_nd_array(coords_values: list[np.ndarray]):
     assert np.allclose(retrieved_values_overwrite, expected_values_overwrite)
 
     # Additive, add one by one
-    arr_additive_incremental = pp.array_operations.SparseNdArray(dim, value_dim=value_dim)
+    arr_additive_incremental = pp.array_operations.SparseNdArray(
+        dim, value_dim=value_dim
+    )
     for ind, coord in enumerate(coords):
-        arr_additive_incremental.add([coord], values[:, ind].reshape((-1, 1)), additive=True)
+        arr_additive_incremental.add(
+            [coord], values[:, ind].reshape((-1, 1)), additive=True
+        )
     retrieved_values_additive_incremental = arr_additive_incremental.get(coords)
     # The expeted value is the same as when all coordinates are added at the same time
     assert np.allclose(retrieved_values_additive_incremental, expected_values_additive)
 
     # Overwrite, one at a time
-    arr_overwrite_incremental = pp.array_operations.SparseNdArray(dim, value_dim=value_dim)
+    arr_overwrite_incremental = pp.array_operations.SparseNdArray(
+        dim, value_dim=value_dim
+    )
     for ind, coord in enumerate(coords):
         arr_overwrite_incremental.add(
             [coord], values[:, ind].reshape((-1, 1)), additive=False

--- a/tests/unit/test_md_grid.py
+++ b/tests/unit/test_md_grid.py
@@ -212,7 +212,7 @@ class TestMixedDimensionalGrid(unittest.TestCase):
         self.assertTrue(intf_list[2] == intf_31)
 
     def test_sort_lists(self):
-        """ Test sorting of lists of subdomains and interfaces.
+        """Test sorting of lists of subdomains and interfaces.
         Includes random lists, noncomplete lists, and lists with duplicates.
         """
         intf_21, intf_31, intf_43, mdg, sd_1, sd_2, sd_3, sd_4 = self.mdg_dims_3211()
@@ -243,7 +243,7 @@ class TestMixedDimensionalGrid(unittest.TestCase):
         self.assertTrue(sorted_duplicates[3] == sd_1)
 
     def mdg_dims_3211(self):
-        """ Create a mixed dimensional grid with 4 subdomains and 3 interfaces."""
+        """Create a mixed dimensional grid with 4 subdomains and 3 interfaces."""
         mdg = pp.MixedDimensionalGrid()
         sd_1 = MockGrid(1)
         sd_2 = MockGrid(1)
@@ -265,7 +265,7 @@ class TestMixedDimensionalGrid(unittest.TestCase):
         return intf_21, intf_31, intf_43, mdg, sd_1, sd_2, sd_3, sd_4
 
     def test_interface_to_subdomain_pair(self):
-        """ Test the method interface_to_subdomain_pair.
+        """Test the method interface_to_subdomain_pair.
         Check that the returned subdomain pair is sorted according to grid dimension and id.
         """
         intf_21, intf_31, intf_43, mdg, sd_1, sd_2, sd_3, sd_4 = self.mdg_dims_3211()

--- a/tests/unit/test_mortars.py
+++ b/tests/unit/test_mortars.py
@@ -21,7 +21,7 @@ The module contains the following groups of tests:
 import pickle
 import unittest
 from itertools import count
-    
+
 import numpy as np
 import pytest
 import scipy.sparse as sps
@@ -531,7 +531,9 @@ class MockGrid:
     """Data structure for a mock grid. Used to mimic the full PorePy grid structure,
     while still having full control of the underlying data.
     """
+
     _counter = count(0)
+
     def __init__(self, nodes, fn, cf, cc, n, cv, dim, frac_face=None, glob_pi=None):
         self.id = next(self._counter)
         self.nodes = nodes

--- a/tests/unit/test_plotting.py
+++ b/tests/unit/test_plotting.py
@@ -31,7 +31,9 @@ def mdg(request):
     return mdg_
 
 
-@pytest.mark.parametrize("vector_variable", [VECTOR_VARIABLE_CELL, VECTOR_VARIABLE_FACE])
+@pytest.mark.parametrize(
+    "vector_variable", [VECTOR_VARIABLE_CELL, VECTOR_VARIABLE_FACE]
+)
 def test_plot_grid_mdg(mdg, vector_variable):
     """Tests that no error is raised if we plot mdg and provide variable names."""
     pp.plot_grid(
@@ -45,14 +47,18 @@ def test_plot_grid_mdg(mdg, vector_variable):
     plt.close()
 
 
-@pytest.mark.parametrize("vector_variable", [VECTOR_VARIABLE_CELL, VECTOR_VARIABLE_FACE])
+@pytest.mark.parametrize(
+    "vector_variable", [VECTOR_VARIABLE_CELL, VECTOR_VARIABLE_FACE]
+)
 def test_plot_grid_simple_grid(mdg, vector_variable):
     """Tests that no error is raised if we plot a single dimension grid and provide variable arrays.
     This use case requires the user to reshape the vector array to the shape (3 x n).
     The redundant dimensions are filled with zeros."""
     grid, data = mdg.subdomains(return_data=True)[0]
     scalar_data = data[pp.STATE][SCALAR_VARIABLE]
-    vector_data = data[pp.STATE][vector_variable].reshape((mdg.dim_max(), -1), order="F")
+    vector_data = data[pp.STATE][vector_variable].reshape(
+        (mdg.dim_max(), -1), order="F"
+    )
     vector_data = np.vstack(
         [vector_data, np.zeros((3 - vector_data.shape[0], vector_data.shape[1]))]
     )
@@ -95,8 +101,12 @@ def _initialize_mdg(mdg_):
         if sd.dim in (mdg_.dim_max(), mdg_.dim_max() - 1):
             data[pp.STATE] = {
                 SCALAR_VARIABLE: np.ones(sd.num_cells),
-                VECTOR_VARIABLE_CELL: np.ones((mdg_.dim_max(), sd.num_cells)).ravel(order="F"),
-                VECTOR_VARIABLE_FACE: np.ones((mdg_.dim_max(), sd.num_faces)).ravel(order="F"),
+                VECTOR_VARIABLE_CELL: np.ones((mdg_.dim_max(), sd.num_cells)).ravel(
+                    order="F"
+                ),
+                VECTOR_VARIABLE_FACE: np.ones((mdg_.dim_max(), sd.num_faces)).ravel(
+                    order="F"
+                ),
             }
         else:
             data[pp.STATE] = {}


### PR DESCRIPTION
## Proposed changes

Allow for empty advective interface flux if the subdomain has no neighboring interfaces. This typically corresponds to a single-domain mdg.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply_

- [ ] Minor change (e.g., dependency bumps, broken links, etc).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [x] Maintenance (e.g., improve logic and performance, remove obsolete code, etc).
- [ ] Other: 

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.	
- [x] Static typing is included in the update.
- [x] This PR does not duplicated existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).


