### PR TITLE
Dynamic_ad_timestep

### DIFF
--- a/src/porepy/models/abstract_equations.py
+++ b/src/porepy/models/abstract_equations.py
@@ -53,6 +53,11 @@ class BalanceEquation:
     :class:`porepy.models.solution_strategy.SolutionStrategy`.
 
     """
+    ad_time_step: pp.ad.Scalar
+    """Time step as an automatic differentiation scalar. Normally set in
+    :class:`porepy.models.solution_strategy.SolutionStrategy`.
+
+    """
 
     def balance_equation(
         self,

--- a/src/porepy/models/abstract_equations.py
+++ b/src/porepy/models/abstract_equations.py
@@ -84,7 +84,7 @@ class BalanceEquation:
         """
 
         dt_operator = pp.ad.time_derivatives.dt
-        dt = pp.ad.Scalar(self.time_manager.dt)
+        dt = self.ad_time_step
         div = pp.ad.Divergence(subdomains, dim=dim)
         return dt_operator(accumulation, dt) + div @ surface_term - source
 

--- a/src/porepy/numerics/ad/operators.py
+++ b/src/porepy/numerics/ad/operators.py
@@ -1417,6 +1417,18 @@ class Scalar(Operator):
         """
         return self._value
 
+    def set_value(self, value: float) -> None:
+        """Set the value of this scalar.
+
+        Usage includes changing the value of the scalar, as needed when using dynamic
+        time stepping.
+
+        Parameters:
+            value: The new value.
+
+        """
+        self._value = value
+
 
 class Variable(Operator):
     """AD operator representing a variable defined on a single grid or mortar grid.


### PR DESCRIPTION
## Proposed changes

Store a Scalar representing the time step and reuse for all equations. This is a first step towards simulations with dynamic time stepping.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [x] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
