### PR TITLE
FIX: Convection bc hint improved

### DIFF
--- a/src/porepy/models/energy_balance.py
+++ b/src/porepy/models/energy_balance.py
@@ -679,17 +679,15 @@ class BoundaryConditionsEnergyBalance:
         # Loop over subdomains to collect boundary values
         for sd in subdomains:
             vals = np.zeros(sd.num_faces)
-            # If you know the boundary temperature, do something like:
-            # boundary_faces = self.domain_boundary_sides(sd).all_bf
-            # vals[boundary_faces] = (
-            #     self.fluid.specific_heat_capacity()
-            #     * dirichlet_values_temperature
-            #     * self.fluid.density()
-            #     / self.fluid.viscosity()
-            # )
-            # Dividing by viscosity is an implementation detail since later these
-            # values are multiplied by `DarcysLaw.darcy_flux`. Those must be divided by
-            # viscosity from the outside to represent the Darcy velocity.
+            # If you know the boundary temperature, you might want to reconstruct
+            # the enthalpy flux at the boundary. Using Dirichlet BCs, the value assigned
+            # herein will be multiplied with the Darcy flux -K \nabla p. Thus, one would
+            # normally convert to fluid flux multiplying by (density/viscosity). Then,
+            # if using EnthalpyFromTemperature, one would compute enthalpy value by
+            # multiplying by specific heat capacity and
+            # (boundary temperature - reference temperature). Note that using
+            # non-default constitutive laws in the interior might require changes to the
+            # above recipe.
 
             #  Append to list of boundary values
             bc_values.append(vals)

--- a/src/porepy/models/energy_balance.py
+++ b/src/porepy/models/energy_balance.py
@@ -679,12 +679,18 @@ class BoundaryConditionsEnergyBalance:
         # Loop over subdomains to collect boundary values
         for sd in subdomains:
             vals = np.zeros(sd.num_faces)
-            # If you know the boundary temperature, do something like: boundary_faces =
-            # self.domain_boundary_sides(sd).all_bf vals[boundary_faces] = (
-            # self.fluid.specific_heat_capacity()
-            # * dirichlet_values
-            # * self.fluid.density()
+            # If you know the boundary temperature, do something like:
+            # boundary_faces = self.domain_boundary_sides(sd).all_bf
+            # vals[boundary_faces] = (
+            #     self.fluid.specific_heat_capacity()
+            #     * dirichlet_values_temperature
+            #     * self.fluid.density()
+            #     / self.fluid.viscosity()
             # )
+            # Dividing by viscosity is an implementation detail since later these
+            # values are multiplied by `DarcysLaw.darcy_flux`. Those must be divided by
+            # viscosity from the outside to represent the Darcy velocity.
+
             #  Append to list of boundary values
             bc_values.append(vals)
 


### PR DESCRIPTION
## Proposed changes

This is a slight improvement of the hint of how to set the Dirichlet boundary condition for the convection term in the energy balance equation. Right now, it may cause errors because it doesn't warn that one must divide by viscosity. Dividing by viscosity is required since later these values are multiplied by the Darcy flux. It is lacking viscosity, so in the mass balance equation we [multiply](https://github.com/pmgbergen/porepy/blob/161bfe14245650ed5eda3434ae445d0f914ad4a5/src/porepy/models/fluid_mass_balance.py#L213) it by the mobility (inversed viscosity). Thus, we must do the same here. @keileg is notified about this change.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [x] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
