### PR TITLE
BUG: Linear vs volumetric expansion

### DIFF
--- a/src/porepy/models/constitutive_laws.py
+++ b/src/porepy/models/constitutive_laws.py
@@ -554,7 +554,8 @@ class FluidDensityFromTemperature:
         # Reference variables are defined in a variables class which is assumed
         # to be available by mixin.
         dtemp = self.perturbation_from_reference("temperature", subdomains)
-        return exp(Scalar(-1) * Scalar(self.fluid.thermal_expansion()) * dtemp)
+        volumetric_thermal_expansion = Scalar(self.nd * self.fluid.thermal_expansion())
+        return exp(Scalar(-1) * volumetric_thermal_expansion * dtemp)
 
 
 class FluidDensityFromPressureAndTemperature(

--- a/src/porepy/models/material_constants.py
+++ b/src/porepy/models/material_constants.py
@@ -139,24 +139,12 @@ class FluidConstants(MaterialConstants):
     """
     Class giving scaled values of fluid parameters.
 
-    Each constant (class attribute) typically corresponds to exactly one method which
-    scales the value and broadcasts to relevant size, typically number of cells in the
-    specified subdomains or interfaces.
+    Each constant (class attribute) corresponds to exactly one method which
+    scales the value to the correct units. Non-default values should be set by
+    passing a dictionary to the constructor. The dictionary should contain
+    the name of the constant as key, and the value as value. The value should
+    be given in SI units.
 
-    Note:
-        Return types are discussed in fluid_density and fluid_thermal_expansion.
-
-        Prefix fluid must be included if we decide for inheritance and not composition
-        for the material classes.
-
-    Parameters:
-        constants (dict): Dictionary of constants. Only keys corresponding to a constant
-            in the class will be used. The permissible keys are:
-                - ``thermal_expansion``: Thermal expansion coefficient [1/K].
-                - ``density``: Density [kg/m^3].
-                - ``viscosity``: Viscosity [Pa s].
-                - ``compressibility``: Compressibility [1/Pa].
-            If not specified, default values are used.
 
     """
 
@@ -254,7 +242,7 @@ class FluidConstants(MaterialConstants):
         )
 
     def thermal_expansion(self) -> number:
-        """Thermal expansion coefficient [1/K].
+        """Linear thermal expansion coefficient [m*m^-1*K].
 
         Returns:
             Thermal expansion coefficient in converted temperature units.
@@ -333,7 +321,7 @@ class SolidConstants(MaterialConstants):
         return self.convert_units(self.constants["density"], "kg * m^-3")
 
     def thermal_expansion(self) -> number:
-        """Thermal expansion coefficient [1/K].
+        """Linear thermal expansion coefficient [m*m^-1*K^-1].
 
         Returns:
             Thermal expansion coefficient in converted temperature units.

--- a/tests/integration/models/test_evaluate_constitutive_laws.py
+++ b/tests/integration/models/test_evaluate_constitutive_laws.py
@@ -59,12 +59,13 @@ from . import setup_utils
             setup_utils.Thermoporomechanics,
             "matrix_porosity",
             # phi_0 + (alpha - phi_ref) * (1 - alpha) / bulk * p
-            # - (alpha - phi_0) * thermal expansion * T
+            # - (alpha - phi_0) * 2 * thermal expansion * T
+            # The 2 is to convert from linear to (2d) volumetric thermal expansion.
             #  Only pressure and temperature, not div(u), is included in this test.
             (
                 7e-3
                 + (0.8 - 7e-3) * (1 - 0.8) / (11.11 * pp.GIGA) * 2
-                - (0.8 - 7e-3) * 1e-5 * 3
+                - (0.8 - 7e-3) * 2 * 1e-5 * 3
             ),
             2,  # Matrix porosity is only defined in Nd
         ),


### PR DESCRIPTION
## Proposed changes

This PR introduces a distinction between linear and volumetric thermal expansion coefficient for the solid. To reviewer: Please check that you agree with the changes to the constitutive laws!

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [x] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
