### PR TITLE
1140 number of time steps in functional tests

### DIFF
--- a/tests/functional/test_mandel.py
+++ b/tests/functional/test_mandel.py
@@ -4,14 +4,15 @@ Module containing functional tests for Mandel's problem.
 We consider two functional tests:
 
     - The first test compares desired and actual relative errors for the pressure,
-      displacement, flux, poroelastic force, and degrees of consolidation, for three
-      different times, namely 10, 30, and 50 seconds.
+      displacement, flux, poroelastic force, and degrees of consolidation, for two
+      different times, namely 25 and 50 seconds.
 
     - The second test checks that the same errors for pressure and displacement (up to
       5 decimals) are obtained for scaled and unscaled problems. Scaling is
       performed for length and mass.
 
 """
+
 from __future__ import annotations
 
 from collections import namedtuple
@@ -36,7 +37,7 @@ def results() -> list[MandelSaveData]:
         "fluid": pp.FluidConstants(mandel_fluid_constants),
         "solid": pp.SolidConstants(mandel_solid_constants),
     }
-    time_manager = pp.TimeManager([0, 10, 30, 50], 10, True)
+    time_manager = pp.TimeManager([0, 25, 50], 25, True)
     params = {
         "material_constants": material_constants,
         "time_manager": time_manager,
@@ -57,34 +58,26 @@ DesiredError = namedtuple(
 )
 
 desired_errors: list[DesiredError] = [
-    # t = 10 [s]
+    # t = 25 [s]
     DesiredError(
-        error_pressure=0.020915626239924504,
-        error_flux=0.4673715742577367,
-        error_displacement=0.00036006562251599753,
-        error_force=0.006174477658138146,
-        error_consolidation_degree=(0.004112823366753098, 2.983724378680108e-16),
-    ),
-    # t = 30 [s]
-    DesiredError(
-        error_pressure=0.01002508912855953,
-        error_flux=0.11759895811865957,
-        error_displacement=0.0003363008805572937,
-        error_force=0.003024676802218547,
-        error_consolidation_degree=(0.002324983805104465, 2.983724378680108e-16),
+        error_pressure=0.02468899282842615,
+        error_flux=0.4277241964548815,
+        error_displacement=0.0007426275934204356,
+        error_force=0.007199561782640474,
+        error_consolidation_degree=(0.005794353839056594, 2.983724378680108e-16),
     ),
     # t = 50 [s]
     DesiredError(
-        error_pressure=0.007059420526689479,
-        error_flux=0.06788475278093752,
-        error_displacement=0.0003094287000315224,
-        error_force=0.002150211938046511,
-        error_consolidation_degree=(0.0018043500295539042, 2.983724378680108e-16),
+        error_pressure=0.01604388082216944,
+        error_flux=0.17474770500364722,
+        error_displacement=0.000710048736369786,
+        error_force=0.0047015988044755526,
+        error_consolidation_degree=(0.004196023265526011, 2.983724378680108e-16),
     ),
 ]
 
 
-@pytest.mark.parametrize("time_index", [0, 1, 2])
+@pytest.mark.parametrize("time_index", [0, 1])
 def test_error_primary_and_secondary_variables(time_index: int, results):
     """Checks error for pressure, displacement, flux, force, and consolidation degree.
 

--- a/tests/functional/test_manu_flow_comp_frac.py
+++ b/tests/functional/test_manu_flow_comp_frac.py
@@ -34,6 +34,7 @@ References:
       elliptic equations. Journal of Numerical Mathematics.
 
 """
+
 from __future__ import annotations
 
 from copy import deepcopy
@@ -127,38 +128,39 @@ def desired_l2_errors() -> list[list[dict[str, float]]]:
         List of lists of dictionaries containing the desired relative L2-errors.
 
     """
