### PR TITLE
Update friction bound

### DIFF
--- a/src/porepy/models/constitutive_laws.py
+++ b/src/porepy/models/constitutive_laws.py
@@ -2222,7 +2222,7 @@ class FrictionBound:
     displacement_jump: Callable[[list[pp.Grid]], pp.ad.Operator]
     """Operator giving the displacement jump on fracture grids. Normally defined in a
     mixin instance of :class:`~porepy.models.models.ModelGeometry`.
-    
+
     """
 
     normal_component: Callable[[list[pp.Grid]], pp.ad.Matrix]
@@ -2254,25 +2254,36 @@ class FrictionBound:
     """
 
     def friction_bound(self, subdomains: list[pp.Grid]) -> pp.ad.Operator:
-        """Friction bound [m].
+        """Friction bound [Pa].
+
+        This is defined in Stefansson et al.(2021): A fully coupled numerical model of
+        thermo-hydro-mechanical processes and fracture contact mechanics in porous
+        media, page 11.
 
         Parameters:
             subdomains: List of fracture subdomains.
 
         Returns:
-            Cell-wise friction bound operator [Pa].
+            Cell-wise friction bound operator.
 
         """
-        u_n: pp.ad.Operator = self.normal_component(subdomains) * \
-                              self.displacement_jump(subdomains)
+        u_n: pp.ad.Operator = self.normal_component(
+            subdomains
+        ) * self.displacement_jump(subdomains)
 
         t_n: pp.ad.Operator = self.normal_component(subdomains) * self.contact_traction(
             subdomains
         )
 
-        bound: pp.ad.Operator = (-1) * self.friction_coefficient(subdomains) * (t_n
-                                + self.contact_mechanics_numerical_constant(subdomains)
-                                * (u_n - self.gap(subdomains)))
+        bound: pp.ad.Operator = (
+            (-1)
+            * self.friction_coefficient(subdomains)
+            * (
+                t_n
+                + self.contact_mechanics_numerical_constant(subdomains)
+                * (u_n - self.gap(subdomains))
+            )
+        )
         bound.set_name("friction_bound")
         return bound
 


### PR DESCRIPTION
This PR changes the friction bound from $b=-F\lambda_n$ to $b=-F(\lambda_n+\tilde{c}([[\mathbf{u}]]_n-g))$. The reason for this proposed change is that the latter definition is what is used in Hüeber’s thesis (Discretization techniques and efficient algorithms for contact problems, p.104) and in the paper by Stefansson et al. (A fully coupled numerical model of thermo-hydro-mechanical processes and fracture contact mechanics in porous media, p. 11). 

Note that this new formula for the friction bound is already being used in the normal complementary function in PorePy (equation (39) in Stefansson et al.), and so this change will only affect the definition of the tangential complementary function (equation (40) in Stefansson et al.).

I have done some simple test simulations using the `MomentumBalance` model, comparing the results when using the two friction bounds. My first impression is that for setups where the Newton solver converges quickly, the results are more or less unaffected by the updated friction bound. However, for setups where the Newton solver struggles to converge, the updated friction bound can have a large impact on the results. For instance, in one of my setups, the Newton solver converged (after about 100 iterations) when using the old friction bound, while the Newton solver did not converge even after 1000 iterations when using the new friction bound.

Ivar said that he will review this PR.


What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply_

- [ ] Minor change (e.g., dependency bumps, broken links, etc).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [x] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code, etc).
- [ ] Other: 

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.	
- [x] Static typing is included in the update.
- [x] This PR does not duplicated existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR): "test_dual_hybrid_vem_2d_ani_simplex" fails on my computer, but all other tests pass. This test should however be unaffected by the updated friction bound, which I have "confirmed" by noting that this test also fails on the develop branch on my computer.


