### PR TITLE
Feat prune tree

### DIFF
--- a/src/porepy/numerics/ad/equation_system.py
+++ b/src/porepy/numerics/ad/equation_system.py
@@ -1258,9 +1258,9 @@ class EquationSystem:
             discr: list storing found discretizations
 
         """
-        if len(operator.tree.children) > 0:
+        if len(operator.children) > 0:
             # Go further in recursion
-            for child in operator.tree.children:
+            for child in operator.children:
                 discr += EquationSystem._recursive_discretization_search(child, list())
 
         if isinstance(operator, _ad_utils.MergedOperator):

--- a/src/porepy/numerics/ad/operator_functions.py
+++ b/src/porepy/numerics/ad/operator_functions.py
@@ -85,7 +85,7 @@ class AbstractFunction(Operator):
 
         super().__init__(name=name, operation=Operator.Operations.evaluate)
 
-    def __call__(self, *args: pp.ad.Operator | AdArray) -> pp.ad.Operator:
+    def __call__(self, *args: pp.ad.Operator) -> pp.ad.Operator:
         """Renders this function operator callable, fulfilling its notion as 'function'.
 
         Parameters:
@@ -98,15 +98,7 @@ class AbstractFunction(Operator):
 
         """
         children = [self, *args]
-
-        # There is an issue with typing here. All the other places assume that children
-        # are pp.ad.Operator and never check if they are AdArray. Pypy complains a lot
-        # about that in "operator.py", but for some reason it never fails. Setting the
-        # type of children to only pp.ad.Operator silences pypy, now it complains only
-        # here. The proper solution is to refactor the operator.py so that it would take
-        # into the account that children can be of type AdArray. Until it is not done,
-        # I leave type: ignore here for now.
-        op = Operator(children=children, operation=self.operation)  # type: ignore
+        op = Operator(children=children, operation=self.operation)
         return op
 
     def __repr__(self) -> str:

--- a/src/porepy/numerics/ad/operators.py
+++ b/src/porepy/numerics/ad/operators.py
@@ -58,8 +58,10 @@ class Operator:
         interfaces (optional): List of interfaces in the mixed-dimensional grid on which
             the operator is defined. Will be empty for operators not associated with any
             interface. Defaults to None (converted to empty list).
-        tree (optional): The tree structure of child operators. Defaults to None
-            (converted to a tree with a single void operator). TODO
+        operation (optional): Arithmetic or other operation represented by this
+            operator. Defaults to void operation.
+        children (optional): List of children, other AD operators. Defaults to empty
+            list.
 
     """
 
@@ -107,11 +109,15 @@ class Operator:
         """
 
         self.children: Sequence[Operator]
-        """TODO
+        """List of children, other AD operators.
+
+        Will be empty if the operator is a leaf.
         """
 
         self.operation: Operator.Operations
