### PR TITLE
Issue 797

### DIFF
--- a/.github/workflows/run-static-checks-docs.yml
+++ b/.github/workflows/run-static-checks-docs.yml
@@ -1,0 +1,31 @@
+# Running checks on updates to docs branch
+
+on:
+  workflow_dispatch:
+    # run jobs manually
+  # NOTE perform workflow only for PRs, not direct pushes to avoid conflict with dev downstream
+  pull_request:
+    branches: 
+      - docs
+
+jobs:
+  # A job checking that changes to docs branch are restricted to directory docs/
+  changes_restricted_to_docs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dorny/paths-filter@v3
+      id: filter
+      with:
+# Filters have limited support in finding patterns
+# Strategy is to compare the number of changes per filter
+# If all changes are greater in number than changes to the docs folder, there is at least 1 change outside docs/
+        filters: |
+          docs:
+            - 'docs/**'
+          all:
+            - '**'
+
+    - name: Restrict accepted changes to docs/ directory in PR to branch 'docs'
+      if: steps.filter.outputs.all_count > steps.filter.outputs.docs_count
+      run: echo "::error::Changes outside directory docs/ not allowed in PR to branch 'docs'." && exit 1

--- a/.github/workflows/run-static-checks.yml
+++ b/.github/workflows/run-static-checks.yml
@@ -21,6 +21,23 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
+  # Assert no docs/ directory on branches main and develop for conflict-free downstream
+  # https://stackoverflow.com/questions/70708306/github-actions-run-step-job-in-a-workflow-if-changes-happen-in-specific-folde
+  no_docs_on_develop_and_main:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dorny/paths-filter@v3
+      id: filter
+      with:
+        filters: |
+          docs:
+            - 'docs/**'
+
+    - name: assert no docs/ directory on branches 'develop' and 'main'
+      if: steps.filter.outputs.docs == 'true'
+      run: echo "::error::No 'docs/' directory allowed on branches 'develop' and 'main'." && exit 1
+
   # Assert successful build and proper code layout
   build:
     name: Static tests
@@ -92,20 +109,3 @@ jobs:
     - name: mypy
       if: ${{ always() }}
       run: mypy src --cache-dir mypy-cache-${{ matrix.python-version}}
-
-  # Assert no docs/ directory on branches main and develop for conflict-free downstream
-  # https://stackoverflow.com/questions/70708306/github-actions-run-step-job-in-a-workflow-if-changes-happen-in-specific-folde
-  no_docs_on_develop_and_main:
-        runs-on: ubuntu-latest
-        steps:
-        - uses: actions/checkout@v4
-        - uses: dorny/paths-filter@v3
-          id: filter
-          with:
-            filters: |
-              docs:
-                - 'docs/**'
-    
-        - name: assert no docs/ directory on branches 'develop' and 'main'
-          if: steps.filter.outputs.docs == 'true'
-          run: echo "::error::No 'docs/' directory allowed on branches 'develop' and 'main'." && exit 1

--- a/.github/workflows/run-static-checks.yml
+++ b/.github/workflows/run-static-checks.yml
@@ -21,7 +21,7 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
+  # Assert successful build and proper code layout
   build:
     name: Static tests
     # The type of runner that the job will run on
@@ -92,3 +92,20 @@ jobs:
     - name: mypy
       if: ${{ always() }}
       run: mypy src --cache-dir mypy-cache-${{ matrix.python-version}}
+
+  # Assert no docs/ directory on branches main and develop for conflict-free downstream
+  # https://stackoverflow.com/questions/70708306/github-actions-run-step-job-in-a-workflow-if-changes-happen-in-specific-folde
+  no_docs_on_develop_and_main:
+        runs-on: ubuntu-latest
+        steps:
+        - uses: actions/checkout@v4
+        - uses: dorny/paths-filter@v3
+          id: filter
+          with:
+            filters: |
+              docs:
+                - 'docs/**'
+    
+        - name: assert no docs/ directory on branches 'develop' and 'main'
+          if: steps.filter.outputs.docs == 'true'
+          run: echo "::error::No 'docs/' directory allowed on branches 'develop' and 'main'." && exit 1


### PR DESCRIPTION
## Proposed changes

Adding two new GitHub jobs according to #797.

1. Existing static checks for PRs to `develop` and `main` are extended to check if changes to directory `docs/` are included. Raises error if so (`docs/` directory only on branch `docs`)
3. PRs to branch docs are checked for changes outside of directory `docs/`. If detected, raises error. This is to avoid conflicts in (future) downstreaming of dev/main to docs. Restricts admissible changes in branch `docs` to Sphinx set-up.

Workflows tested in toy repo https://github.com/pmgbergen/getting_used_to_github

## Types of changes

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [X] Other: Workflows for CI of documentation updates

## Checklist

- [ ] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [X] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
