### PR TITLE
Fix bug when adding boundary grids to a mixed-dimensional grid

### DIFF
--- a/src/porepy/fracs/meshing.py
+++ b/src/porepy/fracs/meshing.py
@@ -82,9 +82,9 @@ def subdomains_to_mdg(
     # we are ready to create mortar grids on the interface between subdomains. These
     # will be added to the mixed-dimensional grid.
     create_interfaces(mdg, node_pairs)
-
-    # We can also add boundary grids to the MixedDimensionalGrid after having split
-    # the fracture faces.
+    # Add boundary grids to the MixedDimensionalGrid (this must be done after having
+    # split the fracture faces, or else the projection to the boundary grids will have
+    # the wrong dimension).
     _add_boundary_grids(mdg)
 
     if time_tot is not None:

--- a/src/porepy/fracs/meshing.py
+++ b/src/porepy/fracs/meshing.py
@@ -83,6 +83,10 @@ def subdomains_to_mdg(
     # will be added to the mixed-dimensional grid.
     create_interfaces(mdg, node_pairs)
 
+    # We can also add boundary grids to the MixedDimensionalGrid after having split
+    # the fracture faces.
+    _add_boundary_grids(mdg)
+
     if time_tot is not None:
         logger.info(
             "Mesh construction completed. Total time " + str(time.time() - time_tot)
@@ -532,10 +536,26 @@ def _assemble_mdg(
     return mdg, sd_pair_to_face_cell_map
 
 
+def _add_boundary_grids(mdg: pp.MixedDimensionalGrid) -> None:
+    """Add boundary grids to a mixed-dimensional grid.
+
+    The grid is added to the dictionary
+    ``~porepy.grids.md_grid.MixedDimensionalGrid._subdomain_boundary_grids``
+
+    Parameters:
+        mdg: The mixed-dimensional grid where the boundary grids are added.
+
+    """
+    for sd in mdg.subdomains():
+        if sd.dim > 0:
+            # Generate a boundary grid for this grid
+            mdg._subdomain_boundary_grids[sd] = pp.BoundaryGrid(g=sd)
+
+
 def create_interfaces(
     mdg: pp.MixedDimensionalGrid,
     sd_pair_to_face_cell_map: dict[tuple[pp.Grid, pp.Grid], sps.spmatrix],
-):
+) -> None:
     """Create interfaces for a given mixed-dimensional grid.
 
     Parameters:

--- a/src/porepy/grids/md_grid.py
+++ b/src/porepy/grids/md_grid.py
@@ -586,9 +586,6 @@ class MixedDimensionalGrid:
         """Compute geometric quantities for each contained grid."""
         for sd in self.subdomains():
             sd.compute_geometry()
-            if sd.dim > 0:
-                # Generate a boundary grid for this grid
-                self._subdomain_boundary_grids[sd] = pp.BoundaryGrid(g=sd)
 
         for intf in self.interfaces():
             intf.compute_geometry()

--- a/src/porepy/models/constitutive_laws.py
+++ b/src/porepy/models/constitutive_laws.py
@@ -1961,7 +1961,7 @@ class GravityForce:
 
         """
         val = self.fluid.convert_units(pp.GRAVITY_ACCELERATION, "m*s^-2")
-        size = np.sum([g.num_cells for g in grids])
+        size = np.sum([g.num_cells for g in grids]).astype(int)
         gravity = pp.wrap_as_ad_array(val, size=size, name="gravity")
         rho = getattr(self, material + "_density")(grids)
         # Gravity acts along the last coordinate direction (z in 3d, y in 2d)


### PR DESCRIPTION
## Proposed changes
Adding `BoundaryGrid`s were added to a later point in the construction of a `MixedDimensionalGrid`. This avoids introducing errors in the projection between the boundary grid and its parent related to the splitting of faces when making room for fracture grids.

Also added a minor fix in the constitutive law for gravitational forces.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [x] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag. NOT RELEVANT
