### PR TITLE
Bug in Differentiable Tpfa related to fracture tips and internal boundaries

### DIFF
--- a/src/porepy/models/constitutive_laws.py
+++ b/src/porepy/models/constitutive_laws.py
@@ -1700,9 +1700,6 @@ class AdTpfaFlux:
         )
         # Also a separate filter for internal boundaries, which are always Neumann.
         internal_boundary_filter = diff_discr.internal_boundary_filter(subdomains)
-        # And a filter for tip faces, which are also Neumann, but where the flux is
-        # known to be zero (by assumptions embedded in the modeling framework).
-        tip_filter = diff_discr.tip_filter(subdomains)
 
         # Face contribution to boundary potential is 1 on Dirichlet faces, -1/t_f_full
         # on Neumann faces (both external and internal - see Tpfa.discretize). Named
@@ -1711,8 +1708,6 @@ class AdTpfaFlux:
         bound_pressure_face_discr = dir_filter - (
             neu_filter + internal_boundary_filter
         ) * (one / t_f_full)
-        # On tip faces, the face contribution to the boundary potential is zero.
-        bound_pressure_face_discr = bound_pressure_face_discr * (one - tip_filter)
 
         # Project the interface flux to the primary grid, preparing for discretization
         # on internal boundaries.

--- a/src/porepy/models/constitutive_laws.py
+++ b/src/porepy/models/constitutive_laws.py
@@ -1510,8 +1510,8 @@ class AdTpfaFlux:
         # Treatment of boundary conditions.
         one = pp.ad.Scalar(1)
         # Obtain filters that lett pass external boundary faces (divided into Dirichlet
-        # and Neumann faces) and internal boundary faces (faces between subdomains),
-        # an tip faces (on immersed tips of domains).
+        # and Neumann faces), internal boundary faces (faces between subdomains), and
+        # tip faces (on immersed tips of domains).
         external_dir_filter, external_neu_filter = diff_discr.external_boundary_filters(
             self.mdg, domains, boundary_grids, "bc_values_" + flux_name
         )

--- a/src/porepy/numerics/fv/tpfa.py
+++ b/src/porepy/numerics/fv/tpfa.py
@@ -330,6 +330,34 @@ class DifferentiableTpfa:
             fracture_faces, name="internal_boundary_filter"
         )
 
