### PR TITLE
BUG: Order of operations when creating boundary grids for wells

### DIFF
--- a/src/porepy/fracs/wells_3d.py
+++ b/src/porepy/fracs/wells_3d.py
@@ -430,11 +430,6 @@ class WellNetwork3d:
                 sd_w.compute_geometry()
                 mdg.add_subdomains(sd_w)
 
-                # Properly initalizing the newly generated boundary grid.
-                if (bg_w := mdg.subdomain_to_boundary_grid(sd_w)) is not None:
-                    bg_w.set_projections()
-                    bg_w.compute_geometry()
-
                 sd_w.well_num = well_num
                 sd_w.name += " well " + str(well_num)
                 sd_w.tags["parent_well_index"] = w.index
@@ -483,6 +478,13 @@ class WellNetwork3d:
                 sd_w.tags["tip_faces"][endp_inds] = endp_tip_tags
                 sd_w.tags["fracture_faces"][endp_inds] = endp_frac_tags
 
+                # Properly initalize the newly generated boundary grid.
+                if (bg_w := mdg.subdomain_to_boundary_grid(sd_w)) is not None:
+                    # Overwrite number of cells. This was initialized wrongly before
+                    # sd_w.tags["domain_boundary_faces"] was set.
+                    bg_w.num_cells = np.sum(boundary)
+                    bg_w.set_projections()
+                    bg_w.compute_geometry()
                 # Reset the points for next iteration/subline.
                 points_subline = np.empty((3, 0))
                 subline_endpoint_inds = [inds_seg[1]]


### PR DESCRIPTION
## Proposed changes

Need to compute well grid's tags before creating its boundary grid.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [x] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
