### PR TITLE
Setup for case 3, flow benchmark 3d

### DIFF
--- a/examples/flow_benchmark_3d_case_3.py
+++ b/examples/flow_benchmark_3d_case_3.py
@@ -2,7 +2,7 @@
 This module contains the implementation of Case 3 from the 3D flow benchmark [1].
 
 Note:
-    The class `Benchmark3dCase3Model` admits the keyword `refinement_level`,
+    The class `FlowBenchmark3dCase3Model` admits the keyword `refinement_level`,
     which can take values 0, 1, 2, 3, to control the mesh refinement level. Level `0`
     contains approximately 30K three-dimensional cells, level `1` contains 140K
     three-dimensional cells, level `2` contains 350K three-dimensional cells,
@@ -122,16 +122,4 @@ class FlowBenchmark3dCase3Model(  # type:ignore[misc]
     FlowBenchmark3dCase3BoundaryConditions,
     pp.fluid_mass_balance.SinglePhaseFlow,
 ):
-    """Mixer class for case 3 from 3D flow benchmark."""
-
-
-# %% Runner
-model = FlowBenchmark3dCase3Model({"material_constants": {"solid": solid_constants}})
-pp.run_time_dependent_model(model, {})
-pressure_norm = np.linalg.norm(
-    model.pressure(model.mdg.subdomains()).value(model.equation_system)
-)
-
-# %%
-print("Pressure norm", pressure_norm)
-np.testing.assert_allclose(pressure_norm, 13.337947636587648)
+    """Mixer class for case 3 from the 3d flow benchmark."""

