### PR TITLE
TST: np.bool and np.float to bool and float

### DIFF
--- a/tests/integration/test_TpfaMonoCoupling.py
+++ b/tests/integration/test_TpfaMonoCoupling.py
@@ -96,7 +96,7 @@ class TestTpfaCouplingDiffGrids(unittest.TestCase):
 
         left_faces = np.argwhere(left_grid.face_centers[0] > split - tol).ravel()
         right_faces = np.argwhere(right_grid.face_centers[0] < split + tol).ravel()
-        val = np.ones(left_faces.size, dtype=np.bool)
+        val = np.ones(left_faces.size, dtype=bool)
         shape = [right_grid.num_faces, left_grid.num_faces]
 
         face_faces = sps.coo_matrix((val, (right_faces, left_faces)), shape=shape)
@@ -252,7 +252,6 @@ class TestTpfaCouplingPeriodicBc(unittest.TestCase):
         self.solve(mdg, analytic_p)
 
     def solve(self, mdg, analytic_p):
-
         # Parameter-discretization keyword:
         kw = "flow"
         # Terms
@@ -337,7 +336,7 @@ class TestTpfaCouplingPeriodicBc(unittest.TestCase):
         tol = 1e-6
         left_faces = np.argwhere(g1.face_centers[1] > ymax - tol).ravel()
         right_faces = np.argwhere(g1.face_centers[1] < 0 + tol).ravel()
-        val = np.ones(left_faces.size, dtype=np.bool)
+        val = np.ones(left_faces.size, dtype=bool)
         shape = [g1.num_faces, g1.num_faces]
 
         face_faces = sps.coo_matrix((val, (right_faces, left_faces)), shape=shape)

--- a/tests/integration/test_fracture_propagation.py
+++ b/tests/integration/test_fracture_propagation.py
@@ -154,7 +154,7 @@ def test_pick_propagation_face_conforming_propagation(generate):
             tip_faces = np.where(sd_frac.tags["tip_faces"])[0]
 
             # Data structure to tag tip faces to propagate from, and angles
-            prop_face = np.zeros(sd_frac.num_faces, dtype=np.bool)
+            prop_face = np.zeros(sd_frac.num_faces, dtype=bool)
             prop_angle = np.zeros(sd_frac.num_faces)
 
             # Loop over all targets for this grid, tag faces to propagate

--- a/tests/integration/test_mpfa_mpsa_partial_update.py
+++ b/tests/integration/test_mpfa_mpsa_partial_update.py
@@ -155,7 +155,7 @@ class TestPartialMPFA(unittest.TestCase):
         flux = sps.csr_matrix((g.num_faces, g.num_cells))
         bound_flux = sps.csr_matrix((g.num_faces, g.num_faces))
         vc = sps.csr_matrix((g.num_faces, g.num_cells * g.dim))
-        faces_covered = np.zeros(g.num_faces, np.bool)
+        faces_covered = np.zeros(g.num_faces, bool)
 
         bnd = pp.BoundaryCondition(g)
 
@@ -364,7 +364,7 @@ class TestPartialMPSA(unittest.TestCase):
 
         stress = sps.csr_matrix((g.num_faces * g.dim, g.num_cells * g.dim))
         bound_stress = sps.csr_matrix((g.num_faces * g.dim, g.num_faces * g.dim))
