### PR TITLE
changed from sps.find to indices

### DIFF
--- a/src/porepy/numerics/fem/rt0.py
+++ b/src/porepy/numerics/fem/rt0.py
@@ -269,7 +269,7 @@ class RT0(DualElliptic):
         # initialize the map
         cell_face_to_opposite_node = np.empty((sd.num_cells, sd.dim + 1), dtype=int)
 
-        nodes, _, _ = sps.find(sd.face_nodes)
+        nodes = sd.face_nodes.indices
         indptr = sd.face_nodes.indptr
 
         # loop on all the cells to construct the map


### PR DESCRIPTION
## Proposed changes

Contributions to PorePy are highly appreciated. Clearly explain why this pull request (PR) is needed and why it should be accepted. If this PR solves an issue, explain how it is done. Please, also summarise the changes to the code.

## Types of changes
In Scipy 1.11, sps.find() will return indices using row-first ordering, also on CSC-matrices.
Due to this change, the opposite_node computation starts to misbehave.
This PR ensures future compatibility with Scipy 1.11 in RT0.

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [x] Minor change (e.g., dependency bumps, broken links).
- [x] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [x] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