+
     # Desired errors for 2d
     desired_errors_2d = [
         {  # t = 0.5 [s]
-            'error_matrix_pressure': 0.05860315482644138, 
-            'error_matrix_flux': 0.01728816711273373,
-            'error_frac_pressure': 4.761115466428997,
-            'error_frac_flux': 0.0027528176884234297,
-            'error_intf_flux': 3.0521278709541946
+            "error_matrix_pressure": 0.05860315482644138,
+            "error_matrix_flux": 0.01728816711273373,
+            "error_frac_pressure": 4.761115466428997,
+            "error_frac_flux": 0.0027528176884234297,
+            "error_intf_flux": 3.0521278709541946,
         },
         {  # t = 1.0 [s]
-            'error_matrix_pressure': 0.056952568619002386,
-            'error_matrix_flux': 0.017206997517806834,
-            'error_frac_pressure': 4.7258340277590865,
-            'error_frac_flux': 0.0036119330001357737,
-            'error_intf_flux': 3.1023316529076546
+            "error_matrix_pressure": 0.056952568619002386,
+            "error_matrix_flux": 0.017206997517806834,
+            "error_frac_pressure": 4.7258340277590865,
+            "error_frac_flux": 0.0036119330001357737,
+            "error_intf_flux": 3.1023316529076546,
         },
     ]
     # Desired errors for 3d
     desired_errors_3d = [
         {  # t = 0.5 [s]
-            'error_matrix_pressure': 0.044142110025893674,
-            'error_matrix_flux': 0.020240531408035483,
-            'error_frac_pressure': 7.345638542028673,
-            'error_frac_flux': 0.04968518024390149,
-            'error_intf_flux': 5.150695781155413
+            "error_matrix_pressure": 0.044142110025893674,
+            "error_matrix_flux": 0.020240531408035483,
+            "error_frac_pressure": 7.345638542028673,
+            "error_frac_flux": 0.04968518024390149,
+            "error_intf_flux": 5.150695781155413,
         },
         {  # t = 1.0 [s]
-            'error_matrix_pressure': 0.043341944057014324,
-            'error_matrix_flux': 0.02031093722149098,
-            'error_frac_pressure': 7.139915887008252,
-            'error_frac_flux': 0.049748152094622,
-            'error_intf_flux': 5.228345273854552
+            "error_matrix_pressure": 0.043341944057014324,
+            "error_matrix_flux": 0.02031093722149098,
+            "error_frac_pressure": 7.139915887008252,
+            "error_frac_flux": 0.049748152094622,
+            "error_intf_flux": 5.228345273854552,
         },
     ]
 

--- a/tests/functional/test_manu_flow_comp_frac.py
+++ b/tests/functional/test_manu_flow_comp_frac.py
@@ -81,8 +81,8 @@ def actual_l2_errors(material_constants: dict) -> list[list[dict[str, float]]]:
     Returns:
         List of lists of dictionaries of actual relative errors. The outer list contains
         two items, the first contains the results for 2d and the second contains the
