### PR TITLE
MAINT: Raising an error in `previous_iteration` and `previous_timestep`

### DIFF
--- a/src/porepy/numerics/ad/operators.py
+++ b/src/porepy/numerics/ad/operators.py
@@ -1623,8 +1623,8 @@ class Variable(Operator):
 
         Raises:
             ValueError:
-                If the variable is a representation of the previous time
-                iteration, previously set by :meth:`~previous_iteration`.
+                If the variable is a representation of the previous iteration,
+                previously set by :meth:`~previous_iteration`.
 
             NotImplementedError:
                 If the variable is already a representation of the previous time step.
@@ -1830,8 +1830,8 @@ class MixedDimensionalVariable(Variable):
 
         Raises:
             ValueError:
-                If the variable is a representation of the previous time
-                iteration, previously set by :meth:`~previous_iteration`.
+                If the variable is a representation of the previous iteration,
+                previously set by :meth:`~previous_iteration`.
 
             NotImplementedError:
                 If the variable is already a representation of the previous time step.

--- a/src/porepy/numerics/ad/operators.py
+++ b/src/porepy/numerics/ad/operators.py
@@ -1621,13 +1621,14 @@ class Variable(Operator):
     def previous_timestep(self) -> Variable:
         """Return a representation of this variable on the previous time step.
 
-        If the variable is already a representation of the previous time step, the
-        method returns itself.
-
         Raises:
             ValueError:
                 If the variable is a representation of the previous time
                 iteration, previously set by :meth:`~previous_iteration`.
+
+            NotImplementedError:
+                If the variable is already a representation of the previous time step.
+                Currently, we support creating only one previous time step.
 
         Returns:
             A representation of this variable at the previous time step,
@@ -1657,11 +1658,13 @@ class Variable(Operator):
         return new_var
 
     def previous_iteration(self) -> Variable:
-        """
+        """Return a representation of this mixed-dimensional variable on the previous
+        iteration.
+
         Raises:
             ValueError:
-                If the variable is a representation of the previous time
-                step, previously set by :meth:`~previous_timestep`.
+                If the variable is a representation of the previous time step,
+                previously set by :meth:`~previous_timestep`.
 
             NotImplementedError:
                 If the variable is already a representation of the previous time
@@ -1825,15 +1828,20 @@ class MixedDimensionalVariable(Variable):
         """Return a representation of this mixed-dimensional variable on the previous
         time step.
 
-        If the md-variable is already defined on the previous time step, return itself.
+        Raises:
+            ValueError:
+                If the variable is a representation of the previous time
+                iteration, previously set by :meth:`~previous_iteration`.
+
+            NotImplementedError:
+                If the variable is already a representation of the previous time step.
+                Currently, we support creating only one previous time step.
 
         Returns:
             A representation of this merged variable on the previous time
             iteration, with its ``prev_iter`` attribute set to ``True``.
 
         """
-        if self.prev_time:
-            return self
 
         new_subs = [var.previous_timestep() for var in self.sub_vars]
         new_var = MixedDimensionalVariable(new_subs)
@@ -1845,6 +1853,15 @@ class MixedDimensionalVariable(Variable):
     def previous_iteration(self) -> MixedDimensionalVariable:
         """Return a representation of this mixed-dimensional variable on the previous
         iteration.
+
+        Raises:
+            ValueError:
+                If the variable is a representation of the previous time step,
+                previously set by :meth:`~previous_timestep`.
+
+            NotImplementedError:
+                If the variable is already a representation of the previous time
+                iteration. Currently, we support creating only one previous iteration.
 
         Returns:
             A representation of this merged variable on the previous

--- a/src/porepy/numerics/ad/operators.py
+++ b/src/porepy/numerics/ad/operators.py
@@ -1635,7 +1635,10 @@ class Variable(Operator):
 
         """
         if self.prev_time:
-            return self
+            raise NotImplementedError(
+                "Currently, it is not supported to create a variable that represents "
+                "more than one time step behind."
+            )
 
         if self.prev_iter:
             raise ValueError(
@@ -1676,8 +1679,8 @@ class Variable(Operator):
             )
         if self.prev_iter:
             raise NotImplementedError(
-                "Currently it is not supported to create a variable representing more"
-                "than one iterations behind."
+                "Currently, it is not supported to create a variable that represents "
+                "more than one iteration behind."
             )
 
         ndof: dict[Literal["cells", "faces", "nodes"], int] = {

--- a/src/porepy/numerics/ad/operators.py
+++ b/src/porepy/numerics/ad/operators.py
@@ -1624,6 +1624,11 @@ class Variable(Operator):
         If the variable is already a representation of the previous time step, the
         method returns itself.
 
+        Raises:
+            ValueError:
+                If the variable is a representation of the previous time
+                iteration, previously set by :meth:`~previous_iteration`.
+
         Returns:
             A representation of this variable at the previous time step,
             with its ``prev_time`` attribute set to ``True``.
@@ -1631,6 +1636,12 @@ class Variable(Operator):
         """
         if self.prev_time:
             return self
