### PR TITLE
BLD: Speed up import by delaying import of dependencies

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -18,6 +18,8 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 [mypy-scipy.spatial]
 ignore_missing_imports = True
+[mypy-scipy.linalg]
+ignore_missing_imports = True
 [mypy-scipy.optimize]
 ignore_missing_imports = True
 [mypy-scipy.spatial.qhull]

--- a/src/porepy/applications/test_utils/vtk.py
+++ b/src/porepy/applications/test_utils/vtk.py
@@ -5,7 +5,6 @@ import xml.etree.ElementTree as ET
 from pathlib import Path
 
 import meshio
-from deepdiff import DeepDiff
 
 # Data structure for defining paths
 PathLike = str | Path
@@ -36,6 +35,9 @@ def compare_vtu_files(
         Boolean. True iff files are identical.
 
     """
+
+    from deepdiff import DeepDiff
+
     if overwrite:
         shutil.copy(test_file, reference_file)
         return True

--- a/src/porepy/fracs/fracture_network_2d.py
+++ b/src/porepy/fracs/fracture_network_2d.py
@@ -9,7 +9,6 @@ import warnings
 from typing import Optional, Union
 
 import meshio
-import networkx
 import numpy as np
 
 import porepy as pp
@@ -1268,53 +1267,6 @@ class FractureNetwork2d:
         fn.tags = tags
 
         return fn
-
-    # --------- Methods for analysis of the fracture set
-
-    def as_graph(
-        self, split_intersections: bool = True
-    ) -> Union[networkx.Graph, tuple[networkx.Graph, FractureNetwork2d]]:
-        """Represent the fracture set as a graph, using the networkx data structure.
-
-        By default, the fractures will first be split into non-intersecting branches.
-
-        Parameters:
-            split_intersections: ``default=True``
-
-                Flag if the network should be split into non-intersecting branches
-                before invoking the graph representation.
-
-        Returns:
-            Graph representation of the network, using the networkx data structure,
-            and if ``split_intersections=True``, also the fracture network,
-            split into non-intersecting branches.
-
-        """
-        if split_intersections:
-            # FIXME: The method split_intersections() does not exist. EK: Suggestions?
-            split_network = self.split_intersections()  # type: ignore[attr-defined]
-            pts = split_network._pts
-            edges = split_network._edges
-        else:
-            edges = self._edges
-            pts = self._pts
-
-        import networkx as nx
-
-        G = nx.Graph()
-        for pi in range(pts.shape[1]):
-            G.add_node(pi, coordinate=pts[:, pi])
-
-        for ei in range(edges.shape[1]):
-            tags = {}
-            for key, value in split_network.tags.items():
-                tags[key] = value[ei]
-            G.add_edge(edges[0, ei], edges[1, ei], labels=tags)
-
-        if split_intersections:
-            return G, split_network
-        else:
-            return G
 
     # --------- Utility functions below here
 

--- a/src/porepy/fracs/fracture_network_2d.py
+++ b/src/porepy/fracs/fracture_network_2d.py
@@ -113,7 +113,7 @@ class FractureNetwork2d:
         This will include intersection points identified.
         """
 
-        # -----> Logging
+        # Logging
         if self.fractures is not None:
             logger.info("Generated empty fracture set")
         elif self._pts is not None and self._edges is not None:
@@ -1098,7 +1098,6 @@ class FractureNetwork2d:
 
     """
     End of methods related to meshing
-    ---------------------------------
     """
 
     def constrain_to_domain(
@@ -1268,7 +1267,7 @@ class FractureNetwork2d:
 
         return fn
 
-    # --------- Utility functions below here
+    # Utility functions below here
 
     def num_frac(self) -> int:
         """

--- a/src/porepy/fracs/fracture_network_3d.py
+++ b/src/porepy/fracs/fracture_network_3d.py
@@ -13,7 +13,6 @@ import warnings
 from typing import Optional, Union
 
 import meshio
-import networkx as nx
 import numpy as np
 from scipy.spatial import ConvexHull
 
@@ -1593,6 +1592,8 @@ class FractureNetwork3d(object):
                     deleted, since they were outside the bounding box.
 
         """
+        import networkx as nx
+
         if domain is None and not self.fractures:
             # Cannot automatically calculate external boundary for non-fractured grids.
             raise ValueError(

--- a/src/porepy/fracs/plane_fracture.py
+++ b/src/porepy/fracs/plane_fracture.py
@@ -9,7 +9,6 @@ from typing import Optional, Union
 
 import numpy as np
 from numpy.typing import ArrayLike
-from sympy.geometry import Point, Polygon
 
 import porepy as pp
 from porepy.utils import setmembership
@@ -232,7 +231,9 @@ class PlaneFracture(Fracture):
     def compute_normal(self) -> np.ndarray:
         return pp.map_geometry.compute_normal(self.pts)[:, None]
 
-    def as_sympy_polygon(self, pts: Optional[np.ndarray] = None) -> Polygon:
+    # EK: Removed typing of return type, since this would necessitate an import of the
+    # full sympy module during import of PorePy, which is not desirable.
+    def as_sympy_polygon(self, pts: Optional[np.ndarray] = None):
         """Represent polygon as a sympy object.
 
         Parameters:
@@ -244,6 +245,7 @@ class PlaneFracture(Fracture):
             Sympy Representation of the polygon formed by ``pts``.
 
         """
+        from sympy.geometry import Point, Polygon
 
         if pts is None:
             pts = self.pts

--- a/src/porepy/fracs/split_grid.py
+++ b/src/porepy/fracs/split_grid.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from typing import Optional
 
-import networkx as nx
 import numpy as np
 from scipy import sparse as sps
 
@@ -651,6 +650,8 @@ def duplicate_nodes(g: pp.Grid, nodes: np.ndarray, offset: float) -> int:
         The number of added nodes.
 
     """
+    import networkx as nx
+
     # In the case of a non-zero offset (presumably intended for visualization),
     # use a (somewhat slow) legacy implementation which can handle this.
     if offset != 0:

--- a/src/porepy/geometry/half_space.py
+++ b/src/porepy/geometry/half_space.py
@@ -1,6 +1,5 @@
 """This module contains functions for computations relating to half spaces."""
 import numpy as np
-from scipy import optimize
 from scipy.spatial import HalfspaceIntersection
 
 
@@ -168,6 +167,8 @@ def vertexes_of_convex_domain(A: np.ndarray, b: np.ndarray) -> np.ndarray:
         Vertexes of a convex domain.
 
     """
+    import scipy.optimize as opt
+
     b = b.reshape((-1, 1))
 
     # First, find an interior point of the half space. For this we could have used
@@ -178,7 +179,7 @@ def vertexes_of_convex_domain(A: np.ndarray, b: np.ndarray) -> np.ndarray:
     # point in the middle (somehow defined) of the domain.
     fun = lambda x: np.linalg.norm(A.dot(x.reshape((-1, 1))) + b)
     # Use scipy optimization to find an interior point to the half space.
-    interior_point = optimize.minimize(fun, np.zeros(A.shape[1])).x
+    interior_point = opt.minimize(fun, np.zeros(A.shape[1])).x
 
     # Set up constraints on the format that scipy.spatial HalfspaceIntersection
     # expects

--- a/src/porepy/grids/partition.py
+++ b/src/porepy/grids/partition.py
@@ -973,7 +973,7 @@ def grid_is_connected(
             component.
 
     """
-    import networkx
+    import networkx as nx
 
     # If no cell indices are specified, we use them all.
     if cell_ind is None:
@@ -988,13 +988,13 @@ def grid_is_connected(
     c2c = c2c.tocsr()[cell_ind, :].tocsc()[:, cell_ind]
 
     # Represent the connections as a networkx graph and check for connectivity
-    graph = networkx.from_scipy_sparse_array(c2c)
-    is_connected = networkx.is_connected(graph)
+    graph = nx.from_scipy_sparse_array(c2c)
+    is_connected = nx.is_connected(graph)
 
     # Get the connected components of the network.
     # networkx gives a generator that produce sets of node indices. Use this to define a
     # list of numpy arrays.
-    component_generator = networkx.connected_components(graph)
+    component_generator = nx.connected_components(graph)
     components = [np.array(list(i)) for i in component_generator]
 
     return is_connected, components

--- a/src/porepy/numerics/ad/operators.py
+++ b/src/porepy/numerics/ad/operators.py
@@ -8,8 +8,6 @@ from functools import reduce
 from itertools import count
 from typing import Any, Literal, Optional, Sequence, Union, overload
 
-import matplotlib.pyplot as plt
-import networkx as nx
 import numpy as np
 import scipy.sparse as sps
 
@@ -588,6 +586,9 @@ class Operator:
 
     def viz(self):
         """Draws a visualization of the operator tree that has this operator as its root."""
+        import matplotlib.pyplot as plt
+        import networkx as nx
+
         G = nx.Graph()
 
         def parse_subgraph(node: Operator):

--- a/src/porepy/numerics/solvers/andersonacceleration.py
+++ b/src/porepy/numerics/solvers/andersonacceleration.py
@@ -1,5 +1,5 @@
 import numpy as np
-import scipy as sp
+from scipy.linalg import lstsq
 
 
 class AndersonAcceleration:
@@ -52,7 +52,7 @@ class AndersonAcceleration:
             self._Gk[:, col] = gk - self._gkm1
 
             # Solve least squares problem
-            lstsq_solution = sp.linalg.lstsq(self._Fk[:, 0:mk], fk)
+            lstsq_solution = lstsq(self._Fk[:, 0:mk], fk)
             gamma_k = lstsq_solution[0]
             # Do the mixing
             xkp1 = gk - np.dot(self._Gk[:, 0:mk], gamma_k)

--- a/src/porepy/utils/setmembership.py
+++ b/src/porepy/utils/setmembership.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 from typing import Any, Tuple
 
-import numba
 import numpy as np
 from scipy.spatial import KDTree
 
@@ -158,6 +157,8 @@ def unique_columns_tol(
         array([0, 1, 0])
 
     """
+    import numba
+
     # Treat 1d array as 2d
     mat = np.atleast_2d(mat)
 
@@ -225,6 +226,7 @@ def unique_columns_tol(
     # IMPLEMENTATION NOTE: It could pay off to make a pure Python implementation
     # to be used for small arrays, however, attempts on making this work in
     # practice failed.
+
     keep, new_2_old, old_2_new = _numba_distance(mat_t, tol)
 
     return mat[:, keep], new_2_old, old_2_new

--- a/src/porepy/viz/diagnostics_mixin.py
+++ b/src/porepy/viz/diagnostics_mixin.py
@@ -23,17 +23,6 @@ from porepy.grids.mortar_grid import MortarGrid
 from porepy.numerics.ad.equation_system import EquationSystem
 from porepy.numerics.ad.operators import Variable
 
-# Seaborn is a visualization library based on Matplotlib. It allows for building nice
-# figures. Seaborn library is not one of the dependencies of PorePy. Thus, it might not
-# be present on the user's device. In this case, Python raises ImportError exception.
-try:
-    # MyPy is not happy with Seaborn since it's not typed. We silence this warning.
-    import seaborn as sns  # type: ignore[import]
-except ImportError:
-    _IS_SEABORN_AVAILABLE: bool = False
-else:
-    _IS_SEABORN_AVAILABLE = True
-
 logger = logging.getLogger(__name__)
 
 
@@ -193,11 +182,6 @@ class DiagnosticsMixin:
         if "max" in default_handlers:
             active_handlers["max"] = get_max
 
-        if not _IS_SEABORN_AVAILABLE:
-            logger.warning(
-                "Plotting the diagnostics image requires seaborn package."
-                ' Run "pip install seaborn". Falling back to text mode.'
-            )
         # Determining the block indices and collecting the submatrices.
         equation_data = self._equations_data(
             grouping=grouping_, add_grid_info=add_grid_info
@@ -252,6 +236,20 @@ class DiagnosticsMixin:
             **kwargs: Passed to Seaborn.
 
         """
+        # Importing here to avoid the cost of importing Seaborn if it's not used.
+        # Seaborn is a visualization library based on Matplotlib. It allows for building
+        # nice figures. Seaborn library is not one of the dependencies of PorePy. Thus,
+        # it might not be present on the user's device. In this case, Python raises
+        # ImportError exception.
+        try:
+            # MyPy is not happy with Seaborn since it's not typed. We silence this
+            # warning.
+            import seaborn as sns  # type: ignore[import]
+        except ImportError:
+            _IS_SEABORN_AVAILABLE: bool = False
+        else:
+            _IS_SEABORN_AVAILABLE = True
+
         row_names: list[str] = []
         col_names: list[str] = []
 

--- a/src/porepy/viz/exporter.py
+++ b/src/porepy/viz/exporter.py
@@ -13,7 +13,6 @@ from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
 import meshio
 import numpy as np
-from deepdiff import DeepDiff
 
 import porepy as pp
 
@@ -339,6 +338,8 @@ class Exporter:
                 corresponding grid.
 
         """
+        import meshio
+        from deepdiff import DeepDiff
 
         # Aux. method: Inverse of _to_vector_format, used to define vector-ranged values
         def _from_vector_format(


### PR DESCRIPTION
## Proposed changes
Reduce the import time of PorePy by delaying import of dependencies that may not be needed. 

The dependencies can roughly be divided into three groups:
* Those that are almost always used, e.g. `numpy`
* Those that are only used in special cases, e.g., `seaborn`
* Those that, in an average session, may or may not be used.

This PR tries to postpone the import of the second class until the packages are actually needed. Moreover, some imports of the third type of dependencies are also postponed, but the choice of when to do this is necessarily pragmatic rather than principled. In particular, while I would have liked to postpone import of `matplotlib`, this would have required too intrusive changes to the code.

Anecdotally, import time was cut by 20-30% by these changes.

The only change not directly related to imports was the deletion of one method in `FractureNetwork2d` which was used hardly if at all.


## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [x] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
