### PR TITLE
BUG: Bad use of typing in nd_cube_domain

### DIFF
--- a/src/porepy/applications/md_grids/domains.py
+++ b/src/porepy/applications/md_grids/domains.py
@@ -7,7 +7,7 @@ import numpy as np
 import porepy as pp
 
 
-def nd_cube_domain(dimension: Literal[2, 3], size=pp.number) -> pp.Domain:
+def nd_cube_domain(dimension: Literal[2, 3], size: pp.number) -> pp.Domain:
     """Return a domain extending from 0 to `size` in all dimensions.
 
     Parameters:


### PR DESCRIPTION
Typing should be indicated by a colon, not equality, or else the parameter defaults to a type

## Proposed changes

Contributions to PorePy are highly appreciated. Clearly explain why this pull request (PR) is needed and why it should be accepted. If this PR solves an issue, explain how it is done. Please, also summarise the changes to the code.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [x] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
