### PR TITLE
BUGFIX: `__str__` method of `MixedDimensionalGrid` class

### DIFF
--- a/src/porepy/grids/md_grid.py
+++ b/src/porepy/grids/md_grid.py
@@ -939,7 +939,7 @@ class MixedDimensionalGrid:
                 f"in total {num_cells} cells and {num_nodes} nodes. \n"
             )
 
-        s += f"Total number of interfaces: {self.num_subdomains()}\n"
+        s += f"Total number of interfaces: {self.num_interfaces()}\n"
         for dim in range(self.dim_max(), self.dim_min(), -1):
             num_e = 0
             nc = 0


### PR DESCRIPTION
## Proposed changes

A small bug fix in the `__str__` method of the `MixedDimensionalGrid` class where the number of subdomains were printed instead of the number of interfaces.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [x] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
