### PR TITLE
[MAINT] Fixed issue #877

### DIFF
--- a/src/porepy/fracs/fracture_network_2d.py
+++ b/src/porepy/fracs/fracture_network_2d.py
@@ -841,12 +841,12 @@ class FractureNetwork2d:
 
                 :obj:`numpy.ndarray`:
 
-                    Array containing the indices of the edges that have been kept.
+                    Array containing the indices of the fractures that have been kept.
 
                 :obj:`numpy.ndarray`:
 
-                    Array containing the indices of the edges that have been deleted,
-                    since they were outside the bounding box.
+                    Array containing the indices of the fractures that have been
+                    deleted, since they were outside the bounding box.
 
         """
 

--- a/src/porepy/fracs/fracture_network_3d.py
+++ b/src/porepy/fracs/fracture_network_3d.py
@@ -1527,7 +1527,7 @@ class FractureNetwork3d(object):
         area_threshold: float = 1e-4,
         clear_gmsh: bool = True,
         finalize_gmsh: bool = True,
-    ) -> np.ndarray:
+    ) -> tuple[np.ndarray, np.ndarray]:
         """Set an external boundary for the contained plane fractures.
 
         If no domain is provided, a box will be fitted outside the fracture network.
@@ -1579,10 +1579,18 @@ class FractureNetwork3d(object):
                 passed to this method.
 
         Returns:
-            Mapping from old to new fractures, referring to the fractures in
-            :attr:`fractures` before and after imposing the external boundary. The
-            mapping does not account for the boundary fractures added to the
-            end of the fracture array (if ``keep_box=True``).
+            Tuple with two elements.
+
+                :obj:`numpy.ndarray`:
+
+                    Array containing the indices of the fractures that have been kept.
+                    The array does not account for the boundary fractures added to the
+                    end of the fracture array (if ``keep_box=True``).
+
+                :obj:`numpy.ndarray`:
+
+                    Array containing the indices of the fractures that have been
+                    deleted, since they were outside the bounding box.
 
         """
         if domain is None and not self.fractures:
@@ -2010,7 +2018,7 @@ class FractureNetwork3d(object):
         self.tags["boundary"] = boundary_tags
 
         self._reindex_fractures()
-        return ind_map
+        return ind_map, delete_frac
 
     def _classify_edges(
         self,

--- a/src/porepy/fracs/structured.py
+++ b/src/porepy/fracs/structured.py
@@ -204,7 +204,11 @@ def _create_lower_dim_grids_3d(
 
     # Create 2D grids
     for fi, f in enumerate(fracs):
-        assert np.all(f.shape == (3, 4)), "fractures must have shape [3,4]"
+        assert np.all(f.shape == (3, 4)), (
+            "Fracture is set by an array of the edge points of shape (3, 4), "
+            f"Passed array has shape: {f.shape}. Could it be because of trimming the "
+            "part of the fracture outside the bounding box?"
+        )
         is_xy_frac = np.allclose(f[2, 0], f[2])
         is_xz_frac = np.allclose(f[1, 0], f[1])
         is_yz_frac = np.allclose(f[0, 0], f[0])

--- a/src/porepy/grids/mdg_generation.py
+++ b/src/porepy/grids/mdg_generation.py
@@ -401,14 +401,12 @@ def _validate_args(
         domain: Union[pp.Domain, None] = _retrieve_domain_instance(fracture_network)
         if dim == 2:
             assert isinstance(fracture_network, FractureNetwork2d)
-            _, edges_deleted = fracture_network.impose_external_boundary(domain)
-            sz = edges_deleted.size
+            _, fractures_deleted = fracture_network.impose_external_boundary(domain)
         elif dim == 3:
             assert isinstance(fracture_network, FractureNetwork3d)
-            fractures_deleted = fracture_network.impose_external_boundary(domain)
-            # Take note of deleted fractures
-            sz = fractures_deleted.size
-        if sz > 0:
+            _, fractures_deleted = fracture_network.impose_external_boundary(domain)
+        # Take note of deleted fractures
+        if (sz := fractures_deleted.size) > 0:
             # It seems most likely that this is an undesired effect (for a
             # Cartesian geomtetry it should be possible to make sure the
             # fractures are within the domain), but we cannot rule out that the

--- a/tests/fracs/test_fracture_network_3d.py
+++ b/tests/fracs/test_fracture_network_3d.py
@@ -112,7 +112,9 @@ def test_impose_external_boundary(points_expected):
     expected_num_fractures = points_expected["expected_num_fractures"]
     fracture = pp.PlaneFracture(points, check_convexity=False)
     network = pp.create_fracture_network([fracture])
-    network.impose_external_boundary(unit_domain(3))
+    fractures_kept, fractures_deleted = network.impose_external_boundary(unit_domain(3))
+    assert len(fractures_kept) == expected_num_fractures
+    assert len(fractures_deleted) == 1 - expected_num_fractures
     assert len(network.fractures) == (6 + expected_num_fractures)
     p_comp = network.fractures[0].pts
     if expected_points := points_expected.get("expected_points", None):


### PR DESCRIPTION
## Proposed changes

This fixes the issue #877. I unified return types for the methods `FractureNetwork3d.impose_external_boundary` and `FractureNetwork2d.impose_external_boundary`, and updated a test for the changed return value in 3D. I also tried to improve some docstrings and warnings. 
Note: I did not try to investigate the performance issue that @keileg mentioned in the issue discussion, but we can discuss it.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [x] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Testing (contribution related to testing of existing or new functionality).
- [x] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