-        faces_covered = np.zeros(g.num_faces, np.bool)
+        faces_covered = np.zeros(g.num_faces, bool)
 
         bnd = pp.BoundaryConditionVectorial(g)
         specified_data = {
@@ -653,8 +653,8 @@ class PartialBiotMpsa(TestPartialMPSA):
         stab = sps.csr_matrix((nc, nc))
         bound_displacement_pressure = sps.csr_matrix((nf * nd, nc))
 
-        faces_covered = np.zeros(g.num_faces, np.bool)
-        cells_covered = np.zeros(g.num_cells, np.bool)
+        faces_covered = np.zeros(g.num_faces, bool)
+        cells_covered = np.zeros(g.num_cells, bool)
 
         bnd = pp.BoundaryConditionVectorial(g)
         specified_data = {
@@ -814,7 +814,6 @@ class UpdateDiscretizations(unittest.TestCase):
     def _update_and_compare(
         self, data_small, data_partial, data_full, g_larger, keywords, discr
     ):
-
         for keyword in keywords:
             # Transfer discretized matrices from the small problem
             for key, val in data_small[pp.DISCRETIZATION_MATRICES][keyword].items():

--- a/tests/integration/test_split_grid.py
+++ b/tests/integration/test_split_grid.py
@@ -154,7 +154,7 @@ def test_duplicate_nodes():
     fn_rows = np.hstack((fn_0_9, fn_10_19, fn_20_29, fn_30_39, fn_40_49, fn_50_58))
 
     fn_cols = np.tile(np.arange(nf), (2, 1)).ravel("f")
-    fn_data = np.ones(nf * 2, dtype=np.bool)
+    fn_data = np.ones(nf * 2, dtype=bool)
     face_nodes = sps.coo_matrix((fn_data, (fn_rows, fn_cols)), shape=(nn, nf)).tocsc()
 
     cf_0_6 = np.array(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -27,9 +27,9 @@ def permute_matrix_vector(A, rhs, block_dof, full_dof, grids, variables):
         np.ndarray(b.size): Permuted rhs vector.
     """
     sz = len(block_dof)
-    mat = np.empty((sz, sz), dtype=np.object)
-    b = np.empty(sz, dtype=np.object)
-    dof = np.empty(sz, dtype=np.object)
+    mat = np.empty((sz, sz), dtype=object)
+    b = np.empty(sz, dtype=object)
+    dof = np.empty(sz, dtype=object)
     # Initialize dof vector
     dof[0] = np.arange(full_dof[0])
     for i in range(1, sz):

--- a/tests/unit/ad/test_forward_ad_standard_functions.py
+++ b/tests/unit/ad/test_forward_ad_standard_functions.py
@@ -19,7 +19,6 @@ warnings.simplefilter("ignore", sps.SparseEfficiencyWarning)
 
 
 class AdFunctionTest(unittest.TestCase):
-
     # Function: exp
     def test_exp_scalar(self):
         a = AdArray(np.array([1]), sps.csr_matrix(np.array([0])))
@@ -572,14 +571,15 @@ class AdFunctionTest(unittest.TestCase):
     def test_arcsinh_scalar(self):
         a = AdArray(np.array([0.5]), sps.csr_matrix(np.array([0])))
         b = af.arcsinh(a)
-        self.assertTrue(b.val == np.arcsinh(0.5) and b.jac == 0)
-        self.assertTrue(a.val == 0.5 and a.jac == 0)
+        self.assertTrue(np.isclose(b.val, np.arcsinh(0.5)) and b.jac == 0)
+        self.assertTrue(np.isclose(a.val, 0.5) and a.jac == 0)
 
     def test_arcsinh_advar(self):
         a = AdArray(np.array([0.2]), sps.csr_matrix(np.array([0.3])))
         b = af.arcsinh(a)
         self.assertTrue(
-            b.val == np.arcsinh(0.2) and b.jac == (1 + 0.2**2) ** (-0.5) * 0.3
+            np.isclose(b.val, np.arcsinh(0.2))
+            and np.isclose(b.jac.A, (1 + 0.2**2) ** (-0.5) * 0.3)
         )
         self.assertTrue(a.val == 0.2 and a.jac == 0.3)
 
@@ -590,7 +590,9 @@ class AdFunctionTest(unittest.TestCase):
         b = af.arcsinh(a)
         jac = np.dot(np.diag((1 + val**2) ** (-0.5)), J)
 
-        self.assertTrue(np.all(b.val == np.arcsinh(val)) and np.all(b.jac == jac))
+        self.assertTrue(
+            np.allclose(b.val, np.arcsinh(val)) and np.allclose(b.jac.A, jac)
+        )
         self.assertTrue(
             np.all(J == np.array([[0.3, 0.2, 0.1], [0.5, 0.6, 0.1], [0.2, 0.3, 0.5]]))
         )
@@ -603,7 +605,9 @@ class AdFunctionTest(unittest.TestCase):
         a = AdArray(val, J)
         b = af.arcsinh(a)
         jac = np.dot(np.diag((1 + val**2) ** (-0.5)), J.A)
-        self.assertTrue(np.all(b.val == np.arcsinh(val)) and np.all(b.jac == jac))
+        self.assertTrue(
+            np.allclose(b.val, np.arcsinh(val)) and np.allclose(b.jac.A, jac)
+        )
 
     def test_arcsinh_scalar_times_ad_var(self):
         val = np.array([0.1, 0.2, 0.3])
@@ -622,14 +626,14 @@ class AdFunctionTest(unittest.TestCase):
     def test_arccosh_scalar(self):
         a = AdArray(np.array([2]), sps.csr_matrix(np.array([0])))
         b = af.arccosh(a)
-        self.assertTrue(b.val == np.arccosh(2) and b.jac == 0)
+        self.assertTrue(np.isclose(b.val, np.arccosh(2)) and b.jac == 0)
         self.assertTrue(a.val == 2 and a.jac == 0)
 
     def test_arccosh_advar(self):
         a = AdArray(np.array([2]), sps.csr_matrix(np.array([3])))
         b = af.arccosh(a)
         self.assertTrue(
-            b.val == np.arccosh(2)
+            np.isclose(b.val, np.arccosh(2))
             and b.jac == (2 - 1) ** (-0.5) * (2 + 1) ** (-0.5) * 3
         )
         self.assertTrue(a.val == 2 and a.jac == 3)
@@ -641,7 +645,9 @@ class AdFunctionTest(unittest.TestCase):
         b = af.arccosh(a)
         jac = np.dot(np.diag((val - 1) ** (-0.5) * (val + 1) ** (-0.5)), J)
 
-        self.assertTrue(np.all(b.val == np.arccosh(val)) and np.all(b.jac == jac))
+        self.assertTrue(
+            np.allclose(b.val, np.arccosh(val)) and np.allclose(b.jac.A, jac)
+        )
         self.assertTrue(np.all(J == np.array([[3, 2, 1], [5, 6, 1], [2, 3, 5]])))
 
     def test_arccosh_sparse_jac(self):
@@ -650,7 +656,9 @@ class AdFunctionTest(unittest.TestCase):
         a = AdArray(val, J)
         b = af.arccosh(a)
         jac = np.dot(np.diag((val - 1) ** (-0.5) * (val + 1) ** (-0.5)), J.A)
-        self.assertTrue(np.all(b.val == np.arccosh(val)) and np.all(b.jac == jac))
+        self.assertTrue(
+            np.allclose(b.val, np.arccosh(val)) and np.allclose(b.jac.A, jac)
+        )
 
     def test_arccosh_scalar_times_ad_var(self):
         val = np.array([1, 2, 3])
@@ -669,14 +677,15 @@ class AdFunctionTest(unittest.TestCase):
     def test_arctanh_scalar(self):
         a = AdArray(np.array([0.5]), sps.csr_matrix(np.array([0])))
         b = af.arctanh(a)
-        self.assertTrue(b.val == np.arctanh(0.5) and b.jac == 0)
+        self.assertTrue(np.isclose(b.val, np.arctanh(0.5)) and b.jac == 0)
         self.assertTrue(a.val == 0.5 and a.jac == 0)
 
     def test_arctanh_advar(self):
         a = AdArray(np.array([0.2]), sps.csr_matrix(np.array([0.3])))
         b = af.arctanh(a)
         self.assertTrue(
-            b.val == np.arctanh(0.2) and b.jac == (1 - 0.2**2) ** (-1) * 0.3
+            np.isclose(b.val, np.arctanh(0.2))
+            and np.isclose(b.jac.A, (1 - 0.2**2) ** (-1) * 0.3)
         )
         self.assertTrue(a.val == 0.2 and a.jac == 0.3)
 
@@ -687,7 +696,9 @@ class AdFunctionTest(unittest.TestCase):
         b = af.arctanh(a)
         jac = np.dot(np.diag((1 - val**2) ** (-1)), J)
 
-        self.assertTrue(np.all(b.val == np.arctanh(val)) and np.all(b.jac == jac))
+        self.assertTrue(
+            np.allclose(b.val, np.arctanh(val)) and np.allclose(b.jac.A, jac)
+        )
         self.assertTrue(
             np.all(J == np.array([[0.3, 0.2, 0.1], [0.5, 0.6, 0.1], [0.2, 0.3, 0.5]]))
         )
@@ -700,7 +711,9 @@ class AdFunctionTest(unittest.TestCase):
         a = AdArray(val, J)
         b = af.arctanh(a)
         jac = np.dot(np.diag((1 - val**2) ** (-1)), J.A)
-        self.assertTrue(np.all(b.val == np.arctanh(val)) and np.all(b.jac == jac))
+        self.assertTrue(
+            np.allclose(b.val, np.arctanh(val)) and np.allclose(b.jac.A, jac)
+        )
 
     def test_arctanh_scalar_times_ad_var(self):
         val = np.array([0.1, 0.2, 0.3])

--- a/tests/unit/test_assembler.py
+++ b/tests/unit/test_assembler.py
@@ -942,7 +942,6 @@ class TestAssembler(unittest.TestCase):
         key_2 = "var_2"
         term = "op"
         for sd, data in mdg.subdomains(return_data=True):
-
             if sd.grid_num == 1:
                 data[pp.PRIMARY_VARIABLES] = {key_1: {"cells": 1}, key_2: {"cells": 1}}
                 data[pp.DISCRETIZATION] = {
@@ -1031,7 +1030,6 @@ class TestAssembler(unittest.TestCase):
         term = "op"
         term2 = "term2"
         for sd, data in mdg.subdomains(return_data=True):
-
             if sd.grid_num == 1:
                 data[pp.PRIMARY_VARIABLES] = {key_1: {"cells": 1}, key_2: {"cells": 1}}
                 data[pp.DISCRETIZATION] = {
@@ -1125,7 +1123,6 @@ class TestAssembler(unittest.TestCase):
         term = "op"
         term2 = "term2"
         for sd, data in mdg.subdomains(return_data=True):
-
             if sd.grid_num == 1:
                 data[pp.PRIMARY_VARIABLES] = {key_1: {"cells": 1}, key_2: {"cells": 1}}
                 data[pp.DISCRETIZATION] = {
@@ -1197,7 +1194,6 @@ class TestAssembler(unittest.TestCase):
 
         # Next, define both variables to be active. Should be equivalent to
         # runing without the variables argument
-        new_assembler = pp.Assembler(mdg, dof_manager)
         A_2, b_2 = general_assembler.assemble_matrix_rhs()
         A_2_permuted, _ = permute_matrix_vector(
             A_2, b_2, dof_manager.block_dof, dof_manager.full_dof, grids, variables
@@ -1590,13 +1586,13 @@ class TestAssembler(unittest.TestCase):
                 self.assertTrue(variable_name_2 in line)
             elif "in dimension 1" in line:
                 self.assertTrue(variable_name_1 in line)
-                self.assertTrue(not variable_name_2 in line)
+                self.assertTrue(variable_name_2 not in line)
 
         self.assertTrue("dimensions 2 and 1" in rep)
         for line in rep.split("\n"):
             if "in dimensions 2 and 1" in line:
                 self.assertTrue(variable_name_1 in line)
-                self.assertTrue(not variable_name_2 in line)
+                self.assertTrue(variable_name_2 not in line)
 
     def test_repr_three_nodes_three_edges_different_variables(self):
         # Assembler.__str__ will be the same as in the above two-node test. Focus on
@@ -1698,7 +1694,6 @@ class MockEdgeDiscretization(
         data_edge,
         local_matrix,
     ):
-
         dof = [local_matrix[0, i].shape[1] for i in range(local_matrix.shape[1])]
         cc = np.array([sps.coo_matrix((i, j)) for i in dof for j in dof])
         cc = cc.reshape((3, 3))
@@ -1736,7 +1731,6 @@ class MockEdgeDiscretizationModifiesNode(
         data_edge,
         local_matrix,
     ):
-
         dof = [local_matrix[0, i].shape[1] for i in range(local_matrix.shape[1])]
         cc = np.array([sps.coo_matrix((i, j)) for i in dof for j in dof])
         cc = cc.reshape((3, 3))
@@ -1773,7 +1767,6 @@ class MockEdgeDiscretizationOneSided(
         self.off_diag_val = off_diag_val
 
     def assemble_matrix_rhs(self, g_primary, data_primary, data_edge, local_matrix):
-
         dof = [local_matrix[0, i].shape[1] for i in range(local_matrix.shape[1])]
         cc = np.array([sps.coo_matrix((i, j)) for i in dof for j in dof])
         cc = cc.reshape((2, 2))
@@ -1800,7 +1793,6 @@ class MockEdgeDiscretizationOneSidedModifiesNode(
         self.off_diag_val = off_diag_val
 
     def assemble_matrix_rhs(self, g_primary, data_primary, data_edge, local_matrix):
-
         dof = [local_matrix[0, i].shape[1] for i in range(local_matrix.shape[1])]
         cc = np.array([sps.coo_matrix((i, j)) for i in dof for j in dof])
         cc = cc.reshape((2, 2))
@@ -1844,7 +1836,6 @@ class MockEdgeDiscretizationEdgeCouplings(
         data_edge,
         local_matrix,
     ):
-
         dof = [local_matrix[0, i].shape[1] for i in range(local_matrix.shape[1])]
         cc = np.array([sps.coo_matrix((i, j)) for i in dof for j in dof])
         cc = cc.reshape((3, 3))

--- a/tests/unit/test_bc_vectorial.py
+++ b/tests/unit/test_bc_vectorial.py
@@ -36,7 +36,6 @@ class testBoundaryConditionsVectorial(unittest.TestCase):
         self.assertTrue(np.allclose(bc.basis, basis_known))
 
     def test_2d(self):
-
         """
         The domain consists of a 3x3 mesh.
         Bottom faces are dirichlet
@@ -88,7 +87,7 @@ class testBoundaryConditionsVectorial(unittest.TestCase):
         is_neu_nd = (
             bound_exclusion.exclude_robin_dirichlet(bound.is_neu.ravel("C"))
             .ravel("F")
-            .astype(np.bool)
+            .astype(bool)
         )
 
         neu_ind = np.argsort(subfno_neu)
@@ -130,7 +129,7 @@ class testBoundaryConditionsVectorial(unittest.TestCase):
         is_dir_nd = (
             bound_exclusion.exclude_neumann_robin(bound.is_dir.ravel("C"))
             .ravel("F")
-            .astype(np.bool)
+            .astype(bool)
         )
 
         dir_ind = np.argsort(subfno_dir)

--- a/tests/unit/test_ccw.py
+++ b/tests/unit/test_ccw.py
@@ -87,7 +87,7 @@ class TestCCW(unittest.TestCase):
         p1, p2, _ = self.setup()
 
         p_test = np.array([[0.5, 0.5], [1, -1]])
-        known = np.array([1, 0], dtype=np.bool)
+        known = np.array([1, 0], dtype=bool)
         self.assertTrue(
             np.allclose(
                 known,

--- a/tests/unit/test_is_point_in_cell.py
+++ b/tests/unit/test_is_point_in_cell.py
@@ -7,7 +7,7 @@ import porepy as pp
 
 class BasicsTest(unittest.TestCase):
     def test_planar_square(self):
-        pts = np.array([[0, 1, 1, 0], [0, 0, 1, 1], [0, 0, 0, 0]], dtype=np.float)
+        pts = np.array([[0, 1, 1, 0], [0, 0, 1, 1], [0, 0, 0, 0]], dtype=float)
 
         pt = np.array([0.2, 0.3, 0])
         self.assertTrue(pp.geometry_property_checks.point_in_cell(pts, pt))
@@ -38,7 +38,7 @@ class BasicsTest(unittest.TestCase):
 
     def test_planar_square_1(self):
         pts = np.array(
-            [[0, 0.5, 1, 1, 0], [0, 0, 0, 1, 1], [0, 0, 0, 0, 0]], dtype=np.float
+            [[0, 0.5, 1, 1, 0], [0, 0, 0, 1, 1], [0, 0, 0, 0, 0]], dtype=float
         )
 
         pt = np.array([0.2, 0.3, 0])
@@ -70,7 +70,7 @@ class BasicsTest(unittest.TestCase):
 
     def test_planar_convex(self):
         pts = np.array(
-            [[0, 1, 1.2, 0.5, -0.2], [0, 0, 1, 1.2, 1], [0, 0, 0, 0, 0]], dtype=np.float
+            [[0, 1, 1.2, 0.5, -0.2], [0, 0, 1, 1.2, 1], [0, 0, 0, 0, 0]], dtype=float
         )
 
         pt = np.array([0.2, 0.3, 0])
@@ -91,7 +91,7 @@ class BasicsTest(unittest.TestCase):
     def test_planar_convex_1(self):
         pts = np.array(
             [[0, 0.5, 1, 1.2, 0.5, -0.2], [0, 0, 0, 1, 1.2, 1], [0, 0, 0, 0, 0, 0]],
-            dtype=np.float,
+            dtype=float,
         )
 
         pt = np.array([0.2, 0.3, 0])
@@ -112,7 +112,7 @@ class BasicsTest(unittest.TestCase):
     def test_planar_concave(self):
         pts = np.array(
             [[0, 0.5, 1, 0.4, 0.5, -0.2], [0, 0, 0, 1, 1.2, 1], [0, 0, 0, 0, 0, 0]],
-            dtype=np.float,
+            dtype=float,
         )
 
         pt = np.array([0.2, 0.3, 0])

--- a/tests/unit/test_merging_non_conforming_grids.py
+++ b/tests/unit/test_merging_non_conforming_grids.py
@@ -106,7 +106,7 @@ class TestMeshMerging(unittest.TestCase):
         new_face_ind = non_conforming.update_face_nodes(g, delete_faces, 1, 2)
         self.assertTrue(new_face_ind.size == 1)
         self.assertTrue(new_face_ind[0] == 1)
-        fn_known = np.array([[0, 0], [0, 0], [1, 1], [1, 1]], dtype=np.bool)
+        fn_known = np.array([[0, 0], [0, 0], [1, 1], [1, 1]], dtype=bool)
 
         self.assertTrue(np.allclose(fn_known, g.face_nodes.A))
 
@@ -121,7 +121,7 @@ class TestMeshMerging(unittest.TestCase):
         new_face_ind = non_conforming.update_face_nodes(g, delete_faces, 1, 0)
         self.assertTrue(new_face_ind.size == 1)
         self.assertTrue(new_face_ind[0] == 1)
-        fn_known = np.array([[0, 1], [1, 1], [1, 1], [1, 0]], dtype=np.bool)
+        fn_known = np.array([[0, 1], [1, 1], [1, 1], [1, 0]], dtype=bool)
 
         self.assertTrue(np.allclose(fn_known, g.face_nodes.A))
 
@@ -138,7 +138,7 @@ class TestMeshMerging(unittest.TestCase):
             g, delete_faces, num_new_faces=0, new_node_offset=2
         )
         self.assertTrue(new_face_ind.size == 0)
-        fn_known = np.array([[0], [0], [1], [1]], dtype=np.bool)
+        fn_known = np.array([[0], [0], [1], [1]], dtype=bool)
 
         self.assertTrue(np.allclose(fn_known, g.face_nodes.A))
 
@@ -154,7 +154,7 @@ class TestMeshMerging(unittest.TestCase):
         new_face_ind = non_conforming.update_face_nodes(g, delete_faces, 1, 2)
         self.assertTrue(new_face_ind.size == 1)
         self.assertTrue(new_face_ind[0] == 0)
-        fn_known = np.array([[0], [0], [1], [1]], dtype=np.bool)
+        fn_known = np.array([[0], [0], [1], [1]], dtype=bool)
 
         self.assertTrue(np.allclose(fn_known, g.face_nodes.A))
 
@@ -273,7 +273,7 @@ class TestMeshMerging(unittest.TestCase):
             g, delete_faces, new_faces, in_combined, fn_orig, nodes_orig
         )
 
-        cf_expected = np.array([[1, 1, 0, 1, 1], [0, 0, 1, 1, 1]], dtype=np.bool).T
+        cf_expected = np.array([[1, 1, 0, 1, 1], [0, 0, 1, 1, 1]], dtype=bool).T
         self.assertTrue(np.allclose(np.abs(g.cell_faces.toarray()), cf_expected))
 
     def test_update_cell_faces_delete_shared_reversed(self):
@@ -302,7 +302,7 @@ class TestMeshMerging(unittest.TestCase):
             g, delete_faces, new_faces, in_combined, fn_orig, nodes_orig
         )
 
-        cf_expected = np.array([[1, 1, 0, 1, 1], [0, 0, 1, 1, 1]], dtype=np.bool).T
+        cf_expected = np.array([[1, 1, 0, 1, 1], [0, 0, 1, 1, 1]], dtype=bool).T
         self.assertTrue(np.allclose(np.abs(g.cell_faces.toarray()), cf_expected))
 
     def test_update_cell_faces_change_all(self):
@@ -330,7 +330,7 @@ class TestMeshMerging(unittest.TestCase):
             g, delete_faces, new_faces, in_combined, fn_orig, nodes_orig
         )
 
-        cf_expected = np.array([[1, 1, 0, 0, 0], [0, 0, 1, 1, 1]], dtype=np.bool).T
+        cf_expected = np.array([[1, 1, 0, 0, 0], [0, 0, 1, 1, 1]], dtype=bool).T
         self.assertTrue(np.allclose(np.abs(g.cell_faces.toarray()), cf_expected))
 
     def test_update_tag_simple(self):
@@ -1048,7 +1048,6 @@ class MockGrid:
         cell_faces=None,
         num_cells=None,
     ):
