### PR TITLE
Numba modifications to eliminate import overhead

### DIFF
--- a/src/porepy/composite/__init__.py
+++ b/src/porepy/composite/__init__.py
@@ -32,7 +32,7 @@ References:
 
 __all__ = []
 
-from . import (
+from . import (  # peng_robinson,
     _core,
     base,
     chem_species,
@@ -42,8 +42,8 @@ from . import (
     equilibrium_mixins,
     flash,
     flash_c,
-    peng_robinson,
     states,
+    utils_c,
 )
 from ._core import *
 from .base import *
@@ -55,6 +55,7 @@ from .equilibrium_mixins import *
 from .flash import *
 from .flash_c import *
 from .states import *
+from .utils_c import *
 
 __all__.extend(_core.__all__)
 __all__.extend(chem_species.__all__)
@@ -66,3 +67,4 @@ __all__.extend(flash.__all__)
 __all__.extend(flash_c.__all__)
 __all__.extend(states.__all__)
 __all__.extend(eos_compiler.__all__)
+__all__.extend(utils_c.__all__)

--- a/src/porepy/composite/_core.py
+++ b/src/porepy/composite/_core.py
@@ -4,6 +4,7 @@ composite subpackage.
 Changes here should be done with much care.
 
 """
+
 from __future__ import annotations
 
 __all__ = [
@@ -15,7 +16,7 @@ __all__ = [
 ]
 
 
-NUMBA_CACHE: bool = False
+NUMBA_CACHE: bool = True
 """Flag to instruct the numba compiler to cache (!and use cached!) functions.
 
 This might cause some confusion in the developing process due to some lack in numba's
@@ -24,6 +25,10 @@ caching functionality.
 re-compilation)
 
 Use with care.
+
+Note:
+    Functions which do not use other numba-compiled functions are cached by default.
+    This flag is for those who do use other functions.
 
 See Also:
     https://numba.readthedocs.io/en/stable/user/jit.html#cache

--- a/src/porepy/composite/_flash.py
+++ b/src/porepy/composite/_flash.py
@@ -1,6 +1,7 @@
 """DEPRACATED.
 
 This module contains functionality to solve the equilibrium problem numerically."""
+
 from __future__ import annotations
 
 import logging
@@ -19,12 +20,12 @@ from ._core import R_IDEAL
 from .base import Mixture
 from .composite_utils import COMPOSITE_LOGGER as logger
 from .composite_utils import safe_sum, trunclog
-from .peng_robinson.eos import PhaseProperties, ThermodynamicState
+from .peng_robinson._eos import PhaseProperties, ThermodynamicState
 
 __all__ = ["FlashSystemNR", "FlashNR"]
 
 
-DeprecationWarning("The module porepy.composite.flash is deprecated.")
+DeprecationWarning("The module porepy.composite._flash is deprecated.")
 
 
 def K_val_Wilson(
@@ -79,9 +80,11 @@ def _rr_pole(i: int, y: list[NumericType], K: list[list[NumericType]]) -> Numeri
     """
     # multiplication is sensitive between numpy arrays and AdArrays...
     t = [
-        y[j] * (K[j][i] - 1)
-        if isinstance(y[j], pp.ad.AdArray)
-        else (K[j][i] - 1) * y[j]
+        (
+            y[j] * (K[j][i] - 1)
+            if isinstance(y[j], pp.ad.AdArray)
+            else (K[j][i] - 1) * y[j]
+        )
         for j in range(len(y))
     ]
 

--- a/src/porepy/composite/base.py
+++ b/src/porepy/composite/base.py
@@ -50,6 +50,7 @@ Note:
     A basic interface for such an equation of state is defined by :class:`AbstractEoS`.
 
 """
+
 from __future__ import annotations
 
 import abc

--- a/src/porepy/composite/chem_species.py
+++ b/src/porepy/composite/chem_species.py
@@ -7,6 +7,7 @@ Use the dataclass contained here for various interfaces with chemical databases
 or other, third-party software.
 
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/src/porepy/composite/composite_mixins.py
+++ b/src/porepy/composite/composite_mixins.py
@@ -2,6 +2,7 @@
 framework.
 
 """
+
 from __future__ import annotations
 
 from typing import Callable, Literal, Optional, Sequence
@@ -191,12 +192,14 @@ class CompositeVariables(pp.VariableMixin):
         x = [
             np.array(
                 [
-                    phase.fraction_of[component](subdomains).value(
-                        self.equation_system, state
-                    )
-                    if self.equilibrium_type is not None
-                    else phase.partial_fraction_of[component](subdomains).value(
-                        self.equation_system, state
+                    (
+                        phase.fraction_of[component](subdomains).value(
+                            self.equation_system, state
+                        )
+                        if self.equilibrium_type is not None
+                        else phase.partial_fraction_of[component](subdomains).value(
+                            self.equation_system, state
+                        )
                     )
                     for component in phase
                 ]

--- a/src/porepy/composite/composite_mixins.py
+++ b/src/porepy/composite/composite_mixins.py
@@ -149,7 +149,7 @@ class CompositeVariables(pp.VariableMixin):
         Evaluates:
 
         1. Overall fractions per component
-        2. Molar fractions per phase
+        2. Fractions per phase
         3. Volumetric fractions per phase (saturations)
         4. Fractions per phase per component
            (extended if equilibrium defined, else partial)
@@ -198,7 +198,7 @@ class CompositeVariables(pp.VariableMixin):
                     else phase.partial_fraction_of[component](subdomains).value(
                         self.equation_system, state
                     )
-                    for component in self.fluid_mixture.components
+                    for component in phase
                 ]
             )
             for phase in self.fluid_mixture.phases

--- a/src/porepy/composite/composite_utils.py
+++ b/src/porepy/composite/composite_utils.py
@@ -3,6 +3,7 @@
 It also contains some older code kept until ready for removal.
 
 """
+
 from __future__ import annotations
 
 import abc

--- a/src/porepy/composite/eos_compiler.py
+++ b/src/porepy/composite/eos_compiler.py
@@ -1,5 +1,6 @@
 """Module containing the abstract base class for compiling EoS-related functions used
 in the evaluation of thermodynamic properties."""
+
 from __future__ import annotations
 
 import abc
@@ -12,7 +13,7 @@ import numpy as np
 from .base import AbstractEoS, Component
 from .composite_utils import COMPOSITE_LOGGER as logger
 from .states import PhaseState
-from .utils_c import extended_compositional_derivatives_v
+from .utils_c import extend_fractional_derivatives
 
 __all__ = [
     "EoSCompiler",
@@ -889,12 +890,12 @@ class EoSCompiler(AbstractEoS):
         )
 
         # Extending derivatives to extended fractions
-        state.dh = extended_compositional_derivatives_v(state.dh, x)
-        state.dv = extended_compositional_derivatives_v(state.dv, x)
-        state.dmu = extended_compositional_derivatives_v(state.dmu, x)
-        state.dkappa = extended_compositional_derivatives_v(state.dkappa, x)
+        state.dh = extend_fractional_derivatives(state.dh, x)
+        state.dv = extend_fractional_derivatives(state.dv, x)
+        state.dmu = extend_fractional_derivatives(state.dmu, x)
+        state.dkappa = extend_fractional_derivatives(state.dkappa, x)
         for i in range(ncomp):
             # TODO check if this is indexed correctly
-            state.dphis[i] = extended_compositional_derivatives_v(state.dphis[i], x)
+            state.dphis[i] = extend_fractional_derivatives(state.dphis[i], x)
 
         return state

--- a/src/porepy/composite/equilibrium_mixins.py
+++ b/src/porepy/composite/equilibrium_mixins.py
@@ -126,7 +126,6 @@ class UnifiedPhaseEquilibriumMixin:
         """The base class method without defined equilibrium type performs a model
         validation to ensure that the assumptions for the unified flash are fulfilled.
         """
-        subdomains = self.mdg.subdomains()
         ncomp = self.fluid_mixture.num_components
         nphase = self.fluid_mixture.num_phases
 
@@ -159,21 +158,6 @@ class UnifiedPhaseEquilibriumMixin:
                     f"Unified equilibrium assumption violated for phase: {phase.name}."
                     + " All phases must have all components modelled in them."
                 )
-
-        # No more equations for p-T based flash
-        if self.equilibrium_type == "p-T":
-            pass
-        # 1 more equation for p-h based flash (T unknown)
-        elif self.equilibrium_type == "p-h":
-            # here T is another unknown, but h is fixed. Introduce 1 more equations
-            equ = self.mixture_enthalpy_constraint(subdomains)
-            self.equation_system.set_equation(equ, subdomains, {"cells": 1})
-        # 2 + num_phase - 1 more equations for v-h flash (p, T, s_j unknown)
-        elif self.equilibrium_type == "v-h":
-            equ = self.mixture_enthalpy_constraint(subdomains)
-            self.equation_system.set_equation(equ, subdomains, {"cells": 1})
-            equ = self.mixture_volume_constraint(subdomains)
-            self.equation_system.set_equation(equ, subdomains, {"cells": 1})
 
     def mass_constraint_for_component(
         self, component: Component, subdomains: Sequence[pp.Grid]

--- a/src/porepy/composite/equilibrium_mixins.py
+++ b/src/porepy/composite/equilibrium_mixins.py
@@ -11,6 +11,7 @@ to be set, which must not be ``None``. This is to inform the remaining framework
 that local equilibrium assumptions (instead of some constitutive laws) were introduced.
 
 """
+
 from __future__ import annotations
 
 import warnings

--- a/src/porepy/composite/flash.py
+++ b/src/porepy/composite/flash.py
@@ -289,6 +289,13 @@ class Flash(abc.ABC):
                         s[:] = fluid_state.sat[j]
                         S.append(s)
                     fluid_state.sat = np.array(S)
+                    p = np.zeros(NF)
+                    p[:] = fluid_state.p
+                    fluid_state.p = p
+                if "T" not in flash_type:
+                    T = np.zeros(NF)
+                    T[:] = fluid_state.T
+                    fluid_state.T = T
             except ValueError as err:
                 if "broadcast" in str(err):
                     xl = [[len(x) for x in phase.x] for phase in fluid_state.phases]

--- a/src/porepy/composite/flash.py
+++ b/src/porepy/composite/flash.py
@@ -1,4 +1,5 @@
 """Module containing an abstraction layer for the flash procedure."""
+
 from __future__ import annotations
 
 import abc
@@ -106,7 +107,12 @@ class Flash(abc.ABC):
         h: Optional[np.ndarray | pp.number] = None,
         v: Optional[np.ndarray | pp.number] = None,
         initial_state: Optional[FluidState] = None,
-    ) -> tuple[FluidState, Literal["p-T", "p-h", "v-T", "v-h"], int, int,]:
+    ) -> tuple[
+        FluidState,
+        Literal["p-T", "p-h", "v-T", "v-h"],
+        int,
+        int,
+    ]:
         """Helper method to parse the input and construct a provisorical fluid state
         with uniform input (numpy arrays of same size).
 

--- a/src/porepy/composite/flash_c.py
+++ b/src/porepy/composite/flash_c.py
@@ -18,6 +18,7 @@ References:
 
 
 """
+
 from __future__ import annotations
 
 import logging
@@ -41,12 +42,11 @@ from .npipm_c import (
 )
 from .states import FluidState
 from .utils_c import (
-    compute_saturations,
-    extended_compositional_derivatives,
+    _compute_saturations,
+    _extend_fractional_derivatives,
     insert_pT,
     insert_sat,
     insert_xy,
-    normalize_fractions,
     parse_pT,
     parse_sat,
     parse_target_state,
@@ -56,10 +56,30 @@ from .utils_c import (
 __all__ = ["CompiledUnifiedFlash"]
 
 
-_import_start = time.time()
-
-
 # region Helper methods
+
+
+@numba.njit("float64[:,:](float64[:,:])", fastmath=True, cache=True)
+def _normalize_x(x: np.ndarray) -> np.ndarray:
+    """Takes a matrix of phase compositions (rows - phase, columns - component)
+    and normalizes the fractions.
+
+    Meaning it divides each matrix element by the sum of respective row.
+
+    NJIT-ed function with signature ``(float64[:,:]) -> float64[:,:]``.
+
+    Parameters:
+        x: ``shape=(num_phases, num_components)``
+
+            A matrix of phase compositions, containing per row the (extended)
+            fractions per component.
+
+    Returns:
+        A normalized version of ``X``, with the normalization performed row-wise
+        (phase-wise).
+
+    """
+    return (x.T / x.sum(axis=1)).T
 
 
 @numba.njit("float64[:](float64[:],float64[:,:])", fastmath=True, cache=True)
@@ -106,10 +126,9 @@ def _rr_binary_vle_inversion(z: np.ndarray, K: np.ndarray) -> float:
     return n / np.sum(d)
 
 
-# NOTE This cache is dependeont on another function
 @numba.njit(
     "float64(float64[:],float64[:],float64[:,:])",
-    cache=NUMBA_CACHE,
+    cache=NUMBA_CACHE,  # NOTE cache is dependent on internal function
 )
 def _rr_potential(z: np.ndarray, y: np.ndarray, K: np.ndarray) -> float:
     """Calculates the potential according to [1] for the j-th Rachford-Rice equation.
@@ -713,7 +732,7 @@ class CompiledUnifiedFlash(Flash):
             # NOTE phi depends on normalized fractions
             # extending derivatives from normalized fractions to extended ones
             for i in range(ncomp):
-                d_phi_j[i] = extended_compositional_derivatives(d_phi_j[i], X)
+                d_phi_j[i] = _extend_fractional_derivatives(d_phi_j[i], X)
 
             # product rule: x * dphi
             d_xphi_j = (d_phi_j.T * X).T
@@ -827,7 +846,7 @@ class CompiledUnifiedFlash(Flash):
             # enthalpy and its gradient of the reference phase
             h_0 = h_c(prearg_res[0], p, T, xn[0])
             # gradient of h_0 w.r.t to extended fraction
-            d_h_0 = extended_compositional_derivatives(
+            d_h_0 = _extend_fractional_derivatives(
                 d_h_c(prearg_res[0], prearg_jac[0], p, T, xn[0]), x[0]
             )
             # contribution to p- and T-derivative of reference phase
@@ -841,7 +860,7 @@ class CompiledUnifiedFlash(Flash):
 
             for j in range(1, nphase):
                 h_j = h_c(prearg_res[j], p, T, xn[j])
-                d_h_j = extended_compositional_derivatives(
+                d_h_j = _extend_fractional_derivatives(
                     d_h_c(prearg_res[j], prearg_jac[j], p, T, xn[j]), x[j]
                 )
                 # contribution to p- and T-derivative of phase j
@@ -930,7 +949,7 @@ class CompiledUnifiedFlash(Flash):
 
             for j in range(nphase):
                 rho_j[j] = rho_c(prearg_res[j], p, T, xn[j])
-                d_rho_j[j] = extended_compositional_derivatives(
+                d_rho_j[j] = _extend_fractional_derivatives(
                     d_rho_c(prearg_res[j], prearg_jac[j], p, T, xn[j]), x[j]
                 )
                 dpT_rho_mix += sat[j] * d_rho_j[j, :2]
@@ -1019,7 +1038,7 @@ class CompiledUnifiedFlash(Flash):
             res[-nphase:] = complementary_conditions_res(x, y)
 
             # EoS specific computations
-            xn = normalize_fractions(x)
+            xn = _normalize_x(x)
             prearg = get_prearg_res(p, T, xn)
 
             res[ncomp - 1 : ncomp - 1 + ncomp * (nphase - 1)] = isofug_constr_c(
@@ -1043,13 +1062,13 @@ class CompiledUnifiedFlash(Flash):
             jac[-nphase:] = complementary_conditions_jac(x, y)
 
             # EoS specific computations
-            xn = normalize_fractions(x)
+            xn = _normalize_x(x)
             prearg_res = get_prearg_res(p, T, xn)
             prearg_jac = get_prearg_jac(p, T, xn)
 
-            jac[
-                ncomp - 1 : ncomp - 1 + ncomp * (nphase - 1), nphase - 1 :
-            ] = d_isofug_constr_c(prearg_res, prearg_jac, p, T, x, xn)[:, 2:]
+            jac[ncomp - 1 : ncomp - 1 + ncomp * (nphase - 1), nphase - 1 :] = (
+                d_isofug_constr_c(prearg_res, prearg_jac, p, T, x, xn)[:, 2:]
+            )
 
             return jac
 
@@ -1070,7 +1089,7 @@ class CompiledUnifiedFlash(Flash):
             res[-nphase:] = complementary_conditions_res(x, y)
 
             # EoS specific computations
-            xn = normalize_fractions(x)
+            xn = _normalize_x(x)
             prearg = get_prearg_res(p, T, xn)
 
             res[ncomp - 1 : ncomp - 1 + ncomp * (nphase - 1)] = isofug_constr_c(
@@ -1097,7 +1116,7 @@ class CompiledUnifiedFlash(Flash):
             jac[-nphase:, 1:] = complementary_conditions_jac(x, y)
 
             # EoS specific computations
-            xn = normalize_fractions(x)
+            xn = _normalize_x(x)
             prearg_res = get_prearg_res(p, T, xn)
             prearg_jac = get_prearg_jac(p, T, xn)
 
@@ -1135,7 +1154,7 @@ class CompiledUnifiedFlash(Flash):
             res[-nphase:] = complementary_conditions_res(x, y)
 
             # EoS specific computations
-            xn = normalize_fractions(x)
+            xn = _normalize_x(x)
             prearg = get_prearg_res(p, T, xn)
 
             res[ncomp - 1 : ncomp - 1 + ncomp * (nphase - 1)] = isofug_constr_c(
@@ -1171,7 +1190,7 @@ class CompiledUnifiedFlash(Flash):
             jac[-nphase:, nphase + 1 :] = complementary_conditions_jac(x, y)
 
             # EoS specific computations
-            xn = normalize_fractions(x)
+            xn = _normalize_x(x)
             prearg_res = get_prearg_res(p, T, xn)
             prearg_jac = get_prearg_jac(p, T, xn)
 
@@ -1245,7 +1264,7 @@ class CompiledUnifiedFlash(Flash):
                         + K_tol
                     )
             else:
-                xn = normalize_fractions(x)
+                xn = _normalize_x(x)
                 prearg = get_prearg_res(p, T, xn)
                 # fugacity coefficients reference phase
                 phi_r = phi_c(prearg[0], p, T, xn[0])
@@ -1344,7 +1363,7 @@ class CompiledUnifiedFlash(Flash):
 
                 # update K-values if another iteration comes
                 if n < N1 - 1:
-                    xn = normalize_fractions(x)
+                    xn = _normalize_x(x)
                     prearg = get_prearg_res(p, T, xn)
                     # fugacity coefficients reference phase
                     phi_r = phi_c(prearg[0], p, T, xn[0])
@@ -1373,7 +1392,7 @@ class CompiledUnifiedFlash(Flash):
             x, y, _ = parse_xyz(X_gen, npnc)
             p, T = parse_pT(X_gen, npnc)
             h, _ = parse_target_state(X_gen, npnc)
-            xn = normalize_fractions(x)
+            xn = _normalize_x(x)
             h_j = np.empty(nphase, dtype=np.float64)
             dT_h_j = np.empty(nphase, dtype=np.float64)
 
@@ -1445,7 +1464,7 @@ class CompiledUnifiedFlash(Flash):
             jac = np.zeros((nphase + 1, nphase + 1))
 
             x, y, _ = parse_xyz(X_gen, npnc)
-            xn = normalize_fractions(x)
+            xn = _normalize_x(x)
             v, h = parse_target_state(X_gen, npnc)
             if gas_index >= 0:
                 y_g = y[gas_index]
@@ -1467,7 +1486,7 @@ class CompiledUnifiedFlash(Flash):
                     rho_j[j] = rho_c(prearg_res[j], p, T, xn[j])
                     h_j[j] = h_c(prearg_res[j], p, T, xn[j])
 
-                sat = compute_saturations(y, rho_j, 1e-10)
+                sat = _compute_saturations(y, rho_j, 1e-10)
                 v_mix = 1.0 / (sat * rho_j).sum()
                 h_mix = (y * h_j).sum()
 
@@ -1595,14 +1614,14 @@ class CompiledUnifiedFlash(Flash):
 
                 # final saturation update
                 x, y, _ = parse_xyz(xf, npnc)
-                xn = normalize_fractions(x)
+                xn = _normalize_x(x)
                 p, T = parse_pT(xf, npnc)
                 rho = np.empty(nphase, dtype=np.float64)
                 for j in range(nphase):
                     rho[j] = rho_c(
                         prearg_val_c(phasetypes[j], p, T, xn[j]), p, T, xn[j]
                     )
-                sat = compute_saturations(y, rho, 1e-10)
+                sat = _compute_saturations(y, rho, 1e-10)
                 X_gen[f] = insert_sat(xf, sat[1:], npnc)
 
             return X_gen
@@ -1764,7 +1783,7 @@ class CompiledUnifiedFlash(Flash):
             init_time = end - start
             logger.info(f"Initial state computed (elapsed time: {init_time} (s)).\n")
         else:
-            init_time = 0.
+            init_time = 0.0
             # parsing phase compositions and molar fractions
             idx = 0
             for j in range(nphase):
@@ -1829,13 +1848,3 @@ class CompiledUnifiedFlash(Flash):
             success,
             num_iter,
         )
-
-
-_import_end = time.time()
-
-logger.debug(
-    "(import composite/flash_c.py)"
-    + f" Done (elapsed time: {_import_end - _import_start} (s)).\n\n"
-)
-
-del _import_start, _import_end

--- a/src/porepy/composite/npipm_c.py
+++ b/src/porepy/composite/npipm_c.py
@@ -471,7 +471,7 @@ def _solver(
             - 2: failure in the evaluation of the residual
             - 3: failure in the evaluation of the Jacobian
             - 4: NAN or infty detected in update (aborted)
-        3. final number of perfored iterations
+        3. final number of performed iterations
 
         If the success flag indicates failure, the last iterate state of the unknown
         is returned.

--- a/src/porepy/composite/npipm_c.py
+++ b/src/porepy/composite/npipm_c.py
@@ -2,9 +2,9 @@
 algorithm and Armijo line search.
 
 To be used by the compiled flash."""
+
 from __future__ import annotations
 
-import time
 from typing import Callable, Literal
 
 import numba
@@ -13,7 +13,6 @@ from numba.core import types as nbtypes
 from numba.typed import Dict as nbdict
 
 from ._core import NUMBA_CACHE
-from .composite_utils import COMPOSITE_LOGGER as logger
 from .utils_c import parse_xyz
 
 SOLVER_PARAMS = dict[
@@ -81,12 +80,7 @@ def convert_param_dict(params: SOLVER_PARAMS) -> nbdict:
     return out
 
 
-_import_start = time.time()
-
 # region NPIPM related functions
-
-
-logger.debug(f"(import composite/npipm_c.py) Compiling NPIPM methods ..\n")
 
 
 @numba.njit(
@@ -241,11 +235,10 @@ def initialize_npipm_nu(X_gen: np.ndarray, npnc: tuple[int, int]) -> np.ndarray:
     return X_gen
 
 
-# NOTE The cache is dependent on another function
 @numba.njit(
     "float64[:](float64[:],float64[:],UniTuple(int32, 2),float64,float64,float64)",
     fastmath=True,
-    cache=NUMBA_CACHE,
+    cache=NUMBA_CACHE,  # NOTE The cache is dependent on another function
 )
 def _npipm_extend_and_regularize_res(
     f_res: np.ndarray,
@@ -294,12 +287,11 @@ def _npipm_extend_and_regularize_res(
     return f_npipm
 
 
-# NOTE The cache is dependent on another function
 @numba.njit(
     "float64[:,:]"
     + "(float64[:,:],float64[:],UniTuple(int32, 2),float64,float64,float64)",
     fastmath=True,
-    cache=NUMBA_CACHE,
+    cache=NUMBA_CACHE,  # NOTE The cache is dependent on another function
 )
 def _npipm_extend_and_regularize_jac(
     f_jac: np.ndarray,
@@ -350,9 +342,9 @@ def _npipm_extend_and_regularize_jac(
         d_slack_expanded[-(1 + (j + 1) * ncomp) : -(1 + j * ncomp)] = vec
 
     # derivatives w.r.t y_j. j != r
-    d_slack_expanded[
-        -(1 + nphase * ncomp + nphase - 1) : -(1 + nphase * ncomp)
-    ] = d_slack[: nphase - 1]
+    d_slack_expanded[-(1 + nphase * ncomp + nphase - 1) : -(1 + nphase * ncomp)] = (
+        d_slack[: nphase - 1]
+    )
 
     df_npipm[-1] = d_slack_expanded
 
@@ -373,55 +365,51 @@ def _npipm_extend_and_regularize_jac(
 
 # TODO below solver methods need a static signature, once typing for functions as
 # arguments is available in numba
-# NOTE functions should be cached once this is available
 # region Methods related to the numerical solution strategy
 
-
-logger.debug(f"(import composite/npipm_c.py) Compiling numerical methods ..\n")
-
-
-@numba.njit("float64[:](float64[:])")
-def _dummy_res(x: np.ndarray):
-    return x.copy()
+# @numba.njit("float64[:](float64[:])")
+# def _dummy_res(x: np.ndarray):
+#     return x.copy()
 
 
-@numba.njit("float64[:,:](float64[:])")
-def _dummy_jac(x: np.ndarray):
-    return np.diag(x)
+# @numba.njit("float64[:,:](float64[:])")
+# def _dummy_jac(x: np.ndarray):
+#     return np.diag(x)
 
 
-_dummy_dict = nbdict.empty(key_type=nbtypes.unicode_type, value_type=nbtypes.float64)
-_dummy_dict["f_dim"] = 5.0
-_dummy_dict["num_phase"] = 2.0
-_dummy_dict["num_comp"] = 2.0
-_dummy_dict["tol"] = 1e-8
-_dummy_dict["max_iter"] = 150.0
-_dummy_dict["rho"] = 0.99
-_dummy_dict["kappa"] = 0.4
-_dummy_dict["j_max"] = 50.0
-_dummy_dict["u1"] = 1.0
-_dummy_dict["u2"] = 10.0
-_dummy_dict["eta"] = 0.5
+# _dummy_dict = nbdict.empty(key_type=nbtypes.unicode_type, value_type=nbtypes.float64)
+# _dummy_dict["f_dim"] = 5.0
+# _dummy_dict["num_phase"] = 2.0
+# _dummy_dict["num_comp"] = 2.0
+# _dummy_dict["tol"] = 1e-8
+# _dummy_dict["max_iter"] = 150.0
+# _dummy_dict["rho"] = 0.99
+# _dummy_dict["kappa"] = 0.4
+# _dummy_dict["j_max"] = 50.0
+# _dummy_dict["u1"] = 1.0
+# _dummy_dict["u2"] = 10.0
+# _dummy_dict["eta"] = 0.5
 
 
-@numba.njit(
-    # numba.types.Tuple((numba.float64[:],numba.int32,numba.int32))(
-    #     numba.float64[:],
-    #     numba.typeof(_dummy_res),
-    #     numba.typeof(_dummy_jac),
-    #     numba.int32,
-    #     numba.types.UniTuple(numba.int32,2),
-    #     numba.float64,
-    #     numba.int32,
-    #     numba.float64,
-    #     numba.float64,
-    #     numba.int32,
-    #     numba.float64,
-    #     numba.float64,
-    #     numba.float64,
-    # ),
-    cache=NUMBA_CACHE
-)
+# @numba.njit(
+#     # numba.types.Tuple((numba.float64[:],numba.int32,numba.int32))(
+#     #     numba.float64[:],
+#     #     numba.typeof(_dummy_res),
+#     #     numba.typeof(_dummy_jac),
+#     #     numba.int32,
+#     #     numba.types.UniTuple(numba.int32,2),
+#     #     numba.float64,
+#     #     numba.int32,
+#     #     numba.float64,
+#     #     numba.float64,
+#     #     numba.int32,
+#     #     numba.float64,
+#     #     numba.float64,
+#     #     numba.float64,
+#     # ),
+#     # cache=True,
+# )
+@numba.njit
 def _solver(
     X_0: np.ndarray,
     F: Callable[[np.ndarray], np.ndarray],
@@ -579,8 +567,8 @@ def _solver(
     #     numba.typeof(_dummy_jac),
     #     numba.typeof(_dummy_dict),
     # ),
+    # cache=True,
     parallel=True,
-    cache=NUMBA_CACHE,
 )
 def parallel_solver(
     X0: np.ndarray,
@@ -647,15 +635,16 @@ def parallel_solver(
     return result, converged, num_iter
 
 
-@numba.njit(
-    # numba.types.Tuple((numba.float64[:,:],numba.int32[:],numba.int32[:]))(
-    #     numba.float64[:,:],
-    #     numba.typeof(_dummy_res),
-    #     numba.typeof(_dummy_jac),
-    #     numba.typeof(_dummy_dict),
-    # ),
-    cache=NUMBA_CACHE
-)
+# @numba.njit(
+#     # numba.types.Tuple((numba.float64[:,:],numba.int32[:],numba.int32[:]))(
+#     #     numba.float64[:,:],
+#     #     numba.typeof(_dummy_res),
+#     #     numba.typeof(_dummy_jac),
+#     #     numba.typeof(_dummy_dict),
+#     # ),
+#     cache=True,
+# )
+@numba.njit
 def linear_solver(
     X0: np.ndarray,
     F: Callable[[np.ndarray], np.ndarray],
@@ -700,12 +689,3 @@ def linear_solver(
 
 
 # endregion
-
-_import_end = time.time()
-
-logger.debug(
-    "(import composite/npipm_c.py)"
-    + f" Done (elapsed time: {_import_end - _import_start} (s)).\n\n"
-)
-
-del _import_start, _import_end

--- a/src/porepy/composite/peng_robinson/__init__.py
+++ b/src/porepy/composite/peng_robinson/__init__.py
@@ -32,9 +32,11 @@ References:
 
 __all__ = []
 
-from . import pr_bip, pr_components
+from . import eos_c, pr_bip, pr_components
+from .eos_c import *
 from .pr_bip import *
 from .pr_components import *
 
 __all__.extend(pr_bip.__all__)
 __all__.extend(pr_components.__all__)
+__all__.extend(eos_c.__all__)

--- a/src/porepy/composite/peng_robinson/_eos.py
+++ b/src/porepy/composite/peng_robinson/_eos.py
@@ -2,6 +2,7 @@
 
 This module contains a class implementing the Peng-Robinson EoS for either
 a liquid- or gas-like phase."""
+
 from __future__ import annotations
 
 import abc
@@ -315,9 +316,9 @@ class ThermodynamicState:
                 X_jacs.append(list())
                 for i in range(num_comp):
                     jac_x_ji = jac_glob_d.copy()
-                    jac_x_ji[
-                        :, n_p + i * num_vals : n_p + (i + 1) * num_vals
-                    ] = id_block
+                    jac_x_ji[:, n_p + i * num_vals : n_p + (i + 1) * num_vals] = (
+                        id_block
+                    )
                     X_jacs[-1].append(jac_x_ji)
 
             # reference phase fraction is dependent by unity
@@ -1680,10 +1681,7 @@ class PengRobinson(AbstractEoS):
             return 0.37464 + 1.54226 * omega - 0.26992 * omega**2
         else:
             return (
-                0.379642
-                + 1.48503 * omega
-                - 0.164423 * omega**2
-                + 0.016666 * omega**3
+                0.379642 + 1.48503 * omega - 0.164423 * omega**2 + 0.016666 * omega**3
             )
 
     @staticmethod
@@ -1853,10 +1851,7 @@ class PengRobinson(AbstractEoS):
     def _Z_polynom(Z: NumericType, A: NumericType, B: NumericType) -> NumericType:
         """Auxiliary method implementing the compressibility polynomial."""
         return (
-            (B**3 + B**2 - A * B)
-            + (B - 1) * Z**2
-            + (A - 2 * B - 3 * B**2) * Z
-            + Z**3
+            (B**3 + B**2 - A * B) + (B - 1) * Z**2 + (A - 2 * B - 3 * B**2) * Z + Z**3
         )
 
     @staticmethod

--- a/src/porepy/composite/peng_robinson/eos_c.py
+++ b/src/porepy/composite/peng_robinson/eos_c.py
@@ -38,6 +38,7 @@ Note:
     Not all functions have a ``_u`` version.
 
 """
+
 from __future__ import annotations
 
 import logging
@@ -87,6 +88,8 @@ from .eos_s import (
     widom_line,
 )
 from .pr_components import ComponentPR
+
+__all__ = ["PengRobinsonCompiler"]
 
 _STATIC_FAST_COMPILE_ARGS: dict[str, Any] = {
     "fastmath": True,
@@ -264,6 +267,7 @@ characteristic_residual_u = numba.vectorize(
 
 
 # endregion
+
 
 # region Functions related to the A-B space
 
@@ -1443,13 +1447,11 @@ class PengRobinsonCompiler(EoSCompiler):
         return d_kappa_c
 
 
-_import_end = time.time()
-
 logger.debug(
-    f"{_import_msg} Done (elapsed time: {_import_end - _import_start} (s)).\n\n"
+    f"{_import_msg} Done (elapsed time: {time.time() - _import_start} (s)).\n\n"
 )
 
-del _import_start, _import_end, _import_msg
+del _import_start, _import_msg
 
 
 class _PR_Compiler_tests:

--- a/src/porepy/composite/peng_robinson/eos_s.py
+++ b/src/porepy/composite/peng_robinson/eos_s.py
@@ -56,6 +56,7 @@ The following standard names are used for thermodynamic quantities:
 - ``_r`` index related to the reference phase (the first one is assumed to be r)
 
 """
+
 from __future__ import annotations
 
 from typing import Any, Callable, Optional, Sequence
@@ -864,8 +865,7 @@ class PengRobinsonSymbolic:
         self.d_B_f = sp.lambdify(self.thd_arg, d_B_e)
 
         a_i_crit: list[float] = [
-            A_CRIT * (R_IDEAL**2 * comp.T_crit**2) / comp.p_crit
-            for comp in components
+            A_CRIT * (R_IDEAL**2 * comp.T_crit**2) / comp.p_crit for comp in components
         ]
         """List of critical cohesion values per component."""
 
@@ -1090,8 +1090,5 @@ class PengRobinsonSymbolic:
             return 0.37464 + 1.54226 * omega - 0.26992 * omega**2
         else:
             return (
-                0.379642
-                + 1.48503 * omega
-                - 0.164423 * omega**2
-                + 0.016666 * omega**3
+                0.379642 + 1.48503 * omega - 0.164423 * omega**2 + 0.016666 * omega**3
             )

--- a/src/porepy/composite/peng_robinson/pr_bip.py
+++ b/src/porepy/composite/peng_robinson/pr_bip.py
@@ -12,6 +12,7 @@ For custom implementation of BIPs, see
 :attr:`~porepy.composite.peng_robinson.pr_components.Component_PR.bip_map`.
 
 """
+
 from __future__ import annotations
 
 from thermo.interaction_parameters import IPDB

--- a/src/porepy/composite/peng_robinson/pr_components.py
+++ b/src/porepy/composite/peng_robinson/pr_components.py
@@ -10,6 +10,7 @@ They are optional in the sense that they are declared, but not implemented.
 Custom implementation must be done in the constructor for child classes.
 
 """
+
 from __future__ import annotations
 
 from typing import Callable
@@ -250,9 +251,7 @@ class NaClBrine(Compound, H2O):
             b = self.molalities[1]
 
             alpha_ = (
-                1
-                + 0.453 * (1 - T_r * (1 - 0.0103 * b**1.1))
-                + 0.0034 * (T_r**-3 - 1)
+                1 + 0.453 * (1 - T_r * (1 - 0.0103 * b**1.1)) + 0.0034 * (T_r**-3 - 1)
             )
 
             return alpha_

--- a/src/porepy/composite/states.py
+++ b/src/porepy/composite/states.py
@@ -1,5 +1,6 @@
 """Module containing various data structures to store thermodynamic state values for
 fluid mixtures."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -8,7 +9,7 @@ from typing import Optional, Sequence, cast
 import numpy as np
 
 from .composite_utils import safe_sum
-from .utils_c import compute_saturations, compute_saturations_v
+from .utils_c import compute_saturations
 
 __all__ = [
     "ExtensiveState",
@@ -244,11 +245,7 @@ class FluidState(IntensiveState, ExtensiveState):
 
         rho = np.array([phase.rho for phase in self.phases])
         assert y.shape == rho.shape, "Mismatch in values for fractions and densities."
-
-        if len(y.shape) == 1:
-            self.sat = compute_saturations(y, rho, eps).reshape((y.shape[0], 1))
-        else:
-            self.sat = compute_saturations_v(y, rho, eps)
+        self.sat = compute_saturations(y, rho, eps)
 
     def evaluate_extensive_state(self) -> None:
         """Evaluates the mixture properties based on the currently stored phase

--- a/src/porepy/examples/geothermal_flow_via_correlations/LinearTracerModelConfiguration.py
+++ b/src/porepy/examples/geothermal_flow_via_correlations/LinearTracerModelConfiguration.py
@@ -1,5 +1,5 @@
-import numpy as np
 import LinearTracerConstitutiveDescription
+import numpy as np
 from Geometries import Benchmark2DC3 as ModelGeometry
 
 import porepy as pp

--- a/src/porepy/examples/geothermal_flow_via_correlations/tracer_flow.py
+++ b/src/porepy/examples/geothermal_flow_via_correlations/tracer_flow.py
@@ -30,8 +30,9 @@ from __future__ import annotations
 import time
 
 import numpy as np
-import porepy as pp
 from LinearTracerModelConfiguration import LinearTracerFlowModel as FlowModel
+
+import porepy as pp
 
 day = 86400
 t_scale = 0.01

--- a/src/porepy/examples/soereide_geothermal.py
+++ b/src/porepy/examples/soereide_geothermal.py
@@ -17,8 +17,10 @@ References:
         https://doi.org/10.1016/0378-3812(92)85105-H
 
 """
+
 from __future__ import annotations
 
+import logging
 from typing import Sequence, cast
 
 import numpy as np
@@ -26,8 +28,12 @@ import numpy as np
 import porepy as pp
 import porepy.composite as ppc
 from porepy.applications.md_grids.domains import nd_cube_domain
-from porepy.composite.peng_robinson.eos_c import PengRobinsonCompiler
 from porepy.models.compositional_flow_with_equilibrium import CFLEModelMixin_ph
+
+ppc.COMPOSITE_LOGGER.setLevel(logging.DEBUG)  # prints informatin about compile progress
+from porepy.composite.peng_robinson import PengRobinsonCompiler
+
+ppc.COMPOSITE_LOGGER.setLevel(logging.INFO)
 
 
 class SoereideMixture:
@@ -154,7 +160,7 @@ class BoundaryConditions:
             return pp.BoundaryCondition(sd)
 
     def bc_type_fourier_flux(self, sd: pp.Grid) -> pp.BoundaryCondition:
-        sides= self.domain_boundary_sides(sd)
+        sides = self.domain_boundary_sides(sd)
         if sd.dim == 2:
             # Temperature at inlet and outlet, as well as heated bottom
             boundary_faces = sides.east | sides.west | sides.bottom
@@ -165,78 +171,72 @@ class BoundaryConditions:
 
     def bc_values_pressure(self, boundary_grid: pp.BoundaryGrid) -> np.ndarray:
         # need to define pressure on east and west side of matrix
+        p_init = 10e6
         sd = boundary_grid.parent
-        bs = self.domain_boundary_sides(sd)
-        vals = np.zeros(sd.num_faces)
-        if sd.dim == 2:
-            inlet_faces = bs.west
-            outlet_faces = bs.east
-            vals[inlet_faces] = 15e6
-            vals[outlet_faces] = 10e6
+        sides = self.domain_boundary_sides(sd)
 
-        vals = vals[bs.all_bf]
-        assert vals.shape == (
-            boundary_grid.num_cells,
-        ), "Mismatch in shape of BC values."
+        # non-trivial BC on matrix
+        if sd.dim == 2:
+            vals = np.ones(sd.num_faces) * p_init
+
+            vals[sides.west] = 15e6
+            vals[sides.east] = 10e6
+
+            vals = vals[sides.all_bf]
+        else:
+            vals = np.zeros(boundary_grid.num_cells)
+
         return vals
 
     def bc_values_temperature(self, boundary_grid: pp.BoundaryGrid) -> np.ndarray:
+        T_init = 550.0
         sd = boundary_grid.parent
-        bs = self.domain_boundary_sides(sd)
-        vals = np.zeros(sd.num_faces)
+        sides = self.domain_boundary_sides(sd)
+
         # non-trivial BC on matrix
         if sd.dim == 2:
-            # T values on inlet and outlet faces to compute boundary equilibrium
-            inlet_faces = bs.west
-            outlet_faces = bs.east
-            vals[inlet_faces] = 460.0
-            # outlet values correspond to initial conditions
-            vals[outlet_faces] = 550.0
+            vals = np.ones(sd.num_faces) * T_init
 
+            vals[sides.west] = 460.0
+            vals[sides.east] = 550.0
             # T values on heated bottom
-            heated_faces = bs.bottom
-            vals[heated_faces] = 600.0
+            vals[sides.bottom] = 600.0
 
-        vals = vals[bs.all_bf]
-        assert vals.shape == (
-            boundary_grid.num_cells,
-        ), "Mismatch in shape of BC values."
+            vals = vals[sides.all_bf]
+        else:
+            vals = np.zeros(boundary_grid.num_cells)
+
         return vals
 
     def bc_values_overall_fraction(
         self, component: ppc.Component, boundary_grid: pp.BoundaryGrid
     ) -> np.ndarray:
         sd = boundary_grid.parent
-        bs = self.domain_boundary_sides(sd)
-        vals = np.zeros(sd.num_faces)
+        sides = self.domain_boundary_sides(sd)
+
+        if component.name == "H2O":
+            z_init = 0.995
+            z_inlet = 0.99
+            z_outlet = z_init
+        elif component.name == "CO2":
+            z_init = 0.005
+            z_inlet = 0.01
+            z_outlet = z_init
+        else:
+            NotImplementedError(
+                f"Initial overlal fraction not implemented for component {component.name}"
+            )
+
         if sd.dim == 2:
-            inlet_faces = bs.west
-            outlet_faces = bs.east
+            vals = np.ones(sd.num_faces) * z_init
 
-            # on inlet, more CO2 enters the system
-            if component.name == "H2O":
-                vals[inlet_faces] = 0.99
-            elif component.name == "CO2":
-                vals[inlet_faces] = 0.01
-            else:
-                raise NotImplementedError(
-                    f"Initial overlal fraction not implemented for component {component.name}"
-                )
+            vals[sides.west] = z_inlet
+            vals[sides.east] = z_outlet
 
-            # on outlet we define something corresponding to initial conditions
-            if component.name == "H2O":
-                vals[outlet_faces] = 0.995
-            elif component.name == "CO2":
-                vals[outlet_faces] = 0.005
-            else:
-                raise NotImplementedError(
-                    f"Initial overlal fraction not implemented for component {component.name}"
-                )
+            vals = vals[sides.all_bf]
+        else:
+            vals = np.zeros(boundary_grid.num_cells)
 
-        vals = vals[bs.all_bf]
-        assert vals.shape == (
-            boundary_grid.num_cells,
-        ), "Mismatch in shape of BC values."
         return vals
 
 
@@ -268,6 +268,7 @@ params = {
     "eliminate_reference_component": True,
     "normalize_state_constraints": True,
     "use_semismooth_complementarity": True,
+    "reduce_linear_system_q": True,
     "time_manager": time_manager,
 }
 model = GeothermalFlow(params)

--- a/src/porepy/models/compositional_flow.py
+++ b/src/porepy/models/compositional_flow.py
@@ -2124,13 +2124,15 @@ class InitialConditionsCF:
         2. Initializes secondary variables and the secondary expressions by which
            they were eliminated
            :meth:`set_initial_values_constitutive_eliminated`
-        3. Copies values of all independent variables to all time and iterate indices.
-        4. Initializes phase properties by computing them using the underlying EoS
+        3. Initializes phase properties by computing them using the underlying EoS
            :meth:`set_intial_values_phase_properties`
+        4. Copies values of all independent variables to all time and iterate indices.
 
         """
         self.set_initial_values_primary_variables()
         self.set_initial_values_constitutive_eliminated()
+        self.set_intial_values_phase_properties()
+
         # updating variable values from current time step, to all previous and iterate
         val = self.equation_system.get_variable_values(iterate_index=0)
         self.equation_system.shift_iterate_values()
@@ -2139,7 +2141,6 @@ class InitialConditionsCF:
                 val,
                 time_step_index=time_step_index,
             )
-        self.set_intial_values_phase_properties()
 
     def set_initial_values_primary_variables(self) -> None:
         """Method to set initial values for primary variables at the current time
@@ -2506,9 +2507,6 @@ class SolutionStrategyCF(
            mixture mixin.
         3. Then it creates the equations so that all secondary expressions are
            instantiated.
-        4. After initial values are computed for all quantities, calls
-           :meth:`initialize_timestep_and_iterate_indices` to copy initial values
-           to all iterate and time step indices.
 
         """
         self.set_materials()
@@ -2523,7 +2521,7 @@ class SolutionStrategyCF(
 
         self.set_equations()
         self.initial_condition()
-        self.reset_state_from_file()  # TODO check if this is in conflict with init vals
+        self.reset_state_from_file()
 
         self.set_discretization_parameters()
         self.discretize()

--- a/src/porepy/models/compositional_flow_with_equilibrium.py
+++ b/src/porepy/models/compositional_flow_with_equilibrium.py
@@ -26,7 +26,6 @@ import porepy.composite as ppc
 from porepy.composite.utils_c import extended_compositional_derivatives_v as _extend
 
 from . import compositional_flow as cf
-from . import mass_and_energy_balance as mass_energy
 
 logger = logging.getLogger(__name__)
 
@@ -69,7 +68,7 @@ class BoundaryConditionsCFLE(cf.BoundaryConditionsCF):
     and thermodynamic properties of phases.
 
     The 'boundary flash' needs to be performed once by the
-    :class:`SolutionStrategyCFLE`.
+    :class:`SolutionStrategyCFLE` during initialization.
 
     If the BC are not constant, the user needs to flag this and this class will
     perform the boundary flash in every time step to update respective values.
@@ -96,54 +95,17 @@ class BoundaryConditionsCFLE(cf.BoundaryConditionsCF):
     flash_params: dict
     """Provided by :class:`~porepy.composite.equilibrium_mixins.FlashMixin`."""
 
-    _boundary_fluid_state: dict[pp.BoundaryGrid, dict[str, np.ndarray]]
-    """Provided by :class:`SolutionStrategyCFLE`."""
-
-    def update_all_boundary_conditions(self) -> None:
-        """Boundary conditions for problems with equilibrium calculations can be
-        done using the provided flash class (see :meth:`boundary_flash`)
-
-        If :attr:`has_time_dependent_boundary_equilibrium` is True,
-        this method performs flash calculations on the boundary using the provided
-        pressure, temperature and overall fractions.
-        It then updates the BC values for all secondary, fractional variables and
-        phase properties.
+    def update_boundary_values_phase_properties(self) -> None:
+        """Instead of performing the update using underlying EoS, a flash is performed
+        to compute the updates for phase properties, as well as for (extended) partial
+        fractions and saturations.
+        
+        Calls :meth:`boundary_flash` if :attr:`has_time_dependent_boundary_equilibrium`
+        is True.
 
         """
-        # cover the base update of parent class and primary CF variables
-        mass_energy.BoundaryConditionsFluidMassAndEnergy.update_all_boundary_conditions(
-            self
-        )
-        self.update_essential_boundary_values()
-        self.update_boundary_values_constitutive_eliminated()
-
         if self.has_time_dependent_boundary_equilibrium:
             self.boundary_flash()
-
-        # flash results for fractions are stored in the boundary fluid states.
-        # Use regular way of updating to acces them.
-        for phase in self.fluid_mixture.phases:
-
-            # phase fractions and saturations
-            if (
-                self.eliminate_reference_phase
-                and phase == self.fluid_mixture.reference_phase
-            ):
-                pass
-            else:
-                s_name = self._saturation_variable(phase)
-                s_bc = partial(self.bc_values_saturation, phase)
-                s_bc = cast(Callable[[pp.BoundaryGrid], np.ndarray], s_bc)
-                self.update_boundary_condition(s_name, s_bc)
-
-            # compositional fractions are always updated (partial and extended are both
-            # named the same if independent)
-            for comp in phase:
-                x_name = self._relative_fraction_variable(comp, phase)
-                x_bc = partial(self.bc_values_relative_fraction, comp, phase)
-                x_bc = cast(Callable[[pp.BoundaryGrid], np.ndarray], x_bc)
-                self.update_boundary_condition(x_name, x_bc)
-
 
     def boundary_flash(self) -> None:
         """This method performs the p-T flash on the Dirichlet boundary, where pressure
@@ -153,7 +115,7 @@ class BoundaryConditionsCFLE(cf.BoundaryConditionsCF):
         properties of phases.
 
         Results for secondary variables (saturations, relative fractions), are also
-        passed to :meth:`update_boundary_condition` in form of lambda functions
+        passed to :meth:`update_boundary_condition` in form of lambda functions.
 
         The method can be called any time once the model is initialized, especially for
         non-constant BC.
@@ -166,7 +128,7 @@ class BoundaryConditionsCFLE(cf.BoundaryConditionsCF):
             ValueError: If the flash did not succeed everywhere.
 
         """
-
+        rphase = self.fluid_mixture.reference_phase
         for bg in self.mdg.boundaries():
             vec = np.zeros(bg.num_cells)
 
@@ -220,22 +182,29 @@ class BoundaryConditionsCFLE(cf.BoundaryConditionsCF):
                     for j, phase in enumerate(self.fluid_mixture.phases):
                         state_j = boundary_state.phases[j]
 
-                        # store update for saturation values
-                        sat_j = vec.copy()
-                        sat_j[dir_idx] = boundary_state.sat[j]
-                        self._boundary_fluid_state[bg].update(
-                            {self._saturation_variable(phase): sat_j}
-                        )
+                        # Updating BC value for saturation
+                        if not (
+                            self.eliminate_reference_phase
+                            and phase == rphase
+                        ):
+                            sat_j = vec.copy()
+                            sat_j[dir_idx] = boundary_state.sat[j]
+                            s_name = self._saturation_variable(phase)
+                            s_bc = lambda bg: sat_j
+                            s_bc = cast(Callable[[pp.BoundaryGrid], np.ndarray], s_bc)
+                            self.update_boundary_condition(s_name, s_bc)
+                        
 
-                        # store update for relative fractions
+                        # Updating BC value for partial fractions
                         for k, comp in enumerate(phase.components):
                             x_kj = vec.copy()
                             x_kj[dir_idx] = state_j.x[k]
-                            self._boundary_fluid_state[bg].update(
-                                {self._relative_fraction_variable(comp, phase): x_kj}
-                            )
+                            x_name = self._relative_fraction_variable(comp, phase)
+                            x_bc = lambda bg: x_kj
+                            x_bc = cast(Callable[[pp.BoundaryGrid], np.ndarray], x_bc)
+                            self.update_boundary_condition(x_name, x_bc)
 
-                        # progress boundary values of phase properties in time
+                        # Update BC values of phase properties in time
                         val = vec.copy()
                         val[dir_idx] = state_j.rho
                         phase.density.update_boundary_value(val, bg)
@@ -248,40 +217,6 @@ class BoundaryConditionsCFLE(cf.BoundaryConditionsCF):
                         val = vec.copy()
                         val[dir_idx] = state_j.mu
                         phase.viscosity.update_boundary_value(val, bg)
-
-    def bc_values_saturation(
-        self, phase: ppc.Phase, boundary_grid: pp.BoundaryGrid
-    ) -> np.ndarray:
-        """Method returns the data stored in the boundary fluid states
-        (boundary flash results)"""
-        if boundary_grid not in self._boundary_fluid_state:
-            vals = np.zeros(boundary_grid.num_cells)
-        else:
-            vals = self._boundary_fluid_state[boundary_grid][
-                self._saturation_variable(phase)
-            ]
-            assert vals.shape == (boundary_grid.num_cells,), (
-                f"Mismatch in required phase enthalpy values for phase {phase.name}"
-                + f" on boundary {boundary_grid}."
-            )
-        return vals
-
-    def bc_values_relative_fraction(
-        self, component: ppc.Component, phase: ppc.Phase, boundary_grid: pp.BoundaryGrid
-    ) -> np.ndarray:
-        """Method returns the data stored in the boundary fluid states
-        (boundary flash results)"""
-        if boundary_grid not in self._boundary_fluid_state:
-            vals = np.zeros(boundary_grid.num_cells)
-        else:
-            vals = self._boundary_fluid_state[boundary_grid][
-                self._relative_fraction_variable(component, phase)
-            ]
-            assert vals.shape == (boundary_grid.num_cells,), (
-                f"Mismatch in required phase enthalpy values for phase {phase.name}"
-                + f" on boundary {boundary_grid}."
-            )
-        return vals
 
 
 class InitialConditionsCFLE(cf.InitialConditionsCF):
@@ -304,35 +239,19 @@ class InitialConditionsCFLE(cf.InitialConditionsCF):
     flash_params: dict
     """Provided by :class:`~porepy.composite.equilibrium_mixins.FlashMixin`."""
 
-    def set_initial_values(self) -> None:
-        """Changes the order of steps, when compared to the parent method, because the
-        secondary variables are computed in the initial flash.
-
-        Shifting of time and iterate values must occur at the end.
-
-        """
-        self.set_initial_values_primary_variables()
-        self.set_initial_values_constitutive_eliminated()
-        self.set_intial_values_phase_properties()
-        # updating variable values from current time step, to all previous and iterate
-        val = self.equation_system.get_variable_values(iterate_index=0)
-        self.equation_system.shift_iterate_values()
-        for time_step_index in self.time_step_indices:
-            self.equation_system.set_variable_values(
-                val,
-                time_step_index=time_step_index,
-            )
+    _relative_fraction_variable: Callable[[ppc.Component, ppc.Phase], str]
+    """Provided by :class:`~porepy.composite.composite_mixins.CompositeVariables`."""
 
     def set_intial_values_phase_properties(self) -> None:
-        """This method hacks into the parent strategy to compute the thermodynamic
-        properties, as well as values for secondary variables, based on the initial
-        values for primary variables.
+        """Instead of computing the initial values using the underlying EoS, it performs
+        the initial flash.
 
         It performes a p-T flash, hence initial conditions for enthalpy are not
         required, but computed by this class.
 
-        Values of properties and secondary variables are stored for all time and
-        iterate indices.
+        Values for phase properties, as well as secondary fractions and enthalpy are
+        then initialized using the results, for all iterate and time step indices.
+
         Derivative values for properties are stored at the current iterate.
 
         """
@@ -340,7 +259,7 @@ class InitialConditionsCFLE(cf.InitialConditionsCF):
 
         for sd in subdomains:
             # pressure, temperature and overall fractions
-            p = self.intial_pressure(sd)
+            p = self.initial_pressure(sd)
             T = self.initial_temperature(sd)
             z = [
                 self.initial_overall_fraction(comp, sd)
@@ -384,8 +303,8 @@ class InitialConditionsCFLE(cf.InitialConditionsCF):
                         iterate_index=0,
                     )
 
-                # pprogress iterates values to all indices
-                for _ in range(self.iterate_indices):
+                # progress iterates values to all indices
+                for _ in self.iterate_indices:
                     phase.density.progress_iterate_values_on_grid(
                         state.phases[j].rho, sd
                     )
@@ -400,20 +319,24 @@ class InitialConditionsCFLE(cf.InitialConditionsCF):
                         state.phases[j].kappa, sd
                     )
                 # progress derivative values only once (current iterate)
+                # extend derivatives from partial to extended fractions.
+                # NOTE This revers the hack performed by the composite mixins when creating
+                # secondary expressions which depend on extended fractions (independent)
+                # quantities, but should actually depend on partial fractions (dependent).
                 phase.density.progress_iterate_derivatives_on_grid(
-                    state.phases[j].drho, sd
+                    _extend(state.phases[j].drho, state.phases[j].x), sd
                 )
                 phase.volume.progress_iterate_derivatives_on_grid(
-                    state.phases[j].dv, sd
+                    _extend(state.phases[j].dv, state.phases[j].x), sd
                 )
                 phase.enthalpy.progress_iterate_derivatives_on_grid(
-                    state.phases[j].dh, sd
+                    _extend(state.phases[j].dh, state.phases[j].x), sd
                 )
                 phase.viscosity.progress_iterate_derivatives_on_grid(
-                    state.phases[j].dmu, sd
+                    _extend(state.phases[j].dmu, state.phases[j].x), sd
                 )
                 phase.conductivity.progress_iterate_derivatives_on_grid(
-                    state.phases[j].dkappa, sd
+                    _extend(state.phases[j].dkappa, state.phases[j].x), sd
                 )
 
                 # fugacities
@@ -423,7 +346,7 @@ class InitialConditionsCFLE(cf.InitialConditionsCF):
                             state.phases[j].phis[k], sd
                         )
                     phase.fugacity_of[comp].progress_iterate_derivatives_on_grid(
-                        state.phases[j].dphis[k], sd
+                        _extend(state.phases[j].dphis[k], state.phases[j].x), sd
                     )
 
         # progress property values in time on subdomain
@@ -432,11 +355,6 @@ class InitialConditionsCFLE(cf.InitialConditionsCF):
                 phase.density.progress_values_in_time(subdomains)
                 phase.volume.progress_values_in_time(subdomains)
                 phase.enthalpy.progress_values_in_time(subdomains)
-                phase.viscosity.progress_values_in_time(subdomains)
-                phase.conductivity.progress_values_in_time(subdomains)
-
-                for comp in phase:
-                    phase.fugacity_of[comp].progress_values_in_time(subdomains)
 
 
 class SolutionStrategyCFLE(cf.SolutionStrategyCF, ppc.FlashMixin):
@@ -455,8 +373,7 @@ class SolutionStrategyCFLE(cf.SolutionStrategyCF, ppc.FlashMixin):
         by the local equilibrium equations.
 
         Hence no secondary variable (as defined by the base variable mixin for CF) is
-        eliminated by some constitutive expression, *because the local equilibrium
-        problem is the constitutive law*.
+        eliminated by some constitutive expression.
 
     """
 
@@ -477,12 +394,6 @@ class SolutionStrategyCFLE(cf.SolutionStrategyCF, ppc.FlashMixin):
 
     def __init__(self, params: dict | None = None) -> None:
         super().__init__(params)
-
-        self._boundary_fluid_state: dict[
-            pp.BoundaryGrid, dict[str, np.ndarray]
-        ] = dict()
-        """Data structure to store results from the boundary flash, required for
-        advective weights on the boundary."""
 
         # Input validation for set-up
         if (
@@ -511,88 +422,8 @@ class SolutionStrategyCFLE(cf.SolutionStrategyCF, ppc.FlashMixin):
         super().initial_condition()
         self.boundary_flash()
 
-    def initialize_timestep_and_iterate_indices(self) -> None:
-        """Propagates the thermodynamic properties of phases, assuming the initial
-        flash was performed before.
-
-        In a model with equilibrium conditions and flash calculations, phase
-        properties don't need to be registered as secondary expressions with the
-        mixin for constitutive laws, since the equilibrium equations *are* the
-        constitutive law.
-
-        Note:
-            This method progresses values for phase properties
-            **on all subdomains**, including
-
-            - phase densities
-            - phase volumes
-            - phase enthalpies
-            - phase viscosities
-
-            Viscosities, conductivities and fugacities are not progressed in time,
-            since they are not expected in the accumulation term.
-
-            It also progresses boundary values of phase properties on
-            **all boundary grids**, for which boundary values are required.
-            That **excludes** the fugacity coefficients.
-
-        """
-
-        subdomains = self.mdg.subdomains()
-
-        # copying the current value of secondary expressions to all indices
-        # NOTE Only values, not derivatives
-        for phase in self.fluid_mixture.phases:
-            # phase properties and their derivatives on each subdomain
-            rho_j = phase.density.subdomain_values
-            v_j = phase.volume.subdomain_values
-            h_j = phase.enthalpy.subdomain_values
-            mu_j = phase.viscosity.subdomain_values
-            kappa_j = phase.conductivity.subdomain_values
-
-            # all properties have iterate values, use framework from sec. expressions
-            # to push back values
-            for _ in self.iterate_indices:
-                phase.density.subdomain_values = rho_j
-                phase.volume.subdomain_values = v_j
-                phase.enthalpy.subdomain_values = h_j
-                phase.viscosity.subdomain_values = mu_j
-                phase.conductivity.subdomain_values = kappa_j
-
-            # all properties have time step values, progress sec. exp. in time
-            for _ in self.time_step_indices:
-                phase.density.progress_values_in_time(subdomains)
-                phase.volume.progress_values_in_time(subdomains)
-                phase.enthalpy.progress_values_in_time(subdomains)
-            # NOTE viscosity and conductivity are not progressed in time
-
-            # fugacity coeffs
-            # NOTE their values are not progressed in time.
-            for comp in phase:
-                phi = phase.fugacity_of[comp].subdomain_values
-                d_phi = phase.fugacity_of[comp].subdomain_derivatives
-
-                for _ in self.iterate_indices:
-                    phase.fugacity_of[comp].subdomain_values = phi
-                    phase.fugacity_of[comp].subdomain_derivatives = d_phi
-
-            # properties have also (time-dependent) values on boundaries
-            # NOTE the different usage of progressing in time on boundaries
-            # NOTE fugacities have no boundary values
-            bc_rho_j = phase.density.boundary_values
-            bc_v_j = phase.volume.boundary_values
-            bc_h_j = phase.enthalpy.boundary_values
-            bc_mu_j = phase.viscosity.boundary_values
-            bc_kappa_j = phase.conductivity.boundary_values
-            for _ in self.time_step_indices:
-                phase.density.boundary_values = bc_rho_j
-                phase.volume.boundary_values = bc_v_j
-                phase.enthalpy.boundary_values = bc_h_j
-                phase.viscosity.boundary_values = bc_mu_j
-                phase.conductivity.boundary_values = bc_kappa_j
-
     def update_thermodynamic_properties_of_phases(self) -> None:
-        """The solution strategy for CF with LE hacks into this step of the
+        """The solution strategy for CF with LE uses this step of the
         algorithm to compute the flash and update the values of thermodynamic
         properites of phases, as well as secondary variables based on the
         flash results.
@@ -602,7 +433,8 @@ class SolutionStrategyCFLE(cf.SolutionStrategyCF, ppc.FlashMixin):
         solving the local equilibrium problem with fixed primary variables.
 
         """
-        fluid = self.postprocess_failures(*self.equilibriate_fluid(None))
+        subdomains = self.mdg.subdomains()
+        fluid = self.postprocess_failures(*self.equilibriate_fluid(subdomains, None))
 
         ### Updating variables which are unknown to the specific equilibrium type
         for j, phase in enumerate(self.fluid_mixture.phases):
@@ -651,14 +483,7 @@ class SolutionStrategyCFLE(cf.SolutionStrategyCF, ppc.FlashMixin):
             # NOTE This revers the hack performed by the composite mixins when creating
             # secondary expressions which depend on extended fractions (independent)
             # quantities, but should actually depend on partial fractions (dependent).
-            x = np.array(
-                [
-                    self.equation_system.get_variable_values(
-                        [self._relative_fraction_variable(comp, phase)]
-                    )
-                    for comp in phase
-                ]
-            )
+            x = fluid.phases[j].x
 
             for k, comp in enumerate(phase.components):
                 phase.fugacity_of[comp].subdomain_values = state.phis[k]
@@ -676,6 +501,7 @@ class SolutionStrategyCFLE(cf.SolutionStrategyCF, ppc.FlashMixin):
 class CFLEModelMixin_ph(
     EquationsCFLE_ph,
     InitialConditionsCFLE,
+    BoundaryConditionsCFLE,
     SolutionStrategyCFLE,
     cf.CFModelMixin,
 ):


### PR DESCRIPTION
Modifications involving import in pp.composite and numba caching.
Should eliminate the import overhead completely after the first import now.

Fixing some BC computations in CFLE model
