### PR TITLE
846 inconsistency in fracture network 2d with domain = none

### DIFF
--- a/src/porepy/fracs/fracture_network_2d.py
+++ b/src/porepy/fracs/fracture_network_2d.py
@@ -742,12 +742,12 @@ class FractureNetwork2d:
         """
 
         # Get min/max point of the domain. If no domain is given, a bounding box
-        # using the `self.tol` will be imposed outside the fracture set
+        # based on `self.tol` will be imposed outside the fracture set
         if domain is None:
             # Sanity check
             if len(self.fractures) == 0:
-                raise ValueError("No fractures given. Domain cannot be imposed.")
-            # Loop through the fracture list and retrieve the pts
+                raise ValueError("No fractures given, domain cannot be imposed.")
+            # Loop through the fracture list and retrieve the points
             x_pts = []
             y_pts = []
             for frac in self.fractures:
@@ -758,21 +758,19 @@ class FractureNetwork2d:
                 y_pts.append(frac.pts[1][0])
                 y_pts.append(frac.pts[1][1])
             # Get min/max points
-            x_min = np.min(np.asarray(x_pts)) - self.tol
-            x_max = np.max(np.asarray(x_pts)) + self.tol
-            y_min = np.min(np.asarray(y_pts)) - self.tol
-            y_max = np.max(np.asarray(y_pts)) + self.tol
+            x_min = np.min(np.asarray(x_pts)) - 10 * self.tol
+            x_max = np.max(np.asarray(x_pts)) + 10 * self.tol
+            y_min = np.min(np.asarray(y_pts)) - 10 * self.tol
+            y_max = np.max(np.asarray(y_pts)) + 10 * self.tol
         else:
-            # First create lines that define the domain
+            # If the domain is given, we know the min/max points
             x_min = domain.bounding_box["xmin"]
             x_max = domain.bounding_box["xmax"]
             y_min = domain.bounding_box["ymin"]
             y_max = domain.bounding_box["ymax"]
 
         # Create the domain lines
-        dom_p: np.ndarray = np.array(
-            [[x_min, x_max, x_max, x_min], [y_min, y_min, y_max, y_max]]
-        )
+        dom_p = np.array([[x_min, x_max, x_max, x_min], [y_min, y_min, y_max, y_max]])
         dom_lines = np.array([[0, 1], [1, 2], [2, 3], [3, 0]]).T
 
         # Constrain the edges to the domain

--- a/src/porepy/fracs/fracture_network_2d.py
+++ b/src/porepy/fracs/fracture_network_2d.py
@@ -740,16 +740,40 @@ class FractureNetwork2d:
                 and therefore deleted.
 
         """
-        if domain is not None:
+
+        # Get min/max point of the domain. If no domain is given, a bounding box
+        # using the `self.tol` will be imposed outside the fracture set
+        if domain is None:
+            # Sanity check
+            if len(self.fractures) == 0:
+                raise ValueError("No fractures given. Domain cannot be imposed.")
+            # Loop through the fracture list and retrieve the pts
+            x_pts = []
+            y_pts = []
+            for frac in self.fractures:
+                # Append all start/end-points in the x-direction
+                x_pts.append(frac.pts[0][0])
+                x_pts.append(frac.pts[0][1])
+                # Append all start/end-points in the y-direction
+                y_pts.append(frac.pts[1][0])
+                y_pts.append(frac.pts[1][1])
+            # Get min/max points
+            x_min = np.min(np.asarray(x_pts)) - self.tol
+            x_max = np.max(np.asarray(x_pts)) + self.tol
+            y_min = np.min(np.asarray(y_pts)) - self.tol
+            y_max = np.max(np.asarray(y_pts)) + self.tol
+        else:
             # First create lines that define the domain
             x_min = domain.bounding_box["xmin"]
             x_max = domain.bounding_box["xmax"]
             y_min = domain.bounding_box["ymin"]
             y_max = domain.bounding_box["ymax"]