-        """TODO
+        """Arithmetic or other operation represented by this operator.
+
+        Will be void if the operator is a leaf.
         """
 
         self._initialize_children(operation=operation, children=children)
@@ -601,7 +607,7 @@ class Operator:
         nx.draw(G, with_labels=True)
         plt.show()
 
-    ### Operator discretization ---------------------------------------------------------------
+    ### Operator discretization --------------------------------------------------------
     # TODO this is specific to discretizations and should not be done here
     # let the EquationSystem do this by calling respective util methods
 
@@ -643,7 +649,7 @@ class Operator:
 
         return discr
 
-    ### Operator parsing ----------------------------------------------------------------------
+    ### Operator parsing ---------------------------------------------------------------
 
     def evaluate(
         self,

--- a/src/porepy/numerics/ad/operators.py
+++ b/src/porepy/numerics/ad/operators.py
@@ -1850,37 +1850,6 @@ class MixedDimensionalVariable(Variable):
         return s
 
 
-# class Tree:
-#     """Simple implementation of a Tree class. Used to represent combinations of
-#     Ad operators.
-
-#     References:
-#         https://stackoverflow.com/questions/2358045/how-can-i-implement-a-tree-in-python
-
-
-#     Parameters:
-#         operation: See :data:`Operation`
-#         children: List of children, either as Ad arrays or other :class:`Operator`.
-
-#     """
-
-#     def __init__(
-#         self,
-#         operation: Operator.Operations,
-#         children: Optional[Sequence[Union[Operator, AdArray]]] = None,
-#     ):
-#         self.op = operation
-
-#         self.children: list[Union[Operator, AdArray]] = []
-#         if children is not None:
-#             for child in children:
-#                 self.add_child(child)
-
-#     def add_child(self, node: Union[Operator, AdArray]) -> None:
-#         """Adds a child to this instance."""
-#         self.children.append(node)
-
-
 @overload
 def _ad_wrapper(
     vals: Union[pp.number, np.ndarray],

--- a/src/porepy/numerics/ad/operators.py
+++ b/src/porepy/numerics/ad/operators.py
@@ -894,7 +894,6 @@ class Operator:
                     # Effectively, this node is one step from the leaf
                     var_list.append(var)
                 elif isinstance(var, list):
-                    assert False
                     # We are further up in the tree.
                     for sub_var in var:
                         if isinstance(sub_var, Variable):

--- a/tests/unit/ad/test_ad_operator_tree.py
+++ b/tests/unit/ad/test_ad_operator_tree.py
@@ -45,11 +45,10 @@ def test_elementary_operations(operator):
     c = eval(f"a {operator[0]} b")
 
     # Check that the combined operator has the expected structure.
-    tree = c.tree
-    assert tree.op == operator[1]
+    assert c.operation == operator[1]
 
-    assert tree.children[0] == a
-    assert tree.children[1] == b
+    assert c.children[0] == a
+    assert c.children[1] == b
 
 
 def test_copy_operator_tree():
@@ -75,19 +74,19 @@ def test_copy_operator_tree():
 
     # First check that the two copies have behaved as they should.
     # The operators should be the same for all trees.
-    assert c.tree.op == c_copy.tree.op
-    assert c.tree.op == c_deepcopy.tree.op
+    assert c.operation == c_copy.operation
+    assert c.operation == c_deepcopy.operation
 
     # The deep copy should have made a new list of children.
     # The shallow copy should have the same list.
-    assert c.tree.children == c_copy.tree.children
-    assert not c.tree.children == c_deepcopy.tree.children
+    assert c.children == c_copy.children
+    assert not c.children == c_deepcopy.children
 
     # Check that the shallow copy also has the same children, while
     # the deep copy has copied these as well.
-    for c1, c2 in zip(c.tree.children, c_copy.tree.children):
+    for c1, c2 in zip(c.children, c_copy.children):
         assert c1 == c2
-    for c1, c2 in zip(c.tree.children, c_deepcopy.tree.children):
+    for c1, c2 in zip(c.children, c_deepcopy.children):
         assert not c1 == c2
 
     # As a second test, also validate that the operators are parsed correctly.


### PR DESCRIPTION
## Proposed changes

As we discussed with @keileg, `operator.tree` slightly disturbs debugging the ad, so I moved its attributes to the `operator` itself.

The minor changes I made are an attempt to improve annotations:
* I reformatted the creation of the enum `Operator.Operations` so now static type checkers can see the enum entries. Values left the same.
* The other thing I changed is the type of `operator.children` (previously `operator.tree.children`) from `Sequence[Operator | AdArray]` to just `Sequence[Operator]`. All the methods inside operators.py treat children as if they are only operators and not the AdArrays. Everything works fine, but mypy complains about that. I removed AdArrays from the signature [here](https://github.com/pmgbergen/porepy/blob/03d2bfc848f3c2950e60de2caafbba301c298163/src/porepy/numerics/ad/operator_functions.py#L93), because it is never used and is the only place where `operator.children` are possibly initialized with AdArrays.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [x] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
