### PR TITLE
ENH: Allow to export only specified times

### DIFF
--- a/src/porepy/models/solution_strategy.py
+++ b/src/porepy/models/solution_strategy.py
@@ -11,7 +11,7 @@ import logging
 import time
 import warnings
 from pathlib import Path
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Optional, Union
 
 import numpy as np
 import scipy.sparse as sps
@@ -449,7 +449,9 @@ class SolutionStrategy(abc.ABC):
             values=solution, time_step_index=0, additive=False
         )
         self.convergence_status = True
-        self.save_data_time_step()
+
+        times_to_export = self.params.get("times_to_export", "none")
+        self.export_solution(times_to_export=times_to_export)
 
     def after_nonlinear_failure(
         self, solution: np.ndarray, errors: float, iteration_counter: int
@@ -635,3 +637,22 @@ class SolutionStrategy(abc.ABC):
 
         """
         self.update_all_boundary_conditions()
+
+    def export_solution(self, times_to_export: Union[str, np.ndarray]) -> None:
+        """Method for exporting only specified solutions.
+
+        Parameters:
+            times_to_export: Contains information about which, if any, solution time
+                steps should be exported. It may hold the value "all", "none" or an
+                array of specified time step indices.
+
+        """
+        if type(times_to_export) is np.ndarray:
+            if self.time_manager.time_index in times_to_export:
+                self.save_data_time_step()
+        elif times_to_export == "all":
+            self.save_data_time_step()
+        elif times_to_export == "none":
+            pass
+        else:
+            raise ValueError("Invalid specification of times_to_export.")


### PR DESCRIPTION
## Proposed changes

Addresses issue #740.  

To be fixed which is not addressed yet:
* Export initial condition or not
* Where to put the export_times method. Currently in the bottom of solution_strategy.py

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [x] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
