### PR TITLE
Limit number of parameters in test of permutations

### DIFF
--- a/tests/utils/test_permutations.py
+++ b/tests/utils/test_permutations.py
@@ -13,8 +13,6 @@ from porepy.utils import permutations
         (3, 2),
         (4, 3),
         (5, 3),
-        (6, 4),
-        (7, 4),  # This is already getting very expensive
     ],
 )
 def test_base_length(base, length):


### PR DESCRIPTION
## Proposed changes
Remove two parameters from test_permutations.test_base_length. The deleted values did not contribute meaningfully to test coverage, but significantly prolonged the run time (at least a few seconds per run).

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
