### PR TITLE
Issue 840

### DIFF
--- a/src/porepy/models/energy_balance.py
+++ b/src/porepy/models/energy_balance.py
@@ -564,17 +564,17 @@ class VariablesEnergyBalance:
         self.equation_system.create_variables(
             self.interface_fourier_flux_variable,
             interfaces=self.mdg.interfaces(codim=1),
-            tags={"si_units": f"W * m^{self.nd-3}"},
+            tags={"si_units": f"W * m^{self.nd - 3}"},
         )
         self.equation_system.create_variables(
             self.interface_enthalpy_flux_variable,
             interfaces=self.mdg.interfaces(codim=1),
-            tags={"si_units": f"W * m^{self.nd-3}"},
+            tags={"si_units": f"W * m^{self.nd - 3}"},
         )
         self.equation_system.create_variables(
             self.well_enthalpy_flux_variable,
             interfaces=self.mdg.interfaces(codim=2),
-            tags={"si_units": f"W * m^{self.nd-3}"},
+            tags={"si_units": f"W * m^{self.nd - 3}"},
         )
 
     def temperature(self, domains: pp.SubdomainsOrBoundaries) -> pp.ad.Operator:

--- a/src/porepy/models/energy_balance.py
+++ b/src/porepy/models/energy_balance.py
@@ -564,17 +564,17 @@ class VariablesEnergyBalance:
         self.equation_system.create_variables(
             self.interface_fourier_flux_variable,
             interfaces=self.mdg.interfaces(codim=1),
-            tags={"si_units": "W"},
+            tags={"si_units": f"W * m^{self.nd-3}"},
         )
         self.equation_system.create_variables(
             self.interface_enthalpy_flux_variable,
             interfaces=self.mdg.interfaces(codim=1),
-            tags={"si_units": "W"},
+            tags={"si_units": f"W * m^{self.nd-3}"},
         )
         self.equation_system.create_variables(
             self.well_enthalpy_flux_variable,
             interfaces=self.mdg.interfaces(codim=2),
-            tags={"si_units": "W"},
+            tags={"si_units": f"W * m^{self.nd-3}"},
         )
 
     def temperature(self, domains: pp.SubdomainsOrBoundaries) -> pp.ad.Operator:

--- a/tests/models/test_poromechanics.py
+++ b/tests/models/test_poromechanics.py
@@ -54,7 +54,7 @@ class NonzeroFractureGapPoromechanics:
         sd, sd_data = self.mdg.subdomains(return_data=True)[0]
         # Initial displacement.
         if len(self.mdg.subdomains()) > 1:
