### PR TITLE
BUG: Fetch previous iteration values from storage

### DIFF
--- a/src/porepy/numerics/ad/operators.py
+++ b/src/porepy/numerics/ad/operators.py
@@ -792,6 +792,7 @@ class Operator:
         # tree-representation, and parse and combine individual operators.
 
         prev_vals = system_manager.get_variable_values(time_step_index=0)
+        prev_iter_vals = system_manager.get_variable_values(iterate_index=0)
 
         if state is None:
             state = system_manager.get_variable_values(iterate_index=0)
@@ -837,7 +838,7 @@ class Operator:
         # This is simpler, since it is only a matter of getting the residual vector
         # correctly (not Jacobian matrix).
 
-        prev_iter_vals_list = [state[ind] for ind in self._prev_iter_dofs]
+        prev_iter_vals_list = [prev_iter_vals[ind] for ind in self._prev_iter_dofs]
         self._prev_iter_vals = {
             var_id: val
             for (var_id, val) in zip(self._prev_iter_ids, prev_iter_vals_list)


### PR DESCRIPTION
## Proposed changes

Ensures values for a previous_iteration variable are fetched from the stored values even if `state` is passed to Operator._evaluate.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [x] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
