### PR TITLE
BUG: Replace @ by *

### DIFF
--- a/src/porepy/models/constitutive_laws.py
+++ b/src/porepy/models/constitutive_laws.py
@@ -2513,7 +2513,7 @@ class FrictionBound:
             subdomains
         )
         bound: pp.ad.Operator = (
-            Scalar(-1.0) * self.friction_coefficient(subdomains) @ t_n
+            Scalar(-1.0) * self.friction_coefficient(subdomains) * t_n
         )
         bound.set_name("friction_bound")
         return bound


### PR DESCRIPTION
## Proposed changes

Replace matmul by mul in friction bound operator to allow for non-scalar (homogenous) friction coefficient.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [x] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
