### PR TITLE
Deactivate redundant residual computation before check_convergence.

### DIFF
--- a/src/porepy/numerics/nonlinear/nonlinear_solvers.py
+++ b/src/porepy/numerics/nonlinear/nonlinear_solvers.py
@@ -103,9 +103,11 @@ class NewtonSolver:
             nonlinear_increment = self.iteration(model)
 
             model.after_nonlinear_iteration(nonlinear_increment)
-            # Note: The residual is extracted after the solution has been updated by the
-            # after_nonlinear_iteration() method.
-            residual = model.equation_system.assemble(evaluate_jacobian=False)
+            if self.params["nl_convergence_tol_res"] is not np.inf:
+                # Note: The residual is extracted after the solution has been updated by the
+                # after_nonlinear_iteration() method. This is only required if the residual
+                # is used to check convergence, i.e., the tolerance is not np.inf.
+                residual = model.equation_system.assemble(evaluate_jacobian=False)
 
             residual_norm, nonlinear_increment_norm, is_converged, is_diverged = (
                 model.check_convergence(


### PR DESCRIPTION
## Proposed changes

Prior to checking the convergence in `check_convergence`, the residual is always computed to ask for the recent residual. However, if the tolerance is `np.inf`, it will actually not be required. The PR only updates the residual if the tolerance is not `np.inf`.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [X] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [X] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [X] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.

No updates to tests are added, as the change only works on improving the logic.