### PR TITLE
Vectorized block diagonal mat inversion

### DIFF
--- a/src/porepy/numerics/fv/biot.py
+++ b/src/porepy/numerics/fv/biot.py
@@ -336,7 +336,7 @@ class Biot(pp.Mpsa):
 
         eta: float = parameter_dictionary.get("mpsa_eta", pp.fvutils.determine_eta(sd))
         inverter: Literal["python", "numba"] = parameter_dictionary.get(
-            "inverter", "numba"
+            "inverter", "python"
         )
 
         alpha: float = parameter_dictionary["biot_alpha"]

--- a/src/porepy/numerics/fv/mpfa.py
+++ b/src/porepy/numerics/fv/mpfa.py
@@ -86,7 +86,7 @@ class Mpfa(pp.FVElliptic):
             - mpfa_eta (``float``): Optional. Range [0, 1). Location of pressure
                 continuity point. If not given, porepy tries to set an optimal value.
             - mpfa_inverter (``str``): Optional. Inverter to apply for local problems.
-                Can take values 'numba' (default), or 'python'.
+                Can take values 'python' (default), or 'numba'.
             - partition_arguments (``dict``): Optional. Arguments to control the number
                 of subproblems used to discretize the grid. Can be either the target
                 maximal memory use (controlled by keyword 'max_memory' in
@@ -151,7 +151,7 @@ class Mpfa(pp.FVElliptic):
 
         eta: Optional[float] = parameter_dictionary.get("mpfa_eta", None)
         inverter: Literal["numba", "python"] = parameter_dictionary.get(
-            "mpfa_inverter", "numba"
+            "mpfa_inverter", "python"
         )
 
         # Control of the number of subdomanis.
@@ -574,7 +574,7 @@ class Mpfa(pp.FVElliptic):
         sd: pp.Grid,
         k: pp.SecondOrderTensor,
         bnd: pp.BoundaryCondition,
-        inverter: Literal["python", "numba"],
+        inverter: Optional[Literal["python", "numba"]] = None,
         ambient_dimension: Optional[int] = None,
         eta: Optional[float] = None,
     ) -> tuple[

--- a/src/porepy/numerics/fv/mpsa.py
+++ b/src/porepy/numerics/fv/mpsa.py
@@ -143,7 +143,7 @@ class Mpsa(Discretization):
                 value. This value is set to all subfaces, except the boundary (where,
                 0 is used).
             - inverter (``str``): Optional. Inverter to apply for local problems.
-                Can take values 'numba' (default), or 'python'.
+                Can take values 'python' (default), or 'numba'.
             - partition_arguments (``dict``): Optional. Arguments to control the number
                 of subproblems used to discretize the grid. Can be either the target
                 maximal memory use (controlled by keyword 'max_memory' in
@@ -181,7 +181,7 @@ class Mpsa(Discretization):
         hf_eta: Optional[float] = parameter_dictionary.get("reconstruction_eta", None)
 
         inverter: Literal["python", "numba"] = parameter_dictionary.get(
-            "inverter", "numba"
+            "inverter", "python"
         )
 
         # Control of the number of subdomanis.
@@ -514,7 +514,7 @@ class Mpsa(Discretization):
         constit: pp.FourthOrderTensor,
         bound: pp.BoundaryConditionVectorial,
         eta: Optional[float] = None,
-        inverter: Literal["numba", "python"] = "numba",
+        inverter: Optional[Literal["python", "numba"]] = None,
         hf_disp: bool = False,
         hf_eta: Optional[float] = None,
     ) -> tuple[sps.spmatrix, sps.spmatrix, sps.spmatrix, sps.spmatrix]:
@@ -577,7 +577,7 @@ class Mpsa(Discretization):
             eta: Parameter controlling continuity of displacement. If None, a default
                 value will be used, adapted to the grid type.
             inverter: Method to be used for inversion of local systems. Options are
-                'numba' (default) and 'python'.
+                'python' and 'numba'.
             hf_disp: If True, the displacement will be represented by subface values
                 instead of cell values. This is not recommended, but kept for the time
                 being for legacy reasons.
@@ -768,7 +768,7 @@ class Mpsa(Discretization):
         subcell_topology: pp.fvutils.SubcellTopology,
         bound_exclusion: pp.fvutils.ExcludeBoundaries,
         eta: float,
-        inverter: Literal["python", "numba"],
+        inverter: Optional[Literal["python", "numba"]] = None,
     ) -> tuple[sps.spmatrix, sps.spmatrix, np.ndarray]:
         """
         This is the function where the real discretization takes place. It contains
@@ -1639,7 +1639,7 @@ class Mpsa(Discretization):
         nno_unique: np.ndarray,
         bound_exclusion: pp.fvutils.ExcludeBoundaries,
         nd: int,
-        inverter: str,
+        inverter: Optional[str] = None,
     ) -> sps.spmatrix:
         """Invert local system to compute the subcell gradient operator.
 

