### PR TITLE
Use fixtures to avoid running simulations on collection

### DIFF
--- a/tests/functional/test_mandel_biot.py
+++ b/tests/functional/test_mandel_biot.py
@@ -21,23 +21,29 @@ import pytest
 
 import porepy as pp
 from porepy.applications.verification_setups.mandel_biot import (
+    MandelSaveData,
     MandelSetup,
     mandel_fluid_constants,
     mandel_solid_constants,
 )
 
-# Run verification setup and retrieve results for three different times
-material_constants = {
-    "fluid": pp.FluidConstants(mandel_fluid_constants),
-    "solid": pp.SolidConstants(mandel_solid_constants),
-}
-time_manager = pp.TimeManager([0, 10, 30, 50], 10, True)
-params = {
-    "material_constants": material_constants,
-    "time_manager": time_manager,
-}
-setup = MandelSetup(params)
-pp.run_time_dependent_model(setup, params)
+
+@pytest.fixture
+def results() -> list[MandelSaveData]:
+    # Run verification setup and retrieve results for three different times
+    material_constants = {
+        "fluid": pp.FluidConstants(mandel_fluid_constants),
+        "solid": pp.SolidConstants(mandel_solid_constants),
+    }
+    time_manager = pp.TimeManager([0, 10, 30, 50], 10, True)
+    params = {
+        "material_constants": material_constants,
+        "time_manager": time_manager,
+    }
+    setup = MandelSetup(params)
+    pp.run_time_dependent_model(setup, params)
+    return setup.results
+
 
 # Desired errors
 DesiredError = namedtuple(
@@ -77,11 +83,8 @@ desired_errors: list[DesiredError] = [
 ]
 
 
-@pytest.mark.parametrize(
-    "desired, actual",
-    [(desired, actual) for (desired, actual) in zip(desired_errors, setup.results)],
-)
-def test_error_primary_and_secondary_variables(desired, actual):
+@pytest.mark.parametrize("time_index", [0, 1, 2])
+def test_error_primary_and_secondary_variables(time_index: int, results):
     """Checks error for pressure, displacement, flux, force, and consolidation degree.
 
     Physical parameters used in this test have been adapted from [1].
@@ -110,6 +113,8 @@ def test_error_primary_and_secondary_variables(desired, actual):
           54(2), 942-968.
 
     """
+    actual = results[time_index]
+    desired = desired_errors[time_index]
 
     np.testing.assert_allclose(
         actual.error_pressure, desired.error_pressure, atol=1e-5, rtol=1e-3

--- a/tests/functional/test_mandel_biot.py
+++ b/tests/functional/test_mandel_biot.py
@@ -28,7 +28,7 @@ from porepy.applications.verification_setups.mandel_biot import (
 )
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def results() -> list[MandelSaveData]:
     # Run verification setup and retrieve results for three different times
     material_constants = {

--- a/tests/functional/test_manu_flow_comp_frac.py
+++ b/tests/functional/test_manu_flow_comp_frac.py
@@ -58,7 +58,7 @@ from porepy.applications.verification_setups.manu_flow_comp_frac import (
 )
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def results() -> list[ManuCompSaveData]:
     # Run verification setup and retrieve results for the scheduled times
     material_constants = {

--- a/tests/functional/test_manu_poromech_nofrac.py
+++ b/tests/functional/test_manu_poromech_nofrac.py
@@ -47,28 +47,33 @@ import pytest
 
 import porepy as pp
 from porepy.applications.verification_setups.manu_poromech_nofrac import (
+    ManuPoroMechSaveData,
     ManuPoroMechSetup,
 )
 
-# Run verification setup and retrieve results for three different times
-fluid = pp.FluidConstants({"compressibility": 0.02})
-solid = pp.SolidConstants({"biot_coefficient": 0.5})
-material_constants = {"fluid": fluid, "solid": solid}
-params = {
-    "mesh_arguments": {"mesh_size_frac": 0.1, "mesh_size_bound": 0.1},
-    "manufactured_solution": "nordbotten_2016",
-    "material_constants": material_constants,
-    "time_manager": pp.TimeManager([0, 0.2, 0.6, 1], 0.2, True),
-}
-setup = ManuPoroMechSetup(params)
-pp.run_time_dependent_model(setup, params)
+
+@pytest.fixture
+def results() -> list[ManuPoroMechSaveData]:
+    # Run verification setup and retrieve results for three different times
+    fluid = pp.FluidConstants({"compressibility": 0.02})
+    solid = pp.SolidConstants({"biot_coefficient": 0.5})
+    material_constants = {"fluid": fluid, "solid": solid}
+    params = {
+        "mesh_arguments": {"mesh_size_frac": 0.1, "mesh_size_bound": 0.1},
+        "manufactured_solution": "nordbotten_2016",
+        "material_constants": material_constants,
+        "time_manager": pp.TimeManager([0, 0.2, 0.6, 1], 0.2, True),
+    }
+    setup = ManuPoroMechSetup(params)
+    pp.run_time_dependent_model(setup, params)
+    return setup.results
+
 
 # Desired errors
 DesiredError = namedtuple(
     "DesiredError",
     "error_pressure, " "error_flux, " "error_displacement, " "error_force ",
 )
-
 desired_errors: list[DesiredError] = [
     # t = 0.2 [s]
     DesiredError(
@@ -95,12 +100,15 @@ desired_errors: list[DesiredError] = [
 
 
 # Now, we write the actual test
-@pytest.mark.parametrize(
-    "desired, actual",
-    [(desired, actual) for (desired, actual) in zip(desired_errors, setup.results)],
-)
-def test_manufactured_poromechanics_unfractured_2d(desired, actual):
-    """Check errors for pressure, flux, displacement, and force."""
+@pytest.mark.parametrize("time_index", [0, 1, 2])
+def test_manufactured_poromechanics_unfractured_2d(time_index: int, results):
+    """Check errors for pressure, flux, displacement, and force.
+
+    Nest test functions to avoid computing the solution multiple times.
+
+    """
+    actual = results[time_index]
+    desired = desired_errors[time_index]
 
     np.testing.assert_allclose(
         actual.error_pressure, desired.error_pressure, atol=1e-5, rtol=1e-3


### PR DESCRIPTION
## Proposed changes

Some of the funcitonal tests ran the simulation on _collection_, not during test run. I fixed the issue using pytest fixture. Note that as far as I understand, the fixture function is only run once, not once for each test.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply_

- [ ] Minor change (e.g., dependency bumps, broken links, etc).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code, etc).
- [ ] Other: 

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.	
- [x] Static typing is included in the update.
- [x] This PR does not duplicated existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).


