### PR TITLE
BUG: Cartesian fracture meshing with intersections

### DIFF
--- a/tests/integration/test_fracture_mesh_generation.py
+++ b/tests/integration/test_fracture_mesh_generation.py
@@ -13,6 +13,7 @@ import numpy as np
 import porepy as pp
 from porepy.fracs import structured
 from porepy.fracs.utils import pts_edges_to_linefractures
+
 from tests import test_utils
 
 # Named tuple used to identify intersections of fractures by their parent fractures
@@ -34,7 +35,6 @@ class TestDFMMeshGeneration(unittest.TestCase):
         expected_num_1d_grids=0,
         expected_num_0d_grids=0,
     ):
-
         if fractures is None:
             fractures = []
         if isect_line is None:
@@ -1206,11 +1206,15 @@ class TestStructuredGrids(unittest.TestCase):
     def test_tripple_x_intersection_3d(self):
         """
         Create a cartesian grid in the unit cube, and insert three fractures.
+
+        On purpose, the fracture planes do not coincide with the grid lines, so that the
+        meshing will have to move the fractures before generating the mesh.
+
         """
 
-        f1 = np.array([[0, 1, 1, 0], [0, 0, 1, 1], [0.5, 0.5, 0.5, 0.5]])
-        f2 = np.array([[0.5, 0.5, 0.5, 0.5], [0, 1, 1, 0], [0, 0, 1, 1]])
-        f3 = np.array([[0, 1, 1, 0], [0.5, 0.5, 0.5, 0.5], [0, 0, 1, 1]])
+        f1 = np.array([[0, 1, 1, 0], [0, 0, 1, 1], [0.4, 0.4, 0.4, 0.4]])
+        f2 = np.array([[0.6, 0.6, 0.6, 0.6], [0, 1, 1, 0], [0, 0, 1, 1]])
+        f3 = np.array([[0, 1, 1, 0], [0.3, 0.3, 0.3, 0.3], [0, 0, 1, 1]])
         f_set = [f1, f2, f3]
 
         mdgs = [pp.meshing.cart_grid(f_set, [2, 2, 2], physdims=[1, 1, 1])]


### PR DESCRIPTION
In Cartesian meshing of fractured domains, the fractures are snapped to the underlying mesh. The subsequent identification of intersections did not consider the snapped fractures, leading to intersection points being identified away from the grid lines, which caused errors.

Also modified one of the meshing tests slightly so that it would have picked up the bug.

NB: I did not modify the surrounding code, e.g., wrap comments etc., since I suspect this being taken care of under #780.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply_

- [ ] Minor change (e.g., dependency bumps, broken links, etc).
- [x] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code, etc).
- [ ] Other: 

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.	
- [x] Static typing is included in the update.
- [x] This PR does not duplicated existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).