-            top_cells = sd.cell_centers[1] > 0.5
+            top_cells = sd.cell_centers[1] > self.fluid.convert_units(0.5, "m")
             vals = np.zeros((self.nd, sd.num_cells))
             vals[1, top_cells] = self.fluid.convert_units(0.042, "m")
             self.equation_system.set_variable_values(

--- a/tests/viz/test_exporter.py
+++ b/tests/viz/test_exporter.py
@@ -635,9 +635,7 @@ def test_rescaled_export(setup: ExporterTestSetup):
         model = TailoredThermoporomechanics(params=params)
         pp.run_time_dependent_model(model, {})
 
-    # units_scaled = pp.Units(m=3.14, kg=42.0, K=3.79)
-    # units_scaled = pp.Units(kg=20, K=100)
-    units_scaled = pp.Units(m=10)
+    units_scaled = pp.Units(m=3.14, kg=42.0, K=3.79)
     units_unscaled = pp.Units()
     scaled_prefix = "scaled"
     unscaled_prefix = "unscaled"
@@ -652,11 +650,10 @@ def test_rescaled_export(setup: ExporterTestSetup):
             continue
         file_name_unscaled = f"{unscaled_prefix}{file_name_scaled[6:]}"
         if file_name_scaled.endswith("vtu"):
-            # BUG: Thermal mortar variables are 10 times larger for the scaled model.
             assert compare_vtu_files(
                 test_file=folder_path / file_name_scaled,
                 reference_file=folder_path / file_name_unscaled,
             ), f"Files don't match: {file_name_scaled} and {file_name_unscaled}"
             num_vtk_tested += 1
 
-            assert num_vtk_tested > 0
+    assert num_vtk_tested > 0, 'No VTU files were tested.'

--- a/tests/viz/test_exporter.py
+++ b/tests/viz/test_exporter.py
@@ -596,6 +596,12 @@ class TailoredThermoporomechanics(
 
 
 def test_rescaled_export(setup: ExporterTestSetup):
+    """The test exports the scaled and unscaled versions of the same simulation and
+    checks whether the output is the same. The output of the scaled model should be
+    rescaled back to the SI units.
+
+    """
+
     def run_simulation_save_results(units: pp.Units, file_name: str):
         nontrivial_solid = {
             "biot_coefficient": 0.47,  # [-]
@@ -653,7 +659,7 @@ def test_rescaled_export(setup: ExporterTestSetup):
             assert compare_vtu_files(
                 test_file=folder_path / file_name_scaled,
                 reference_file=folder_path / file_name_unscaled,
-            ), f"Files don't match: {file_name_scaled} and {file_name_unscaled}"
+            ), f"Files don't match: {file_name_scaled} and {file_name_unscaled}."
             num_vtk_tested += 1
 
     assert num_vtk_tested > 0, 'No VTU files were tested.'

--- a/tests/viz/test_exporter.py
+++ b/tests/viz/test_exporter.py
@@ -27,6 +27,8 @@ from porepy.applications.test_utils.vtk import (
     compare_vtu_files,
 )
 from porepy.fracs.utils import pts_edges_to_linefractures
+from tests.models.test_poromechanics import NonzeroFractureGapPoromechanics
+from porepy.applications.test_utils.models import Thermoporomechanics
 
 # Globally store location of reference files
 FOLDER_REFERENCE = (
@@ -580,3 +582,81 @@ def test_fracture_network_3d(setup: ExporterTestSetup):
         f"{setup.folder}/{setup.file_name}.vtu",
         f"{setup.folder_reference}/fractures_3d.vtu",
     )
+
+
+class TailoredThermoporomechanics(
+    NonzeroFractureGapPoromechanics,
+    pp.model_boundary_conditions.TimeDependentMechanicalBCsDirNorthSouth,
+    pp.model_boundary_conditions.BoundaryConditionsEnergyDirNorthSouth,
+    pp.model_boundary_conditions.BoundaryConditionsMassDirNorthSouth,
+    Thermoporomechanics,
+):
+    def grid_type(self):
+        return "cartesian"
+
+
+def test_rescaled_export(setup: ExporterTestSetup):
+    def run_simulation_save_results(units: pp.Units, file_name: str):
+        nontrivial_solid = {
+            "biot_coefficient": 0.47,  # [-]
+            "density": 2.6,  # [kg * m^-3]
+            "friction_coefficient": 0.6,  # [-]
+            "lame_lambda": 7.02,  # [Pa]
+            "permeability": 0.5,  # [m^2]
+            "porosity": 1.3e-1,  # [-]
+            "shear_modulus": 1.4,  # [Pa]
+            "specific_heat_capacity": 7.2,  # [J * kg^-1 * K^-1]
+            "specific_storage": 4e-1,  # [Pa^-1]
+            "thermal_conductivity": 3.1,  # [W * m^-1 * K^-1]
+            "thermal_expansion": 9.6e-1,  # [K^-1]
+            "temperature": 2,  # [K]
+        }
+        nontrivial_fluid = {
+            "compressibility": 1e-1,  # [Pa^-1], isentropic compressibility
+            "density": 9.2,  # [kg m^-3]
+            "specific_heat_capacity": 4.2,  # [J kg^-1 K^-1], isochoric specific heat
+            "thermal_conductivity": 0.5,  # [kg m^-3]
+            "thermal_expansion": 2.068e-1,  # [K^-1]
+            "viscosity": 1.002e-1,  # [Pa s], absolute viscosity
+            "pressure": 1,  # [Pa]
+            "temperature": 2,  # [K]
+        }
+
+        params = {
+            "suppress_export": False,
+            "units": units,
+            "file_name": file_name,
+            "folder_name": setup.folder,
+            "material_constants": {
+                "solid": pp.SolidConstants(nontrivial_solid),
+                "fluid": pp.FluidConstants(nontrivial_fluid),
+            },
+        }
+        model = TailoredThermoporomechanics(params=params)
+        pp.run_time_dependent_model(model, {})
+
+    # units_scaled = pp.Units(m=3.14, kg=42.0, K=3.79)
+    # units_scaled = pp.Units(kg=20, K=100)
+    units_scaled = pp.Units(m=10)
+    units_unscaled = pp.Units()
+    scaled_prefix = "scaled"
+    unscaled_prefix = "unscaled"
+
+    run_simulation_save_results(units=units_scaled, file_name=scaled_prefix)
+    run_simulation_save_results(units=units_unscaled, file_name=unscaled_prefix)
+
+    folder_path = Path(setup.folder)
+    num_vtk_tested = 0
+    for file_name_scaled in os.listdir(setup.folder):
+        if not file_name_scaled.startswith(scaled_prefix):
+            continue
+        file_name_unscaled = f"{unscaled_prefix}{file_name_scaled[6:]}"
+        if file_name_scaled.endswith("vtu"):
+            # BUG: Thermal mortar variables are 10 times larger for the scaled model.
+            assert compare_vtu_files(
+                test_file=folder_path / file_name_scaled,
+                reference_file=folder_path / file_name_unscaled,
+            ), f"Files don't match: {file_name_scaled} and {file_name_unscaled}"
+            num_vtk_tested += 1
+
+            assert num_vtk_tested > 0


### PR DESCRIPTION
## Proposed changes

This PR adds a test of the rescaled export according to issue #840. The new test revealed an error in the units of the mortar variables corresponding to energy transfer, so the units are fixed. Thanks to @OmarDuran for catching this bug.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [x] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Testing (contribution related to testing of existing or new functionality).
- [x] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
