### PR TITLE
Barton bandis

### DIFF
--- a/src/porepy/models/constitutive_laws.py
+++ b/src/porepy/models/constitutive_laws.py
@@ -2524,6 +2524,23 @@ class BartonBandis:
     """Implementation of the Barton-Bandis model for elastic fracture normal
     deformation.
 
+    """
+
+    normal_component: Callable[[list[pp.Grid]], pp.ad.SparseArray]
+    """Operator giving the normal component of vectors. Normally defined in a mixin
+    instance of :class:`~porepy.models.models.ModelGeometry`.
+
+    """
+    contact_traction: Callable[[list[pp.Grid]], pp.ad.Operator]
+    """Contact traction variable. Normally defined in a mixin instance of
+    :class:`~porepy.models.momentum_balance.VariablesMomentumBalance`.
+
+    """
+
+    solid: pp.SolidConstants
+    """Solid constant object that takes care of scaling of solid-related quantities.
+    Normally, this is set by a mixin of instance
+    :class:`~porepy.models.solution_strategy.SolutionStrategy`.
 
     """
 
@@ -2558,7 +2575,7 @@ class BartonBandis:
         # The effective contact traction. Units: Force / area = Pa / m^(nd-1).
         # The papers by Barton and Bandis assumes positive traction in contact, thus we
         # need to switch the sign.
-        contact_traction = -self.contact_traction(subdomains)
+        contact_traction = Scalar(-1) * self.contact_traction(subdomains)
 
         # Normal component of the traction.
         normal_traction = nd_vec_to_normal @ contact_traction
@@ -2608,7 +2625,7 @@ class BartonBandis:
 
         """
 
-        normal_stiffness = self.solid.normal_fracture_stiffness()
+        normal_stiffness = self.solid.fracture_normal_stiffness()
         return Scalar(normal_stiffness, "fracture_normal_stiffness")
 
 

--- a/src/porepy/models/material_constants.py
+++ b/src/porepy/models/material_constants.py
@@ -286,6 +286,8 @@ class SolidConstants(MaterialConstants):
             "thermal_conductivity": 1,
             "thermal_expansion": 0,
             "well_radius": 0.1,
+            "fracture_normal_stiffness": 1,
+            "maximal_fracture_closure": 0,
         }
 
         if constants is not None:
@@ -457,3 +459,27 @@ class SolidConstants(MaterialConstants):
 
         """
         return self.convert_units(self.constants["well_radius"], "m")
+
+    def fracture_normal_stiffness(self) -> number:
+        """The normal stiffness of a fracture [Pa * m^-1].
+
+        Intended use is in Barton-Bandis-type models for elastic fracture deformation.
+
+        Returns:
+            The fracture normal stiffness in converted units.
+
+        """
+        return self.convert_units(
+            self.constants["fracture_normal_stiffness"], "Pa*m^-1"
+        )
+
+    def fracture_maximal_closure(self) -> number:
+        """The maximal closure of a fracture [m].
+
+        Intended use is in Barton-Bandis-type models for elastic fracture deformation.
+
+        Returns:
+            The maximal closure of a fracture.
+
+        """
+        return self.convert_units(self.constants["maximal_fracture_closure"], "m")

--- a/src/porepy/models/material_constants.py
+++ b/src/porepy/models/material_constants.py
@@ -473,7 +473,7 @@ class SolidConstants(MaterialConstants):
             self.constants["fracture_normal_stiffness"], "Pa*m^-1"
         )
 
-    def fracture_maximal_closure(self) -> number:
+    def maximal_fracture_closure(self) -> number:
         """The maximal closure of a fracture [m].
 
         Intended use is in Barton-Bandis-type models for elastic fracture deformation.

--- a/tests/integration/models/setup_utils.py
+++ b/tests/integration/models/setup_utils.py
@@ -422,6 +422,16 @@ class MomentumBalance(
     pass
 
 
+class BartonBandisMechanics(
+    RectangularDomainThreeFractures,
+    pp.momentum_balance.MomentumBalance,
+    pp.constitutive_laws.BartonBandis,
+):
+    """Special class for testing the Barton-Bandis model."""
+
+    pass
+
+
 class MassAndEnergyBalance(
     RectangularDomainThreeFractures,
     pp.mass_and_energy_balance.MassAndEnergyBalance,
@@ -543,6 +553,8 @@ granite_values = {
     "specific_heat_capacity": 790,
     "thermal_conductivity": 2.5,
     "thermal_expansion": 1e-5,
+    "fracture_normal_stiffness": 1529,
+    "maximal_fracture_closure": 0.1683,
 }
 # Cf. fluid.py
 water_values = {

--- a/tests/integration/models/test_constitutive_laws.py
+++ b/tests/integration/models/test_constitutive_laws.py
@@ -219,6 +219,13 @@ def test_parse_constitutive_laws(
             # \mu (3 \lambda + 2 \mu) / (\lambda + \mu)
             16.67 * (3 * 11.11 + 2 * 16.67) / (11.11 + 16.67) * pp.GIGA,
         ),
+        (
+            setup_utils.BartonBandisMechanics,
+            "elastic_normal_fracture_deformation",
+            # (-normal_traction) * maximum_closure /
+            #    (normal_stiffness * maximum_closure + (-normal_traction))
+            (1 * 0.1683) / (1529 * 0.1683 + 1),
+        ),
     ],
 )
 def test_evaluated_values(model, method_name, expected):


### PR DESCRIPTION
## Proposed changes
This PR implements the Barton-Bandis model for normal elastic fracture deformation. The model is implemented as a mixin class, located in the library of constitutive laws.

Particular points to consider in the review:
* I tried to emphasize in the documentation that the computed quantity represents a decrease in the fracture aperture, but stayed mute on how to combine this with a wider concept of fracture opening, apertures etc. Please review this carefully, users (including the future me) will be confused.
* For testing I implemented a quantitiative test and placed it as a new parameter value in `test_constitutive_laws.test_evaluated_methods`. To do this, I also had to introduce a BartonBandis class in the file `setup_utils` in the relative test directory. This was most natural given the existing structure of the test, but I am not fond of the additional entropy in the setup file. The alternative that I see is to move the test to `test_momentum_balance`, but without a wider plan, this would break with the current test structure for constitutitive laws. Let me know if you see other ideas.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply_

- [ ] Minor change (e.g., dependency bumps, broken links, etc).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code, etc).
- [ ] Other: 

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.	
- [x] Static typing is included in the update.
- [x] This PR does not duplicated existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).