-
         self.dim = dim
         self.face_nodes = face_nodes.tocsc()
         self.num_faces = num_faces

--- a/tests/unit/test_mesh_size_determination.py
+++ b/tests/unit/test_mesh_size_determination.py
@@ -119,7 +119,7 @@ class TestMeshSize(unittest.TestCase):
 
         # Many of the points should have mesh size of 2, adjust the exceptions below
         mesh_size_known = np.full(
-            decomp["points"].shape[1], mesh_size_bound, dtype=np.float
+            decomp["points"].shape[1], mesh_size_bound, dtype=float
         )
 
         # Find the points on the fracture

--- a/tests/unit/test_mpsa.py
+++ b/tests/unit/test_mpsa.py
@@ -73,7 +73,7 @@ class MpsaBoundTest(unittest.TestCase):
         right = g.face_centers[0] > 1 - 1e-10
 
         is_dir = left + top
-        is_neu = np.zeros(left.size, dtype=np.bool)
+        is_neu = np.zeros(left.size, dtype=bool)
         is_rob = right + bot
 
         bnd = pp.BoundaryConditionVectorial(g)
@@ -194,8 +194,8 @@ class MpsaBoundTest(unittest.TestCase):
         right = g.face_centers[0] > 1 - 1e-10
 
         is_dir = left + top + right + bot