--- a/examples/flow_benchmark_3d_case_3.py
+++ b/examples/flow_benchmark_3d_case_3.py
@@ -1,0 +1,137 @@
+"""
+This module contains the implementation of Case 3 from the 3D flow benchmark [1].
+
+Note:
+    The class `Benchmark3dCase3Model` admits the keyword `refinement_level`,
+    which can take values 0, 1, 2, 3, to control the mesh refinement level. Level `0`
+    contains approximately 30K three-dimensional cells, level `1` contains 140K
+    three-dimensional cells, level `2` contains 350K three-dimensional cells,
+    and level `3` contains 500K three-dimensional cells.
+
+References:
+    [1] Berre, I., Boon, W. M., Flemisch, B., Fumagalli, A., Gläser, D., Keilegavlen,
+        E., ... & Zulian, P. (2021). Verification benchmarks for single-phase flow in
+        three-dimensional fractured porous media. Advances in Water Resources, 147,
+        103759.
+
+"""
+from typing import Callable
+
+import numpy as np
+
+import porepy as pp
+from porepy.applications.md_grids.mdg_library import benchmark_3d_case_3
+from porepy.fracs.fracture_network_3d import FractureNetwork3d
+from porepy.models.constitutive_laws import DimensionDependentPermeability
+
+solid_constants = pp.SolidConstants(
+    {
+        "residual_aperture": 1e-2,
+        "normal_permeability": 1e4,
+    }
+)
+
+
+class FlowBenchmark3dCase3Geometry(pp.ModelGeometry):
+    """Define Geometry as"""
+
+    params: dict
+    """User-defined model parameters."""
+
+    def set_geometry(self) -> None:
+        """Read geometry from the `geo` files associated to the benchmark."""
+
+        # Create mixed-dimensional grid and fracture network
+        self.mdg, self.fracture_network = benchmark_3d_case_3(
+            refinement_level=self.params.get("refinement_level", 0)
+        )
+        self.nd: int = self.mdg.dim_max()
+
+        # Obtain domain and fracture list directly from the fracture network
+        self._domain = self.fracture_network.domain
+        self._fractures = self.fracture_network.fractures
+
+        # Create projections between local and global coordinates for fracture grids.
+        pp.set_local_coordinate_projections(self.mdg)
+
+        self.set_well_network()
+        if len(self.well_network.wells) > 0:
+            # Compute intersections
+            assert isinstance(self.fracture_network, FractureNetwork3d)
+            pp.compute_well_fracture_intersections(
+                self.well_network, self.fracture_network
+            )
+            # Mesh wells and add fracture + intersection grids to mixed-dimensional
+            # grid along with these grids' new interfaces to fractures.
+            self.well_network.mesh(self.mdg)
+
+
+class FlowBenchmark3dCase3Permeability(DimensionDependentPermeability):
+    def fracture_permeability(self, subdomains: list[pp.Grid]) -> pp.ad.Operator:
+        """Constant fracture permeability"""
+        size = sum(sd.num_cells for sd in subdomains)
+        val = self.solid.convert_units(1e4, "m^2")
+        permeability = pp.wrap_as_dense_ad_array(val, size, name="permeability")
+        return self.isotropic_second_order_tensor(subdomains, permeability)
+
+    def intersection_permeability(self, subdomains: list[pp.Grid]) -> pp.ad.Operator:
+        """Constant intersection permeability"""
+        size = sum(sd.num_cells for sd in subdomains)
+        val = self.solid.convert_units(1e4, "m^2")
+        permeability = pp.wrap_as_dense_ad_array(val, size, name="permeability")
+        return self.isotropic_second_order_tensor(subdomains, permeability)
+
+
+class FlowBenchmark3dCase3BoundaryConditions:
+    """Define inlet and outlet boundary conditions as specified by the benchmark."""
+
+    domain_boundary_sides: Callable
+
+    def bc_type_darcy_flux(self, sd: pp.Grid) -> pp.BoundaryCondition:
+        """Assign Dirichlet to top North and bottom North parts of the boundary."""
+        # Retrieve boundary sides
+        bounds = self.domain_boundary_sides(sd)
+        # Get Dirichlet faces
+        dir_faces = np.zeros(sd.num_faces, dtype=bool)
+        north_top_dir_cells = sd.face_centers[2][bounds.north] > (2 / 3)
+        north_bottom_dir_faces = sd.face_centers[2][bounds.north] < (1 / 3)
+        dir_faces[bounds.north] = north_top_dir_cells + north_bottom_dir_faces
+        # Assign boundary conditions, the rest are Neumann by default
+        bc = pp.BoundaryCondition(sd, dir_faces, "dir")
+        return bc
+
+    def bc_values_darcy_flux(self, boundary_grid: pp.BoundaryGrid) -> np.ndarray:
+        """Assign non-zero Darcy flux to the middle South boundary."""
+        # Retrieve boundary sides and cell centers
+        bounds = self.domain_boundary_sides(boundary_grid)
+        cc = boundary_grid.cell_centers
+        # Get inlet faces
+        inlet_faces = np.zeros(boundary_grid.num_cells, dtype=bool)
+        inlet_faces[bounds.south] = (cc[2][bounds.south] < (2 / 3)) & (
+            cc[2][bounds.south] > (1 / 3)
+        )
+        # Assign unitary flow. Negative since fluid is entering into the domain.
+        values = np.zeros(boundary_grid.num_cells)
+        values[inlet_faces] = -1 * boundary_grid.cell_volumes[inlet_faces]
+        return values
+
+
+class FlowBenchmark3dCase3Model(  # type:ignore[misc]
+    FlowBenchmark3dCase3Geometry,
+    FlowBenchmark3dCase3Permeability,
+    FlowBenchmark3dCase3BoundaryConditions,
+    pp.fluid_mass_balance.SinglePhaseFlow,
+):
+    """Mixer class for case 3 from 3D flow benchmark."""
+
+
+# %% Runner
+model = FlowBenchmark3dCase3Model({"material_constants": {"solid": solid_constants}})
+pp.run_time_dependent_model(model, {})
+pressure_norm = np.linalg.norm(
+    model.pressure(model.mdg.subdomains()).value(model.equation_system)
+)
+
+# %%
+print("Pressure norm", pressure_norm)
+np.testing.assert_allclose(pressure_norm, 13.337947636587648)

