### PR TITLE
Bugfix in finite volume discretizations for (relatively) large problems

### DIFF
--- a/src/porepy/applications/test_utils/common_xpfa_tests.py
+++ b/src/porepy/applications/test_utils/common_xpfa_tests.py
@@ -901,14 +901,11 @@ def test_split_discretization_into_subproblems(
             pp.DISCRETIZATION_MATRICES: {flow_keyword: {}, mechanics_keyword: {}},
         }
         data_partition[pp.PARAMETERS][flow_keyword][  # type: ignore[index]
-            "partition_arguments"] = {
-            "num_subproblems": 2
-        }
-        data_partition[pp.PARAMETERS][mechanics_keyword][   # type: ignore[index]
             "partition_arguments"
-        ] = {
-            "num_subproblems": 2
-        }
+        ] = {"num_subproblems": 2}
+        data_partition[pp.PARAMETERS][mechanics_keyword][  # type: ignore[index]
+            "partition_arguments"
+        ] = {"num_subproblems": 2}
         # Discretize
         discr_class.discretize(g, data_partition)
 

--- a/src/porepy/applications/test_utils/common_xpfa_tests.py
+++ b/src/porepy/applications/test_utils/common_xpfa_tests.py
@@ -900,10 +900,13 @@ def test_split_discretization_into_subproblems(
             },
             pp.DISCRETIZATION_MATRICES: {flow_keyword: {}, mechanics_keyword: {}},
         }
