### PR TITLE
Documentation and minor change in the Peaceman well model

### DIFF
--- a/src/porepy/models/constitutive_laws.py
+++ b/src/porepy/models/constitutive_laws.py
@@ -2187,8 +2187,21 @@ class PeacemanWellFlux:
         # We assume isotropic permeability and extract xx component.
         e_i = self.e_i(subdomains, i=0, dim=9).T  # type: ignore[call-arg]
 
-        # To get a transmissivity, we multiply the permeability with the specific
-        # volume of the fracture.
+        # To get a transmissivity, we multiply the permeability with the length of the
+        # well within one cell. For a 0d-2d coupling, this will be the aperture of the
+        # 2d fracture cell; in practice the number can be obtained by multiplying with
+        # the specific volume, or by taking a volume integral over the mortar cell
+        # (which will incorporate the specific volume of the higher-dimensional
+        # neighbor, that is, the fracture). For a 1d-3d coupling, we will need the
+        # length of the well within the 3d cell (see the MRST book, p.128, for comments
+        # regarding deviated wells). Again, this could be obtained by a volume integral
+        # over the mortar cell; however, as 1d-3d couplings have not yet been
+        # implemented, we will raise an error in this case.
+        if any([sd.dim == 3 for sd in subdomains]):
+            raise NotImplementedError(
+                "The 1d-3d coupling has not yet been implemented. "
+            )
+
         isotropic_permeability = e_i @ self.permeability(subdomains)
         specific_volume = self.specific_volume(subdomains)
         transmissivity = isotropic_permeability * specific_volume

--- a/src/porepy/models/constitutive_laws.py
+++ b/src/porepy/models/constitutive_laws.py
@@ -2202,6 +2202,11 @@ class PeacemanWellFlux:
             raise NotImplementedError(
                 "The 1d-3d coupling has not yet been implemented. "
             )
+        elif any([sd.dim == 1 for sd in subdomains]):
+            # This is a 1d-2d (or 1d-1d) coupling, for which the Peaceman model is
+            # not applicable.
+            # TODO: Revisit when we implement 1d-3d coupling.
+            raise("The Peaceman model assumes a coupling of codimension 2")
 
         isotropic_permeability = e_i @ self.permeability(subdomains)
 

--- a/src/porepy/models/constitutive_laws.py
+++ b/src/porepy/models/constitutive_laws.py
@@ -2206,7 +2206,7 @@ class PeacemanWellFlux:
             # This is a 1d-2d (or 1d-1d) coupling, for which the Peaceman model is
             # not applicable.
             # TODO: Revisit when we implement 1d-3d coupling.
-            raise("The Peaceman model assumes a coupling of codimension 2")
+            raise ValueError("The Peaceman model assumes a coupling of codimension 2")
 
         isotropic_permeability = e_i @ self.permeability(subdomains)
 

--- a/src/porepy/models/fluid_mass_balance.py
+++ b/src/porepy/models/fluid_mass_balance.py
@@ -218,7 +218,7 @@ class MassBalanceEquations(pp.BalanceEquation):
                 called using a list of boundary grids.
 
         Returns:
-            Operator representing the fluid density times mobility.
+            Operator representing the fluid density times mobility [s * m^-2].
 
         """
         return self.fluid_density(domains) * self.mobility(domains)
@@ -314,7 +314,7 @@ class MassBalanceEquations(pp.BalanceEquation):
             interfaces: List of interface grids.
 
         Returns:
-            Operator representing the interface fluid flux.
+            Operator representing the interface fluid flux [kg * s^-1].
 
         """
         subdomains = self.interfaces_to_subdomains(interfaces)
@@ -342,7 +342,7 @@ class MassBalanceEquations(pp.BalanceEquation):
             subdomains: List of subdomains.
 
         Returns:
-            Operator representing the source term [kg/s].
+            Operator representing the source term [kg * s^-1].
 
         """
         # Interdimensional fluxes manifest as source terms in lower-dimensional
@@ -630,7 +630,7 @@ class VariablesSinglePhaseFlow(pp.VariableMixin):
             ValueError: If the grids are not all subdomains or all boundary grids.
 
         Returns:
-            Operator representing the pressure.
+            Operator representing the pressure [Pa].
 
         """
         if len(domains) > 0 and isinstance(domains[0], pp.BoundaryGrid):
@@ -650,11 +650,13 @@ class VariablesSinglePhaseFlow(pp.VariableMixin):
     ) -> pp.ad.MixedDimensionalVariable:
         """Interface Darcy flux.
 
+        Integrated over faces in the mortar grid.
+
         Parameters:
             interfaces: List of interface grids.
 
         Returns:
-            Variable representing the interface Darcy flux.
+            Variable representing the interface Darcy flux [kg * m^2 * s^-2].
 
         """
         flux = self.equation_system.md_variable(
@@ -665,13 +667,13 @@ class VariablesSinglePhaseFlow(pp.VariableMixin):
     def well_flux(
         self, interfaces: list[pp.MortarGrid]
     ) -> pp.ad.MixedDimensionalVariable:
-        """Well flux.
+        """Variable for the volumetric well flux.
 
         Parameters:
             interfaces: List of interface grids.
 
         Returns:
-            Variable representing the well flux.
+            Variable representing the Darcy-like well flux [kg * m^2 * s^-2].
 
         """
         flux = self.equation_system.md_variable(self.well_flux_variable, interfaces)
@@ -684,7 +686,7 @@ class VariablesSinglePhaseFlow(pp.VariableMixin):
             subdomains: List of subdomains.
 
         Returns:
-            Operator representing the reference pressure.
+            Operator representing the reference pressure [Pa].
 
         """
         # TODO: Confirm that this is the right place for this method. # IS: Definitely

--- a/tests/models/test_poromechanics.py
+++ b/tests/models/test_poromechanics.py
@@ -526,7 +526,7 @@ class PoromechanicsWell(
         return mesh_sizes
 
 
-def test_poromechanics():
+def test_poromechanics_well():
     """Test that the poromechanics model runs without errors."""
     # These parameters hopefully yield a relatively easy problem
     params = {


### PR DESCRIPTION
## Proposed changes
This PR introduce contains a slight modification of the Peaceman well model, and more importantly better documentation of that model. Moreover, the units of some constitutive laws were added.

Consider in particular:
1. For the specific volume in Peaceman, should we take the volume integral over the interface or the subdomain? It seems the former has the better chance of being correct for 1d-3d couplings, but I am not sure.
2. Please pay attention to the formatting in the documentation of units. I prefer this style, but if we want changes, it is best to do that now, and define whatever comes out of it as a template. Also, should we always document in SI units, or are derived units (Pa, N etc.) also okay?


## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [x] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [x] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