--- a/tests/functional/test_benchmark_3d_case_3.py
+++ b/tests/functional/test_benchmark_3d_case_3.py
@@ -1,0 +1,137 @@
+"""
+Module containing tests for the flow three-dimensional benchmark, case 3.
+"""
+import sys
+
+import numpy as np
+import pytest
+
+import porepy as pp
+
+# Append the top PorePy folder to the path, to allow for imports of the examples folder
+sys.path.append("../..")
+
+from examples.flow_benchmark_3d_case_3 import (
+    solid_constants,
+    FlowBenchmark3dCase3Model,
+)
+
+
+class ModelWithEffectivePermeability(FlowBenchmark3dCase3Model):
+    """
+    Mixin that contains the computation of effective normal permeabilities.
+    """
+
+    def effective_normal_permeability(
+            self, interfaces: list[pp.MortarGrid]
+            ) -> pp.ad.Operator:
+        """
+        Computes the effective normal permeability, see Eq. 6b from [1].
+
+        Note:
+            The effective normal permeability is the scalar that multiplies the
+            pressure jump in the continuous interface law.
+
+        Reference:
+            [1] https://doi.org/10.1016/j.advwatres.2020.103759
+
+        Parameters:
+            interfaces: List of interfaces.
+
+        Returns:
+            Wrapped ad operator containing the effective normal permeabilities for
+            the given list of interfaces.
+        """
+        subdomains = self.interfaces_to_subdomains(interfaces)
+        projection = pp.ad.MortarProjections(self.mdg, subdomains, interfaces, dim=1)
+
+        normal_gradient = pp.ad.Scalar(2) * (
+            projection.secondary_to_mortar_avg
+            @ self.aperture(subdomains) ** pp.ad.Scalar(-1)
+        )
+
+        effective_normal_permeability = (
+            self.specific_volume(interfaces)
+            * self.normal_permeability(interfaces)
+            * normal_gradient
+        )
+
+        return effective_normal_permeability
+
+
+@pytest.fixture(scope="module")
+def model() -> ModelWithEffectivePermeability:
+    """
+    Run the benchmark model with the coarsest mesh resolution.
+
+    Returns:
+        The solved model, an instance of `ModelWithEffectivePermeability`.
+
+    """
+    model = ModelWithEffectivePermeability(
+        {"material_constants": {"solid": solid_constants}}
+    )
+    pp.run_time_dependent_model(model, {})
+    return model
+
+
+def test_effective_tangential_permeability_values(model) -> None:
+    """
+    Test if the permeability values are consistent with the benchmark specification.
+
+    Parameters:
+        model: ModelWithEffectivePermeability
+            Solved model. Returned by the `model()` fixture.
+
+    """
+    for sd, d in model.mdg.subdomains(return_data=True):
+        val = np.mean(
+            d[pp.PARAMETERS][model.darcy_keyword]["second_order_tensor"].values[0][0]
+        )
+        if sd.dim == 3:
+            np.testing.assert_allclose(val, 1)
+        elif sd.dim == 2:
+            np.testing.assert_allclose(val, 1E2)
+        else:  # sd.dim == 1
+            np.testing.assert_allclose(val, 1)
+
+
+def test_effective_normal_permeability_values(model) -> None:
+    """
+    Test if the permeability values are consistent with the benchmark specification.
+
+    Parameters:
+        model: ModelWithEffectivePermeability
+            Solved model. Returned by the `model()` fixture.
+
+    """
+    for intf in model.mdg.interfaces():
+        val = np.mean(
+            model.effective_normal_permeability([intf]).value(model.equation_system)
+            )
+        if intf.dim == 2:
+            np.testing.assert_allclose(val, 2e6)
+        else:
+            np.testing.assert_allclose(val, 2e4)
+
+
+def test_boundary_specification(model) -> None:
+    """
+    Check that the inlet and outlet boundaries are correctly specified.
+
+    Note:
+        At the inlet boundary, we check if the total amount of fluid is entering into
+        the domain. At the outlet boundary, we check that the pressure value is zero.
+
+    """
+    bg, data_bg = model.mdg.boundaries(return_data=True, dim=2)[0]
+
+    # Inlet boundary
+    south_side = model.domain_boundary_sides(bg).south
+    inlet_flux = np.sum(data_bg["iterate_solutions"]["darcy_flux"][0][south_side])
+    np.testing.assert_allclose(inlet_flux, desired=-1/3, atol=1e-5)
+
+    # Outlet boundary
+    north_side = model.domain_boundary_sides(bg).north
+    outlet_pressure = np.sum(data_bg["iterate_solutions"]["pressure"][0][north_side])
+    np.testing.assert_allclose(outlet_pressure, desired=0, atol=1e-5)