+    def tip_filter(self, subdomains: list[pp.Grid]) -> pp.ad.DenseArray:
+        """Construct a dense array that filters out everything but faces on immersed
+        tips.
+
+        Parameters:
+            subdomains: List of grids.
+
+        Returns:
+            DenseArray representation of the internal boundary filter.
+
+        """
+        is_tip = []
+        for sd in subdomains:
+            # Find faces that are tagged as tip faces, but exclude those that are also
+            # tagged as domain boundary faces.
+            is_tip.append(
+                np.logical_and(
+                    sd.tags["tip_faces"],
+                    np.logical_not(sd.tags["domain_boundary_faces"]),
+                )
+            )
+        if len(is_tip) == 0:
+            tip_faces = np.array([], dtype=int)
+        else:
+            tip_faces = np.hstack(is_tip)
+
+        return pp.wrap_as_dense_ad_array(tip_faces, name="tip_filter")
+
     def _block_diagonal_grid_property_matrix(
         self,
         domains: list[pp.Grid],

--- a/tests/models/test_thermoporomechanics.py
+++ b/tests/models/test_thermoporomechanics.py
@@ -338,8 +338,8 @@ class ThermoporomechanicsWell(
         return mesh_sizes
 
 
-def test_poromechanics():
-    """Test that the poromechanics model runs without errors."""
+def test_thermoporomechanics_well():
+    """Test that the thermoporomechanics model runs without errors."""
     # These parameters hopefully yield a relatively easy problem
     params = {
         "fracture_indices": [2],

--- a/tests/numerics/fv/test_tpfa.py
+++ b/tests/numerics/fv/test_tpfa.py
@@ -16,6 +16,9 @@ from porepy.applications.md_grids.model_geometries import (
     CubeDomainOrthogonalFractures,
 )
 from porepy.numerics.ad.operators import Operator
+from porepy.applications.md_grids import model_geometries
+from porepy.applications.test_utils import well_models
+
 
 """Local utility functions."""
 
@@ -796,3 +799,109 @@ def test_diff_tpfa_and_standard_tpfa_give_same_linear_system(base_discr: str):
 
     assert np.allclose(matrix[0].A, matrix[1].A)
     assert np.allclose(vector[0], vector[1])
+
+
+class TestDiffTpfaFractureTipsInternalBoundaries(
+    model_geometries.OrthogonalFractures3d,
+    well_models.OneVerticalWell,
+    well_models.BoundaryConditionsWellSetup,
+    _SetFluxDiscretizations,
+    pp.constitutive_laws.DarcysLawAd,
+    pp.constitutive_laws.FouriersLawAd,
+    pp.mass_and_energy_balance.MassAndEnergyBalance,
+):
+    """Helper class to test that the methods for differentiating diffusive fluxes and
+    potential reconstructions work as intended on fracture tips and internal boundaries.
+
+    The model geometry consists of two fractures: One extending to the boundary, one
+    that is immersed in the domain. The model also includes a well which intersects
+    with one of the fractures.
+    """
+
+    def __init__(self, params):
+        # From the default fractures, use one with a constant z-coordinate.
+        params.update({"fracture_indices": [2]})
+        super().__init__(params)
+
+    def set_fractures(self) -> None:
+        """In addition to the default fracture (which extends to the boundary), we add
+        one fracture that is fully immersed in the domain.
+        """
+        super().set_fractures()
+
+        # Add a fracture that is immersed in the domain, to test the discretization of
+        # the Darcy flux on a fracture that is not on the boundary.
+        frac = pp.PlaneFracture(
+            np.array([[0.3, 0.3, 0.3, 0.3], [0.2, 0.8, 0.8, 0.2], [0.2, 0.2, 0.8, 0.8]])
+        )
+        self._fractures.append(frac)
+
+    def initial_condition(self):
+        """Set a random initial condition, to avoid the trivial case of a constant
+        pressure hiding difficulties.
+        """
+        super().initial_condition()
+        num_dofs = self.equation_system.num_dofs()
+        np.random.seed(42)
+        values = np.random.rand(num_dofs)
+        self.equation_system.set_variable_values(values, iterate_index=0)
+
+
+@pytest.mark.parametrize("base_discr", ["tpfa", "mpfa"])
+def test_flux_potential_trace_on_tips_and_internal_boundaries(base_discr: str):
+    """Test that the flux and potential trace can be computed on fracture tips and
+    internal boundaries.
+
+    Both Darcy and Fourier fluxes are tested.
+
+    For the fluxes, we test that the Jacobian matrix is zero on the Neumann faces (which
+    include fracture tips, internal boundaries, and any external boundaries that are
+    assigned a Neumann boundary condition). On tips we also test that the potential
+    trace is equal to the pressure in the adjacent cell.
+
+    """
+    model = TestDiffTpfaFractureTipsInternalBoundaries({"base_discr": base_discr})
+    model.prepare_simulation()
+
+    mdg = model.mdg
+
+    for sd in mdg.subdomains():
+        data = mdg.subdomain_data(sd)
+
+        # For both Darcy and Fourier flux, check that the Jacobian matrix is zero on
+        # Neumann faces.
+        bc_darcy = data[pp.PARAMETERS][model.darcy_keyword]["bc"]
+        darcy_flux = model.darcy_flux([sd]).value_and_jacobian(model.equation_system)
+        assert np.allclose(darcy_flux.jac[bc_darcy.is_neu].data, 0)
+
+        bc_fourier = data[pp.PARAMETERS][model.darcy_keyword]["bc"]
+        fourier_flux = model.fourier_flux([sd]).value_and_jacobian(
+            model.equation_system
+        )
+        assert np.allclose(fourier_flux.jac[bc_fourier.is_neu].data, 0)
+
+        # The potential trace should be equal to the pressure in the adjacent cell on
+        # fracture tip faces (but not on internal nor external boundaries, where
+        # boundary conditions may change the boundary value).
+
+        # Get the indices of the fracture tip faces and that of the adjacent cell.
+        tip_faces = np.where(
+            np.logical_and(
+                sd.tags["tip_faces"], np.logical_not(sd.tags["domain_boundary_faces"])
+            )
+        )[0]
+        _, tip_cells = sd.signs_and_cells_of_boundary_faces(tip_faces)
+
+        # Check that the pressure trace is equal to the pressure in the adjacent cell.
+        pressure_trace = model.potential_trace(
+            [sd], model.pressure, model.permeability, "darcy_flux"
+        ).value(model.equation_system)
+        p = model.pressure([sd]).value(model.equation_system)
+        assert np.allclose(pressure_trace[tip_faces], p[tip_cells])
+        # Check that the temperature trace is equal to the temperature in the adjacent
+        # cell.
+        temperature_trace = model.potential_trace(
+            [sd], model.temperature, model.thermal_conductivity, "fourier_flux"
+        ).value(model.equation_system)
+        T = model.temperature([sd]).value(model.equation_system)
+        assert np.allclose(temperature_trace[tip_faces], T[tip_cells])

--- a/tests/numerics/fv/test_tpfa.py
+++ b/tests/numerics/fv/test_tpfa.py
@@ -15,7 +15,6 @@ from porepy.applications.test_utils import common_xpfa_tests as xpfa_tests
 from porepy.applications.md_grids.model_geometries import (
     CubeDomainOrthogonalFractures,
 )
-from porepy.numerics.ad.operators import Operator
 from porepy.applications.md_grids import model_geometries
 from porepy.applications.test_utils import well_models
 
@@ -874,13 +873,13 @@ def test_flux_potential_trace_on_tips_and_internal_boundaries(base_discr: str):
         darcy_flux = model.darcy_flux([sd]).value_and_jacobian(model.equation_system)
         assert np.allclose(darcy_flux.jac[bc_darcy.is_neu].data, 0)
 
-        bc_fourier = data[pp.PARAMETERS][model.darcy_keyword]["bc"]
+        bc_fourier = data[pp.PARAMETERS][model.fourier_keyword]["bc"]
         fourier_flux = model.fourier_flux([sd]).value_and_jacobian(
             model.equation_system
         )
         assert np.allclose(fourier_flux.jac[bc_fourier.is_neu].data, 0)
 
-        # The potential trace should be equal to the pressure in the adjacent cell on
+        # The potential trace should be equal to the potential in the adjacent cell on
         # fracture tip faces (but not on internal nor external boundaries, where
         # boundary conditions may change the boundary value).
 


### PR DESCRIPTION
## Proposed changes
The previous implementation of differentiable Tpfa contained a bug which gave non-zero transmissibilities on fracture tips and internal boundaries (where the transmissibilities should be zero, but were not). This PR introduces a fix which by filtering sets the transmissibilites to zero at the relevant faces.

A similar fix was also introduced for the potential_trace function, but this is only relevant for the fracture tips.

A new test that covers the fixed code has been added.

Resolves #1104
Resolves #1107 
Resolves #1108

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [x] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
