### PR TITLE
DOC: Remove redundant reference and doc to attribute.

### DIFF
--- a/src/porepy/viz/data_saving_model_mixin.py
+++ b/src/porepy/viz/data_saving_model_mixin.py
@@ -26,8 +26,6 @@ class DataSavingMixin:
     """Equation system manager."""
     params: dict[str, Any]
     """Dictionary of parameters. May contain data saving parameters."""
-    time_manager: pp.TimeManager
-    """Time manager for the simulation."""
     mdg: pp.MixedDimensionalGrid
     """Mixed dimensional grid for the simulation."""
 


### PR DESCRIPTION
## Proposed changes

A recent update of DataSavingMixin has removed the use of teh attribute `time_manager` but did not remove the mention in the doc, making its presence redundant at the moment. This PR simply removes the redundancy.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply_

- [ ] Minor change (e.g., dependency bumps, broken links, etc).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [X] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code, etc).
- [ ] Other: 

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [X] The documentation is up-to-date.	
- [X] Static typing is included in the update.
- [X] This PR does not duplicated existing functionality.
- [X] The update is covered by the test suite (including tests added in the PR).


