### PR TITLE
FEAT: Pass "meshing_arguments" from the model parameters

### DIFF
--- a/src/porepy/models/geometry.py
+++ b/src/porepy/models/geometry.py
@@ -125,8 +125,8 @@ class ModelGeometry:
         """
         return self.params.get("grid_type", "cartesian")
 
-    def meshing_arguments(self) -> dict:
-        """Meshing arguments for md-grid creation.
+    def meshing_arguments(self) -> dict[str, float]:
+        """Meshing arguments for mixed-dimensional grid generation.
 
         Returns:
             Meshing arguments compatible with
@@ -134,8 +134,9 @@ class ModelGeometry:
 
         """
         # Default value of 1/2, scaled by the length unit.
-        mesh_args: dict[str, float] = {"cell_size": 0.5 / self.units.m}
-        return mesh_args
+        cell_size: float = self.params.get("cell_size", 0.5) / self.units.m
+        meshing_args: dict[str, float] = {"cell_size": cell_size}
+        return meshing_args
 
     def meshing_kwargs(self) -> dict:
         """Keyword arguments for md-grid creation.

--- a/src/porepy/models/geometry.py
+++ b/src/porepy/models/geometry.py
@@ -134,9 +134,8 @@ class ModelGeometry:
 
         """
         # Default value of 1/2, scaled by the length unit.
-        cell_size: float = self.params.get("cell_size", 0.5) / self.units.m
-        meshing_args: dict[str, float] = {"cell_size": cell_size}
-        return meshing_args
+        default_meshing_args: dict[str, float] = {"cell_size": 0.5 / self.units.m}
+        return self.params.get("meshing_arguments", default_meshing_args)
 
     def meshing_kwargs(self) -> dict:
         """Keyword arguments for md-grid creation.


### PR DESCRIPTION
## Proposed changes

This PR adds the possibility to pass `meshing_arguments: dict[str, float]` as a model parameter. This unlocks the possibility to control the meshing arguments without having to re-define the method `self.meshing_arguments()`.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [x] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
