### PR TITLE
BUG: Fix num. time steps for iterative models and in progress bar

### DIFF
--- a/src/porepy/models/run_models.py
+++ b/src/porepy/models/run_models.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from typing import Union
 
+import numpy as np
+
 # ``tqdm`` is not a dependency. Up to the user to install it.
 try:
     # Avoid some mypy trouble.
@@ -119,9 +121,12 @@ def run_time_dependent_model(model, params: dict) -> None:
             # bar will increase with partial steps corresponding to the ratio of the
             # modified time step size to the initial time step size.
             expected_timesteps: int = int(
-                (model.time_manager.schedule[-1] - model.time_manager.schedule[0])
-                / model.time_manager.dt
+                np.round(
+                    (model.time_manager.schedule[-1] - model.time_manager.schedule[0])
+                    / model.time_manager.dt
+                )
             )
+
             initial_time_step: float = model.time_manager.dt
             time_progressbar = trange(
                 expected_timesteps,
@@ -197,7 +202,7 @@ def _run_iterative_model(model, params: dict) -> None:
 
     # Progressbars turned off or tqdm not installed:
     if not params.get("progressbars", False) or not _IS_TQDM_AVAILABLE:
-        while model.time_manager.time < model.time_manager.time_final:
+        while not model.time_manager.final_time_reached():
             time_step()
     # Progressbars turned on:
     else:
@@ -211,8 +216,10 @@ def _run_iterative_model(model, params: dict) -> None:
             # time bar will increase with partial steps corresponding to the ratio of
             # the modified time step size to the initial time step size.
             expected_timesteps: int = int(
-                (model.time_manager.schedule[-1] - model.time_manager.schedule[0])
-                / model.time_manager.dt
+                np.round(
+                    (model.time_manager.schedule[-1] - model.time_manager.schedule[0])
+                    / model.time_manager.dt
+                )
             )
             initial_time_step: float = model.time_manager.dt
             # Assert that the initial time step is not zero, to avoid division by zero
@@ -224,7 +231,7 @@ def _run_iterative_model(model, params: dict) -> None:
                 position=0,
             )
 
-            while model.time_manager.time < model.time_manager.time_final:
+            while not model.time_manager.final_time_reached():
                 time_progressbar.set_description_str(
                     f"Time step {model.time_manager.time_index}"
                 )


### PR DESCRIPTION
## Proposed changes

Inconsistency in time step numbers in:
* Iterative models. Now the check-if-final-time is reached is done by calling the method final_time_reached()
* Progress bar: A rounding error caused visualization of the wrong final time step number. This is fixed by using np.round(), which rounds e.g. the time 199.999999 to 200 instead of rounding down to 199, as the int()-functionality did before.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [x] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