--- a/tests/functional/test_benchmark_3d_case_3.py
+++ b/tests/functional/test_benchmark_3d_case_3.py
@@ -1,9 +1,15 @@
 """
-Module containing tests for the flow three-dimensional benchmark, case 3.
+Module containing tests for the flow three-dimensional benchmark, case 3 from [1].
 
 The tests check whether effective permeabilities and boundary are correctly assigned.
 Since we solved the actual model, we also implicitly check that the model does not
 crash. However, we are currently not checking that the solution is the "correct" one.
+
+Reference:
+    - [1] Berre, I., Boon, W. M., Flemisch, B., Fumagalli, A., Gläser, D., Keilegavlen,
+      E., ... & Zulian, P. (2021). Verification benchmarks for single-phase flow in
+      three-dimensional fractured porous media. Advances in Water Resources, 147,
+      103759. https://doi.org/10.1016/j.advwatres.2020.103759
 
 """
 import sys
@@ -16,14 +22,45 @@ import porepy as pp
 # Append the top PorePy folder to the path, to allow for imports of the examples folder
 sys.path.append("../..")
 
-from examples.flow_benchmark_3d_case_3 import (
-    solid_constants,
-    FlowBenchmark3dCase3Model,
-)
+from examples.flow_benchmark_3d_case_3 import FlowBenchmark3dCase3Model, solid_constants
 
 
 class ModelWithEffectivePermeability(FlowBenchmark3dCase3Model):
-    """Mixin that contains the computation of effective normal permeabilities."""
+    """Mixin that contains the computation of effective permeabilities."""
+
+    def effective_tangential_permeability(
+        self, subdomains: list[pp.Grid]
+    ) -> pp.ad.Operator:
+        """Retrieves the effective tangential permeability, see Eq. 6a from [1].
+
+        This method implicitly assumes that, in each subdomain, the effective
+        tangential permeability can be fully represented by one scalar per cell.
+
+        The effective tangential permeability is the permeability tensor multiplied
+        by the specific volume. PorePy "transforms" the intrinsic permeability into
+        an effective one using the method `operator_to_SecondOrderTensor` defined in
+        the mixin class `~porepy.models.constitutive_laws.SecondOrderTensorUtils`.
+
+        Parameters:
+            subdomains: list of pp.Grid
+                List of subdomain grids.
+
+        Returns:
+            Wrapped ad operator containing the effective tangential permeabilities
+            for the given list of subdomains.
+
+        """
+        values = []
+        size = self.mdg.num_subdomain_cells()
+        for sd in subdomains:
+            d = self.mdg.subdomain_data(sd)
+            val_loc = d[pp.PARAMETERS][self.darcy_keyword][
+                "second_order_tensor"
+            ].values[0][0]
+            values.append(val_loc)
+        return pp.wrap_as_dense_ad_array(
+            np.hstack(values), size, "effective_tangential_permeability"
+        )
 
     def effective_normal_permeability(
         self, interfaces: list[pp.MortarGrid]
@@ -31,19 +68,17 @@ class ModelWithEffectivePermeability(FlowBenchmark3dCase3Model):
         """
         Computes the effective normal permeability, see Eq. 6b from [1].
 
-        Note:
-            The effective normal permeability is the scalar that multiplies the pressure
-            jump in the continuous interface law.
-
-        Reference:
-            [1] https://doi.org/10.1016/j.advwatres.2020.103759
+        The effective normal permeability is the scalar that multiplies the pressure
+        jump in the continuous interface law.
 
         Parameters:
-            interfaces: List of interfaces.
+            interfaces: List of pp.MortarGrid
+                List of interface grids.
 
         Returns:
             Wrapped ad operator containing the effective normal permeabilities for the
             given list of interfaces.
+
         """
         subdomains = self.interfaces_to_subdomains(interfaces)
         projection = pp.ad.MortarProjections(self.mdg, subdomains, interfaces, dim=1)
@@ -58,6 +93,7 @@ class ModelWithEffectivePermeability(FlowBenchmark3dCase3Model):
             * self.normal_permeability(interfaces)
             * normal_gradient
         )
