### PR TITLE
Make meshing compatible with scipy v1.12

### DIFF
--- a/src/porepy/grids/structured.py
+++ b/src/porepy/grids/structured.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 from typing import Optional, Union
 
 import numpy as np
-import scipy as sp
 import scipy.sparse as sps
 
 from porepy.grids.grid import Grid
@@ -148,10 +147,10 @@ class TensorGrid(Grid):
         num_faces = num_faces
         num_nodes = num_nodes
 
-        x_coord, y_coord = sp.meshgrid(nodes_x, nodes_y)
+        x_coord, y_coord = np.meshgrid(nodes_x, nodes_y)
 
         nodes = np.vstack(
-            (x_coord.flatten(), y_coord.flatten(), np.zeros(x_coord.size))
+            (x_coord.ravel(order="C"), y_coord.ravel(order="C"), np.zeros(x_coord.size))
         )
 
         # Face nodes


### PR DESCRIPTION
## Proposed changes
The newest version of scipy removed the function meshgrid. This PR replaces the deprecated function with a call to numpy.meshgrid instead (the syntax is the same).

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [x] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
