### PR TITLE
Feat default minimum coordinates

### DIFF
--- a/examples/terzaghi_biot.py
+++ b/examples/terzaghi_biot.py
@@ -507,9 +507,7 @@ class PseudoOneDimensionalColumn(pp.ModelGeometry):
         """A fracture network without fractures."""
 
         # Define the domain
-        domain = pp.Domain(
-            {"xmin": 0, "xmax": self.height(), "ymin": 0, "ymax": self.height()}
-        )
+        domain = pp.Domain({"xmax": self.height(), "ymax": self.height()})
         self._domain = domain
 
     def meshing_arguments(self) -> dict:

--- a/src/porepy/applications/md_grids/domains.py
+++ b/src/porepy/applications/md_grids/domains.py
@@ -25,13 +25,13 @@ def nd_cube_domain(dimension: Literal[2, 3], size=pp.number) -> pp.Domain:
     """
 
     assert dimension in np.arange(2, 4)
-    box: dict[str, pp.number] = {"xmin": 0, "xmax": size}
+    box: dict[str, pp.number] = {"xmax": size}
 
     if dimension > 1:
-        box.update({"ymin": 0, "ymax": size})
+        box.update({"ymax": size})
 
     if dimension > 2:
-        box.update({"zmin": 0, "zmax": size})
+        box.update({"zmax": size})
 
     return pp.Domain(box)
 

--- a/src/porepy/fracs/structured.py
+++ b/src/porepy/fracs/structured.py
@@ -297,10 +297,8 @@ def _create_lower_dim_grids_3d(
             "zmax": np.max(g_3d.nodes[2]),
         }
     else:
+        # Use default 0 for minima.
         box = {
-            "xmin": 0,
-            "ymin": 0,
-            "zmin": 0,
             "xmax": physdims[0],
             "ymax": physdims[1],
             "zmax": physdims[2],

--- a/src/porepy/geometry/domain.py
+++ b/src/porepy/geometry/domain.py
@@ -25,9 +25,13 @@ class Domain:
 
         .. code:: python3
 
-            # Create a domain from a bounding box
+            # Create a domain from a bounding box using default minimum corner (0, 0)
+            domain_from_box_defualt_minima = pp.Domain(
+                bounding_box={"xmax": 1, "ymin": 1}
+            )
+            # Create a domain from a bounding box with a custom minimum corner
             domain_from_box = pp.Domain(
-                bounding_box={"xmin": 0, "xmax": 1, "ymin": 0, "ymin": 1}
+                bounding_box={"xmin": 0, "xmax": 1, "ymin": 0.5, "ymin": 1}
             )
 
             # Create a domain from a 2d-polytope
@@ -45,7 +49,8 @@ class Domain:
 
     Parameters:
         bounding_box: Dictionary containing the minimum and maximum coordinates
-            defining the bounding box of the domain.
+            defining the bounding box of the domain. If not given, the minimum corner
+            is placed at the origin by default.
 
             Expected keywords are ``xmin``, ``xmax``, ``ymin``, ``ymax``, and if 3d,
             ``zmin`` and ``zmax``.
@@ -94,8 +99,9 @@ class Domain:
 
         if bounding_box is not None:
             self.bounding_box = bounding_box
+            self._set_default_minimum_coordinates()
             self.polytope = self.polytope_from_bounding_box()
-            self.dim = bounding_box_dimension(bounding_box)
+            self.dim = bounding_box_dimension(self.bounding_box)
             self.is_boxed = True
         elif polytope is not None:
             self.polytope = polytope
@@ -283,6 +289,13 @@ class Domain:
         bound_planes = [west, east, south, north, bottom, top]
 
         return bound_planes
+
+    def _set_default_minimum_coordinates(self) -> None:
+        """Set default 0 minimum coordinates for the bounding box."""
+        keys = self.bounding_box.keys()
+        for dim in ["x", "y", "z"]:
+            if dim + "min" not in keys and dim + "max" in keys:
+                self.bounding_box[dim + "min"] = 0
 
 
 class DomainSides(NamedTuple):

--- a/src/porepy/models/constitutive_laws.py
+++ b/src/porepy/models/constitutive_laws.py
@@ -747,7 +747,7 @@ class CubicLawPermeability(ConstantPermeability):
 
     equation_system: pp.ad.EquationSystem
     """EquationSystem object for the current model. Normally defined in a mixin class
