### PR TITLE
Enable Python 3.11, drop support for 3.8 and 3.9

### DIFF
--- a/.github/workflows/run-pytest-all.yml
+++ b/.github/workflows/run-pytest-all.yml
@@ -21,7 +21,7 @@ jobs:
     # https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#specifying-a-python-version
     strategy:
       matrix:
-        python-version:  ["3.10"]  # run only the last python version
+        python-version:  ["3.11"]  # run only the last python version
       # Complete all versions in matrix even if one fails.
       fail-fast: false
 

--- a/.github/workflows/run-pytest.yml
+++ b/.github/workflows/run-pytest.yml
@@ -29,7 +29,7 @@ jobs:
     # https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#specifying-a-python-version
     strategy:
       matrix:
-        python-version:  ["3.8", "3.9", "3.10"]
+        python-version:  ["3.10", "3.11"]
       # Complete all versions in matrix even if one fails.
       fail-fast: false
 

--- a/.github/workflows/run-static-checks.yml
+++ b/.github/workflows/run-static-checks.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         # Run the tests only on the latest supported Python version (currently 3.10).
-        python-version:  ["3.10"]
+        python-version:  ["3.11"]
       # Complete all versions in matrix even if one fails.
       fail-fast: false
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ gmsh
 matplotlib
 meshio >= 5.0
 networkx
-numba >= 0.56.3
+numba >= 0.57
 numpy
 requests
 scipy


### PR DESCRIPTION
## Proposed changes
This PR introduces support for Python 3.11. Also, support for 3.8 and 3.9 is officially dropped, and the tests on GH actions are only run for 3.10 and 3.11.


## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [x] Other: Considers Python versions.

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

These are not relevant.

- [ ] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