+        effective_normal_permeability.set_name("effective_normal_permeability")
 
         return effective_normal_permeability
 
@@ -81,26 +117,31 @@ def model() -> ModelWithEffectivePermeability:
 def test_effective_tangential_permeability_values(model) -> None:
     """Test if the permeability values are consistent with the benchmark specification.
 
+    The values are specified in Table 5 from [1]. We expect a value of normal
+    permeability = 2E6 for 2d interfaces, and 2e4 for 1d interfaces.
+
     Parameters:
         model: ModelWithEffectivePermeability
             Solved model. Returned by the `model()` fixture.
 
     """
-    for sd, d in model.mdg.subdomains(return_data=True):
-        val = np.mean(
-            d[pp.PARAMETERS][model.darcy_keyword]["second_order_tensor"].values[0][0]
-        )
+    for sd in model.mdg.subdomains():
+        val = model.effective_tangential_permeability([sd]).value(model.equation_system)
         if sd.dim == 3:
-            np.testing.assert_allclose(val, 1)
+            np.testing.assert_array_almost_equal(val, 1.0)
         elif sd.dim == 2:
-            np.testing.assert_allclose(val, 1e2)
+            np.testing.assert_array_almost_equal(val, 1e2)
         else:  # sd.dim == 1
-            np.testing.assert_allclose(val, 1)
+            np.testing.assert_array_almost_equal(val, 1.0)
 
 
 @pytest.mark.skipped  # reason: slow
 def test_effective_normal_permeability_values(model) -> None:
     """Test if the permeability values are consistent with the benchmark specification.
+
+    The values are specified in Table 5, from [1]. Specifically, we expect a value of
+    normal permeability = 2e6 for 2d interfaces, and a value of normal permeability
+    = 2e4 for 1d interfaces.
 
     Parameters:
         model: ModelWithEffectivePermeability
@@ -108,22 +149,19 @@ def test_effective_normal_permeability_values(model) -> None:
 
     """
     for intf in model.mdg.interfaces():
-        val = np.mean(
-            model.effective_normal_permeability([intf]).value(model.equation_system)
-        )
+        val = model.effective_normal_permeability([intf]).value(model.equation_system)
         if intf.dim == 2:
-            np.testing.assert_allclose(val, 2e6)
-        else:
-            np.testing.assert_allclose(val, 2e4)
+            np.testing.assert_array_almost_equal(val, 2e6)
+        else:  # intf.dim == 1
+            np.testing.assert_array_almost_equal(val, 2e4)
 
 
 @pytest.mark.skipped  # reason: slow
 def test_boundary_specification(model) -> None:
     """Check that the inlet and outlet boundaries are correctly specified.
 
-    Note:
-        At the inlet boundary, we check if the total amount of fluid is entering into
-        the domain. At the outlet boundary, we check that the pressure value is zero.
+    At the inlet boundary, we check if the total amount of fluid is entering into the
+    domain. At the outlet boundary, we check that the pressure value is zero.
 
     """
     bg, data_bg = model.mdg.boundaries(return_data=True, dim=2)[0]
