### PR TITLE
TST: Use xfail instead of skip to mark expected failures

### DIFF
--- a/tests/grids/test_coarsening.py
+++ b/tests/grids/test_coarsening.py
@@ -18,7 +18,7 @@ class TestPartitioning:
     # Skipped: The test fails after update to scipy 1.13 due to changes in the sparse
     # matrix format. Since the underlying code is marked for deprecation, the test will
     # not be updated.
-    @pytest.mark.skipped
+    @pytest.mark.xfail
     def test_coarse_grid_2d(self):
         g = pp.CartGrid([3, 2])
         g.compute_geometry()
@@ -65,7 +65,7 @@ class TestPartitioning:
     # Skipped: The test fails after update to scipy 1.13 due to changes in the sparse
     # matrix format. Since the underlying code is marked for deprecation, the test will
     # not be updated.
-    @pytest.mark.skipped
+    @pytest.mark.xfail
     def test_coarse_grid_3d(self):
         g = pp.CartGrid([2, 2, 2])
         g.compute_geometry()


### PR DESCRIPTION
The (deprecated) coarsening module has a few tests that are expected to fail. These used to be marked with `@pytest.mark.skip`, but this is confusing, furthermore, the test make the weekly test run (which includes skipped tests) fail. Using xfail instead should resolve this.

## Proposed changes

Contributions to PorePy are highly appreciated. Clearly explain why this pull request (PR) is needed and why it should be accepted. If this PR solves an issue, explain how it is done. Please, also summarise the changes to the code.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
