### PR TITLE
Estimate order of convergence for a subset of data points

### DIFF
--- a/tests/unit/test_convergence_analysis.py
+++ b/tests/unit/test_convergence_analysis.py
@@ -688,6 +688,46 @@ class TestOrderOfConvergence:
         np.testing.assert_almost_equal(ooc["ooc_var_0"], 1.0, decimal=10)
         np.testing.assert_almost_equal(ooc["ooc_var_1"], 2.0, decimal=10)
 
+    def test_order_of_convergence_with_reduced_range(
+            self,
+            stationary_mock_model,
+    ) -> None:
+        """Test order of convergence for a subset of the data.
+
+        Parameters:
+            stationary_mock_model: Stationary mock model.
+
+        """
+        @dataclass
+        class MockDataClass:
+            """Minimal data class to save error and cell diameter."""
+            error_var: float
+            cell_diameter: float
+
+        # Create convergence analysis object
+        conv = ConvergenceAnalysis(
+            model_class=stationary_mock_model,
+            model_params={},
+            levels=4,
+            spatial_refinement_rate=2,
+        )
+
+        # Set linear convergence only for the last two levels
+        results = [
+            MockDataClass(error_var=42, cell_diameter=1.0),
+            MockDataClass(error_var=np.pi, cell_diameter=0.5),
+            MockDataClass(error_var=1.0, cell_diameter=0.25),
+            MockDataClass(error_var=0.5, cell_diameter=0.125),
+        ]
+
+        # Order of convergence for the reduced range (last two levels) should be 1.0
+        ooc_reduced_range = conv.order_of_convergence(
+            list_of_results=results,
+            data_range=slice(-2, None, None),
+        )
+
+        assert np.isclose(ooc_reduced_range["ooc_var"], 1.0, 1e-10)
+
 
 # -----> TEST: The `export_errors_to_txt` method.
 class TestExportErrors:


### PR DESCRIPTION
## Proposed changes

This PR extends the signature of the `order_of_convergence()` method from the `ConvergenceAnalysis` class with the optional parameter `data_range: slice`. Now, it is possible to select a subset of the data points to estimate the order of convergence by setting a data range as a slice. By default, all points are used. This PR solves #912. A unit test for the new functionality has been added. See #912 for the motivation of the requested feature. 

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Testing (contribution related to testing of existing or new functionality).
- [x] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