@@ -131,9 +169,9 @@ def test_boundary_specification(model) -> None:
     # Inlet boundary
     south_side = model.domain_boundary_sides(bg).south
     inlet_flux = np.sum(data_bg["iterate_solutions"]["darcy_flux"][0][south_side])
-    np.testing.assert_allclose(inlet_flux, desired=-1 / 3, atol=1e-5)
+    assert np.isclose(inlet_flux, -1 / 3, atol=1e-5)
 
     # Outlet boundary
     north_side = model.domain_boundary_sides(bg).north
     outlet_pressure = np.sum(data_bg["iterate_solutions"]["pressure"][0][north_side])
-    np.testing.assert_allclose(outlet_pressure, desired=0, atol=1e-5)
+    assert np.isclose(outlet_pressure, 0, atol=1e-5)

--- a/tests/functional/test_benchmark_3d_case_3.py
+++ b/tests/functional/test_benchmark_3d_case_3.py
@@ -1,5 +1,10 @@
 """
 Module containing tests for the flow three-dimensional benchmark, case 3.
+
+The tests check whether effective permeabilities and boundary are correctly assigned.
+Since we solved the actual model, we also implicitly check that the model does not
+crash. However, we are currently not checking that the solution is the "correct" one.
+
 """
 import sys
 
@@ -75,6 +80,7 @@ def model() -> ModelWithEffectivePermeability:
     return model
 
 
+@pytest.mark.skipped  # reason: slow
 def test_effective_tangential_permeability_values(model) -> None:
     """
     Test if the permeability values are consistent with the benchmark specification.
@@ -96,6 +102,7 @@ def test_effective_tangential_permeability_values(model) -> None:
             np.testing.assert_allclose(val, 1)
 
 
+@pytest.mark.skipped  # reason: slow
 def test_effective_normal_permeability_values(model) -> None:
     """
     Test if the permeability values are consistent with the benchmark specification.
@@ -115,6 +122,7 @@ def test_effective_normal_permeability_values(model) -> None:
             np.testing.assert_allclose(val, 2e4)
 
 
+@pytest.mark.skipped  # reason: slow
 def test_boundary_specification(model) -> None:
     """
     Check that the inlet and outlet boundaries are correctly specified.

--- a/tests/functional/test_benchmark_3d_case_3.py
+++ b/tests/functional/test_benchmark_3d_case_3.py
@@ -23,19 +23,17 @@ from examples.flow_benchmark_3d_case_3 import (
 
 
 class ModelWithEffectivePermeability(FlowBenchmark3dCase3Model):
-    """
-    Mixin that contains the computation of effective normal permeabilities.
-    """
+    """Mixin that contains the computation of effective normal permeabilities."""
 
     def effective_normal_permeability(
-            self, interfaces: list[pp.MortarGrid]
-            ) -> pp.ad.Operator:
+        self, interfaces: list[pp.MortarGrid]
+    ) -> pp.ad.Operator:
         """
         Computes the effective normal permeability, see Eq. 6b from [1].
 
         Note:
-            The effective normal permeability is the scalar that multiplies the
-            pressure jump in the continuous interface law.
+            The effective normal permeability is the scalar that multiplies the pressure
+            jump in the continuous interface law.
 
         Reference:
             [1] https://doi.org/10.1016/j.advwatres.2020.103759
@@ -44,8 +42,8 @@ class ModelWithEffectivePermeability(FlowBenchmark3dCase3Model):
             interfaces: List of interfaces.
 
         Returns:
