### PR TITLE
Extend boundary grid functionality

### DIFF
--- a/src/porepy/fracs/meshing.py
+++ b/src/porepy/fracs/meshing.py
@@ -83,6 +83,10 @@ def subdomains_to_mdg(
     # will be added to the mixed-dimensional grid.
     create_interfaces(mdg, node_pairs)
 
+    # Set projections to the boundary grids (this must be done after having
+    # split the fracture faces, or else the projections will have the wrong dimension).
+    mdg.set_boundary_grid_projections()
+
     if time_tot is not None:
         logger.info(
             "Mesh construction completed. Total time " + str(time.time() - time_tot)

--- a/src/porepy/fracs/meshing.py
+++ b/src/porepy/fracs/meshing.py
@@ -82,10 +82,6 @@ def subdomains_to_mdg(
     # we are ready to create mortar grids on the interface between subdomains. These
     # will be added to the mixed-dimensional grid.
     create_interfaces(mdg, node_pairs)
-    # Add boundary grids to the MixedDimensionalGrid (this must be done after having
-    # split the fracture faces, or else the projection to the boundary grids will have
-    # the wrong dimension).
-    _add_boundary_grids(mdg)
 
     if time_tot is not None:
         logger.info(
@@ -534,22 +530,6 @@ def _assemble_mdg(
                 sd_pair_to_face_cell_map[(hsd, lsd)] = face_cell_map
 
     return mdg, sd_pair_to_face_cell_map
-
-
-def _add_boundary_grids(mdg: pp.MixedDimensionalGrid) -> None:
-    """Add boundary grids to a mixed-dimensional grid.
-
-    The grid is added to the dictionary
-    ``~porepy.grids.md_grid.MixedDimensionalGrid._subdomain_boundary_grids``
-
-    Parameters:
-        mdg: The mixed-dimensional grid where the boundary grids are added.
-
-    """
-    for sd in mdg.subdomains():
-        if sd.dim > 0:
-            # Generate a boundary grid for this grid
-            mdg._subdomain_boundary_grids[sd] = pp.BoundaryGrid(g=sd)
 
 
 def create_interfaces(

--- a/src/porepy/grids/boundary_grid.py
+++ b/src/porepy/grids/boundary_grid.py
@@ -63,7 +63,7 @@ class BoundaryGrid:
         grid. Initialized in :meth:`~compute_geometry`.
 
         """
-        self._projs: sps.csr_matrix
+        self._projections: sps.csr_matrix
         """Projection matrix from the parent grid to the boundary grid.
 
         Initialized in :meth:`~compute_geometry`.
@@ -92,7 +92,7 @@ class BoundaryGrid:
         self.cell_centers = self._parent.face_centers[:, parent_boundary]
 
         sz = self.num_cells
-        self._proj = sps.coo_matrix(
+        self._projections = sps.coo_matrix(
             (np.ones(sz), (np.arange(sz), np.where(parent_boundary)[0])),
             shape=(self.num_cells, self._parent.num_faces),
         ).tocsr()
@@ -106,7 +106,7 @@ class BoundaryGrid:
         which maps face-wise values on the parent grid to the boundary grid.
 
         """
-        return self._proj
+        return self._projections
 
     @property
     def id(self):
@@ -135,7 +135,8 @@ class BoundaryGrid:
                 f"Boundary grid of dimension {self.dim} "
                 f"containing {self.num_cells} cells.\n"
                 f"ID of parent grid: {self._parent.id}.\n"
-                f"Dimension of the projection from the parent grid: {self._proj.shape}."
+                "Dimension of the projection from the parent grid: "
+                f"{self._projections.shape}."
             )
 
         return (

--- a/src/porepy/grids/boundary_grid.py
+++ b/src/porepy/grids/boundary_grid.py
@@ -60,30 +60,30 @@ class BoundaryGrid:
         """Number of cells in the boundary grid.
 
         Will correspond to the number of faces on the domain boundary in the parent
-        grid. Initialized in :meth:`~compute_geometry`.
+        grid. Initialized in :meth:`~set_projections`.
 
         """
         self._projections: sps.csr_matrix
         """Projection matrix from the parent grid to the boundary grid.
 
-        Initialized in :meth:`~compute_geometry`.
+        Initialized in :meth:`~set_projections`.
 
         """
         self.cell_centers: np.ndarray
         """Cell centers of the boundary grid.
 
         Subset of the face centers of the parent grid. Initialized in
-        :meth:`~compute_geometry`.
+        :meth:`~set_projections`.
 
         """
 
-    def compute_geometry(self) -> None:
-        """Compute geometric quantities for the boundary grid.
+    def set_projections(self) -> None:
+        """Set projections from the parent grid and set the corresponding attributes.
 
-        Currently, there are no heavy computations here. However, the parent grid can
-        be modified during its construction, and the boundary grid must reflect these
-        changes. Thus, it is required to call this method after calling
-        :meth:`Grid.compute_geometry`. Usually, this is done by the MDG.
+        The parent grid can be modified during its construction, and the boundary grid
+        must reflect these changes. It is required to call this method after having
+        split the fracture faces in order to finish the initialization of
+        the boundary grid.
 
         """
         parent_boundary = self._parent.tags["domain_boundary_faces"]
@@ -107,6 +107,11 @@ class BoundaryGrid:
 
         """
         return self._projections
+
+    @property
+    def parent(self) -> pp.Grid:
+        """Subdomain associated with this boundary grid."""
+        return self._parent
 
     @property
     def id(self):

--- a/src/porepy/grids/boundary_grid.py
+++ b/src/porepy/grids/boundary_grid.py
@@ -3,6 +3,9 @@ boundary of a domain in the form of a grid. The intention is to use this class t
 boundary conditions in cases where constitutive laws are defined on the boundary.
 
 """
+from __future__ import annotations
+
+from itertools import count
 from typing import Optional
 
 import numpy as np
@@ -11,7 +14,7 @@ import scipy.sparse as sps
 import porepy as pp
 
 
-class BoundaryGrid(pp.Grid):
+class BoundaryGrid:
     """A grid representing the boundary of a domain.
 
     The BoundaryGrid is generated from a parent grid, and represents those faces in the
@@ -21,33 +24,25 @@ class BoundaryGrid(pp.Grid):
     The boundary grid is intended for computing boundary conditions, e.g. when
     constitutive laws must be evaluated on the boundary.
 
-    Todo:
-        The BoundaryGrid is not a full grid, and should not be used as such. The current
-        inheritance from Grid is a hack to get the BoundaryGrid to work with methods
-        that expect a Grid.
-        The natural solution is to make an abc superclass, say, GridBase, which is
-        inherited by both Grid and BoundaryGrid, and then use GridBase in type hints
-        when either a Grid or a BoundaryGrid can be used.
-
     Note:
         The BoundaryGrid class is an experimental feature which is subject to major
         changes, hereunder deletion.
 
-        Boundary grids have a id counter, which is shared with the parent class Grid.
-        This may confuse expectations of consecutive numbering of grids, if generation
-        of standard grids is interleaved with generation of boundary grids.
-
     """
 
+    _counter = count(0)
+    """Counter of instantiated grids. See :meth:`__new__` and :meth:`id`."""
+    __id: int
+    """Name-mangled reference to assigned ID."""
+
+    def __new__(cls, *args, **kwargs) -> BoundaryGrid:
+        """Make object and set ID by forwarding :attr:`_counter`."""
+
+        obj = object.__new__(cls)
+        obj.__id = next(cls._counter)
+        return obj
+
     def __init__(self, g: pp.Grid, name: Optional[str] = None) -> None:
-        parent_boundary = g.tags["domain_boundary_faces"]
-
-        self.num_cells: int = np.sum(parent_boundary)
-        """Number of cells in the boundary grid. Will correspond to the number of
-        faces on the domain boundary in the parent grid.
-
-        """
-
         if name is None:
             name = "boundary_grid"
         self.name: str = name
@@ -56,24 +51,50 @@ class BoundaryGrid(pp.Grid):
         self._parent = g
         """Parent grid from which the boundary grid is constructed."""
 
-        self.cell_centers = g.face_centers[:, parent_boundary]
-        """Cell centers of the boundary grid.
-
-        Subset of the face centers of the parent grid.
-
-        """
-
         if g.dim == 0:
             raise ValueError("Boundary grids are not supported for 0d grids.")
         self.dim = g.dim - 1
         """Dimension of the boundary grid."""
 
-        sz = self.num_cells
-        """Number of cells in the boundary grid."""
+        self.num_cells: int
+        """Number of cells in the boundary grid.
 
+        Will correspond to the number of faces on the domain boundary in the parent
+        grid. Initialized in :meth:`~compute_geometry`.
+
+        """
+        self._projs: sps.csr_matrix
+        """Projection matrix from the parent grid to the boundary grid.
+
+        Initialized in :meth:`~compute_geometry`.
+
+        """
+        self.cell_centers: np.ndarray
+        """Cell centers of the boundary grid.
+
+        Subset of the face centers of the parent grid. Initialized in
+        :meth:`~compute_geometry`.
+
+        """
+
+    def compute_geometry(self) -> None:
+        """Compute geometric quantities for the boundary grid.
+
+        Currently, there are no heavy computations here. However, the parent grid can
+        be modified during its construction, and the boundary grid must reflect these
+        changes. Thus, it is required to call this method after calling
+        :meth:`Grid.compute_geometry`. Usually, this is done by the MDG.
+
+        """
+        parent_boundary = self._parent.tags["domain_boundary_faces"]
+
+        self.num_cells = int(np.sum(parent_boundary))
+        self.cell_centers = self._parent.face_centers[:, parent_boundary]
+
+        sz = self.num_cells
         self._proj = sps.coo_matrix(
             (np.ones(sz), (np.arange(sz), np.where(parent_boundary)[0])),
-            shape=(self.num_cells, g.num_faces),
+            shape=(self.num_cells, self._parent.num_faces),
         ).tocsr()
 
     @property
@@ -87,6 +108,20 @@ class BoundaryGrid(pp.Grid):
         """
         return self._proj
 
+    @property
+    def id(self):
+        """BoundaryGrid ID.
+
+        The returned attribute must not be changed.
+        This may severely compromise other parts of the code,
+        such as sorting in md grids.
+
+        The attribute is set in :meth:`__new__`.
+        This avoids calls to the super constructor in child classes.
+
+        """
+        return self.__id
+
     def __repr__(self) -> str:
         """Get a string representation of the boundary grid.
 
@@ -94,20 +129,20 @@ class BoundaryGrid(pp.Grid):
             A string representation of the boundary grid.
 
         """
-        s = f"Boundary grid of dimension {self.dim} containing {self.num_cells}"
-        s += "cells.\n"
-        s += f"ID of parent grid: {self._parent.id}.\n"
-        s += f"Dimension of the projection from the parent grid: {self._proj.shape}"
-        return s
+        geometry_computed = hasattr(self, "num_cells")
+        if geometry_computed:
+            return (
+                f"Boundary grid of dimension {self.dim} "
+                f"containing {self.num_cells} cells.\n"
+                f"ID of parent grid: {self._parent.id}.\n"
+                f"Dimension of the projection from the parent grid: {self._proj.shape}."
+            )
+
+        return (
+            f"Boundary grid of dimension {self.dim}.\n"
+            f"ID of parent grid: {self._parent.id}.\n"
+            "Geometry has not been computed yet."
+        )
 
     def __str__(self) -> str:
-        """Get a string representation of the boundary grid.
-
-        Returns:
-            A string representation of the boundary grid.
-
-        """
-        s = f"Boundary grid of dimension {self.dim} containing {self.num_cells} "
-        s += f"cells.\n"
-        s += f"ID of parent grid: {self._parent.id}\n"
-        return s
+        return self.__repr__()

--- a/src/porepy/grids/md_grid.py
+++ b/src/porepy/grids/md_grid.py
@@ -655,7 +655,7 @@ class MixedDimensionalGrid:
         for intf in self.interfaces():
             intf.compute_geometry()
 
-    def set_boundary_grid_projections(self):
+    def set_boundary_grid_projections(self) -> None:
         """Set projections to the boundary grids.
 
         This method must be called after having split the fracture faces, or else

--- a/src/porepy/grids/md_grid.py
+++ b/src/porepy/grids/md_grid.py
@@ -37,7 +37,7 @@ class MixedDimensionalGrid:
         """Dictionary storing the boundary grids associated with subdomains.
 
         Note:
-            We assume there is only one boundary grid for one subdomain.
+            We assume there is only one boundary grid for each subdomain.
 
         """
         self._boundary_grid_data: dict[pp.BoundaryGrid, dict] = {}
@@ -53,7 +53,7 @@ class MixedDimensionalGrid:
             and key is among the subdomains of this mixed-dimensional grid,
             *or* ``key`` is a :class:`~porepy.grids.mortar_grid.MortarGrid` and among
             the interfaces of this mixed-dimensional grid, *or* ``key`` is a
-            :class:`~porepy.grids.boundary_grid.BoundaryGrid`. and among the boundary
+            :class:`~porepy.grids.boundary_grid.BoundaryGrid` and among the boundary
             grids of this mixed-dimensional grid.
 
         """
@@ -167,8 +167,8 @@ class MixedDimensionalGrid:
         Parameters:
             return_data: ``default=False``
 
-                If True, the data dictionary of the interface will
-                be returned together with the interface mortar grids.
+                If True, the data dictionary of the interface will be returned together
+                with the interface mortar grids.
             dim: ``default=None``
 
                 If provided, only interfaces of the specified dimension will
@@ -230,8 +230,8 @@ class MixedDimensionalGrid:
         Parameters:
             return_data: ``default=False``
 
-                If True, the data dictionary of the boundary grid will
-                be returned together with the boundary grids.
+                If True, the data dictionary of the boundary grid will be returned
+                together with the boundary grids.
 
             dim: ``default=None``
 
@@ -350,11 +350,11 @@ class MixedDimensionalGrid:
             bg: A boundary grid in the mixed-dimensional grid.
 
         Returns:
-            The subdomain associated with this boundary grid. If ``bg`` is not is not in
-            this mixed-dimensional grid, ``None`` is returned.
+            The subdomain associated with this boundary grid. If ``bg`` is not in this
+            mixed-dimensional grid, ``None`` is returned.
 
         """
-        # We assume there is always only one boundary grid for one subdomain.
+        # We assume there is always only one boundary grid for each subdomain.
         for sd, other_bg in self._subdomain_to_boundary_grid.items():
             if other_bg.id == bg.id:
                 return sd
@@ -444,6 +444,7 @@ class MixedDimensionalGrid:
 
     def add_subdomains(self, new_subdomains: Union[pp.Grid, Iterable[pp.Grid]]) -> None:
         """Add new subdomains to the mixed-dimensional grid.
+
         Creates a boundary grid for the subdomain.
 
         Parameters:
@@ -534,7 +535,7 @@ class MixedDimensionalGrid:
 
     def remove_subdomain(self, sd: pp.Grid) -> None:
         """Remove a subdomain, related interfaces and boundary grid from the
-            mixed-dimensional grid.
+        mixed-dimensional grid.
 
         Parameters:
            sd: The subdomain to be removed.
@@ -675,8 +676,8 @@ class MixedDimensionalGrid:
             bg.compute_geometry()
 
     def copy(self) -> MixedDimensionalGrid:
-        """Make a shallow copy of the mixed-dimensional grid. The underlying subdomain
-        and interface grids are not copied.
+        """Make a shallow copy of the mixed-dimensional grid. The underlying subdomain,
+        interface and boundary grids are not copied.
 
         Returns:
             Copy of this mixed-dimensional grid.

--- a/src/porepy/grids/md_grid.py
+++ b/src/porepy/grids/md_grid.py
@@ -819,7 +819,7 @@ class MixedDimensionalGrid:
         """
         # Access protected attribute instead of subdomains() to avoid sorting, which can
         # lead to a recursion error.
-        return max([sd.dim for sd in self._subdomain_data.keys()], default=0)
+        return max([sd.dim for sd in self._subdomain_data.keys()])
 
     def num_subdomain_cells(
         self, cond: Optional[Callable[[pp.Grid], bool]] = None

--- a/src/porepy/grids/md_grid.py
+++ b/src/porepy/grids/md_grid.py
@@ -343,23 +343,6 @@ class MixedDimensionalGrid:
         """
         return self._subdomain_to_boundary_grid.get(sd, None)
 
-    def boundary_grid_to_subdomain(self, bg: pp.BoundaryGrid) -> Optional[pp.Grid]:
-        """Get the subdomain associated with a boundary grid.
-
-        Parameters:
-            bg: A boundary grid in the mixed-dimensional grid.
-
-        Returns:
-            The subdomain associated with this boundary grid. If ``bg`` is not in this
-            mixed-dimensional grid, ``None`` is returned.
-
-        """
-        # We assume there is always only one boundary grid for each subdomain.
-        for sd, other_bg in self._subdomain_to_boundary_grid.items():
-            if other_bg.id == bg.id:
-                return sd
-        return None
-
     def neighboring_subdomains(
         self, sd: pp.Grid, only_higher: bool = False, only_lower: bool = False
     ) -> list[pp.Grid]:
@@ -672,8 +655,15 @@ class MixedDimensionalGrid:
         for intf in self.interfaces():
             intf.compute_geometry()
 
+    def set_boundary_grid_projections(self):
+        """Set projections to the boundary grids.
+
+        This method must be called after having split the fracture faces, or else
+        the projections will have the wrong dimension.
+
+        """
         for bg in self.boundaries():
-            bg.compute_geometry()
+            bg.set_projections()
 
     def copy(self) -> MixedDimensionalGrid:
         """Make a shallow copy of the mixed-dimensional grid. The underlying subdomain,

--- a/src/porepy/grids/md_grid.py
+++ b/src/porepy/grids/md_grid.py
@@ -624,6 +624,22 @@ class MixedDimensionalGrid:
 
         """
         sort_inds_all: list[np.ndarray] = list()
+
+        # Special case: No subdomains in the mixed-dimensional grid
+        if len(self._subdomain_data) == 0:
+            # IMPLEMENTATION NOTE (EK): Strictly speaking, there is no requirement that
+            # the grids to be sorted are subdomains in this mixed-dimensional grid (note
+            # there are no calls to ``self`` in the below code, except for
+            # ``self.dim_max()``). While one can imagine use cases where a
+            # mixed-dimensional grid is used to sort grids that are not subdomains in
+            # the mixed-dimensional grid, this is not the intended use case. Therefore,
+            # we raise an error if the mixed-dimensional grid is empty, but the grid
+            # list is not. To remove this restriction, one could by default convert the
+            # iterator of grids into a list, and pick the maximum dimension from the
+            # list of grids, instead of using ``self.dim_max()``..
+            assert len([g for g in grids]) == 0
+            return np.array([], dtype=int)
+
         # Traverse dimensions in descending order. Progress to 0 in case dim_min is
         # greater than minimum dimension of interface grids.
         for dim in np.arange(self.dim_max(), -1, -1):
@@ -802,10 +818,16 @@ class MixedDimensionalGrid:
     def dim_min(self) -> int:
         """Get the minimal dimension represented in the mixed-dimensional grid.
 
+        Raises:
+            ValueError: If the mixed-dimensional grid has no subdomains.
+
         Returns:
             Minimum dimension of the grids present in the hierarchy.
 
         """
+        if len(self._subdomain_data) == 0:
+            raise ValueError("The mixed-dimensional grid has no subdomains.")
+
         # Access protected attribute instead of subdomains() to avoid sorting, which can
         # lead to a recursion error.
         return np.min([sd.dim for sd in self._subdomain_data.keys()])
@@ -813,10 +835,16 @@ class MixedDimensionalGrid:
     def dim_max(self) -> int:
         """Get the maximal dimension represented in the grid.
 
+        Raises:
+            ValueError: If the mixed-dimensional grid has no subdomains.
+
         Returns:
             Maximum dimension of the grids present in the hierarchy.
 
         """
+        if len(self._subdomain_data) == 0:
+            raise ValueError("The mixed-dimensional grid has no subdomains.")
+
         # Access protected attribute instead of subdomains() to avoid sorting, which can
         # lead to a recursion error.
         return max([sd.dim for sd in self._subdomain_data.keys()])

--- a/src/porepy/models/material_constants.py
+++ b/src/porepy/models/material_constants.py
@@ -113,7 +113,8 @@ class MaterialConstants:
         # Make a copy of the value to avoid modifying the original.
         # This is not strictly necessary for scalars, but is done in case the method is
         # used for arrays.
-        value = value.copy() if hasattr(value, "copy") else value
+        if isinstance(value, np.ndarray):
+            value = value.copy()
         # Trim any spaces
         units = units.replace(" ", "")
         if units in ["", "1", "-"]:

--- a/src/porepy/numerics/ad/equation_manager.py
+++ b/src/porepy/numerics/ad/equation_manager.py
@@ -10,12 +10,11 @@ import numpy as np
 import scipy.sparse as sps
 
 import porepy as pp
+from porepy.utils.porepy_types import GridLike
 
 from . import _ad_utils, operators
 
 __all__ = ["EquationManager"]
-
-GridLike = Union[pp.Grid, pp.MortarGrid]
 
 
 class EquationManager:

--- a/src/porepy/numerics/ad/operators.py
+++ b/src/porepy/numerics/ad/operators.py
@@ -14,6 +14,7 @@ import numpy as np
 import scipy.sparse as sps
 
 import porepy as pp
+from porepy.utils.porepy_types import GridLike
 
 from . import _ad_utils
 from .forward_mode import AdArray, initAdArrays
@@ -28,8 +29,6 @@ __all__ = [
     "MixedDimensionalVariable",
     "sum_operator_list",
 ]
-
-GridLike = Union[pp.Grid, pp.MortarGrid]
 
 
 def _get_shape(mat):

--- a/src/porepy/numerics/mixed_dim/dof_manager.py
+++ b/src/porepy/numerics/mixed_dim/dof_manager.py
@@ -3,19 +3,18 @@
 from __future__ import annotations
 
 import itertools
-from typing import Literal, Optional, Sequence, TypeVar, Union
+from typing import Literal, Optional, Sequence, TypeVar
 
 import numpy as np
 import scipy.sparse as sps
 
 import porepy as pp
+from porepy.utils.porepy_types import GridLike
 
 csc_or_csr_matrix = TypeVar("csc_or_csr_matrix", sps.csc_matrix, sps.csr_matrix)
 
 
 __all__ = ["DofManager"]
-
-GridLike = Union[pp.Grid, pp.MortarGrid]
 
 
 class DofManager:

--- a/tests/unit/test_equation_system.py
+++ b/tests/unit/test_equation_system.py
@@ -22,6 +22,7 @@ To be tested:
 
 """
 import numpy as np
+from porepy.grids.standard_grids.md_grids_2d import single_horizontal
 import pytest
 import scipy.sparse as sps
 
@@ -36,7 +37,8 @@ def test_variable_creation():
 
     Also tested is the methods num_dofs() and partly dofs_of()
     """
-    mdg, _ = pp.grids.standard_grids.md_grids_2d.single_horizontal(simplex=False)
+
+    mdg, _ = single_horizontal(simplex=False)
 
     sys_man = pp.ad.EquationSystem(mdg)
 
@@ -116,9 +118,18 @@ def test_variable_creation():
         sys_man.num_dofs() == ndof_subdomains + ndof_single_subdomain + ndof_interface
     )
 
+    # Check that the variables registered in the boundary data storage.
+    for bg, data in mdg.boundaries(return_data=True):
+        assert subdomain_variable.name in data
+        assert interface_variable.name not in data
+        if mdg.boundary_grid_to_subdomain(bg) == single_subdomain[0]:
+            assert single_subdomain_variable.name in data
+        else:
+            assert single_subdomain_variable.name not in data
+
 
 def test_variable_tags():
-    mdg, _ = pp.grids.standard_grids.md_grids_2d.single_horizontal(simplex=False)
+    mdg, _ = single_horizontal(simplex=False)
 
     sys_man = pp.ad.EquationSystem(mdg)
 

--- a/tests/unit/test_equation_system.py
+++ b/tests/unit/test_equation_system.py
@@ -118,7 +118,7 @@ def test_variable_creation():
         sys_man.num_dofs() == ndof_subdomains + ndof_single_subdomain + ndof_interface
     )
 
-    # Check that the variables registered in the boundary data storage.
+    # Check that the variables are registered in the boundary data storage.
     for bg, data in mdg.boundaries(return_data=True):
         assert subdomain_variable.name in data
         assert interface_variable.name not in data

--- a/tests/unit/test_equation_system.py
+++ b/tests/unit/test_equation_system.py
@@ -120,12 +120,12 @@ def test_variable_creation():
 
     # Check that the variables are registered in the boundary data storage.
     for bg, data in mdg.boundaries(return_data=True):
-        assert subdomain_variable.name in data
-        assert interface_variable.name not in data
-        if mdg.boundary_grid_to_subdomain(bg) == single_subdomain[0]:
-            assert single_subdomain_variable.name in data
+        assert subdomain_variable.name in data[pp.TIME_STEP_SOLUTIONS]
+        assert interface_variable.name not in data[pp.TIME_STEP_SOLUTIONS]
+        if bg.parent == single_subdomain[0]:
+            assert single_subdomain_variable.name in data[pp.TIME_STEP_SOLUTIONS]
         else:
-            assert single_subdomain_variable.name not in data
+            assert single_subdomain_variable.name not in data[pp.TIME_STEP_SOLUTIONS]
 
 
 def test_variable_tags():

--- a/tests/unit/test_grid.py
+++ b/tests/unit/test_grid.py
@@ -767,7 +767,7 @@ def test_boundary_grid():
     g.compute_geometry()
 
     boundary_grid = pp.BoundaryGrid(g)
-    boundary_grid.compute_geometry()
+    boundary_grid.set_projections()
 
     # Hardcoded value for the number of cells
     assert boundary_grid.num_cells == 8
@@ -785,7 +785,7 @@ def test_boundary_grid():
     # The boundary grid should then be empty.
     g.tags["domain_boundary_faces"] = np.zeros(g.num_faces, dtype=bool)
     boundary_grid = pp.BoundaryGrid(g)
-    boundary_grid.compute_geometry()
+    boundary_grid.set_projections()
     assert boundary_grid.num_cells == 0
     assert boundary_grid.projection.shape == (0, 12)
 

--- a/tests/unit/test_grid.py
+++ b/tests/unit/test_grid.py
@@ -524,7 +524,9 @@ class TestStructuredTetrahedralGrid(unittest.TestCase):
         g.compute_geometry()
         self.g = g
 
-        # The ordering of faces may differ depending on the test system (presumably version of scipy or similar). Below are hard-coded combination of face-nodes, and the corresponding faces and face_areas.
+        # The ordering of faces may differ depending on the test system (presumably
+        # version of scipy or similar). Below are hard-coded combination of face-nodes,
+        # and the corresponding faces and face_areas.
         self.fn = np.array(
             [
                 [0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 3, 3, 3, 4, 5],

--- a/tests/unit/test_grid.py
+++ b/tests/unit/test_grid.py
@@ -765,6 +765,7 @@ def test_boundary_grid():
     g.compute_geometry()
 
     boundary_grid = pp.BoundaryGrid(g)
+    boundary_grid.compute_geometry()
 
     # Hardcoded value for the number of cells
     assert boundary_grid.num_cells == 8
@@ -782,6 +783,7 @@ def test_boundary_grid():
     # The boundary grid should then be empty.
     g.tags["domain_boundary_faces"] = np.zeros(g.num_faces, dtype=bool)
     boundary_grid = pp.BoundaryGrid(g)
+    boundary_grid.compute_geometry()
     assert boundary_grid.num_cells == 0
     assert boundary_grid.projection.shape == (0, 12)
 

--- a/tests/unit/test_md_grid.py
+++ b/tests/unit/test_md_grid.py
@@ -41,12 +41,6 @@ class MockGrid(pp.CartGrid):
         return self.box
 
 
-class MockMortarGrid:
-    def __init__(self, dim, side_grids):
-        self.dim = dim
-        self.side_grids = side_grids
-
-
 def mock_mortar_grid(sd_primary: pp.Grid, sd_secondary: pp.Grid) -> pp.MortarGrid:
     """Construct mock mortar grid.
 
@@ -76,7 +70,6 @@ def mock_mortar_grid(sd_primary: pp.Grid, sd_secondary: pp.Grid) -> pp.MortarGri
     )  # (([1], ([0], [0])), shape=(shape_0, sd_secondary.num_cells))
     mg = pp.MortarGrid(sd_secondary.dim, {"left": sd_secondary}, primary_secondary=map)
     return mg
-    # return MockMortarGrid(sd_secondary.dim, {"left": sd_primary, "right": sd_secondary})
 
 
 class TestMixedDimensionalGrid(unittest.TestCase):
@@ -88,11 +81,23 @@ class TestMixedDimensionalGrid(unittest.TestCase):
         return mdg
 
     # ----- Tests of adding nodes and edges ----- #
-    def test_add_subdomains(self):
+    def test_add_remove_subdomains(self):
         # Simply add grid. Should work.
         mdg = pp.MixedDimensionalGrid()
         mdg.add_subdomains(MockGrid())
         mdg.add_subdomains(MockGrid())
+
+        # Check that they are stored.
+        subdomains = mdg.subdomains()
+        assert len(subdomains) == 2
+        assert len(mdg.boundaries()) == 2, "Boundary grids must be created."
+
+        # Check removal.
+        for sd in subdomains:
+            mdg.remove_subdomain(sd)
+
+        assert len(mdg.subdomains()) == 0
+        assert len(mdg.boundaries()) == 0
 
     def test_add_subdomains_same_grid_twice(self):
         # Add the same grid twice. Should raise an exception
@@ -279,8 +284,32 @@ class TestMixedDimensionalGrid(unittest.TestCase):
         self.assertTrue(sd_pair_43[0] == sd_4)  # First because of dimension
         self.assertTrue(sd_pair_43[1] == sd_3)
 
+    def test_subdomain_to_boundary_grid(self) -> None:
+        """Test the methods `subdomain_to_boundary_grid` and
+        `boundary_grid_to_subdomain`.
+
+        """
+        _, _, _, mdg, sd_1d_0, sd_1d_1, sd_2d, sd_3d = self.mdg_dims_3211()
+
+        # First, check the mapping for the present subdomains and boundaries.
+        bg = mdg.subdomain_to_boundary_grid(sd_3d)
+        assert bg is not None
+        assert bg.dim == 2, "Subdomain is 3D, boundary must be 2D."
+
+        result_sd = mdg.boundary_grid_to_subdomain(bg)
+        assert result_sd is not None
+        assert result_sd is sd_3d, "Must be the same object."
+
+        # Next, check the grids which are not present in the mdg.
+        unwanted_sd = MockGrid(3)
+        unwanted_bg = pp.BoundaryGrid(unwanted_sd)
+        bg_or_none = mdg.subdomain_to_boundary_grid(unwanted_sd)
+        assert bg_or_none is None
+        sd_or_none = mdg.boundary_grid_to_subdomain(unwanted_bg)
+        assert sd_or_none is None
+
     # ------ Test of iterators ------*
-    def test_subdomain_and_interface_iterators(self):
+    def test_subdomain_interface_boundary_iterators(self):
         mdg = pp.MixedDimensionalGrid()
         sd_1 = MockGrid(1)
         sd_2 = MockGrid(2)
@@ -293,33 +322,91 @@ class TestMixedDimensionalGrid(unittest.TestCase):
         mdg.add_interface(intf_12, [sd_1, sd_2], None)
         mdg.add_interface(intf_32, [sd_2, sd_3], None)
 
-        # First test traversal by gb.__iter__
+        # First, use the subdomains() function
         found = {sd_1: False, sd_2: False, sd_3: False}
         for sd in mdg.subdomains():
             found[sd] = True
-        self.assertTrue(all([v for v in list(found.values())]))
+        assert all(found.values())
 
-        # Next, use the subdomains() function
-        found = {sd_1: False, sd_2: False, sd_3: False}
-        for sd in mdg.subdomains():
-            found[sd] = True
-        self.assertTrue(all([v for v in list(found.values())]))
-
-        # Finally, check the interfaces
+        # Next, check the interfaces
         found = {intf_12: False, intf_32: False}
         for intf in mdg.interfaces():
             found[intf] = True
-        self.assertTrue(all([v for v in list(found.values())]))
+        assert all(found.values())
+
+        # Finally, check the boundaries
+        parent_grids_found = {sd_1: False, sd_2: False, sd_3: False}
+        for bg in mdg.boundaries():
+            parent_sd = mdg.boundary_grid_to_subdomain(bg)
+            parent_grids_found[parent_sd] = True
+        assert all(parent_grids_found.values())
+
+    def test_iterators_dim_keyword(self):
+        mdg = pp.MixedDimensionalGrid()
+        sd_1 = MockGrid(1)
+        sd_2 = MockGrid(2)
+        sd_3 = MockGrid(3)
+        sd_4 = MockGrid(2)
+        for sd in [sd_1, sd_2, sd_3, sd_4]:
+            mdg.add_subdomains(sd)
+
+        intf_12 = mock_mortar_grid(sd_2, sd_1)
+        intf_32 = mock_mortar_grid(sd_3, sd_2)
+        all_interfaces = set([intf_12, intf_32])
+        mdg.add_interface(intf_12, [sd_1, sd_2], None)
+        mdg.add_interface(intf_32, [sd_2, sd_3], None)
+
+        # First, use the subdomains() function
+        found = {sd_2: False, sd_4: False}
+        for sd in mdg.subdomains(dim=2):
+            found[sd] = True
+        assert all(found.values())
+
+        # Next, use the interfaces() function
+        found = {intf_32: False}
+        for intf in mdg.interfaces(dim=2):
+            found[intf] = True
+        assert all(found.values())
+
+        # Finally, use the boundaries() function
+        found_parent_grid = {sd_2: False, sd_4: False}
+        for bg in mdg.boundaries(dim=1):
+            parent_sd = mdg.boundary_grid_to_subdomain(bg)
+            found_parent_grid[parent_sd] = True
+
+        assert all(found_parent_grid.values())
+
+    def test_data_getters(self) -> None:
+        """Check methods `boundary_grid_data`, `interface_data` and `subdomain_data."""
+        _, _, _, mdg, _, _, _, _ = self.mdg_dims_3211()
+
+        # First, check subdomains.
+        for sd, data_from_iterator in mdg.subdomains(return_data=True):
+            data_from_getter = mdg.subdomain_data(sd)
+            assert isinstance(data_from_iterator, dict), "Must be initialized."
+            assert data_from_iterator is data_from_getter, "Must be the same object."
+
+        # Next, check interfaces.
+        for intf, data_from_iterator in mdg.interfaces(return_data=True):
+            data_from_getter = mdg.interface_data(intf)
+            assert isinstance(data_from_iterator, dict), "Must be initialized."
+            assert data_from_iterator is data_from_getter, "Must be the same object."
+
+        # Finally, check boundaries.
+        for bg, data_from_iterator in mdg.boundaries(return_data=True):
+            data_from_getter = mdg.boundary_grid_data(bg)
+            assert isinstance(data_from_iterator, dict), "Must be initialized."
+            assert data_from_iterator is data_from_getter, "Must be the same object."
 
     def test_contains_subdomain(self):
         mdg = self.simple_mdg(1)
 
         for sd in mdg.subdomains():
-            self.assertTrue(sd in mdg.subdomains())
+            assert sd in mdg
 
         # Define a grid that is not in the mdg
         sd = MockGrid()
-        self.assertTrue(not sd in mdg.subdomains())
+        assert sd not in mdg
 
     def test_contains_interface(self):
         mdg = pp.MixedDimensionalGrid()
@@ -333,10 +420,19 @@ class TestMixedDimensionalGrid(unittest.TestCase):
         mdg.add_interface(intf_12, [sd_1, sd_2], None)
 
         # This edge is defined
-        self.assertTrue(intf_12 in mdg.interfaces())
+        assert intf_12 in mdg
         # this is not
         intf_31 = mock_mortar_grid(sd_3, sd_1)
-        self.assertFalse(intf_31 in mdg.interfaces())
+        assert intf_31 not in mdg
+
+    def test_contains_boundary_grid(self) -> None:
+        mdg = self.simple_mdg(2)
+        for bg in mdg.boundaries():
+            assert bg in mdg
+
+        # Creating new boundary outside mdg.
+        bg = pp.BoundaryGrid(mdg.subdomains()[0])
+        assert bg not in mdg
 
     def test_diameter(self):
         sd_1 = MockGrid(1, 2)
@@ -364,7 +460,6 @@ class TestMixedDimensionalGrid(unittest.TestCase):
         self.assertTrue(np.allclose(bmax, sd_2.nodes.max(axis=1)))
 
     def test_num_cells(self):
-
         sd_1 = MockGrid(dim=1, num_cells=1, num_faces=3, num_nodes=3)
         sd_2 = MockGrid(dim=2, num_cells=3, num_faces=7, num_nodes=3)
         mdg = pp.MixedDimensionalGrid()
@@ -391,15 +486,12 @@ class TestMixedDimensionalGrid(unittest.TestCase):
         self.assertTrue(mdg.num_subdomains() == 3)
 
     def test_str_repr(self):
-
         sd_1 = MockGrid(dim=1, num_cells=1, num_faces=3, num_nodes=3)
         sd_2 = MockGrid(dim=2, num_cells=3, num_faces=7, num_nodes=3)
         mdg = pp.MixedDimensionalGrid()
         mdg.add_subdomains([sd_1, sd_2])
         mdg.__str__()
         mdg.__repr__()
-
-    # ------------ Tests for removers
 
 
 def test_pickle_md_grid():

--- a/tests/unit/test_md_grid.py
+++ b/tests/unit/test_md_grid.py
@@ -342,6 +342,11 @@ class TestMixedDimensionalGrid(unittest.TestCase):
         assert all(parent_grids_found.values())
 
     def test_iterators_dim_keyword(self):
+        """Check that the iterators `subdomains`, `interfaces` and `boundaries`
+        return only the grids of the right dimension when the argument `dim` is
+        provided.
+        
+        """
         mdg = pp.MixedDimensionalGrid()
         sd_1 = MockGrid(1)
         sd_2 = MockGrid(2)
@@ -352,26 +357,26 @@ class TestMixedDimensionalGrid(unittest.TestCase):
 
         intf_12 = mock_mortar_grid(sd_2, sd_1)
         intf_32 = mock_mortar_grid(sd_3, sd_2)
-        all_interfaces = set([intf_12, intf_32])
         mdg.add_interface(intf_12, [sd_1, sd_2], None)
         mdg.add_interface(intf_32, [sd_2, sd_3], None)
 
-        # First, use the subdomains() function
+        # First, use the subdomains(dim=2) function
         found = {sd_2: False, sd_4: False}
         for sd in mdg.subdomains(dim=2):
             found[sd] = True
         assert all(found.values())
 
-        # Next, use the interfaces() function
+        # Next, use the interfaces(dim=2) function
         found = {intf_32: False}
         for intf in mdg.interfaces(dim=2):
             found[intf] = True
         assert all(found.values())
 
-        # Finally, use the boundaries() function
+        # Finally, use the boundaries(dim=1) function
         found_parent_grid = {sd_2: False, sd_4: False}
         for bg in mdg.boundaries(dim=1):
             parent_sd = mdg.boundary_grid_to_subdomain(bg)
+            assert parent_sd is not None
             found_parent_grid[parent_sd] = True
 
         assert all(found_parent_grid.values())

--- a/tests/unit/test_md_grid.py
+++ b/tests/unit/test_md_grid.py
@@ -285,8 +285,8 @@ class TestMixedDimensionalGrid(unittest.TestCase):
         self.assertTrue(sd_pair_43[1] == sd_3)
 
     def test_subdomain_to_boundary_grid(self) -> None:
-        """Test the methods `subdomain_to_boundary_grid` and
-        `boundary_grid_to_subdomain`.
+        """Test the method `subdomain_to_boundary_grid`. Also test restoring
+        a subdomain from its boundary grid.
 
         """
         _, _, _, mdg, sd_1d_0, sd_1d_1, sd_2d, sd_3d = self.mdg_dims_3211()
@@ -296,17 +296,13 @@ class TestMixedDimensionalGrid(unittest.TestCase):
         assert bg is not None
         assert bg.dim == 2, "Subdomain is 3D, boundary must be 2D."
 
-        result_sd = mdg.boundary_grid_to_subdomain(bg)
-        assert result_sd is not None
+        result_sd = bg.parent
         assert result_sd is sd_3d, "Must be the same object."
 
         # Next, check the grids which are not present in the mdg.
         unwanted_sd = MockGrid(3)
-        unwanted_bg = pp.BoundaryGrid(unwanted_sd)
         bg_or_none = mdg.subdomain_to_boundary_grid(unwanted_sd)
         assert bg_or_none is None
-        sd_or_none = mdg.boundary_grid_to_subdomain(unwanted_bg)
-        assert sd_or_none is None
 
     # ------ Test of iterators ------*
     def test_subdomain_interface_boundary_iterators(self):
@@ -337,7 +333,7 @@ class TestMixedDimensionalGrid(unittest.TestCase):
         # Finally, check the boundaries
         parent_grids_found = {sd_1: False, sd_2: False, sd_3: False}
         for bg in mdg.boundaries():
-            parent_sd = mdg.boundary_grid_to_subdomain(bg)
+            parent_sd = bg.parent
             parent_grids_found[parent_sd] = True
         assert all(parent_grids_found.values())
 
@@ -345,7 +341,7 @@ class TestMixedDimensionalGrid(unittest.TestCase):
         """Check that the iterators `subdomains`, `interfaces` and `boundaries`
         return only the grids of the right dimension when the argument `dim` is
         provided.
-        
+
         """
         mdg = pp.MixedDimensionalGrid()
         sd_1 = MockGrid(1)
@@ -375,8 +371,7 @@ class TestMixedDimensionalGrid(unittest.TestCase):
         # Finally, use the boundaries(dim=1) function
         found_parent_grid = {sd_2: False, sd_4: False}
         for bg in mdg.boundaries(dim=1):
-            parent_sd = mdg.boundary_grid_to_subdomain(bg)
-            assert parent_sd is not None
+            parent_sd = bg.parent
             found_parent_grid[parent_sd] = True
 
         assert all(found_parent_grid.values())

--- a/tests/unit/test_mortars.py
+++ b/tests/unit/test_mortars.py
@@ -1,5 +1,5 @@
 """Tests of the mortar grids. Mainly focuses on mappings between mortar grids and
-surrounding grids. 
+surrounding grids.
 
 The module contains the following groups of tests:
 
@@ -600,40 +600,40 @@ class MockGrid:
 
 
 class TestReplace1dand2dGridsIn3dDomain(unittest.TestCase):
-    """Various tests for replacing subdomain and interface grids in a 3d mixed-dimensional
-    grid.
+    """Various tests for replacing subdomain and interface grids in a 3d mixed-
+    dimensional grid.
 
     The grid consists of the following components:
         A 3d grid, which is intersected by a fracture at y=0. On each side of this plane
-        the grid has 5 nodes (four of them along y=0, the fifth is at y=+-1) and two cells.
-        Most importantly, each side (above and below y=0) has two faces at y=0, one
-        with node coordinates {(0, 0), (1, 0), (1, 1)}, the other with {(0, 0), (1, 1), (0, 1)}.
-        The node at (1, 1) will in some cases be perturbed to (1, 2) (if pert=True),
-        besides this, the 3d grid is not changed in the tests, and really not that
-        important.
+        the grid has 5 nodes (four of them along y=0, the fifth is at y=+-1) and two
+        cells. Most importantly, each side (above and below y=0) has two faces at y=0,
+        one with node coordinates {(0, 0), (1, 0), (1, 1)}, the other with
+        {(0, 0), (1, 1), (0, 1)}. The node at (1, 1) will in some cases be perturbed to
+        (1, 2) (if pert=True), besides this, the 3d grid is not changed in the tests,
+        and really not that important.
 
         A 2d grid, which is located at y=0. Two versions of this grid can be generated:
             1) One with four nodes, at {(0, 0), (1, 0), (1, 1), (0, 1)} - the third node
-               is moved to (1, 2) if pert=True - and two cells formed by the sets of nodes
-               {(0, 0), (1, 0), (1, 1)} and {(0, 0), (1, 1), (0, 1)}.
+               is moved to (1, 2) if pert=True - and two cells formed by the sets of
+               nodes {(0, 0), (1, 0), (1, 1)} and {(0, 0), (1, 1), (0, 1)}.
             2) One with five nodes, at {(0, 0), (1, 0), (1, 1), (0, 1), (0.5, 0.5)}, and
-               four cells formed by the midle node and pairs of neighboring nodes on the sides.
-               Again, pert=True will move the node (1, 1), but it this case, it will also
-               move the midle node to (0.5, 1) to ensure it stays on the line between
-               (0, 0) and now (1, 2) - or else the 1d grid defined below will not conform
-               to the 2d faces.
+               four cells formed by the midle node and pairs of neighboring nodes on the
+               sides. Again, pert=True will move the node (1, 1), but it this case, it
+               will also move the midle node to (0.5, 1) to ensure it stays on the line
+               between (0, 0) and now (1, 2) - or else the 1d grid defined below will
+               not conform to the 2d faces.
         Several of the tests below consists of replacing the 2d grid with two cells with
         that with four cells, and ensure all mappings are correct.
 
         A 1d grid that extends from (0, 0) to (1, 1) (or (1, 2) if pert=True).
 
-        At the 3d-2d and 2d-1d interfaces, there are of course mortar grids that will have
-        their mappings updated as the adjacent subdomain grids are replaced.
+        At the 3d-2d and 2d-1d interfaces, there are of course mortar grids that will
+        have their mappings updated as the adjacent subdomain grids are replaced.
 
-    IMPLEMENTATION NOTE: When perturbing the grid (moving (1, 1) -> (1, 2)), several updates
-    of the grid geometry are hardcoded, like cell centers, face normals etc. This is messy,
-    and a more transparent approach would have been preferrable, but it will have to do
-    for now.
+    IMPLEMENTATION NOTE: When perturbing the grid (moving (1, 1) -> (1, 2)), several
+    updates of the grid geometry are hardcoded, like cell centers, face normals etc.
+    This is messy, and a more transparent approach would have been preferrable, but it
+    will have to do for now.
 
     """
 
@@ -797,7 +797,6 @@ class TestReplace1dand2dGridsIn3dDomain(unittest.TestCase):
         return g
 
     def grid_2d_two_cells(self, pert=False):
-
         n = np.array(
             [[0, 0, 0], [1, 0, 0], [1, 0, 1], [0, 0, 0], [1, 0, 1], [0, 0, 1]]
         ).T
@@ -842,7 +841,6 @@ class TestReplace1dand2dGridsIn3dDomain(unittest.TestCase):
         return g
 
     def grid_2d_two_cells_no_1d(self, pert=False):
-
         n = np.array([[0, 0, 0], [1, 0, 0], [1, 0, 1], [0, 0, 1]]).T
         if pert:
             n[2, 2] = 2
@@ -974,7 +972,6 @@ class TestReplace1dand2dGridsIn3dDomain(unittest.TestCase):
         return g
 
     def grid_2d_four_cells_no_1d(self, pert=False):
-
         n = np.array([[0, 0, 0], [1, 0, 0], [1, 0, 1], [0, 0, 1], [0.5, 0, 0.5]]).T
         if pert:
             n[2, 2] = 2


### PR DESCRIPTION
## Proposed changes

This PR closes #903. It adds several methods to the mdg in order to work with boundary grids in the same manner as we work with subdomains and interfaces. Some things to notice:

It changes the place of creation of the boundary grids. Previously, they were created outside the mdg, in the function `subdomains_to_mdg`. Now they are created inside the class in order to maintain the agreement between the subdomains and their boundary grids. Thus, if the subdomain is registered in the mdg, the corresponding boundary grid is created automatically. The same applies to subdomain removal. The subdomain can be changed in the process of creation, for instance, when two intersecting fractures are divided. To avoid inconsistency, I added the method `compute_geometry` to the boundary grid, which fetches the data from the parent subdomain. It is called in the mdg only after the call to `compute_geometry` of the subdomains. At that point, all the changes must be made.

I covered the new functionality with new tests and modified some oldtests. In those tests that I modified, I updated the style from `unittest` to `pytest`, as we are leaning towards the latter.

Before the PR, the `BoundaryGrid` class was inherited from `Grid`, which was subject to change according to the note in the docstring. I discarded this inheritance and restored the lacking features. Luckily, there were not many of them: 
* Tracking the id. Now the ids of boundary grids are separate from the subdomain ids, the same as for interface ids.
* Ability to sort grids with `mdg.argsort_grids`. I changed the method signature to support this.

The latter change may suggest us to append `BoundaryGrid` to the `GridLike` type. I did not do it now, because `BoundaryGrid` lacks several attributes, such as `num_faces`. But from what I see now, it can be a good generalization when we start updating the AD in order to support boundary grids.

I removed several redeclarations of `GridLike`. Now they all reference one declaration.

I initialize the data storage of boundary grids at the same place as it is done for the other grid types - in the `EquationSystem.create_variable`. However, since boundary variables will not be the actual variables, I do not create ITERATEs and STATEs for them. Instead, I set an empty dict for each variable as a placeholder. Maybe when we start implementing boundary grid variables, it will be more clear how to store the values.

I changed the line `pp.grids.standard_grids.md_grids_2d.single_horizontal` to just `single_horizontal` and added the proper import to satisfy vscode type checker. Not sure why it can not resolve it how it was.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Testing (contribution related to testing of existing or new functionality).
- [x] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
