### PR TITLE
880 outdated pp.FractureNetwork3d

### DIFF
--- a/src/porepy/grids/standard_grids/md_grids_2d.py
+++ b/src/porepy/grids/standard_grids/md_grids_2d.py
@@ -39,6 +39,10 @@ def single_horizontal(
     """
     Create a grid bucket for a domain containing a single horizontal fracture at y=0.5.
 
+    .. deprecated::
+        This function is deprecated and will be removed at an unspecified point in the
+        future.
+
     Args:
         mesh_args:  For triangular grids: Dictionary containing at least "mesh_size_frac". If
                         the optional values of "mesh_size_bound" and "mesh_size_min" are
@@ -81,6 +85,10 @@ def single_vertical(
 ):
     """
     Create a grid bucket for a domain containing a single vertical fracture at x=0.5.
+
+    .. deprecated::
+        This function is deprecated and will be moved or removed at an unspecified
+        point in the future.
 
     Args:
         mesh_args:
@@ -130,6 +138,10 @@ def two_intersecting(
     """
     Create a grid bucket for a domain containing fractures, one horizontal and one vertical
     at y=0.5 and x=0.5 respectively.
+
+    .. deprecated::
+        This function is deprecated and will be moved or removed at an unspecified
+        point in the future.
 
     Args:
         mesh_args:  For triangular grids: Dictionary containing at least "mesh_size_frac". If
@@ -188,6 +200,10 @@ def seven_fractures_one_L_intersection(mesh_args: dict):
     Berge et al. 2019: Finite volume discretization for poroelastic media with fractures
     modeled by contact mechanics.
 
+    .. deprecated::
+        This function is deprecated and will be moved or removed at an unspecified
+        point in the future.
+
     Args:
         mesh_args: Dictionary containing at least "mesh_size_frac". If the optional
             values of "mesh_size_bound" and "mesh_size_min" are not provided, these are
@@ -224,6 +240,10 @@ def benchmark_regular(mesh_args: dict, is_coarse: bool = False):
     """
     Create a grid bucket for a domain containing the network introduced as example 2 of
     Berre et al. 2018: Benchmarks for single-phase flow in fractured porous media.
+
+    .. deprecated::
+        This function is deprecated and will be moved or removed at an unspecified
+        point in the future.
 
     Args:
         mesh_args: Dictionary containing at least "mesh_size_frac". If the optional

--- a/src/porepy/grids/standard_grids/md_grids_3d.py
+++ b/src/porepy/grids/standard_grids/md_grids_3d.py
@@ -6,6 +6,7 @@ The provided geometries are:
         Simple unit square geometries
     single_horizontal: Single horizontal plane at z=0.5
 """
+from __future__ import annotations
 
 import numpy as np
 
@@ -15,6 +16,10 @@ import porepy.grids.standard_grids.utils as utils
 
 def single_horizontal(mesh_args=None, x_coords=None, y_coords=None, simplex=True):
     """Mixed-dimensional grid for a domain with a horizontal rectangular fracture at z=0.5.
+
+    .. deprecated::
+        This function is deprecated and will be moved or removed at an unspecified
+        point in the future.
 
     Args:
         mesh_args:  For triangular grids: Dictionary containing at least "mesh_size_frac". If
@@ -43,9 +48,11 @@ def single_horizontal(mesh_args=None, x_coords=None, y_coords=None, simplex=True
     if simplex:
         if mesh_args is None:
             mesh_args = {"mesh_size_frac": 0.2, "mesh_size_min": 0.2}
-        network = pp.FractureNetwork3d([pp.PlaneFracture(fracture)], domain=domain)
+        network = pp.create_fracture_network([pp.PlaneFracture(fracture)], domain)
         mdg = network.mesh(mesh_args)
 
     else:
+        if mesh_args is None:
+            mesh_args = np.array([5, 5, 5])
         mdg = pp.meshing.cart_grid([fracture], mesh_args, physdims=np.ones(3))
     return mdg, domain

--- a/src/porepy/grids/standard_grids/utils.py
+++ b/src/porepy/grids/standard_grids/utils.py
@@ -8,6 +8,10 @@ import porepy as pp
 def unit_domain(dimension: int) -> pp.Domain:
     """Return a domain of unitary size extending from 0 to 1 in all dimensions.
 
+    .. deprecated::
+        This function is deprecated and will be moved or removed at an unspecified
+        point in the future.
+
     Parameters:
         dimension: the dimension of the domain.
 
@@ -29,6 +33,10 @@ def set_mesh_sizes(mesh_args: dict):
     Checks whether mesh_size_min and mesh_size_bound are present in the mesh_args dictionary.
     If not, they are set to 1/5 and 2 of the mesh_size_frac value, respectively.
 
+    .. deprecated::
+        This function is deprecated and will be moved or removed at an unspecified
+        point in the future.
+
     """
     if "mesh_size_frac" not in mesh_args:
         raise ValueError("Mesh size parameters should be specified via mesh_size_frac")
@@ -42,6 +50,10 @@ def make_mdg_2d_simplex(
     mesh_args: dict, points: np.ndarray, fractures: np.ndarray, domain: pp.Domain
 ):
     """Construct a mixed-dimensional simplex grid in the 2d domain.
+
+    .. deprecated::
+        This function is deprecated and will be moved or removed at an unspecified
+        point in the future.
 
     Parameters:
         mesh_args: Contains at least "mesh_size_frac". If the optional values of
@@ -69,6 +81,10 @@ def make_mdg_2d_cartesian(
 ):
     """
     Construct a Cartesian mixed-dimensional grid in the 2d domain.
+
+    .. deprecated::
+        This function is deprecated and will be moved or removed at an unspecified
+        point in the future.
 
     Parameters:
         n_cells: Contains number of cells in x and y direction.


### PR DESCRIPTION
## Proposed changes

This PR fixes a bug where `pp.FractureNetwork3d` was used instead of `pp.create_fracture_network()`. This PR solves #880 .

Deprecation warnings were added to the doctoring of the methods belonging to `porepy.grids.standard_grids`.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [x] Minor change (e.g., dependency bumps, broken links).
- [x] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [x] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