--- a/src/porepy/numerics/linalg/matrix_operations.py
+++ b/src/porepy/numerics/linalg/matrix_operations.py
@@ -704,7 +704,7 @@ def invert_diagonal_blocks(
     # Variable to check if we have tried and failed with numba
     if method == "numba" or method is None:
         try:
-            inv_vals = invert_diagonal_blocks_python(mat, s)
+            inv_vals = invert_diagonal_blocks_numba(mat, s)
         except np.linalg.LinAlgError:
             raise ValueError("Error in inversion of local linear systems")
     # Variable to check if we should fall back on python

--- a/src/porepy/numerics/linalg/matrix_operations.py
+++ b/src/porepy/numerics/linalg/matrix_operations.py
@@ -568,11 +568,12 @@ def invert_diagonal_blocks(
         inv_a inverse matrix
         """
 
+        if not sps.isspmatrix_csr(a):
+            raise TypeError("Sparse array type not implemented: ", type(a))
+
         row, col = a.nonzero()
         idx_blocks = np.cumsum([0] + list(sz))
         idx_nnz = np.searchsorted(row, idx_blocks)
-        if not sps.isspmatrix_csr(a):
-            raise TypeError("Sparse array type not implemented: ", type(a))
 
         def sub_block(ib):
             lr = row[idx_nnz[ib] : idx_nnz[ib + 1]] - idx_blocks[ib]

--- a/src/porepy/numerics/linalg/matrix_operations.py
+++ b/src/porepy/numerics/linalg/matrix_operations.py
@@ -629,8 +629,7 @@ def invert_diagonal_blocks(
             import numba
         except ImportError:
             raise ImportError("Numba not available on the system")
-        # Sort matrix storage before pulling indices and data
-        a.sorted_indices()
+
         ptr = a.indptr
         indices = a.indices
         dat = a.data

--- a/src/porepy/numerics/linalg/matrix_operations.py
+++ b/src/porepy/numerics/linalg/matrix_operations.py
@@ -604,10 +604,10 @@ def invert_diagonal_blocks(
         # Maps retrieve_block to indexation
         iterator_blocks = map(retrieve_block, range(sz.size))
 
-        # Maps np.linalg.inv to blocks
+        # Maps linalg.inv to blocks
         iterator_block_inverses = map(np.linalg.inv, iterator_blocks)
 
-        # Maps np.ravel to block_inverses, perform the actual computation and concatenate
+        # Maps ravel to block_inverses, performs the actual computation and concatenates
         v = np.concatenate(list(map(np.ravel, iterator_block_inverses)))
         return v
 


### PR DESCRIPTION
## Proposed changes

This PR refactor and introduce a vectorized solution for the function `invert_diagonal_blocks_python` in file `matrix_operations.py`. The function is 2x faster than numba function for a large block diagonal matrix with irregular block sizes.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [x] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
