### PR TITLE
Allow for possibility to run workflows manually

### DIFF
--- a/.github/workflows/push-develop-docker-image.yml
+++ b/.github/workflows/push-develop-docker-image.yml
@@ -5,6 +5,8 @@
 name: Publish Docker image for develop branch
 
 on:
+  workflow_dispatch:
+    # run jobs manually
   push:
     branches:
        - develop

--- a/.github/workflows/push-stable-docker-image.yml
+++ b/.github/workflows/push-stable-docker-image.yml
@@ -1,6 +1,8 @@
 name: Publish Docker image for main branch
 
 on:
+  workflow_dispatch:
+    # run jobs manually
   push:
     branches:
       - main

--- a/.github/workflows/run-pytest.yml
+++ b/.github/workflows/run-pytest.yml
@@ -4,6 +4,8 @@ name: Pytest
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events for the main and develop branches
 on:
+  workflow_dispatch:
+    # run jobs manually
   push:
     branches:
       - develop

--- a/.github/workflows/run-static-checks.yml
+++ b/.github/workflows/run-static-checks.yml
@@ -5,6 +5,8 @@ name: Static tests
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events for the main and develop branches
 on:
+  workflow_dispatch:
+    # run jobs manually
   push:
     branches:
       - develop


### PR DESCRIPTION
## Proposed changes

This PR introduces the `workflow_dispatch` keyword in the GH workflows. The `workflow_dispatch` unlocks the possibility of running the workflows manually. The changes are fully backward-compatible.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [x] Other: GH workflows.