### PR TITLE
MAINT: Classes with init are not meant to be "collectable"

### DIFF
--- a/tests/numerics/fv/test_tpfa.py
+++ b/tests/numerics/fv/test_tpfa.py
@@ -628,7 +628,7 @@ def test_transmissibility_calculation(vector_source: bool, base_discr: str):
     )
 
 
-class TestDiffTpfaGridsOfAllDimensions(
+class DiffTpfaGridsOfAllDimensions(
     CubeDomainOrthogonalFractures,
     _SetFluxDiscretizations,
     pp.constitutive_laws.CubicLawPermeability,
@@ -699,7 +699,7 @@ def test_diff_tpfa_on_grid_with_all_dimensions(base_discr: str, grid_type: str):
     are not checked.
 
     """
-    model = TestDiffTpfaGridsOfAllDimensions(
+    model = DiffTpfaGridsOfAllDimensions(
         {"base_discr": "tpfa", "grid_type": grid_type}
     )
     model.prepare_simulation()
@@ -800,7 +800,7 @@ def test_diff_tpfa_and_standard_tpfa_give_same_linear_system(base_discr: str):
     assert np.allclose(vector[0], vector[1])
 
 
-class TestDiffTpfaFractureTipsInternalBoundaries(
+class DiffTpfaFractureTipsInternalBoundaries(
     model_geometries.OrthogonalFractures3d,
     well_models.OneVerticalWell,
     well_models.BoundaryConditionsWellSetup,
@@ -859,7 +859,7 @@ def test_flux_potential_trace_on_tips_and_internal_boundaries(base_discr: str):
     trace is equal to the pressure in the adjacent cell.
 
     """
-    model = TestDiffTpfaFractureTipsInternalBoundaries({"base_discr": base_discr})
+    model = DiffTpfaFractureTipsInternalBoundaries({"base_discr": base_discr})
     model.prepare_simulation()
 
     mdg = model.mdg


### PR DESCRIPTION
## Proposed changes

Remove a undesireable warning while running pytest. 
`PytestCollectionWarning`: cannot collect test class 'TestXYZ' because it has a `__init__ `constructor 
From: `tests/numerics/fv/test_tpfa.py`

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [x] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