-            dom_p: np.ndarray = np.array(
-                [[x_min, x_max, x_max, x_min], [y_min, y_min, y_max, y_max]]
-            )
-            dom_lines = np.array([[0, 1], [1, 2], [2, 3], [3, 0]]).T
+
+        # Create the domain lines
+        dom_p: np.ndarray = np.array(
+            [[x_min, x_max, x_max, x_min], [y_min, y_min, y_max, y_max]]
+        )
+        dom_lines = np.array([[0, 1], [1, 2], [2, 3], [3, 0]]).T
 
         # Constrain the edges to the domain
         p, e, edges_kept = pp.constrain_geometry.lines_by_polygon(

--- a/src/porepy/grids/mdg_generation.py
+++ b/src/porepy/grids/mdg_generation.py
@@ -731,15 +731,6 @@ def create_mdg(
                 meshing_args, kwargs, FractureNetwork2d.mesh
             )
 
-            # TODO: Remove this ValueError when issue #846 is fixed:
-            # If one tries to generate an mdg with FractureNetwork2d and domain = None,
-            # the method impose_external_boundary will generate an UnboundLocalError:
-            # "local variable 'dom_p' referenced before assignment".
-            if _retrieve_domain_instance(fracture_network) is None:
-                raise ValueError(
-                    "Inconsistency in FractureNetwork2d for DFN generation"
-                )
-
             # perform the actual meshing
             mdg = fracture_network.mesh(lower_level_args, *extra_args, **kwargs)
         elif dim == 3:

--- a/tests/integration/test_mdg_generation.py
+++ b/tests/integration/test_mdg_generation.py
@@ -6,6 +6,7 @@ Functionalities being tested:
 * Generation with/without fractures
 * Generation of meshes with type {"simplex", "cartesian", "tensor_grid"}
 * Generation of meshes with dimension {2,3}
+* Generation of simplicial DFN meshes with dimension {2, 3}
 
 """
 from typing import List, Union
@@ -498,3 +499,96 @@ class TestGenerationInconsistencies(TestMDGridGeneration):
             )
             pp.create_mdg(grid_type, mesh_arguments, complex(1, 2))
         assert ref_msg in str(error_message.value)
+
+
+class TestMDGridGenerationWithoutDomains:
+    """Tests whether mdgs are correctly created in the absence of domains.
+
+    The known usage for such cases is meshing of DFNs.
+
+    """
+
+    @pytest.fixture(scope="class")
+    def line_fractures(self) -> list[list[pp.LineFracture]]:
+        f1 = pp.LineFracture(np.array([[0.5, 0.5], [0.25, 0.75]]))
+        f2 = pp.LineFracture(np.array([[0.25, 0.75], [0.5, 0.5]]))
+        return [[f1], [f1, f2]]
+
+    @pytest.fixture(scope="class")
+    def plane_fractures(self) -> list[list[pp.PlaneFracture]]:
+        f1 = pp.PlaneFracture(
+            np.array([[0, 0, 0, 0], [-2, 2, 2, -2], [-2, -2, 2, 2]])
+        )
+        f2 = pp.PlaneFracture(
+            np.array([[-2, -2, 2, 2], [0, 0, 0, 0], [-2, 2, 2, -2]])
+        )
+        return [[f1], [f1, f2]]
+
+    @pytest.mark.parametrize("fracs_idx", [0, 1])
+    def test_mdg_no_domain_in_2d(
+            self,
+            fracs_idx: int,
+            line_fractures: list[list[pp.LineFracture]],
+    ) -> None:
+        """Check if a mdg is correctly created when domain=None and dfn=True in 2d.
+
+        Parameters:
+            fracs_idx: Index to access the items of ``line_fractures``.
+            line_fractures: List (of length 2) of lists of line fractures. The first
+                item of the list corresponds to a list containing a single vertical
+                fracture. The second item of the list corresponds to a list
+                containing two intersecting line fractures.
+
+        """
+        fn = pp.create_fracture_network(fractures=line_fractures[fracs_idx])
+        mdg = pp.create_mdg(
+            grid_type="simplex",
+            meshing_args={"cell_size": 0.125},
+            fracture_network=fn,
+            **{"dfn": True},
+        )
+        if fracs_idx == 0:  # the case of a single line fracture
+            assert mdg.dim_max() == 1
+            assert mdg.dim_min() == 1
+            assert mdg.num_subdomains() == 1
+            assert mdg.num_interfaces() == 0
+        else:  # the case of two intersecting line fractures
+            assert mdg.dim_max() == 1
+            assert mdg.dim_min() == 0
+            assert mdg.num_subdomains() == 3
+            assert mdg.num_interfaces() == 2
+
+    @pytest.mark.parametrize("fracs_idx", [0, 1])
+    def test_mdg_no_domain_in_3d(
+            self,
+            fracs_idx: int,
+            plane_fractures: list[list[pp.PlaneFracture]],
+    ) -> None:
+        """Check if a mdg is correctly created when domain=None and dfn=True in 3d.
+
+        Parameters:
+            fracs_idx: Index to access the items of ``line_fractures``.
+            plane_fractures: List (of length 2) of lists of plane fractures. The first
+                item of the list corresponds to a list containing a single vertical
+                plane fracture. The second item of the list corresponds to a list
+                containing two intersecting plane fractures.
+
+        """
+        fn = pp.create_fracture_network(fractures=plane_fractures[fracs_idx])
+        fn.impose_external_boundary()
+        mdg = pp.create_mdg(
+            grid_type="simplex",
+            meshing_args={"cell_size": 2.0},
+            fracture_network=fn,
+            **{"dfn": True},
+        )
+        if fracs_idx == 0:  # the case of a single plane fracture
+            assert mdg.dim_max() == 2
+            assert mdg.dim_min() == 2
+            assert mdg.num_subdomains() == 1
+            assert mdg.num_interfaces() == 0
+        else:  # the case of two intersecting plane fractures
+            assert mdg.dim_max() == 2
+            assert mdg.dim_min() == 1
+            assert mdg.num_subdomains() == 3
+            assert mdg.num_interfaces() == 2

--- a/tests/integration/test_mdg_generation.py
+++ b/tests/integration/test_mdg_generation.py
@@ -9,6 +9,8 @@ Functionalities being tested:
 * Generation of simplicial DFN meshes with dimension {2, 3}
 
 """
+from __future__ import annotations
+
 from typing import List, Union
 
 import numpy as np

--- a/tests/integration/test_mdg_generation.py
+++ b/tests/integration/test_mdg_generation.py
@@ -569,7 +569,7 @@ class TestMDGridGenerationWithoutDomains:
         """Check if a mdg is correctly created when domain=None and dfn=True in 3d.
 
         Parameters:
-            fracs_idx: Index to access the items of ``line_fractures``.
+            fracs_idx: Index to access the items of ``plane_fractures``.
             plane_fractures: List (of length 2) of lists of plane fractures. The first
                 item of the list corresponds to a list containing a single vertical
                 plane fracture. The second item of the list corresponds to a list


### PR DESCRIPTION
## Proposed changes

Fix bug while creating fracture networks in 2d with the flag `domain = none`. The fix consists of imposing a domain outside the bounding box span by the fractures composing the fracture set based on the tolerance used for geometric computations. This PR solves #846.

Unit tests for 2d and 3d were added.

Note that the documentation of the method `impose_external_boundary` is not updated. This will be properly included in the PR that has to do with the unification of fracture network generation.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [x] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