-            Wrapped ad operator containing the effective normal permeabilities for
-            the given list of interfaces.
+            Wrapped ad operator containing the effective normal permeabilities for the
+            given list of interfaces.
         """
         subdomains = self.interfaces_to_subdomains(interfaces)
         projection = pp.ad.MortarProjections(self.mdg, subdomains, interfaces, dim=1)
@@ -66,8 +64,7 @@ class ModelWithEffectivePermeability(FlowBenchmark3dCase3Model):
 
 @pytest.fixture(scope="module")
 def model() -> ModelWithEffectivePermeability:
-    """
-    Run the benchmark model with the coarsest mesh resolution.
+    """Run the benchmark model with the coarsest mesh resolution.
 
     Returns:
         The solved model, an instance of `ModelWithEffectivePermeability`.
@@ -82,8 +79,7 @@ def model() -> ModelWithEffectivePermeability:
 
 @pytest.mark.skipped  # reason: slow
 def test_effective_tangential_permeability_values(model) -> None:
-    """
-    Test if the permeability values are consistent with the benchmark specification.
+    """Test if the permeability values are consistent with the benchmark specification.
 
     Parameters:
         model: ModelWithEffectivePermeability
@@ -97,15 +93,14 @@ def test_effective_tangential_permeability_values(model) -> None:
         if sd.dim == 3:
             np.testing.assert_allclose(val, 1)
         elif sd.dim == 2:
-            np.testing.assert_allclose(val, 1E2)
+            np.testing.assert_allclose(val, 1e2)
         else:  # sd.dim == 1
             np.testing.assert_allclose(val, 1)
 
 
 @pytest.mark.skipped  # reason: slow
 def test_effective_normal_permeability_values(model) -> None:
-    """
-    Test if the permeability values are consistent with the benchmark specification.
+    """Test if the permeability values are consistent with the benchmark specification.
 
     Parameters:
         model: ModelWithEffectivePermeability
@@ -115,7 +110,7 @@ def test_effective_normal_permeability_values(model) -> None:
     for intf in model.mdg.interfaces():
         val = np.mean(
             model.effective_normal_permeability([intf]).value(model.equation_system)
-            )
+        )
         if intf.dim == 2:
             np.testing.assert_allclose(val, 2e6)
         else:
@@ -124,8 +119,7 @@ def test_effective_normal_permeability_values(model) -> None:
 
 @pytest.mark.skipped  # reason: slow
 def test_boundary_specification(model) -> None:
-    """
-    Check that the inlet and outlet boundaries are correctly specified.
+    """Check that the inlet and outlet boundaries are correctly specified.
 
     Note:
         At the inlet boundary, we check if the total amount of fluid is entering into
@@ -137,7 +131,7 @@ def test_boundary_specification(model) -> None:
     # Inlet boundary
     south_side = model.domain_boundary_sides(bg).south
     inlet_flux = np.sum(data_bg["iterate_solutions"]["darcy_flux"][0][south_side])
-    np.testing.assert_allclose(inlet_flux, desired=-1/3, atol=1e-5)
+    np.testing.assert_allclose(inlet_flux, desired=-1 / 3, atol=1e-5)
 
     # Outlet boundary
     north_side = model.domain_boundary_sides(bg).north

--- a/tests/functional/test_benchmark_3d_case_3.py
+++ b/tests/functional/test_benchmark_3d_case_3.py
@@ -117,8 +117,9 @@ def model() -> ModelWithEffectivePermeability:
 def test_effective_tangential_permeability_values(model) -> None:
     """Test if the permeability values are consistent with the benchmark specification.
 
-    The values are specified in Table 5 from [1]. We expect a value of normal
-    permeability = 2E6 for 2d interfaces, and 2e4 for 1d interfaces.
+    The values are specified in Table 5 from [1]. We expect a value of effective
+    tangential permeability = 1 for the 3d subdomain, 1e2 for the fractures, and 1.0
+    for the fracture intersections.
 
     Parameters:
         model: ModelWithEffectivePermeability


### PR DESCRIPTION
## Proposed changes

This PR introduces the setup for case 3, flow benchmark 3d, as a porepy example. Tests for the sanity of benchmark parameters specification (e.g., effective permeabilities and boundary conditions) are included. 

Idea for a proper test: Ideally, we should try to sample the reference value of the plot over line from the benchmark and compare them with the approximate pressure solutions. Might be a nice little side project for the user group.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Testing (contribution related to testing of existing or new functionality).
- [x] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [x] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