-        results for 3d. Both inner lists contain three items each, each of which is a
-        dictionary of results for the scheduled times, i.e., 0.2 [s], 0.8 [s], and
+        results for 3d. Both inner lists contain two items each, each of which is a
+        dictionary of results for the scheduled times, i.e., 0.5 [s], and
         1.0 [s].
 
     """
@@ -92,7 +92,7 @@ def actual_l2_errors(material_constants: dict) -> list[list[dict[str, float]]]:
         "grid_type": "cartesian",
         "material_constants": material_constants,
         "meshing_arguments": {"cell_size": 0.125},
-        "time_manager": pp.TimeManager([0, 0.2, 0.8, 1.0], 0.2, True),
+        "time_manager": pp.TimeManager([0, 0.5, 1.0], 0.5, True),
     }
 
     # Retrieve actual L2-relative errors.
@@ -129,50 +129,36 @@ def desired_l2_errors() -> list[list[dict[str, float]]]:
     """
     # Desired errors for 2d
     desired_errors_2d = [
-        {  # t = 0.2 [s]
-            "error_matrix_pressure": 0.05925007221301212,
-            "error_matrix_flux": 0.017427251422474147,
-            "error_frac_pressure": 4.639395967257667,
-            "error_frac_flux": 0.002124677195582403,
-            "error_intf_flux": 2.9141633825921764,
-        },
-        {  # t = 0.8 [s]
-            "error_matrix_pressure": 0.05763683424696444,
-            "error_matrix_flux": 0.017256638140139675,
-            "error_frac_pressure": 4.749914708440596,
-            "error_frac_flux": 0.003280737213089598,
-            "error_intf_flux": 3.0896181780350087,
+        {  # t = 0.5 [s]
+            'error_matrix_pressure': 0.05860315482644138, 
+            'error_matrix_flux': 0.01728816711273373,
+            'error_frac_pressure': 4.761115466428997,
+            'error_frac_flux': 0.0027528176884234297,
+            'error_intf_flux': 3.0521278709541946
         },
         {  # t = 1.0 [s]
-            "error_matrix_pressure": 0.056955711514823516,
-            "error_matrix_flux": 0.01720817118615666,
-            "error_frac_pressure": 4.726676447078315,
-            "error_frac_flux": 0.003612830093695507,
-            "error_intf_flux": 3.1029228202482684,
+            'error_matrix_pressure': 0.056952568619002386,
+            'error_matrix_flux': 0.017206997517806834,
+            'error_frac_pressure': 4.7258340277590865,
+            'error_frac_flux': 0.0036119330001357737,
+            'error_intf_flux': 3.1023316529076546
         },
     ]
     # Desired errors for 3d
     desired_errors_3d = [
-        {  # t = 0.8 [s]
-            "error_matrix_pressure": 0.044571753794961005,
-            "error_matrix_flux": 0.020249130740834082,
-            "error_frac_pressure": 7.255330029340333,
-            "error_frac_flux": 0.04952574895586101,
-            "error_intf_flux": 4.934788300523336,
-        },
-        {  # t = 0.8 [s]
-            "error_matrix_pressure": 0.04366494151054094,
-            "error_matrix_flux": 0.02026938096079742,
-            "error_frac_pressure": 7.238981125109468,
-            "error_frac_flux": 0.049735390892742634,
-            "error_intf_flux": 5.210187699312009,
+        {  # t = 0.5 [s]
+            'error_matrix_pressure': 0.044142110025893674,
+            'error_matrix_flux': 0.020240531408035483,
+            'error_frac_pressure': 7.345638542028673,
+            'error_frac_flux': 0.04968518024390149,
+            'error_intf_flux': 5.150695781155413
         },
         {  # t = 1.0 [s]
-            "error_matrix_pressure": 0.043342993753491044,
-            "error_matrix_flux": 0.020310895974943288,
-            "error_frac_pressure": 7.142274002520263,
-            "error_frac_flux": 0.04974929638115217,
-            "error_intf_flux": 5.230143440439021,
+            'error_matrix_pressure': 0.043341944057014324,
+            'error_matrix_flux': 0.02031093722149098,
+            'error_frac_pressure': 7.139915887008252,
+            'error_frac_flux': 0.049748152094622,
+            'error_intf_flux': 5.228345273854552
         },
     ]
 
@@ -184,7 +170,7 @@ def desired_l2_errors() -> list[list[dict[str, float]]]:
     "var",
     ["matrix_pressure", "matrix_flux", "frac_pressure", "frac_flux", "intf_flux"],
 )
-@pytest.mark.parametrize("time_idx", [0, 1, 2])
+@pytest.mark.parametrize("time_idx", [0, 1])
 def test_relative_l2_errors_cartesian_grid(
     dim_idx: int,
     var: str,
@@ -205,16 +191,15 @@ def test_relative_l2_errors_cartesian_grid(
         and on the interfaces). The errors are measured using the discrete relative
         L2-error norm. The desired errors were obtained by running the model using the
         physical constants from :meth:`~material_constants` on a Cartesian grid with
-        64 cells in 2d and 512 in 3d. We test the errors for three different times,
-        namely: 0.2 [s], 0.8 [s], and 1.0 [s].
+        64 cells in 2d and 512 in 3d. We test the errors for two different times,
+        namely: 0.5 [s], and 1.0 [s].
 
     Parameters:
         dim_idx: Dimension index acting on the outer list of `actual_l2_errors` and
             `desired_l2_errors`. `0` refers to 2d and `1` to 3d.
         var: Name of the variable to be tested.
         time_idx: Time index acting on the inner lists of 'actual_l2_errors' and
-            'desired_l2_errors'. `0` refers to 0.2 [s], `1` to 0.8 [s], and `2` to
-            1.0 [s].
+            'desired_l2_errors'. `0` refers to 0.5 [s], and `1` to 1.0 [s].
         actual_l2_errors: List of lists of dictionaries containing the actual
             L2-relative errors.
         desired_l2_errors: List of lists of dictionaries containing the desired

--- a/tests/functional/test_manu_flow_comp_frac.py
+++ b/tests/functional/test_manu_flow_comp_frac.py
@@ -83,8 +83,7 @@ def actual_l2_errors(material_constants: dict) -> list[list[dict[str, float]]]:
         List of lists of dictionaries of actual relative errors. The outer list contains
         two items, the first contains the results for 2d and the second contains the
         results for 3d. Both inner lists contain two items each, each of which is a
-        dictionary of results for the scheduled times, i.e., 0.5 [s], and
-        1.0 [s].
+        dictionary of results for the scheduled times, i.e., 0.5 [s], and 1.0 [s].
 
     """
 

--- a/tests/functional/test_manu_poromech_nofrac.py
+++ b/tests/functional/test_manu_poromech_nofrac.py
@@ -182,17 +182,16 @@ def test_relative_l2_errors_cartesian_grid(
         For this functional test, we are comparing errors for the pressure, fluxes,
         displacement, and forces. The errors are measured using the discrete relative
         L2-error norm. The desired errors were obtained by running the model using the
-        physical constants from :meth:`~material_constants` on a Cartesian grid with
-        16 cells in 2d and 64 in 3d. We test the errors for three different times,
-        namely: 0.2 [s], 0.6[s], and 1.0 [s].
+        physical constants from :meth:`~material_constants` on a Cartesian grid with 16
+        cells in 2d and 64 in 3d. We test the errors for two different times, namely:
+        0.5 [s] and 1.0 [s].
 
     Parameters:
         dim_idx: Dimension index acting on the outer list of `actual_l2_errors` and
             `desired_l2_errors`. `0` refers to 2d and `1` to 3d.
         var: Name of the variable to be tested.
         time_idx: Time index acting on the inner lists of 'actual_l2_errors' and
-            'desired_l2_errors'. `0` refers to 0.2 [s], `1` to 0.6 [s], and `2` to
-            1.0 [s].
+            'desired_l2_errors'. `0` refers to 0.5 [s], `1` 1.0 [s].
         actual_l2_errors: List of lists of dictionaries containing the actual
             L2-relative errors.
         desired_l2_errors: List of lists of dictionaries containing the desired

--- a/tests/functional/test_manu_poromech_nofrac.py
+++ b/tests/functional/test_manu_poromech_nofrac.py
@@ -85,8 +85,7 @@ def actual_l2_errors(material_constants: dict) -> list[list[dict[str, float]]]:
         List of lists of dictionaries of actual relative errors. The outer list contains
         two items, the first contains the results for 2d and the second contains the
         results for 3d. Both inner lists contain three items each, each of which is a
-        dictionary of results for the scheduled times, i.e., 0.2 [s], 0.6 [s], and
-        1.0 [s].
+        dictionary of results for the scheduled times, i.e., 0.5 [s] and 1.0 [s].
 
     """
 
@@ -96,7 +95,7 @@ def actual_l2_errors(material_constants: dict) -> list[list[dict[str, float]]]:
         "material_constants": material_constants,
         "meshing_arguments": {"cell_size": 0.25},
         "manufactured_solution": "nordbotten_2016",
-        "time_manager": pp.TimeManager([0, 0.2, 0.6, 1.0], 0.2, True),
+        "time_manager": pp.TimeManager([0, 0.5, 1.0], 0.5, True),
     }
 
     # Retrieve actual L2-relative errors.
@@ -130,44 +129,32 @@ def desired_l2_errors() -> list[list[dict[str, float]]]:
 
     """
     desired_errors_2d = [
-        {  # t = 0.2 [s]
-            "error_pressure": 0.2545484162739883,
-            "error_flux": 0.19100289160484132,
-            "error_displacement": 0.39563032313594826,
-            "error_force": 0.16374154620456183,
-        },
-        {  # t = 0.6 [s]
-            "error_pressure": 0.20403618663140907,
-            "error_flux": 0.10127514065678846,
-            "error_displacement": 0.3952832045853454,
-            "error_force": 0.16378390892609127,
+        {  # t = 0.5 [s]
+            "error_pressure": 0.20711096997503695,
+            "error_flux": 0.10810627224942725,
+            "error_displacement": 0.3953172876400884,
+            "error_force": 0.16377962778847108,
         },
         {  # t = 1.0 [s]
-            "error_pressure": 0.19880638363091166,
-            "error_flux": 0.08957848409690061,
-            "error_displacement": 0.3952120639213762,
-            "error_force": 0.1637924768371908,
+            "error_pressure": 0.1987998797257252,
+            "error_flux": 0.08957210872187034,
+            "error_displacement": 0.3952120364196121,
+            "error_force": 0.1637924594814397,
         },
     ]
 
     desired_errors_3d = [
-        {  # t = 0.2 [s]
-            "error_pressure": 0.23782662757050732,
-            "error_flux": 0.14769646432955522,
-            "error_displacement": 0.44395480741716725,
-            "error_force": 0.22057082769118985,
+        {  # t = 0.5 [s]
+            "error_pressure": 0.2164612681791387,
+            "error_flux": 0.10469929694089308,
+            "error_displacement": 0.44379951512274146,
+            "error_force": 0.22059921122808707,
         },
-        {  # t = 0.6 [s]
-            "error_pressure": 0.21514558283750523,
-            "error_flux": 0.10164613256599124,
-            "error_displacement": 0.4437824620154635,
-            "error_force": 0.2206023522490412,
-        },
-        {  # t = 1.0 [s]
-            "error_pressure": 0.2128149520464844,
-            "error_flux": 0.09661797541885192,
-            "error_displacement": 0.44374742980986287,
-            "error_force": 0.22060876087140713,
+        {  # t = 1.0[s]
+            "error_pressure": 0.2128131032248365,
+            "error_flux": 0.09661636990837687,
+            "error_displacement": 0.4437474284152431,
+            "error_force": 0.2206087610242069,
         },
     ]
 

--- a/tests/functional/test_manu_thermoporomech_nofrac.py
+++ b/tests/functional/test_manu_thermoporomech_nofrac.py
@@ -71,8 +71,7 @@ def actual_l2_errors(material_constants) -> list[list[dict[str, float]]]:
         List of lists of dictionaries of actual relative errors. The outer list contains
         two items, the first contains the results for 2d and the second contains the
         results for 3d. Both inner lists contain three items each, each of which is a
-        dictionary of results for the scheduled times, i.e., 0.2 [s], 0.6 [s], and
-        1.0 [s].
+        dictionary of results for the scheduled times, i.e., 0.5 [s] and 1.0 [s].
 
     """
 
@@ -182,9 +181,9 @@ def test_relative_l2_errors_cartesian_grid(
         For this functional test, we are comparing errors for the pressure, fluxes,
         displacement, and forces. The errors are measured using the discrete relative
         L2-error norm. The desired errors were obtained by running the model using the
-        physical constants from :meth:`~material_constants` on a Cartesian grid with
-        16 cells in 2d and 64 in 3d. We test the errors for three different times,
-        namely: 0.5 [s],  and 1.0 [s].
+        physical constants from :meth:`~material_constants` on a Cartesian grid with 16
+        cells in 2d and 64 in 3d. We test the errors for two different times, namely:
+        0.5 [s],  and 1.0 [s].
 
     Parameters:
         dim_idx: Dimension index acting on the outer list of `actual_l2_errors` and

--- a/tests/functional/test_manu_thermoporomech_nofrac.py
+++ b/tests/functional/test_manu_thermoporomech_nofrac.py
@@ -81,7 +81,7 @@ def actual_l2_errors(material_constants) -> list[list[dict[str, float]]]:
         "grid_type": "cartesian",
         "material_constants": material_constants,
         "meshing_arguments": {"cell_size": 0.25},
-        "time_manager": pp.TimeManager([0, 0.2, 0.6, 1.0], 0.2, True),
+        "time_manager": pp.TimeManager([0, 0.5, 1.0], 0.5, True),
         "heterogeneity": 10.0,
     }
 
@@ -119,55 +119,39 @@ def desired_l2_errors() -> list[list[dict[str, float]]]:
 
     """
     desired_errors_2d = [
-        {  # t = 0.2 [s]
-            "error_pressure": 0.29245525657228516,
-            "error_darcy_flux": 0.14866807005212218,
-            "error_displacement": 0.4060794558177133,
-            "error_force": 0.16882241805995685,
-            "error_temperature": 0.2805373010672497,
-            "error_energy_flux": 0.14224713493285213,
-        },
-        {  # t = 0.6 [s]
-            "error_pressure": 0.29915191269112884,
-            "error_darcy_flux": 0.143731386301777,
-            "error_displacement": 0.4058790962545719,
-            "error_force": 0.168891116834099,
-            "error_temperature": 0.2817656772923569,
-            "error_energy_flux": 0.14418402387993626,
+        {  # t = 0.5 [s]
+            "error_pressure": 0.29827252435393803,
+            "error_darcy_flux": 0.1439958241169773,
+            "error_displacement": 0.4058988627472109,
+            "error_force": 0.16888424201570365,
+            "error_temperature": 0.28326347851869543,
+            "error_energy_flux": 0.143777694649805,
         },
         {  # t = 1.0 [s]
-            "error_pressure": 0.30102053594879236,
-            "error_darcy_flux": 0.1433305592811348,
-            "error_displacement": 0.40583744381509923,
-            "error_force": 0.16890514243228508,
-            "error_temperature": 0.2734736165434784,
-            "error_energy_flux": 0.14568673457608622,
+            "error_pressure": 0.3010187539654323,
+            "error_darcy_flux": 0.1433298407071359,
+            "error_displacement": 0.4058374630516512,
+            "error_force": 0.16890514221989356,
+            "error_temperature": 0.27340859892936803,
+            "error_energy_flux": 0.14567435981074586,
         },
     ]
     desired_errors_3d = [
-        {  # t = 0.2 [s]
-            "error_pressure": 0.29483420733078686,
-            "error_darcy_flux": 0.17486321642288996,
-            "error_displacement": 0.4486172675647366,
-            "error_force": 0.21447111918990183,
-            "error_temperature": 0.2658002623034062,
-            "error_energy_flux": 0.14494419847742834,
-        },
-        {  # t = 0.6 [s]
-            "error_pressure": 0.28178892740044215,
-            "error_darcy_flux": 0.1510526423353489,
-            "error_displacement": 0.4482245605585491,
-            "error_force": 0.2145593104444151,
-            "error_temperature": 0.26570376518127564,
-            "error_energy_flux": 0.1473799407417573,
+        {  # t = 0.5 [s]
+            "error_pressure": 0.28233484316067864,
+            "error_darcy_flux": 0.15250403155748207,
+            "error_displacement": 0.4482633717525385,
+            "error_force": 0.21455044408871599,
+            "error_temperature": 0.2668424103750087,
+            "error_energy_flux": 0.14699614090181903,
         },
         {  # t = 1.0 [s]
-            "error_pressure": 0.28113091748952695,
-            "error_darcy_flux": 0.14877473367953858,
-            "error_displacement": 0.44814466743009757,
-            "error_force": 0.21457738875513135,
-            "error_temperature": 0.2593720615174321,
-            "error_energy_flux": 0.14849416613002764,
+            "error_pressure": 0.28113090124404544,
+            "error_darcy_flux": 0.1487747552893976,
+            "error_displacement": 0.448144662794714,
+            "error_force": 0.21457738933054352,
+            "error_temperature": 0.2593080002077755,
+            "error_energy_flux": 0.14847494492738805,
         },
     ]
 
@@ -200,15 +184,14 @@ def test_relative_l2_errors_cartesian_grid(
         L2-error norm. The desired errors were obtained by running the model using the
         physical constants from :meth:`~material_constants` on a Cartesian grid with
         16 cells in 2d and 64 in 3d. We test the errors for three different times,
-        namely: 0.2 [s], 0.6[s], and 1.0 [s].
+        namely: 0.5 [s],  and 1.0 [s].
 
     Parameters:
         dim_idx: Dimension index acting on the outer list of `actual_l2_errors` and
             `desired_l2_errors`. `0` refers to 2d and `1` to 3d.
         var: Name of the variable to be tested.
         time_idx: Time index acting on the inner lists of 'actual_l2_errors' and
-            'desired_l2_errors'. `0` refers to 0.2 [s], `1` to 0.6 [s], and `2` to
-            1.0 [s].
+            'desired_l2_errors'. `0` refers to 0.5 [s], and `1` to 1.0 [s].
         actual_l2_errors: List of lists of dictionaries containing the actual
             L2-relative errors.
         desired_l2_errors: List of lists of dictionaries containing the desired

--- a/tests/functional/test_terzaghi.py
+++ b/tests/functional/test_terzaghi.py
@@ -113,22 +113,21 @@ def test_pressure_and_consolidation_degree_errors():
             "solid": pp.SolidConstants(terzaghi_solid_constants),
             "fluid": pp.FluidConstants(terzaghi_fluid_constants),
         },
-        "time_manager": pp.TimeManager([0, 0.05, 0.1, 0.3], 0.05, True),
+        "time_manager": pp.TimeManager([0, 0.15, 0.3], 0.15, True),
         "num_cells": 10,
     }
     setup = TerzaghiSetup(params)
     pp.run_time_dependent_model(setup, params)
 
     # Check pressure error
-    desired_error_p = [0.06884857957987067, 0.0455347877406611, 0.022391576732172767]
+    desired_error_p = [0.09073522073879309, 0.0613512657231161]
     actual_error_p = [result.error_pressure for result in setup.results]
     np.testing.assert_allclose(actual_error_p, desired_error_p, rtol=1e-3, atol=1e-5)
 
     # Check consolidation degree error
     desired_error_consol = [
-        0.0270053052913328,
-        0.018839104164792175,
-        0.010927390550216687,
+        0.03840054346677685,
+        0.028730080280409465,
     ]
     actual_error_consol = [
         result.error_consolidation_degree for result in setup.results


### PR DESCRIPTION
## Proposed changes

Addresses issue #1140. Reduces number of time steps in the functional tests. They are consistently reduced to 2 time steps to reduce computational cost.

At the time of writing: The time to run the functional tests is reduced from about 40s to 25s (in my laptop).

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
