### PR TITLE
Fix of issue #0939

### DIFF
--- a/src/porepy/models/run_models.py
+++ b/src/porepy/models/run_models.py
@@ -103,7 +103,7 @@ def run_time_dependent_model(model, params: dict) -> None:
 
     # Progressbars turned off or tqdm not installed:
     if not params.get("progressbars", False) or not _IS_TQDM_AVAILABLE:
-        while model.time_manager.time < model.time_manager.time_final:
+        while not model.time_manager.final_time_reached():
             time_step()
 
     # Progressbars turned on:

--- a/src/porepy/numerics/time_step_control.py
+++ b/src/porepy/numerics/time_step_control.py
@@ -404,6 +404,15 @@ class TimeManager:
 
         return s
 
+    def final_time_reached(self) -> bool:
+        """Check whether the time manager has reached the end of the schedule.
+
+        Returns:
+            Whether the final time has reached or been overstepped.
+
+        """
+        return self.time > self.time_final or np.isclose(self.time, self.time_final)
+
     def compute_time_step(
         self, iterations: Optional[int] = None, recompute_solution: bool = False
     ) -> Union[float, None]:
@@ -431,7 +440,7 @@ class TimeManager:
         self._iters = iterations
 
         # First, check if we reach final simulation time
-        if self.time >= self.time_final:
+        if self.final_time_reached():
             return None
 
         # If the time step is constant, always return that value

--- a/src/porepy/numerics/time_step_control.py
+++ b/src/porepy/numerics/time_step_control.py
@@ -159,6 +159,8 @@ class TimeManager:
         allowable
             number of consecutive recomputation attempts.
         print_info. Whether to print on-the-fly time-stepping information or not.
+        rtol: Relative tolerance parameter for float point equality.
+        atol: Absolute tolerance parameter for float point equality.
 
     Example:
         # The following is an example on how to initialize a time-stepping object
@@ -206,6 +208,8 @@ class TimeManager:
         recomp_factor: float = 0.5,
         recomp_max: int = 10,
         print_info: bool = False,
+        rtol: float = 1e-10,
+        atol: float = 1e-16,
     ) -> None:
         schedule = np.array(schedule)
         # Sanity checks for schedule
@@ -223,6 +227,9 @@ class TimeManager:
             raise ValueError(
                 "Initial time step cannot be larger than final simulation time."
             )
+
+        self.rtol = rtol
+        self.atol = atol
 
         # If dt_min_max is not given, set dt_min=0.001*final_time and
         # dt_max=0.1*final_time
@@ -319,13 +326,11 @@ class TimeManager:
             # If the time step is constant, check that the scheduled times and the time
             # step are compatible. See documentation of ``schedule``.
             sim_times = np.arange(schedule[0], schedule[-1] + dt_init, dt_init)
-            compat_rtol = 1e-05
-            compat_atol = 1e-08
             is_compatible = self.is_schedule_in_simulated_times(
                 schedule,
                 sim_times,
-                rtol=compat_rtol,
-                atol=compat_atol,
+                rtol=self.rtol,
+                atol=self.atol,
             )
             if not is_compatible:
                 msg = (
@@ -411,7 +416,9 @@ class TimeManager:
             Whether the final time has reached or been overstepped.
 
         """
-        return self.time > self.time_final or np.isclose(self.time, self.time_final)
+        return self.time > self.time_final or np.isclose(
+            self.time, self.time_final, rtol=self.rtol, atol=self.atol
+        )
 
     def compute_time_step(
         self, iterations: Optional[int] = None, recompute_solution: bool = False
@@ -648,8 +655,8 @@ class TimeManager:
     def is_schedule_in_simulated_times(
         schedule: np.ndarray,
         sim_times: np.ndarray,
-        rtol: float = 1e-05,
-        atol: float = 1e-08,
+        rtol: float = 1e-10,
+        atol: float = 1e-16,
     ) -> bool:
         """Checks if ``schedule`` is a proper subset of ``sim_times`` for given
            tolerances

--- a/tests/numerics/test_time_step_control.py
+++ b/tests/numerics/test_time_step_control.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+
 import porepy as pp
 from porepy.models.fluid_mass_balance import SinglePhaseFlow
 

--- a/tests/numerics/test_time_step_control.py
+++ b/tests/numerics/test_time_step_control.py
@@ -356,8 +356,6 @@ class TestParameterInputs:
             (3, 1.0e-14),
             (1, 1.0),
             (3, 1.0),
-            (1, 1.0e14),
-            (3, 1.0e14),
         ],
     )
     def test_number_time_steps(self, num_time_steps, final_time):

--- a/tests/numerics/test_time_step_control.py
+++ b/tests/numerics/test_time_step_control.py
@@ -348,6 +348,29 @@ class TestParameterInputs:
             )
         assert msg in str(excinfo.value)
 
+    @pytest.mark.parametrize("num_time_steps", [10, 20])
+    def test_number_time_steps(self, num_time_steps):
+        """An error should be reaised it the number of performed time steps should differ
+        from the effective definition via the time step size."""
+        time_manager = pp.TimeManager(
+            schedule=[0.0, 1.0],
+            dt_init=1.0 / num_time_steps,
+            constant_dt=True,
+        )
+
+        params = {
+            "time_manager": time_manager,
+            "suppress_export": True,
+        }
+
+        from porepy.models.momentum_balance import MomentumBalance
+
+        model = MomentumBalance(params)
+        pp.run_time_dependent_model(model, params)
+        performed_time_steps = model.time_manager.time_index
+
+        assert performed_time_steps == num_time_steps
+
 
 class TestTimeControl:
     """The following tests are written to check the overall behavior of the time-stepping

--- a/tests/numerics/test_time_step_control.py
+++ b/tests/numerics/test_time_step_control.py
@@ -352,10 +352,10 @@ class TestParameterInputs:
     @pytest.mark.parametrize(
         "num_time_steps, final_time",
         [
-            (1, 1.0e-14),
             (3, 1.0e-14),
-            (1, 1.0),
+            (7, 1.0e-14),
             (3, 1.0),
+            (10, 1.0),
         ],
     )
     def test_number_time_steps(self, num_time_steps, final_time):

--- a/tests/numerics/test_time_step_control.py
+++ b/tests/numerics/test_time_step_control.py
@@ -350,8 +350,9 @@ class TestParameterInputs:
 
     @pytest.mark.parametrize("num_time_steps", [10, 20])
     def test_number_time_steps(self, num_time_steps):
-        """An error should be reaised it the number of performed time steps should differ
-        from the effective definition via the time step size."""
+        """An error should be realised if the number of performed time steps should differ
+        from the effective definition via the time step size. Implicitly, this test also
+        tests whether the time manager correctly detects final times."""
         time_manager = pp.TimeManager(
             schedule=[0.0, 1.0],
             dt_init=1.0 / num_time_steps,


### PR DESCRIPTION
## Proposed changes

Fix for issue #0939. By introducing a new method for `TimeManager` to check when a final time is reached, the time manager now behaves as expected. 

## Types of changes

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [X] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [x] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