-        data_partition[pp.PARAMETERS][flow_keyword]["partition_arguments"] = {
+        data_partition[pp.PARAMETERS][flow_keyword][  # type: ignore[index]
+            "partition_arguments"] = {
             "num_subproblems": 2
         }
-        data_partition[pp.PARAMETERS][mechanics_keyword]["partition_arguments"] = {
+        data_partition[pp.PARAMETERS][mechanics_keyword][   # type: ignore[index]
+            "partition_arguments"
+        ] = {
             "num_subproblems": 2
         }
         # Discretize

--- a/src/porepy/applications/test_utils/common_xpfa_tests.py
+++ b/src/porepy/applications/test_utils/common_xpfa_tests.py
@@ -823,7 +823,7 @@ class XpfaBoundaryPressureTests:
 def test_split_discretization_into_subproblems(
     discr_class: Union[pp.Mpfa, pp.Mpsa, pp.Biot]
 ):
-    """Test that the discretization matrices produced by Xpfa are the same if they
+    """Test that the discretization matrices produced by Mpxa are the same if they
     are split into subproblems or not.
 
     The test is designed to be run with all three discretization classes, Mpfa, Mpsa and
@@ -832,7 +832,7 @@ def test_split_discretization_into_subproblems(
     reuse the test for all three classes.
 
     Failure of this test indicates that the gradual discretization, by means of
-    constructing subdomains, is not working. Provided that the standard tests for
+    constructing subgrids, is not working. Provided that the standard tests for
     discretizing do not fail, a likely reason for the failure is that something has
     changed in the extraction of subgrids, including the construction of mappings
     between local and global grids; see the individual discretization classes for

--- a/src/porepy/applications/test_utils/common_xpfa_tests.py
+++ b/src/porepy/applications/test_utils/common_xpfa_tests.py
@@ -4,7 +4,7 @@ Some simple for getting grid, permeability, bc object etc.
 Then more specific functions related to specific tests defined both here and for mpfa.
 
 """
-from typing import Literal
+from typing import Literal, Union
 
 import numpy as np
 import scipy.sparse.linalg as spla
@@ -821,7 +821,7 @@ class XpfaBoundaryPressureTests:
 
 
 def test_split_discretization_into_subproblems(
-    discr_class: Literal[pp.Mpfa, pp.Mpsa, pp.Biot]
+    discr_class: Union[pp.Mpfa, pp.Mpsa, pp.Biot]
 ):
     """Test that the discretization matrices produced by Xpfa are the same if they
     are split into subproblems or not.
@@ -866,10 +866,10 @@ def test_split_discretization_into_subproblems(
     # used the same parametrization on each of the wrappers, but that would have been a
     # bit messy).
     grid_list = [
-        pp.CartGrid([4, 2]),
-        pp.CartGrid([4, 2, 2]),
-        pp.StructuredTriangleGrid([4, 2]),
-        pp.StructuredTetrahedralGrid([4, 2, 2]),
+        pp.CartGrid(np.array([4, 2])),
+        pp.CartGrid(np.array([4, 2, 2])),
+        pp.StructuredTriangleGrid(np.array([4, 2])),
+        pp.StructuredTetrahedralGrid(np.array([4, 2, 2])),
     ]
 
     # Loop over the grids, discretize twice (with different data dictionaries): Once
@@ -919,11 +919,17 @@ def test_split_discretization_into_subproblems(
         # Compare the discretization matrices. We should have the same matrices for both
         # types of physics, and for all individual matrices.
         for key in [flow_keyword, mechanics_keyword]:
-            for mat_key in data_partition[pp.DISCRETIZATION_MATRICES][key]:
+            for mat_key in data_partition[pp.DISCRETIZATION_MATRICES][
+                key
+            ]:  # type: ignore[index]
                 assert np.allclose(
                     (
-                        data_partition[pp.DISCRETIZATION_MATRICES][key][mat_key]
-                        - data_no_partition[pp.DISCRETIZATION_MATRICES][key][mat_key]
+                        data_partition[pp.DISCRETIZATION_MATRICES][
+                            key  # type: ignore[index]
+                        ][mat_key]
+                        - data_no_partition[pp.DISCRETIZATION_MATRICES][
+                            key  # type: ignore[index]
+                        ][mat_key]
                     ).A,
                     0,
                 )

--- a/src/porepy/applications/test_utils/common_xpfa_tests.py
+++ b/src/porepy/applications/test_utils/common_xpfa_tests.py
@@ -885,12 +885,10 @@ def test_split_discretization_into_subproblems(
         flow_param = {
             "bc": pp.BoundaryCondition(g),
             "second_order_tensor": pp.SecondOrderTensor(np.ones(nc)),
-            "partition_arguments": {"num_subproblems": 2},
         }
         mechanics_param = {
             "bc": pp.BoundaryConditionVectorial(g),
             "fourth_order_tensor": pp.FourthOrderTensor(np.ones(nc), np.ones(nc)),
-            "partition_arguments": {"num_subproblems": 2},
             "biot_alpha": 1,
         }
 
@@ -902,10 +900,17 @@ def test_split_discretization_into_subproblems(
             },
             pp.DISCRETIZATION_MATRICES: {flow_keyword: {}, mechanics_keyword: {}},
         }
+        data_partition[pp.PARAMETERS][flow_keyword]["partition_arguments"] = {
+            "num_subproblems": 2
+        }
+        data_partition[pp.PARAMETERS][mechanics_keyword]["partition_arguments"] = {
+            "num_subproblems": 2
+        }
         # Discretize
         discr_class.discretize(g, data_partition)
 
         # Set up a data dictionary that will not split the discretization into two.
+
         data_no_partition = {
             pp.PARAMETERS: {
                 flow_keyword: flow_param,

--- a/src/porepy/grids/partition.py
+++ b/src/porepy/grids/partition.py
@@ -468,7 +468,7 @@ def extract_subgrid(
     fn_sub, unique_nodes = _extract_submatrix(g.face_nodes.tocsc(), unique_faces)
 
     # Append information on subgrid extraction to the new grid's history
-    history = list(g.name)
+    history = [g.name]
     history.append("Extract subgrid")
 
     # Construct new grid.

--- a/src/porepy/numerics/fv/biot.py
+++ b/src/porepy/numerics/fv/biot.py
@@ -318,8 +318,8 @@ class Biot(pp.Mpsa):
         these, see self.assemble_matrix()
 
         Parameters:
-            sd: Grid to be discretized. sd_data: Containing data for discretization. See
-                above for specification.
+            sd: Grid to be discretized.
+            sd_data: Containing data for discretization. See above for specification.
 
         """
         parameter_dictionary: dict[str, Any] = sd_data[pp.PARAMETERS][

--- a/src/porepy/numerics/fv/biot.py
+++ b/src/porepy/numerics/fv/biot.py
@@ -285,10 +285,11 @@ class Biot(pp.Mpsa):
         NOTE: This function does *not* discretize purely flow-related terms (Darcy flow
         and compressibility).
 
-        The parameters needed for the discretization are stored in the
-        dictionary sd_data, which should contain the following mandatory keywords:
+        The parameters needed for the discretization are stored in the dictionary
+        sd_data, which should contain the following mandatory keywords:
 
-            Related to mechanics equation (in sd_data[pp.PARAMETERS][self.mechanics_keyword]):
+            Related to mechanics equation (in
+            sd_data[pp.PARAMETERS][self.mechanics_keyword]):
                 fourth_order_tensor: Fourth order tensor representing elastic moduli.
                 bc: BoundaryCondition object for mechanics equation.
                     Used in mpsa.
@@ -299,20 +300,26 @@ class Biot(pp.Mpsa):
                     Defaults to 1.
 
             Related to numerics:
-                inverter: Which method to use for block inversion. See
+                - inverter (``str``): Which method to use for block inversion. See
                     pp.fvutils.invert_diagonal_blocks for detail, and for default
                     options.
-                mpfa_eta: Location of continuity point in MPSA. Defaults to 1/3 for
-                    simplex grids, 0 otherwise.
+                - mpfa_eta (``float``): Location of continuity point in MPSA. Defaults
+                    to 1/3 for simplex grids, 0 otherwise.
+                - partition_arguments (``dict``): Arguments to control the number
+                    of subproblems used to discretize the grid. Can be either the target
+                    maximal memory use (controlled by keyword 'max_memory' in
+                    ``partition_arguments``), or the number of subproblems (keyword
+                    'num_subproblems' in ``partition_arguments``). If none are given,
+                    the default is to use 1e9 bytes of memory per subproblem. If both
+                    are given, the maximal memory use is prioritized.
 
-        The discretization is stored in the data dictionary, in the form of
-        several matrices representing different coupling terms. For details,
-        and how to combine these, see self.assemble_matrix()
+        The discretization is stored in the data dictionary, in the form of several
+        matrices representing different coupling terms. For details, and how to combine
+        these, see self.assemble_matrix()
 
         Parameters:
-            sd: Grid to be discretized.
-            sd_data: Containing data for discretization. See above
-                for specification.
+            sd: Grid to be discretized. sd_data: Containing data for discretization. See
+                above for specification.
 
         """
         parameter_dictionary: dict[str, Any] = sd_data[pp.PARAMETERS][
@@ -334,7 +341,10 @@ class Biot(pp.Mpsa):
 
         alpha: float = parameter_dictionary["biot_alpha"]
 
-        max_memory: int = parameter_dictionary.get("max_memory", 1e9)
+        # Control of the number of subdomanis.
+        max_memory, num_subproblems = pp.fvutils.parse_partition_arguments(
+            parameter_dictionary.get("partition_arguments", {})
+        )
 
         # Whether to update an existing discretization, or construct a new one.
         # If True, either specified_cells, _faces or _nodes should also be given, or
@@ -369,8 +379,18 @@ class Biot(pp.Mpsa):
         nf = active_grid.num_faces
         nc = active_grid.num_cells
 
-        # There are quite a few items to keep track of, but then the discretization
-        # does quite a few different things
+        # To limit the memory need of discretization, we will split the discretization
+        # into sub-problems, discretize these separately, and glue together the results.
+        # This procedure requires some bookkeeping, in particular to keep track of how
+        # many times a face has been discretized (faces may be shared between subgrids,
+        # thus discretized multiple times).
+        faces_in_subgrid_accum = []
+        # Find an estimate of the peak memory need. This is used to decide how many
+        # subproblems to split the discretization into.
+        peak_memory_estimate = self._estimate_peak_memory_mpsa(active_grid)
+
+        # Holders for discretizations. There are quite a few items to keep track of, but
+        # then the discretization does quite a few different things
         active_stress = sps.csr_matrix((nf * nd, nc * nd))
         active_bound_stress = sps.csr_matrix((nf * nd, nf * nd))
         active_grad_p = sps.csr_matrix((nf * nd, nc))
@@ -381,17 +401,40 @@ class Biot(pp.Mpsa):
         active_bound_displacement_face = sps.csr_matrix((nf * nd, nf * nd))
         active_bound_displacement_pressure = sps.csr_matrix((nf * nd, nc))
 
-        # Find an estimate of the peak memory need
-        peak_memory_estimate = self._estimate_peak_memory_mpsa(active_grid)
-
         # Loop over all partition regions, construct local problems, and transfer
         # discretization to the entire active grid
-        for (
-            reg_i,
-            (sub_sd, faces_in_subgrid, cells_in_subgrid, l2g_cells, l2g_faces),
+        for reg_i, (
+            sub_sd,
+            faces_in_subgrid,
+            cells_in_subgrid,
+            l2g_cells,
+            l2g_faces,
         ) in enumerate(
-            pp.fvutils.subproblems(active_grid, max_memory, peak_memory_estimate)
+            pp.fvutils.subproblems(
+                active_grid,
+                peak_memory_estimate,
+                max_memory=max_memory,
+                num_subproblems=num_subproblems,
+            )
         ):
+            # The partitioning into subgrids is done with an overlap (see
+            # fvutils.subproblems for a description). Cells and faces in the overlap
+            # will have a wrong discretization in one of two ways: Those faces that are
+            # strictly in the overlap should not be included in the current
+            # sub-discretization (their will be in the interior of a different
+            # subdomain). This contribution will be deleted locally, below. Faces that
+            # are on the boundary between two subgrids will be discretized twice. This
+            # will be handled by dividing the discretization by two. We cannot know
+            # which faces are on the boundary (or perhaps we could, but that would
+            # require more advanced bookkeeping), so we count the number of times a face
+            # has been discretized, and divide by that number at the end (after having
+            # iterated over all subdomains).
+            #
+            # Take note of which faces are discretized in this subgrid. Note that this
+            # needs to use faces_in_subgrid, not l2g_faces, since the latter contains
+            # faces in the overlap.
+            faces_in_subgrid_accum.append(faces_in_subgrid)
+
             tic = time()
             # Copy stiffness tensor, and restrict to local cells
             loc_c: pp.FourthOrderTensor = self._constit_for_subgrid(
@@ -482,6 +525,35 @@ class Biot(pp.Mpsa):
             )
             logger.info(f"Done with subproblem {reg_i}. Elapsed time {time() - tic}")
             # Done with this subdomain, move on to the next one
+
+        # Divide by the number of times a face has been discretized. This is necessary
+        # to avoid double counting of faces on the boundary between subproblems. Note
+        # that this is done before mapping from the active to the full grid, since the
+        # subgrids (thus face map) was computed on the active grid.
+        #
+        # IMPLEMENTATION NOTE: With the current implementation, this scaling is only
+        # needed for the vector quantities, that is, not for the stabilization and div_u
+        # terms. This is because the latter are computed cell-wise rather than
+        # face-wise, and it so happens that this is sufficient to avoid double counting.
+        # If we ever change the implementation (e.g., when introducing tensor Biot
+        # coefficients), it is likely the scaling will be needed also for the scalar
+        # terms.
+        num_face_repetitions_vector = np.tile(
+            np.bincount(np.concatenate(faces_in_subgrid_accum)), (nd, 1)
+        ).ravel("F")
+        scaling_vector = sps.dia_matrix(
+            (1.0 / num_face_repetitions_vector, 0), shape=(nf * nd, nf * nd)
+        )
+
+        # Vector fields
+        active_stress = scaling_vector @ active_stress
+        active_bound_stress = scaling_vector @ active_bound_stress
+        active_bound_displacement_cell = scaling_vector @ active_bound_displacement_cell
+        active_bound_displacement_face = scaling_vector @ active_bound_displacement_face
+        active_grad_p = scaling_vector @ active_grad_p
+        active_bound_displacement_pressure = (
+            scaling_vector @ active_bound_displacement_pressure
+        )
 
         # We are done with the discretization. What remains is to map the computed
         # matrices back from the active grid to the full one.

--- a/src/porepy/numerics/fv/fvutils.py
+++ b/src/porepy/numerics/fv/fvutils.py
@@ -351,8 +351,8 @@ def find_active_indices(
 
 
 def parse_partition_arguments(
-    partition_arguments: Optional[dict[str, float]] = None
-) -> tuple[float | None, float | None]:
+    partition_arguments: Optional[dict[str, int]] = None
+) -> tuple[int | None, int | None]:
     """Parse arguments related to the splitting of discretization into subproblems.
 
     Parameters:
@@ -365,14 +365,14 @@ def parse_partition_arguments(
         former to define a partitioning.
 
 
-        float | None: Maximum memory footprint allowed for the discretization. If
+        int | None: Maximum memory footprint allowed for the discretization. If
             ``partition_arguments`` has a key ``max_memory``, this value will be
             returned. If ``partition_arguments`` is ``None``, the default value of 1e9
             will be returned. If ``partition_arguments`` does not have a key
             ``max_memory``, but has a key ``num_subproblems``, the value will be set to
             ``None``.
 
-        float | None: The number of subproblems to construct. If ``partition_arguments``
+        int | None: The number of subproblems to construct. If ``partition_arguments``
             has a key ``num_subproblems``, but no key ``max_memory``, the value will be
             returned. In all other cases, the value will be set to ``None``.
 
@@ -385,8 +385,9 @@ def parse_partition_arguments(
             or "num_subproblems" not in partition_arguments
         ):
             # If max_memory is given, use it. If num_subproblems is not given, use
-            # default (which is max_memory = 1e9)
-            max_memory = partition_arguments.get("max_memory", 1e9)
+            # default (which is max_memory = 1e9). Cast to int to avoid problems with
+            # mypy.
+            max_memory = int(partition_arguments.get("max_memory", 1e9))
             # Explicitly set num_subproblems to None, to signal that it should not
             # be used.
             num_subproblems = None
@@ -396,8 +397,8 @@ def parse_partition_arguments(
             # used.
             max_memory = None
     else:
-        # No values are given, use default.
-        max_memory: int = 1e9
+        # No values are given, use default. Cast to int to avoid problems with mypy.
+        max_memory = int(1e9)
         # Explicitly set num_subproblems to None, to signal that it should not be
         # used.
         num_subproblems = None

--- a/src/porepy/numerics/fv/fvutils.py
+++ b/src/porepy/numerics/fv/fvutils.py
@@ -417,7 +417,7 @@ def subproblems(
     """Split a grid into subgrids in preparation for discretization with limited memory
     footprint.
 
-    The subgrids are constructructed by partititoning the grid; see comments in the code
+    The subgrids are constructed by partititoning the grid; see comments in the code
     for details, including information on overlap between subgrids.
 
     Parameters:

--- a/src/porepy/numerics/fv/fvutils.py
+++ b/src/porepy/numerics/fv/fvutils.py
@@ -350,6 +350,61 @@ def find_active_indices(
     return active_cells, active_faces
 
 
+def parse_partition_arguments(
+    partition_arguments: Optional[dict[str, float]] = None
+) -> tuple[float | None, float | None]:
+    """Parse arguments related to the splitting of discretization into subproblems.
+
+    Parameters:
+        parameter_dictionary (dict): Parameters, potentially containing fields
+            "max_memory" and "num_subproblems".
+
+    Returns:
+        Values to be used in the partitioning of the grid. One of the values will be
+        numerical, the other will be None; it is up to the calling method to use the
+        former to define a partitioning.
+
+
+        float | None: Maximum memory footprint allowed for the discretization. If
+            ``partition_arguments`` has a key ``max_memory``, this value will be
+            returned. If ``partition_arguments`` is ``None``, the default value of 1e9
+            will be returned. If ``partition_arguments`` does not have a key
+            ``max_memory``, but has a key ``num_subproblems``, the value will be set to
+            ``None``.
+
+        float | None: The number of subproblems to construct. If ``partition_arguments``
+            has a key ``num_subproblems``, but no key ``max_memory``, the value will be
+            returned. In all other cases, the value will be set to ``None``.
+
+    """
+
+    # Control of the number of subdomanis.
+    if partition_arguments is not None:
+        if (
+            "max_memory" in partition_arguments
+            or "num_subproblems" not in partition_arguments
+        ):
+            # If max_memory is given, use it. If num_subproblems is not given, use
+            # default (which is max_memory = 1e9)
+            max_memory = partition_arguments.get("max_memory", 1e9)
+            # Explicitly set num_subproblems to None, to signal that it should not
+            # be used.
+            num_subproblems = None
+        else:  # Only num_subproblems is given
+            num_subproblems = partition_arguments["num_subproblems"]
+            # Explicitly set max_memory to None, to signal that it should not be
+            # used.
+            max_memory = None
+    else:
+        # No values are given, use default.
+        max_memory: int = 1e9
+        # Explicitly set num_subproblems to None, to signal that it should not be
+        # used.
+        num_subproblems = None
+
+    return max_memory, num_subproblems
+
+
 def subproblems(
     sd: pp.Grid,
     peak_memory_estimate: int,

--- a/src/porepy/numerics/fv/mpfa.py
+++ b/src/porepy/numerics/fv/mpfa.py
@@ -87,6 +87,13 @@ class Mpfa(pp.FVElliptic):
                 continuity point. If not given, porepy tries to set an optimal value.
             - mpfa_inverter (``str``): Optional. Inverter to apply for local problems.
                 Can take values 'numba' (default), or 'python'.
+            - partition_arguments (``dict``): Optional. Arguments to control the number
+                of subproblems used to discretize the grid. Can be either the target
+                maximal memory use (controlled by keyword 'max_memory' in
+                ``partition_arguments``), or the number of subproblems (keyword
+                'num_subproblems' in ``partition_arguments``). If none are given, the
+                default is to use 1e9 bytes of memory per subproblem. If both are given,
+                the maximal memory use is prioritized.
 
         matrix_dictionary will be updated with the following entries:
             - ``flux: sps.csc_matrix (sd.num_faces, sd.num_cells)``
@@ -147,7 +154,10 @@ class Mpfa(pp.FVElliptic):
             "mpfa_inverter", "numba"
         )
 
-        max_memory: int = parameter_dictionary.get("max_memory", 1e9)
+        # Control of the number of subdomanis.
+        max_memory, num_subproblems = pp.fvutils.parse_partition_arguments(
+            parameter_dictionary.get("partition_arguments", {})
+        )
 
         # Whether to update an existing discretization, or construct a new one.
         # If True, either specified_cells, _faces or _nodes should also be given, or
@@ -186,6 +196,16 @@ class Mpfa(pp.FVElliptic):
         nf = active_grid.num_faces
         nc = active_grid.num_cells
 
+        # To limit the memory need of discretization, we will split the discretization
+        # into sub-problems, discretize these separately, and glue together the results.
+        # This procedure requires some bookkeeping, in particular to keep track of how
+        # many times a face has been discretized (faces may be shared between subgrids,
+        # thus discretized multiple times).
+        faces_in_subgrid_accum = []
+        # Find an estimate of the peak memory need. This is used to decide how many
+        # subproblems to split the discretization into.
+        peak_memory_estimate = self._estimate_peak_memory(active_grid)
+
         # Empty matrices for flux, bound_flux and boundary pressure reconstruction. Will
         # be expanded as we go.
         # Implementation note: It should be relatively straightforward to
@@ -211,15 +231,32 @@ class Mpfa(pp.FVElliptic):
         active_vector_source = sps.csr_matrix((nf, nc * cell_vector_dim))
         active_bound_pressure_vector_source = sps.csr_matrix((nf, nc * cell_vector_dim))
 
-        # Find an estimate of the peak memory need.
-        peak_memory_estimate = self._estimate_peak_memory(active_grid)
-
         # Loop over all partition regions, construct local problems, and transfer
         # discretization to the entire active grid.
         for reg_i, (sub_sd, faces_in_subgrid, _, l2g_cells, l2g_faces) in enumerate(
-            pp.fvutils.subproblems(active_grid, max_memory, peak_memory_estimate)
+            pp.fvutils.subproblems(
+                active_grid, peak_memory_estimate, max_memory, num_subproblems
+            )
         ):
-            # Copy stiffness tensor, and restrict to local cells
+            # The partitioning into subgrids is done with an overlap (see
+            # fvutils.subproblems for a description). Cells and faces in the overlap
+            # will have a wrong discretization in one of two ways: Those faces that are
+            # strictly in the overlap should not be included in the current
+            # sub-discretization (their will be in the interior of a different
+            # subdomain). This contribution will be deleted locally, below. Faces that
+            # are on the boundary between two subgrids will be discretized twice. This
+            # will be handled by dividing the discretization by two. We cannot know
+            # which faces are on the boundary (or perhaps we could, but that would
+            # require more advanced bookkeeping), so we count the number of times a face
+            # has been discretized, and divide by that number at the end (after having
+            # iterated over all subdomains).
+            #
+            # Take note of which faces are discretized in this subgrid. Note that this
+            # needs to use faces_in_subgrid, not l2g_faces, since the latter contains
+            # faces in the overlap.
+            faces_in_subgrid_accum.append(faces_in_subgrid)
+
+            # Copy permeability tensor, and restrict to local cells
             loc_c: pp.SecondOrderTensor = self._constit_for_subgrid(
                 active_constit, l2g_cells
             )
@@ -257,11 +294,10 @@ class Mpfa(pp.FVElliptic):
             ) = discr_fields
 
             # Next, transfer discretization matrices from the local to the active grid
-            if (
-                sub_sd.num_cells == active_grid.num_cells
-                and sub_sd.num_faces == active_grid.num_faces
-            ):
-                # Shortcut
+            if active_grid.num_faces == faces_in_subgrid.size:
+                # If all faces in the grid are truly within this subgrid (identified by
+                # faces_in_subgrid, which does not include faces in the overlap), we
+                # know the domain was not split, thus we need not bother with mappings.
                 active_flux = loc_flux
                 active_bound_flux = loc_bound_flux
                 active_bound_pressure_cell = loc_bound_pressure_cell
@@ -297,6 +333,23 @@ class Mpfa(pp.FVElliptic):
                 active_bound_pressure_vector_source += (
                     face_map * loc_bound_pressure_vector_source * cell_map_vec
                 )
+
+        # Divide by the number of times a face has been discretized. This is necessary
+        # to avoid double counting of faces on the boundary between subproblems. Note
+        # that this is done before mapping from the active to the full grid, since the
+        # subgrids (thus face map) was computed on the active grid.
+        num_face_repetitions = np.bincount(np.concatenate(faces_in_subgrid_accum))
+
+        scaling = sps.dia_matrix((1.0 / num_face_repetitions, 0), shape=(nf, nf))
+        # All the discretization matrices must be updated.
+        active_flux = scaling @ active_flux
+        active_bound_flux = scaling @ active_bound_flux
+        active_bound_pressure_cell = scaling @ active_bound_pressure_cell
+        active_bound_pressure_face = scaling @ active_bound_pressure_face
+        active_vector_source = scaling @ active_vector_source
+        active_bound_pressure_vector_source = (
+            scaling @ active_bound_pressure_vector_source
+        )
 
         # We have reached the end of the discretization, what remains is to map the
         # discretization back from the active grid to the entire grid.

--- a/src/porepy/numerics/fv/mpsa.py
+++ b/src/porepy/numerics/fv/mpsa.py
@@ -185,27 +185,9 @@ class Mpsa(Discretization):
         )
 
         # Control of the number of subdomanis.
-        if "partition_arguments" in parameter_dictionary:
-            # If the user has specified partition arguments, use them.
-            part_arg = parameter_dictionary["partition_arguments"]
-            if "max_memory" in part_arg or "num_subproblems" not in part_arg:
-                # If max_memory is given, use it. If num_subproblems is not given, use
-                # default (which is max_memory = 1e9)
-                max_memory = part_arg.get("max_memory", 1e9)
-                # Explicitly set num_subproblems to None, to signal that it should not
-                # be used.
-                num_subproblems = None
-            else:  # Only num_subproblems is given
-                num_subproblems = part_arg["num_subproblems"]
-                # Explicitly set max_memory to None, to signal that it should not be
-                # used.
-                max_memory = None
-        else:
-            # No values are given, use default.
-            max_memory: int = 1e9
-            # Explicitly set num_subproblems to None, to signal that it should not be
-            # used.
-            num_subproblems = None
+        max_memory, num_subproblems = pp.fvutils.parse_partition_arguments(
+            parameter_dictionary.get("partition_arguments", {})
+        )
 
         # Whether to update an existing discretization, or construct a new one. If True,
         # either specified_cells, _faces or _nodes should also be given, or else a full
@@ -347,7 +329,7 @@ class Mpsa(Discretization):
         # Divide by the number of times a face has been discretized. This is necessary
         # to avoid double counting of faces on the boundary between subproblems. Note
         # that this is done before mapping from the active to the full grid, since the
-        # subgrids (thus face map) was computed on the active grid..
+        # subgrids (thus face map) was computed on the active grid.
         num_face_repetitions = np.tile(
             np.bincount(np.concatenate(faces_in_subgrid_accum)), (nd, 1)
         ).ravel("F")

--- a/tests/numerics/fv/test_biot.py
+++ b/tests/numerics/fv/test_biot.py
@@ -6,6 +6,7 @@ import porepy as pp
 from porepy.applications.test_utils.partial_discretization import (
     perform_partial_discretization_specified_nodes,
 )
+from porepy.applications.test_utils import common_xpfa_tests as xpfa_tests
 
 
 @pytest.fixture
@@ -152,3 +153,15 @@ def test_partial_discretization_specified_nodes(
         # zero and check that the rest is zero.
         pp.fvutils.remove_nonlocal_contribution(active_cells, 1, partial)
         assert np.allclose(partial.data, 0)
+
+
+def test_split_discretization_into_parts():
+    """Test that the discretization matrices are correct if the domain is split into
+    subdomains.
+
+    This test is just a shallow wrapper around the common test function for the XPFA
+    discretization.
+    """
+    # Keywords for flow and mechanics is automatically set in Biot
+    discr = pp.Biot(mechanics_keyword="mechanics", flow_keyword="flow")
+    xpfa_tests.test_split_discretization_into_subproblems(discr)

--- a/tests/numerics/fv/test_biot.py
+++ b/tests/numerics/fv/test_biot.py
@@ -162,6 +162,5 @@ def test_split_discretization_into_parts():
     This test is just a shallow wrapper around the common test function for the XPFA
     discretization.
     """
-    # Keywords for flow and mechanics is automatically set in Biot
     discr = pp.Biot(mechanics_keyword="mechanics", flow_keyword="flow")
     xpfa_tests.test_split_discretization_into_subproblems(discr)

--- a/tests/numerics/fv/test_mpfa.py
+++ b/tests/numerics/fv/test_mpfa.py
@@ -1220,3 +1220,17 @@ class TestRobinBoundaryCondition:
         bnd_ind = np.hstack((dir_ind, rob_ind))
         bnd = pp.BoundaryCondition(g, bnd_ind, names)
         return bnd
+
+
+def test_split_discretization_into_parts():
+    """Test that the discretization matrices are correct if the domain is split into
+    subdomains.
+
+    This test is just a shallow wrapper around the common test function for the XPFA
+    discretization.
+    """
+    discr = pp.Mpfa("flow")
+    xpfa_tests.test_split_discretization_into_subproblems(discr)
+
+
+test_split_discretization_into_parts()

--- a/tests/numerics/fv/test_mpfa.py
+++ b/tests/numerics/fv/test_mpfa.py
@@ -1231,6 +1231,3 @@ def test_split_discretization_into_parts():
     """
     discr = pp.Mpfa("flow")
     xpfa_tests.test_split_discretization_into_subproblems(discr)
-
-
-test_split_discretization_into_parts()

--- a/tests/numerics/fv/test_mpsa.py
+++ b/tests/numerics/fv/test_mpsa.py
@@ -405,6 +405,17 @@ class TestMpsaExactReproduction:
                 assert np.all(np.sum(traction_2d[:, fid] * sgn, axis=1) < 1e-10)
 
 
+def test_split_discretization_into_parts():
+    """Test that the discretization matrices are correct if the domain is split into
+    subdomains.
+
+    This test is just a shallow wrapper around the common test function for the XPFA
+    discretization.
+    """
+    discr = pp.Mpsa("mechanics")
+    xpfa_tests.test_split_discretization_into_subproblems(discr)
+
+
 class TestUpdateMpsaDiscretization(TestMpsaExactReproduction):
     """
     Class for testing updating the discretization, including the reconstruction


### PR DESCRIPTION
## Proposed changes
This PR removes a bug from the MPxA discretizations that kicked in for problems of a certain size: To limit their memory footprint, the discretization methods split the grid into subproblems and thereby gradually build the discretization matrices. In this process, faces on the boundary between the subproblems were discretized twice. This is fixed in the current PR.

The test suite has been extended to cover gradual discretization for all MPxA discretizations. To facilitate easy testing, the splitting into subproblems can now be done by passing the number of subproblems, in addition to the traditional controlled based on the estimated maximum memory footprint. The memory-based criterion is given priority, as this is the option which is closest to the original motivation behind the splitting.

I also improved the documentation of those parts of the code that was changed, while choosing to ignore other parts of the files that also could have been better documented.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [x] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Testing (contribution related to testing of existing or new functionality).
- [x] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