-        is_neu = np.zeros(left.size, dtype=np.bool)
-        is_rob = np.zeros(left.size, dtype=np.bool)
+        is_neu = np.zeros(left.size, dtype=bool)
+        is_rob = np.zeros(left.size, dtype=bool)
 
         bnd = pp.BoundaryConditionVectorial(g)
         bnd.is_neu[:] = False
@@ -245,8 +245,8 @@ class MpsaBoundTest(unittest.TestCase):
         left = g.face_centers[0] < 1e-10
         right = g.face_centers[0] > 1 - 1e-10
 
-        is_dir = np.zeros(left.size, dtype=np.bool)
-        is_neu = np.zeros(left.size, dtype=np.bool)
+        is_dir = np.zeros(left.size, dtype=bool)
+        is_neu = np.zeros(left.size, dtype=bool)
         is_rob = left + top + right + bot
 
         bnd = pp.BoundaryConditionVectorial(g)
@@ -298,9 +298,9 @@ class MpsaBoundTest(unittest.TestCase):
         left = g.face_centers[0] < 1e-10
         right = g.face_centers[0] > 1 - 1e-10
 
-        is_dir = np.zeros(left.size, dtype=np.bool)
+        is_dir = np.zeros(left.size, dtype=bool)
         is_neu = left + top + right + bot
-        is_rob = np.zeros(left.size, dtype=np.bool)
+        is_rob = np.zeros(left.size, dtype=bool)
 
         bnd = pp.BoundaryConditionVectorial(g)
         bnd.is_neu[:] = False

--- a/tests/unit/test_plotting.py
+++ b/tests/unit/test_plotting.py
@@ -110,7 +110,7 @@ def _initialize_mdg(mdg_):
             vals_vect_cell = np.ones((mdg_.dim_max(), sd.num_cells)).ravel(order="F")
             vals_vect_face = np.ones((mdg_.dim_max(), sd.num_faces)).ravel(order="F")
 
-            values = np.array([vals_scalar, vals_vect_cell, vals_vect_face])
+            values = [vals_scalar, vals_vect_cell, vals_vect_face]
 
             for i in range(len(variables)):
                 pp.set_solution_values(


### PR DESCRIPTION
## Proposed changes

Fixes failed tests caused by https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [x] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
