### PR TITLE
Fix inconsistent number of time steps

### DIFF
--- a/src/porepy/models/run_models.py
+++ b/src/porepy/models/run_models.py
@@ -129,7 +129,7 @@ def run_time_dependent_model(model, params: dict) -> None:
                 position=0,
             )
 
-            while model.time_manager.time < model.time_manager.time_final:
+            while not model.time_manager.final_time_reached():
                 time_progressbar.set_description_str(
                     f"Time step {model.time_manager.time_index} + 1"
                 )


### PR DESCRIPTION
## Proposed changes

Addresses #939. PR #1100, which originally addressed the issue, created a method for checking whether final time was reached. The method was not called in the case where progress bars were turned on, causing inconsistent number of time steps. This PR addresses that bug by calling the method final_time_reached() also when progress bars are turned on. 

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [x] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