-    defining the solution strategy.
+    definin the solution strategy.
 
     """
     specific_volume: Callable[

--- a/src/porepy/models/constitutive_laws.py
+++ b/src/porepy/models/constitutive_laws.py
@@ -3317,7 +3317,7 @@ class ThermoPoroMechanicsPorosity(PoroMechanicsPorosity):
     ) -> pp.ad.Operator:
         """Thermal contribution to the changes in porosity [-].
 
-        TODO: Discuss cf. Coussy p. 73. Not sure about the interpretation of alpha_phi.
+        beta_phi = (alpha - phi_ref) * beta_solid according to Coussy Eq. 4.44.
 
         Parameters:
             subdomains: List of subdomains where the porosity is defined.

--- a/src/porepy/models/constitutive_laws.py
+++ b/src/porepy/models/constitutive_laws.py
@@ -746,8 +746,8 @@ class CubicLawPermeability(ConstantPermeability):
     """Cubic law permeability for fractures and intersections."""
 
     equation_system: pp.ad.EquationSystem
-    """EquationSystem object for the current model. Normally defined in a mixin class
-    definin the solution strategy.
+    """EquationSystem object for the current model. Solution strategies are normally
+    defined in a mixin class.
 
     """
     specific_volume: Callable[

--- a/src/porepy/models/run_models.py
+++ b/src/porepy/models/run_models.py
@@ -103,7 +103,7 @@ def run_time_dependent_model(model, params: dict) -> None:
     def time_step() -> None:
         model.time_manager.increase_time()
         model.time_manager.increase_time_index()
-        logger.debug(
+        logger.info(
             f"\nTime step {model.time_manager.time_index} at time"
             + f" {model.time_manager.time:.1e}"
             + f" of {model.time_manager.time_final:.1e}"
@@ -198,7 +198,7 @@ def _run_iterative_model(model, params: dict) -> None:
         model.propagation_index = 0
         model.time_manager.increase_time()
         model.time_manager.increase_time_index()
-        logger.debug(
+        logger.info(
             f"\nTime step {model.time_manager.time_index} at time"
             + f" {model.time_manager.time:.1e} of"
             + f" {model.time_manager.time_final:.1e}"

--- a/src/porepy/utils/default_domains.py
+++ b/src/porepy/utils/default_domains.py
@@ -1,6 +1,4 @@
-"""
-Module for creating standard domain dictionaries.
-"""
+"""Module for creating standard domain dictionaries."""
 from typing import Dict, Sequence, Union
 
 

--- a/tests/integration/test_mdg_generation.py
+++ b/tests/integration/test_mdg_generation.py
@@ -69,10 +69,8 @@ class TestMDGridGeneration:
 
     def domains(self):
         """Domain list"""
-        domain_2d = pp.Domain({"xmin": 0, "xmax": 5, "ymin": 0, "ymax": 5})
-        domain_3d = pp.Domain(
-            {"xmin": 0, "xmax": 5, "ymin": 0, "ymax": 5, "zmin": 0, "zmax": 5}
-        )
+        domain_2d = pp.Domain({"xmax": 5, "ymax": 5})
+        domain_3d = pp.Domain({"xmax": 5, "ymax": 5, "zmax": 5})
         return [domain_2d, domain_3d]
 
     # Extra mesh arguments

--- a/tests/unit/geometry/test_domains.py
+++ b/tests/unit/geometry/test_domains.py
@@ -42,6 +42,13 @@ def test_init(bounding_box, dim):
     if bounding_box:
         # Generate from bounding box
         domain = pp.Domain(bounding_box=known_box)
+        # Generate bounding box without providing min values
+        max_box = {key: val for key, val in known_box.items() if "max" in key}
+        domain_default_min = pp.Domain(bounding_box=max_box)
+        # Check that the two domains are the same
+        assert domain == domain_default_min
+        # Proceed with the rest of the tests for the domain with min values.
+
     else:
         # Generate from polytope
         domain = pp.Domain(polytope=known_polytope)


### PR DESCRIPTION
## Proposed changes

Provide default coordinates for "xmin" etc. when creating a box-shaped domain. For convenience in the very common case that xmin=ymin(=zmin)=0. A full purging of explicit declarations of "xmin": 0 etc. was not performed. I think this can wait for the test overhaul.

I suggest @jhabriel does initial review.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
