### PR TITLE
STY: Fix flake8 error message

### DIFF
--- a/src/porepy/geometry/map_geometry.py
+++ b/src/porepy/geometry/map_geometry.py
@@ -347,7 +347,7 @@ def project_line_matrix(
         reference = np.array([0.0, 0.0, 1.0])
 
     # Appease mypy
-    assert type(tangent) == np.ndarray
+    assert isinstance(tangent, np.ndarray)
 
     reference = np.asarray(reference, dtype=float)
     angle = np.arccos(np.dot(tangent, reference))
@@ -431,7 +431,8 @@ def normal_matrix(
         raise ValueError(
             "Need either points or normal vector to compute normal matrix."
         )
-    assert type(normal) == np.ndarray
+    # Appease mypy
+    assert isinstance(normal, np.ndarray)
 
     # Ravel normal vector for the calculation to work
     return np.tensordot(normal, normal.ravel(), axes=0)


### PR DESCRIPTION
## Proposed changes
Fix an error (from flake8) related to two type checks in `map_geometry`.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [x] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag. NOT RELEVANT
