### PR TITLE
Remove obsolete note on incomplete upwind implementation.

### DIFF
--- a/src/porepy/models/fluid_mass_balance.py
+++ b/src/porepy/models/fluid_mass_balance.py
@@ -11,8 +11,6 @@ Notes:
     Refactoring needed for constitutive equations. Modularisation and moving to the
     library.
 
-    Upwind for the mobility of the fluid flux is not complete.
-
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Proposed changes

The fluid_mass_balance module contained a note regarding incomplete upwind implementation. This note is obsolete and is removed with this PR.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [X] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [X] The documentation is up-to-date. (Only relevant box for this PR.)
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