+
+        if self.prev_iter:
+            raise ValueError(
+                "Cannot create a variable both on the previous time step and "
+                "previous iteration."
+            )
 
         ndof: dict[Literal["cells", "faces", "nodes"], int] = {
             "cells": self._cells,
@@ -1644,11 +1655,31 @@ class Variable(Operator):
 
     def previous_iteration(self) -> Variable:
         """
+        Raises:
+            ValueError:
+                If the variable is a representation of the previous time
+                step, previously set by :meth:`~previous_timestep`.
+
+            NotImplementedError:
+                If the variable is already a representation of the previous time
+                iteration. Currently, we support creating only one previous iteration.
+
         Returns:
             A representation of this variable on the previous time iteration,
             with its ``prev_iter`` attribute set to ``True``.
 
         """
+        if self.prev_time:
+            raise ValueError(
+                "Cannot create a variable both on the previous time step and "
+                "previous iteration."
+            )
+        if self.prev_iter:
+            raise NotImplementedError(
+                "Currently it is not supported to create a variable representing more"
+                "than one iterations behind."
+            )
+
         ndof: dict[Literal["cells", "faces", "nodes"], int] = {
             "cells": self._cells,
             "faces": self._faces,

--- a/tests/unit/ad/test_ad_operator_tree.py
+++ b/tests/unit/ad/test_ad_operator_tree.py
@@ -376,6 +376,16 @@ def test_ad_variable_creation():
     assert mvar_1_prev_iter.id != mvar_1.id
     assert mvar_1_prev_time.id != mvar_1.id
 
+    # It must be impossible to create a variable both on previous time step and iter.
+    with pytest.raises(ValueError):
+        _ = mvar_1_prev_iter.previous_timestep()
+    with pytest.raises(ValueError):
+        _ = mvar_1_prev_time.previous_iteration()
+
+    # It must be impossible to create a variable on more than one iteration behind.
+    with pytest.raises(NotImplementedError):
+        _ = mvar_1_prev_iter.previous_iteration()
+
 
 def test_ad_variable_evaluation():
     """Test that the values of Ad variables are as expected under evalutation

--- a/tests/unit/ad/test_ad_operator_tree.py
+++ b/tests/unit/ad/test_ad_operator_tree.py
@@ -376,15 +376,18 @@ def test_ad_variable_creation():
     assert mvar_1_prev_iter.id != mvar_1.id
     assert mvar_1_prev_time.id != mvar_1.id
 
-    # It must be impossible to create a variable both on previous time step and iter.
+    # We prohibit creating a variable both on previous time step and iter.
     with pytest.raises(ValueError):
         _ = mvar_1_prev_iter.previous_timestep()
     with pytest.raises(ValueError):
         _ = mvar_1_prev_time.previous_iteration()
 
-    # It must be impossible to create a variable on more than one iteration behind.
+    # We prohibit creating a variable on more than one iter or time step behind.
+    # NOTE: This should be removed when this feature is implemented.
     with pytest.raises(NotImplementedError):
         _ = mvar_1_prev_iter.previous_iteration()
+    with pytest.raises(NotImplementedError):
+        _ = mvar_1_prev_time.previous_timestep()
 
 
 def test_ad_variable_evaluation():
@@ -805,12 +808,3 @@ def test_time_differentiation():
     dt_mvar = pp.ad.dt(mvar * mvar, time_step)
     assert np.allclose(dt_mvar.evaluate(eq_system).val[: sd.num_cells], 4)
     assert np.allclose(dt_mvar.evaluate(eq_system).val[sd.num_cells :], 0.5)
-
-    # Finally create a variable at the previous time step. Its derivative should be
-    # zero.
-    var_2 = var_1.previous_timestep()
-    dt_var_2 = pp.ad.dt(var_2, time_step)
-    assert np.allclose(dt_var_2.evaluate(eq_system), 0)
-    # Also test the time increment method
-    diff_var_2 = pp.ad.time_increment(var_2)
-    assert np.allclose(diff_var_2.evaluate(eq_system), 0)


### PR DESCRIPTION
## Proposed changes

This PR attempts to close #936. By this, we raise `ValueError` early if the user attempts to create an ad variable both on the previous time step and the previous iteration. I also raise `NotImplementedError` if the user attempts to create a variable on more than one previous iteration or time step behind, because it is currently not supported: [here](https://github.com/pmgbergen/porepy/blob/c9bbe84f8ae6caa0676da56828ead33c759f4aed/src/porepy/numerics/ad/operators.py#L826) we take only one `original_variable`, which leads again to an unclear error message.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [x] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [x] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
