### PR TITLE
bug fix 0d grid for rt0 and mvem

### DIFF
--- a/src/porepy/numerics/fem/rt0.py
+++ b/src/porepy/numerics/fem/rt0.py
@@ -53,7 +53,7 @@ class RT0(DualElliptic):
             matrix_dictionary[self.div_matrix_key] = sps.csr_matrix(
                 (sd.num_faces, sd.num_cells)
             )
-            matrix_dictionary[self.vector_proj_key] = sps.csr_matrix((3, sd.num_cells))
+            matrix_dictionary[self.vector_proj_key] = sps.csr_matrix((3, 0))
             return
 
         # Get dictionary for parameter storage

--- a/src/porepy/numerics/vem/mvem.py
+++ b/src/porepy/numerics/vem/mvem.py
@@ -62,7 +62,7 @@ class MVEM(DualElliptic):
             matrix_dictionary[self.div_matrix_key] = sps.csr_matrix(
                 (sd.num_faces, sd.num_cells)
             )
-            matrix_dictionary[self.vector_proj_key] = sps.csr_matrix((3, sd.num_cells))
+            matrix_dictionary[self.vector_proj_key] = sps.csr_matrix((3, 0))
             return
 
         # Get dictionary for parameter storage


### PR DESCRIPTION
bug fix 0d grid for rt0 (and mvem), the vector projector should be of size (3, 0) since no vector dofs are associated to a 0d grid.

## Proposed changes

Contributions to PorePy are highly appreciated. Clearly explain why this pull request (PR) is needed and why it should be accepted. If this PR solves an issue, explain how it is done. Please, also summarise the changes to the code.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ X] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [X ] The documentation is up-to-date.
- [X ] Static typing is included in the update.
- [X ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
