### PR TITLE
Limit-cases-of-ad-functions

### DIFF
--- a/src/porepy/models/momentum_balance.py
+++ b/src/porepy/models/momentum_balance.py
@@ -301,7 +301,7 @@ class MomentumBalanceEquations(pp.BalanceEquation):
 
         # Variables
         nd_vec_to_normal = self.normal_component(subdomains)
-        # The normal component of the contact traction and the displacement jump
+        # The normal component of the contact traction and the displacement jump.
         t_n: pp.ad.Operator = nd_vec_to_normal @ self.contact_traction(subdomains)
         u_n: pp.ad.Operator = nd_vec_to_normal @ self.displacement_jump(subdomains)
 
@@ -392,8 +392,6 @@ class MomentumBalanceEquations(pp.BalanceEquation):
         ones_frac = pp.ad.DenseArray(np.ones(num_cells * (self.nd - 1)))
         zeros_frac = pp.ad.DenseArray(np.zeros(num_cells))
 
-        # Functions EK: Should we try to agree on a name convention for ad functions?
-        # EK: Yes. Suggestions?
         f_max = pp.ad.Function(pp.ad.maximum, "max_function")
         f_norm = pp.ad.Function(partial(pp.ad.l2_norm, self.nd - 1), "norm_function")
 

--- a/src/porepy/numerics/ad/functions.py
+++ b/src/porepy/numerics/ad/functions.py
@@ -91,9 +91,10 @@ def l2_norm(dim: int, var: pp.ad.AdArray) -> pp.ad.AdArray:
     """L2 norm of a vector variable.
 
     For the example of dim=3 components and n vectors, the ordering is assumed
-    to be ``[u0, v0, w0, u1, v1, w1, ..., un, vn, wn]``
+    to be ``[u0, v0, w0, u1, v1, w1, ..., un, vn, wn]``.
 
-    Vectors satisfying ui=vi=wi=0 are assigned zero entries in the jacobi matrix
+    Vectors satisfying ui=vi=wi=0 are assigned positive entries in the Jacobi
+    matrix.
 
     Note:
         See module level documentation on how to wrap functions like this in ad.Function.
@@ -306,9 +307,10 @@ class RegularizedHeaviside:
 def maximum(var_0: FloatType, var_1: FloatType) -> FloatType:
     """Ad maximum function represented as an AdArray.
 
-    The maximum function is defined as the element-wise maximum of two arrays. At
-    equality, the maximum is taken from the first argument. The order of the arguments
-    may be important, since it determines which Jacobian is used in the case of equality.
+    The maximum function is defined as the element-wise maximum of two arrays.
+    At equality, the Jacobian is taken from the first argument. The order of the
+    arguments may be important, since it determines which Jacobian is used in
+    the case of equality.
 
     The arguments can be either AdArrays or ndarrays, this duality is needed to allow
     for parsing of operators that can be taken at the current iteration (in which case

--- a/src/porepy/numerics/ad/functions.py
+++ b/src/porepy/numerics/ad/functions.py
@@ -306,6 +306,10 @@ class RegularizedHeaviside:
 def maximum(var_0: FloatType, var_1: FloatType) -> FloatType:
     """Ad maximum function represented as an AdArray.
 
+    The maximum function is defined as the element-wise maximum of two arrays. At
+    equality, the maximum is taken from the first argument. The order of the arguments
+    may be important, since it determines which Jacobian is used in the case of equality.
+
     The arguments can be either AdArrays or ndarrays, this duality is needed to allow
     for parsing of operators that can be taken at the current iteration (in which case
     it will parse as an AdArray) or at the previous iteration or time step (in which
@@ -375,7 +379,7 @@ def maximum(var_0: FloatType, var_1: FloatType) -> FloatType:
     # the case.
     assert isinstance(vals[0], np.ndarray) and isinstance(vals[1], np.ndarray)
     # Maximum of the two arrays
-    inds = (vals[1] >= vals[0]).nonzero()[0]
+    inds = (vals[1] > vals[0]).nonzero()[0]
 
     max_val = vals[0].copy()
     max_val[inds] = vals[1][inds]

--- a/src/porepy/numerics/ad/functions.py
+++ b/src/porepy/numerics/ad/functions.py
@@ -118,7 +118,7 @@ def l2_norm(dim: int, var: pp.ad.AdArray) -> pp.ad.AdArray:
     # Avoid dividing by zero
     tol = 1e-12
     nonzero_inds = vals > tol
-    jac_vals = np.zeros(resh.shape)
+    jac_vals = np.ones(resh.shape)
     jac_vals[:, nonzero_inds] = resh[:, nonzero_inds] / vals[nonzero_inds]
     # Prepare for left multiplication with var.jac to yield
     # norm(var).jac = var/norm(var) * var.jac


### PR DESCRIPTION
## Proposed changes

This PR introduces two minor modifications of the ad.functions:
1. Uses first argument in the case of equality of the arguments of the max function. This impact the tangential contact mechanics and the aperture calculation.
2. Assigns unitary jacobian values for l2_norm of an argument with val=0. Thus, derivative information is nonzero and we avoid special cases where a block of the linear system vanishes.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [x] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
