### PR TITLE
BUG: Honor is_diverged when progress bars are off

### DIFF
--- a/src/porepy/numerics/nonlinear/nonlinear_solvers.py
+++ b/src/porepy/numerics/nonlinear/nonlinear_solvers.py
@@ -118,6 +118,7 @@ class NewtonSolver:
 
                 if is_diverged:
                     model.after_nonlinear_failure(sol, errors, iteration_counter)
+                    break
                 elif is_converged:
                     model.after_nonlinear_convergence(sol, errors, iteration_counter)
 


### PR DESCRIPTION
## Proposed changes

Bug: Missing break of while loop if progress bar are not turned on. Thus, the nonlinear loop continued running.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [x] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [ ] Static typing is included in the update. NA
- [ ] This PR does not duplicate existing functionality. (well, sort of does, but that's because of the progress bar implementation)
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
