### PR TITLE
Time step and iteration indexation in pp.AD

### DIFF
--- a/src/porepy/__init__.py
+++ b/src/porepy/__init__.py
@@ -160,6 +160,7 @@ from porepy.numerics.ad.operators import wrap_as_dense_ad_array, wrap_as_sparse_
 from porepy.numerics.ad.equation_system import EquationSystem
 from porepy.numerics.ad._ad_utils import set_solution_values
 from porepy.numerics.ad._ad_utils import get_solution_values
+from porepy.numerics.ad._ad_utils import shift_solution_values
 
 # Time stepping control
 from porepy.numerics.time_step_control import TimeManager

--- a/src/porepy/applications/test_utils/models.py
+++ b/src/porepy/applications/test_utils/models.py
@@ -222,10 +222,10 @@ def compare_scaled_primary_variables(
     for var_name, var_unit in zip(variable_names, variable_units):
         # Obtain scaled values.
         scaled_values_0 = setup_0.equation_system.get_variable_values(
-            variables=[var_name], time_step_index=1
+            variables=[var_name], time_step_index=0
         )
         scaled_values_1 = setup_1.equation_system.get_variable_values(
-            variables=[var_name], time_step_index=1
+            variables=[var_name], time_step_index=0
         )
         # Convert back to SI units.
         values_0 = setup_0.fluid.convert_units(scaled_values_0, var_unit, to_si=True)

--- a/src/porepy/examples/mandel_biot.py
+++ b/src/porepy/examples/mandel_biot.py
@@ -1435,7 +1435,7 @@ class MandelSolutionStrategy(poromechanics.SolutionStrategyPoromechanics):
             values=self.exact_sol.pressure(sd, 0),
             data=data,
             iterate_index=0,
-            time_step_index=1,
+            time_step_index=0,
         )
 
         # Set initial displacement
@@ -1444,7 +1444,7 @@ class MandelSolutionStrategy(poromechanics.SolutionStrategyPoromechanics):
             values=self.exact_sol.displacement(sd, 0),
             data=data,
             iterate_index=0,
-            time_step_index=1,
+            time_step_index=0,
         )
 
     def after_simulation(self) -> None:

--- a/src/porepy/examples/terzaghi_biot.py
+++ b/src/porepy/examples/terzaghi_biot.py
@@ -699,7 +699,7 @@ class TerzaghiSolutionStrategy(poromechanics.SolutionStrategyPoromechanics):
             values=initial_p,
             data=data,
             iterate_index=0,
-            time_step_index=1,
+            time_step_index=0,
         )
 
     def after_simulation(self) -> None:

--- a/src/porepy/models/boundary_condition.py
+++ b/src/porepy/models/boundary_condition.py
@@ -92,7 +92,7 @@ class BoundaryConditionMixin:
                 # No previous time step exists. The method was called during
                 # the initialization.
                 vals = function(bg)
-            pp.set_solution_values(name=name, values=vals, data=data, time_step_index=1)
+            pp.set_solution_values(name=name, values=vals, data=data, time_step_index=0)
 
             # Set the unknown time step values.
             vals = function(bg)

--- a/src/porepy/models/momentum_balance.py
+++ b/src/porepy/models/momentum_balance.py
@@ -790,7 +790,7 @@ class SolutionStrategyMomentumBalance(pp.SolutionStrategy):
         self.equation_system.set_variable_values(
             traction_vals.ravel("F"),
             [self.contact_traction_variable],
-            time_step_index=1,
+            time_step_index=0,
             iterate_index=0,
         )
 

--- a/src/porepy/models/solution_strategy.py
+++ b/src/porepy/models/solution_strategy.py
@@ -264,7 +264,7 @@ class SolutionStrategy(abc.ABC):
             An array of the indices of which time step solutions will be stored.
 
         """
-        return np.array([1])
+        return np.array([0])
 
     @property
     def iterate_indices(self) -> np.ndarray:
@@ -302,9 +302,9 @@ class SolutionStrategy(abc.ABC):
                     time_index,
                     times_file,
                 )
-            vals = self.equation_system.get_variable_values(time_step_index=1)
+            vals = self.equation_system.get_variable_values(time_step_index=0)
             self.equation_system.set_variable_values(
-                vals, iterate_index=0, time_step_index=1
+                vals, iterate_index=0, time_step_index=0
             )
             # Update the boundary conditions to both the time step and iterate solution.
             self.update_time_dependent_ad_arrays()
@@ -442,7 +442,7 @@ class SolutionStrategy(abc.ABC):
         solution = self.equation_system.get_variable_values(iterate_index=0)
         self.equation_system.shift_time_step_values()
         self.equation_system.set_variable_values(
-            values=solution, time_step_index=1, additive=False
+            values=solution, time_step_index=0, additive=False
         )
         self.convergence_status = True
         self.save_data_time_step()

--- a/src/porepy/numerics/ad/equation_system.py
+++ b/src/porepy/numerics/ad/equation_system.py
@@ -569,22 +569,23 @@ class EquationSystem:
         index specified by the user. The global order is preserved and independent of
         the order of the argument.
 
+        See also:
+            :meth:`~porepy.numerics.ad._ad_utils.get_solution_values`.
+
         Parameters:
-            variables (optional): VariableType input for which the values are
-                requested. If None (default), the global vector of unknowns is returned.
-            time_step_index: Specified by user if they want to gather variable values
-                from a specific time-step. Value 0 provides the most recent time-step. A
-                value of 1 will give the values of one time-step back in time.
-            iterate_index: Specified by user if they want to gather a specific set of
-                iterate values. Similar to ``time_step_index``, value 0 is the
-                default value and gives the most recent iterate.
+            variables: ``default=None``
+
+                VariableType input for which the values are requested.
+                If None (default), the global vector of unknowns is returned.
+            time_step_index: Time step index for which the values should be fetched.
+            iterate_index: Iterate index for which the values should be fetched.
+
+        Raises:
+            ValueError: If unknown VariableType arguments are passed.
 
         Returns:
             The respective (sub) vector in numerical format, size anywhere between 0 and
                 :meth:`num_dofs`.
-
-        Raises:
-            ValueError: If unknown VariableType arguments are passed.
 
         """
         variables = self._parse_variable_type(variables)
@@ -638,15 +639,15 @@ class EquationSystem:
         Parameters:
             values: Vector of size corresponding to number of DOFs of the specified
                 variables.
-            variables (optional): VariableType input for which the values are
-                requested. If None (default), the global vector of unknowns will be
-                set.
-            time_step_index: Index of previous time step for which the values are
-                intended.
-            iterate_index: Iterate index for current time step for which the values are
-                intended.
-            additive (optional): Flag to write values additively. To be used in
-                iterative procedures.
+            variables: ``default=None``
+
+                VariableType input for which the values are requested.
+                If None (default), the global vector of unknowns will be set.
+            time_step_index: Time step index for which the values are intended.
+            iterate_index: Iterate index for which the values are intended.
+            additive: ``default=False``
+
+                Flag to write values additively. To be used in iterative procedures.
 
         Raises:
             ValueError: If unknown VariableType arguments are passed.
@@ -696,81 +697,31 @@ class EquationSystem:
     ) -> None:
         """Method for shifting stored time step values in data sub-dictionary.
 
-        For details of the value shifting see the method :meth:`_shift_variable_values`.
+        For details of the value shifting see the method
+        :func:`~porepy.numerics.ad._ad_utils.shift_solution_values`.
 
         Parameters:
-            variables (optional): VariableType input for which the values are
-                requested. If None (default), the global vector of unknowns will
-                be shifted.
+            variables (optional): ``default=None``
+
+                VariableType input for which the values should be shifted in time.
+                If None, all variables created by this system will be shifted.
 
         """
-        self._shift_variable_values(
-            location=pp.TIME_STEP_SOLUTIONS, variables=variables
-        )
+        for var in self._parse_variable_type(variables):
+            pp.shift_solution_values(
+                var.name, self._get_data(var.domain), pp.TIME_STEP_SOLUTIONS
+            )
 
     def shift_iterate_values(
         self,
         variables: Optional[VariableList] = None,
     ) -> None:
-        """Method for shifting stored iterate values in data sub-dictionary.
-
-        For details of the value shifting see the method :meth:`_shift_variable_values`.
-
-        Parameters:
-            variables (optional): VariableType input for which the values are
-                requested. If None (default), the global vector of unknowns will
-                be shifted.
-
-        """
-        self._shift_variable_values(location=pp.ITERATE_SOLUTIONS, variables=variables)
-
-    def _shift_variable_values(
-        self,
-        location: str,
-        variables: Optional[VariableList] = None,
-    ) -> None:
-        """Method for shifting values in data dictionary.
-
-        Time step and iterate values are stored with storage indices as keys in
-        the data dictionary for the subdomain or interface in question. For each
-        time-step/iteration, these values are shifted such that the most recent
-        variable value later can be placed at index 0. The previous
-        time-step/iterate values have their index incremented by one. Values
-        of key 0 is moved to key 1, values of key 1 is moved to key 2, and so
-        on. The value at the highest key is discarded.
-
-        Parameters:
-            location: Should be ``pp.TIME_STEP_SOLUTIONS`` or ``pp.ITERATE_SOLUTIONS``
-                depending on which one of solutions/iterates that are to be shifted.
-            variables (optional): VariableType input for which the values are
-                requested. If None (default), the global vector of unknowns will
-                be shifted.
-
-        Raises:
-            ValueError: If unknown VariableType arguments are passed.
-
-        """
-        # Looping through the variables and shifting the values
-        variables = self._parse_variable_type(variables)
-        for variable in variables:
-            name = variable.name
-            grid = variable.domain
-            data = self._get_data(grid=grid)
-
-            # Shift old values as requested.
-            num_stored = len(data[location][name])
-            if location == pp.ITERATE_SOLUTIONS:
-                range_ = range(num_stored - 1, 0, -1)
-            # previous time step values start with index 1.
-            # NOTE this functionality should be in _ad_utils, together with set and get
-            elif location == pp.TIME_STEP_SOLUTIONS:
-                range_ = range(num_stored, 1, -1)
-            else:
-                raise NotImplementedError(
-                    f"Shift values not implemented for location {location}"
-                )
-            for i in range_:
-                data[location][name][i] = data[location][name][i - 1].copy()
+        """Analogous to :meth:`shift_time_step_values`, but for iterates of the current
+        (unknown) time step."""
+        for var in self._parse_variable_type(variables):
+            pp.shift_solution_values(
+                var.name, self._get_data(var.domain), pp.ITERATE_SOLUTIONS
+            )
 
     def _get_data(
         self,

--- a/src/porepy/numerics/fracture_deformation/conforming_propagation.py
+++ b/src/porepy/numerics/fracture_deformation/conforming_propagation.py
@@ -574,7 +574,7 @@ class ConformingFracturePropagation(FracturePropagation):
         cells = np.unique(sd_primary.cell_faces[faces_primary].nonzero()[1])
         vals[cells] = 1
         pp.set_solution_values(
-            name="neighbor_cells", values=vals, data=data_primary, time_step_index=1
+            name="neighbor_cells", values=vals, data=data_primary, time_step_index=0
         )
 
     def _tip_bases(

--- a/src/porepy/numerics/nonlinear/nonlinear_solvers.py
+++ b/src/porepy/numerics/nonlinear/nonlinear_solvers.py
@@ -74,7 +74,7 @@ class NewtonSolver:
         is_converged = False
         is_diverged = False
         nonlinear_increment = model.equation_system.get_variable_values(
-            time_step_index=1
+            time_step_index=0
         )
 
         # Extract residual of initial guess.

--- a/src/porepy/numerics/vem/dual_elliptic.py
+++ b/src/porepy/numerics/vem/dual_elliptic.py
@@ -42,7 +42,7 @@ def project_flux(
         # we need to recover the flux from the mortar variable before
         # the projection, only lower dimensional edges need to be considered.
         edge_flux = np.zeros(
-            pp.get_solution_values(name=flux, data=data, time_step_index=1).size
+            pp.get_solution_values(name=flux, data=data, time_step_index=0).size
         )
         faces = sd.tags["fracture_faces"]
         if np.any(faces):
@@ -63,14 +63,14 @@ def project_flux(
                 # edge_flux += sign * g_m.mortar_to_primary_int() *
                 # d_e[pp.TIME_STEP_SOLUTIONS][mortar_key][0]
                 mortar_values = pp.get_solution_values(
-                    name=mortar_key, data=data_intf, time_step_index=1
+                    name=mortar_key, data=data_intf, time_step_index=0
                 )
                 edge_flux += sign * intf.primary_to_mortar_avg().T * mortar_values
 
-        flux_values = pp.get_solution_values(name=flux, data=data, time_step_index=1)
+        flux_values = pp.get_solution_values(name=flux, data=data, time_step_index=0)
         discr_projected_flux = discr.project_flux(sd, edge_flux + flux_values, data)
         pp.set_solution_values(
-            name=P0_flux, values=discr_projected_flux, data=data, time_step_index=1
+            name=P0_flux, values=discr_projected_flux, data=data, time_step_index=0
         )
 
 

--- a/src/porepy/viz/data_saving_model_mixin.py
+++ b/src/porepy/viz/data_saving_model_mixin.py
@@ -99,7 +99,7 @@ class DataSavingMixin:
         variables = self.equation_system.variables
         for var in variables:
             scaled_values = self.equation_system.get_variable_values(
-                variables=[var], time_step_index=1
+                variables=[var], time_step_index=0
             )
             units = var.tags["si_units"]
             values = self.fluid.convert_units(scaled_values, units, to_si=True)

--- a/src/porepy/viz/exporter.py
+++ b/src/porepy/viz/exporter.py
@@ -500,7 +500,7 @@ class Exporter:
                                 value[offset : offset + sd.num_cells], sd
                             )
                             pp.set_solution_values(
-                                name=key, values=values, data=sd_data, time_step_index=1
+                                name=key, values=values, data=sd_data, time_step_index=0
                             )
 
                             offset += sd.num_cells
@@ -516,7 +516,7 @@ class Exporter:
                                 name=key,
                                 values=values,
                                 data=intf_data,
-                                time_step_index=1,
+                                time_step_index=0,
                             )
 
                             offset += intf.num_cells
@@ -966,7 +966,7 @@ class Exporter:
                     ):
                         # Fetch data and convert to vectorial format if needed
                         data_to_convert = pp.get_solution_values(
-                            name=key, data=grid_data, time_step_index=1
+                            name=key, data=grid_data, time_step_index=0
                         )
                         value: np.ndarray = _to_vector_format(
                             data_to_convert,
@@ -1058,7 +1058,7 @@ class Exporter:
 
                     # Fetch data and convert to vectorial format if suitable
                     data_to_convert = pp.get_solution_values(
-                        name=key, data=sd_data, time_step_index=1
+                        name=key, data=sd_data, time_step_index=0
                     )
                     value = _to_vector_format(data_to_convert, sd)
 
@@ -1130,7 +1130,7 @@ class Exporter:
 
                     # Fetch data and convert to vectorial format if suitable
                     data_to_convert = pp.get_solution_values(
-                        name=key, data=intf_data, time_step_index=1
+                        name=key, data=intf_data, time_step_index=0
                     )
                     value = _to_vector_format(data_to_convert, intf)
 

--- a/src/porepy/viz/plot_grid.py
+++ b/src/porepy/viz/plot_grid.py
@@ -263,7 +263,7 @@ def plot_mdg(
             extr_value = np.array([np.inf, -np.inf])
             for _, sd_data in mdg.subdomains(return_data=True):
                 values = pp.get_solution_values(
-                    name=cell_value, data=sd_data, time_step_index=1
+                    name=cell_value, data=sd_data, time_step_index=0
                 )
                 extr_value[0] = min(
                     np.amin(values),

--- a/tests/functional/setups/manu_flow_comp_2d_frac.py
+++ b/tests/functional/setups/manu_flow_comp_2d_frac.py
@@ -747,7 +747,7 @@ class ManuCompSolutionStrategy2d(pp.fluid_mass_balance.SolutionStrategySinglePha
             name="external_sources",
             values=matrix_source,
             data=data_matrix,
-            time_step_index=1,
+            time_step_index=0,
         )
 
         frac_source = self.exact_sol.fracture_source(sd_frac, t)
@@ -756,7 +756,7 @@ class ManuCompSolutionStrategy2d(pp.fluid_mass_balance.SolutionStrategySinglePha
             name="external_sources",
             values=frac_source,
             data=data_frac,
-            time_step_index=1,
+            time_step_index=0,
         )
 
     def after_simulation(self) -> None:

--- a/tests/functional/setups/manu_poromech_nofrac_2d.py
+++ b/tests/functional/setups/manu_poromech_nofrac_2d.py
@@ -753,13 +753,13 @@ class ManuPoroMechSolutionStrategy2d(poromechanics.SolutionStrategyPoromechanics
         # Mechanics source
         mech_source = self.exact_sol.mechanics_source(sd=sd, time=t)
         pp.set_solution_values(
-            name="source_mechanics", values=mech_source, data=data, time_step_index=1
+            name="source_mechanics", values=mech_source, data=data, time_step_index=0
         )
 
         # Flow source
         flow_source = self.exact_sol.flow_source(sd=sd, time=t)
         pp.set_solution_values(
-            name="source_flow", values=flow_source, data=data, time_step_index=1
+            name="source_flow", values=flow_source, data=data, time_step_index=0
         )
 
     def after_simulation(self) -> None:

--- a/tests/functional/setups/manu_thermoporomech_nofrac_2d.py
+++ b/tests/functional/setups/manu_thermoporomech_nofrac_2d.py
@@ -1071,18 +1071,18 @@ class ManuThermoPoroMechSolutionStrategy2d(
         # Mechanics source
         mech_source = self.exact_sol.mechanics_source(sd=sd, time=t)
         pp.set_solution_values(
-            name="source_mechanics", values=mech_source, data=data, time_step_index=1
+            name="source_mechanics", values=mech_source, data=data, time_step_index=0
         )
 
         # Flow source
         flow_source = self.exact_sol.flow_source(sd=sd, time=t)
         pp.set_solution_values(
-            name="source_flow", values=flow_source, data=data, time_step_index=1
+            name="source_flow", values=flow_source, data=data, time_step_index=0
         )
         # Energy source
         energy_source = self.exact_sol.energy_source(sd=sd, time=t)
         pp.set_solution_values(
-            name="source_energy", values=energy_source, data=data, time_step_index=1
+            name="source_energy", values=energy_source, data=data, time_step_index=0
         )
 
     def _is_nonlinear_problem(self) -> bool:

--- a/tests/functional/setups/manu_thermoporomech_nofrac_3d.py
+++ b/tests/functional/setups/manu_thermoporomech_nofrac_3d.py
@@ -909,18 +909,18 @@ class ManuThermoPoroMechSolutionStrategy3d(
         # Mechanics source
         mech_source = self.exact_sol.mechanics_source(sd=sd, time=t)
         pp.set_solution_values(
-            name="source_mechanics", values=mech_source, data=data, time_step_index=1
+            name="source_mechanics", values=mech_source, data=data, time_step_index=0
         )
 
         # Flow source
         flow_source = self.exact_sol.flow_source(sd=sd, time=t)
         pp.set_solution_values(
-            name="source_flow", values=flow_source, data=data, time_step_index=1
+            name="source_flow", values=flow_source, data=data, time_step_index=0
         )
         # Energy source
         energy_source = self.exact_sol.energy_source(sd=sd, time=t)
         pp.set_solution_values(
-            name="source_energy", values=energy_source, data=data, time_step_index=1
+            name="source_energy", values=energy_source, data=data, time_step_index=0
         )
 
     def _is_nonlinear_problem(self) -> bool:

--- a/tests/models/test_energy_balance.py
+++ b/tests/models/test_energy_balance.py
@@ -154,7 +154,7 @@ def test_advection_or_diffusion_dominated(fluid_vals, solid_vals):
         for sd in setup.mdg.subdomains():
             var = setup.equation_system.get_variables(["temperature"], [sd])
             vals = setup.equation_system.get_variable_values(
-                variables=var, time_step_index=1
+                variables=var, time_step_index=0
             )
             assert np.allclose(
                 vals,

--- a/tests/models/test_fluid_mass_balance.py
+++ b/tests/models/test_fluid_mass_balance.py
@@ -740,21 +740,21 @@ class TestMixedDimGravity:
     def solve(self):
         pp.run_time_dependent_model(self.model, self.model.params)
         pressure = self.model.equation_system.get_variable_values(
-            [self.model.pressure_variable], time_step_index=1
+            [self.model.pressure_variable], time_step_index=0
         )
         return pressure
 
     def verify_pressure(self, p_known: float = 0):
         """Verify that the pressure of all subdomains equals p_known."""
         pressure = self.model.equation_system.get_variable_values(
-            [self.model.pressure_variable], time_step_index=1
+            [self.model.pressure_variable], time_step_index=0
         )
         assert np.allclose(pressure, p_known, rtol=1e-3, atol=1e-3)
 
     def verify_mortar_flux(self, u_known: float):
         """Verify that the mortar flux of all interfaces equals u_known."""
         flux = self.model.equation_system.get_variable_values(
-            [self.model.interface_darcy_flux_variable], time_step_index=1
+            [self.model.interface_darcy_flux_variable], time_step_index=0
         )
         assert np.allclose(np.abs(flux), u_known, rtol=1e-3, atol=1e-3)
 
@@ -770,7 +770,7 @@ class TestMixedDimGravity:
         sd_primary = mdg.subdomains(dim=mdg.dim_max())[0]
         data_primary = mdg.subdomain_data(sd_primary)
         p_primary = pp.get_solution_values(
-            name="pressure", data=data_primary, time_step_index=1
+            name="pressure", data=data_primary, time_step_index=0
         )
 
         # The cells above the fracture
@@ -782,7 +782,7 @@ class TestMixedDimGravity:
         sd_secondary = mdg.subdomains(dim=mdg.dim_max() - 1)[0]
         data_secondary = mdg.subdomain_data(sd_secondary)
         p_secondary = pp.get_solution_values(
-            name="pressure", data=data_secondary, time_step_index=1
+            name="pressure", data=data_secondary, time_step_index=0
         )
 
         # Half the additional jump is added to the fracture pressure
@@ -791,7 +791,7 @@ class TestMixedDimGravity:
 
         assert np.allclose(p_secondary, p_known, rtol=1e-3, atol=1e-3)
         flux = self.model.equation_system.get_variable_values(
-            [self.model.interface_darcy_flux_variable], time_step_index=1
+            [self.model.interface_darcy_flux_variable], time_step_index=0
         )
         assert np.allclose(flux, 0, rtol=1e-3, atol=1e-3)
 

--- a/tests/models/test_momentum_balance.py
+++ b/tests/models/test_momentum_balance.py
@@ -58,7 +58,7 @@ def test_2d_single_fracture(solid_vals, north_displacement):
     # Check that the pressure is linear
     sd = setup.mdg.subdomains(dim=setup.nd)[0]
     var = setup.equation_system.get_variables([setup.displacement_variable], [sd])
-    vals = setup.equation_system.get_variable_values(variables=var, time_step_index=1)
+    vals = setup.equation_system.get_variable_values(variables=var, time_step_index=0)
     if np.isclose(north_displacement, 0):
         assert np.allclose(vals, 0)
     else:
@@ -257,7 +257,7 @@ def test_lithostatic(dim: int):
     # Fetch the displacement variable and convert it to an model.nd x model.num_cells
     # array.
     var = model.equation_system.get_variables([model.displacement_variable], [sd])
-    vals = model.equation_system.get_variable_values(variables=var, time_step_index=1)
+    vals = model.equation_system.get_variable_values(variables=var, time_step_index=0)
     vals = vals.reshape((model.nd, -1), order="F")
 
     # Analytical displacement.

--- a/tests/models/test_poromechanics.py
+++ b/tests/models/test_poromechanics.py
@@ -49,7 +49,7 @@ class NonzeroFractureGapPoromechanics:
         self.equation_system.set_variable_values(
             self.fluid.pressure() * np.ones(self.mdg.num_subdomain_cells()),
             [self.pressure_variable],
-            time_step_index=1,
+            time_step_index=0,
             iterate_index=0,
         )
         sd, sd_data = self.mdg.subdomains(return_data=True)[0]
@@ -61,7 +61,7 @@ class NonzeroFractureGapPoromechanics:
             self.equation_system.set_variable_values(
                 vals.ravel("F"),
                 [self.displacement_variable],
-                time_step_index=1,
+                time_step_index=0,
                 iterate_index=0,
             )
             # Find mortar cells on the top boundary
@@ -86,7 +86,7 @@ class NonzeroFractureGapPoromechanics:
             self.equation_system.set_variable_values(
                 vals.ravel("F"),
                 [self.interface_displacement_variable],
-                time_step_index=1,
+                time_step_index=0,
                 iterate_index=0,
             )
 
@@ -207,20 +207,20 @@ def get_variables(
     sd = setup.mdg.subdomains(dim=setup.nd)[0]
     u_var = setup.equation_system.get_variables([setup.displacement_variable], [sd])
     u_vals = setup.equation_system.get_variable_values(
-        variables=u_var, time_step_index=1
+        variables=u_var, time_step_index=0
     ).reshape(setup.nd, -1, order="F")
 
     p_var = setup.equation_system.get_variables(
         [setup.pressure_variable], setup.mdg.subdomains()
     )
     p_vals = setup.equation_system.get_variable_values(
-        variables=p_var, time_step_index=1
+        variables=p_var, time_step_index=0
     )
     p_var = setup.equation_system.get_variables(
         [setup.pressure_variable], setup.mdg.subdomains(dim=setup.nd - 1)
     )
     p_frac = setup.equation_system.get_variable_values(
-        variables=p_var, time_step_index=1
+        variables=p_var, time_step_index=0
     )
     # Fracture
     sd_frac = setup.mdg.subdomains(dim=setup.nd - 1)

--- a/tests/models/test_thermoporomechanics.py
+++ b/tests/models/test_thermoporomechanics.py
@@ -79,13 +79,13 @@ def get_variables(setup):
         [setup.temperature_variable], setup.mdg.subdomains()
     )
     t_vals = setup.equation_system.get_variable_values(
-        variables=t_var, time_step_index=1
+        variables=t_var, time_step_index=0
     )
     t_var = setup.equation_system.get_variables(
         [setup.temperature_variable], setup.mdg.subdomains(dim=setup.nd - 1)
     )
     t_frac = setup.equation_system.get_variable_values(
-        variables=t_var, time_step_index=1
+        variables=t_var, time_step_index=0
     )
     return u_vals, p_vals, p_frac, jump, traction, t_vals, t_frac
 

--- a/tests/numerics/ad/test_equation_system.py
+++ b/tests/numerics/ad/test_equation_system.py
@@ -57,7 +57,7 @@ def test_evaluate_variables():
         vals_it = 2 * np.ones([sd.num_cells])
 
         pp.set_solution_values(
-            name=var_name, values=vals_sol, data=d, time_step_index=1
+            name=var_name, values=vals_sol, data=d, time_step_index=0
         )
         pp.set_solution_values(name=var_name, values=vals_it, data=d, iterate_index=0)
         # Provide values for previous iterate as well
@@ -381,7 +381,7 @@ class EquationSystemSetup:
             self.name_intf_top_variable,
         ]
         sys_man.set_variable_values(
-            global_vals, variables=all_variables, iterate_index=0, time_step_index=1
+            global_vals, variables=all_variables, iterate_index=0, time_step_index=0
         )
         self.initial_values = global_vals
 
@@ -646,18 +646,18 @@ def test_set_get_methods(
         # the global ordering.
         assert np.allclose(setup.initial_values[np.sort(inds)], retrieved_vals)
     # The time step solution should not have been updated
-    retrieved_vals_state = sys_man.get_variable_values(variables, time_step_index=1)
+    retrieved_vals_state = sys_man.get_variable_values(variables, time_step_index=0)
     assert np.allclose(setup.initial_values[np.sort(inds)], retrieved_vals_state)
 
     # Set values again, this time also to the time step solutions.
     if iterate:
-        sys_man.set_variable_values(vals, variables, iterate_index=0, time_step_index=1)
+        sys_man.set_variable_values(vals, variables, iterate_index=0, time_step_index=0)
     else:
-        sys_man.set_variable_values(vals, variables, time_step_index=1)
+        sys_man.set_variable_values(vals, variables, time_step_index=0)
     # Retrieve only values from time step solutions; iterate should be the same as
     # before (and the additive mode is checked below).
 
-    retrieved_vals_state = sys_man.get_variable_values(variables, time_step_index=1)
+    retrieved_vals_state = sys_man.get_variable_values(variables, time_step_index=0)
 
     assert np.allclose(vals, retrieved_vals_state)
 
@@ -668,7 +668,7 @@ def test_set_get_methods(
         sys_man.set_variable_values(new_vals, variables, iterate_index=0)
         retrieved_vals2 = sys_man.get_variable_values(variables, iterate_index=0)
     if not iterate:
-        retrieved_vals2 = sys_man.get_variable_values(variables, time_step_index=1)
+        retrieved_vals2 = sys_man.get_variable_values(variables, time_step_index=0)
     # Iterate has either been updated, or it still has the initial value
     if iterate:
         assert np.allclose(new_vals, retrieved_vals2)
@@ -679,11 +679,11 @@ def test_set_get_methods(
     # Set values to time step solutions. This should overwrite the old values.
     if iterate:
         sys_man.set_variable_values(
-            new_vals, variables, iterate_index=0, time_step_index=1
+            new_vals, variables, iterate_index=0, time_step_index=0
         )
     else:
-        sys_man.set_variable_values(new_vals, variables, time_step_index=1)
-    retrieved_vals_state_2 = sys_man.get_variable_values(variables, time_step_index=1)
+        sys_man.set_variable_values(new_vals, variables, time_step_index=0)
+    retrieved_vals_state_2 = sys_man.get_variable_values(variables, time_step_index=0)
     assert np.allclose(new_vals, retrieved_vals_state_2)
 
     # Set the values again, this time with additive=True. This should double the
@@ -692,7 +692,7 @@ def test_set_get_methods(
         sys_man.set_variable_values(new_vals, variables, iterate_index=0, additive=True)
         retrieved_vals3 = sys_man.get_variable_values(variables, iterate_index=0)
     elif not iterate:
-        retrieved_vals3 = sys_man.get_variable_values(variables, time_step_index=1)
+        retrieved_vals3 = sys_man.get_variable_values(variables, time_step_index=0)
 
     if iterate:
         assert np.allclose(2 * new_vals, retrieved_vals3)
@@ -703,13 +703,13 @@ def test_set_get_methods(
     # Set to time step solutions, with additive=True. This should double the retrieved
     if iterate:
         sys_man.set_variable_values(
-            new_vals, variables, iterate_index=0, time_step_index=1, additive=True
+            new_vals, variables, iterate_index=0, time_step_index=0, additive=True
         )
     else:
         sys_man.set_variable_values(
-            new_vals, variables, time_step_index=1, additive=True
+            new_vals, variables, time_step_index=0, additive=True
         )
-    retrieved_vals_state_3 = sys_man.get_variable_values(variables, time_step_index=1)
+    retrieved_vals_state_3 = sys_man.get_variable_values(variables, time_step_index=0)
     assert np.allclose(2 * new_vals, retrieved_vals_state_3)
 
     # Test storage of multiple values of time step and iterate solutions from here and
@@ -722,7 +722,7 @@ def test_set_get_methods(
         # are as expected.
         for ind, val in enumerate(known_values):
             assert np.allclose(
-                sys_man.get_variable_values(variables, time_step_index=ind + 1), val
+                sys_man.get_variable_values(variables, time_step_index=ind), val
             )
 
     # Building a few solution vectors and defining the desired solution indices
@@ -730,7 +730,7 @@ def test_set_get_methods(
     vals1 = vals0 * 2
     vals2 = vals0 * 3
 
-    solution_indices = np.array([1, 2, 3])
+    solution_indices = np.array([0, 1, 2])
     vals_mat = np.array([vals0, vals1, vals2])
 
     # Test setting values at several indices and then gathering them
@@ -749,7 +749,7 @@ def test_set_get_methods(
     # Test additive = True to make sure only the most recently stored values are added
     # to.
     sys_man.set_variable_values(
-        values=vals0, variables=variables, time_step_index=1, additive=True
+        values=vals0, variables=variables, time_step_index=0, additive=True
     )
     _retrieve_and_check_time_step([2 * vals0, vals0, vals1])
 

--- a/tests/numerics/ad/test_operator_functions.py
+++ b/tests/numerics/ad/test_operator_functions.py
@@ -41,7 +41,7 @@ def test_ad_function():
     vals = np.ones(mdg.num_subdomain_cells())
     eqsys.set_variable_values(vals, [var], iterate_index=0)
     eqsys.set_variable_values(vals * 2, [var], iterate_index=1)
-    eqsys.set_variable_values(vals * 10, [var], time_step_index=1)
+    eqsys.set_variable_values(vals * 10, [var], time_step_index=0)
 
     # test that the function without call with operator is inoperable
     for op in ['*', '/', '+', '-', '**', '@']:
@@ -52,14 +52,21 @@ def test_ad_function():
 
     F_var = F(var)
 
-    val = F_var.value_and_jacobian(eqsys)
+    val_ad = F_var.value_and_jacobian(eqsys)
     # test values at current time step
-    assert np.all(val.val == 1.)
-    assert np.all(val.jac.A == np.eye(mdg.num_subdomain_cells()))
+    assert np.all(val_ad.val == 1.)
+    assert np.all(val_ad.jac.A == np.eye(mdg.num_subdomain_cells()))
 
     # vals at previous iter and zero Jacobian
+    # previous iterate has the same values as the original operator, but no Jacobian
     F_var_pi = F_var.previous_iteration()
     val = F_var_pi.value_and_jacobian(eqsys)
+    assert np.all(val.val == val_ad.val)
+    assert np.all(val.jac.A == 0.)
+
+    # 1 iterate before has the respective values
+    F_var_pii = F_var_pi.previous_iteration()
+    val = F_var_pii.value_and_jacobian(eqsys)
     assert np.all(val.val == 2.)
     assert np.all(val.jac.A == 0.)
 

--- a/tests/numerics/fracture_deformation/test_fracture_propagation.py
+++ b/tests/numerics/fracture_deformation/test_fracture_propagation.py
@@ -855,7 +855,7 @@ class TestVariableMappingInitializationUnderPropagation:
         val_sol = cell_val_2d
         val_it = 2 * cell_val_2d
 
-        pp.set_solution_values(name=self.cv2, values=val_sol, data=d, time_step_index=1)
+        pp.set_solution_values(name=self.cv2, values=val_sol, data=d, time_step_index=0)
         pp.set_solution_values(name=self.cv2, values=val_it, data=d, iterate_index=0)
 
         for g in g_1d:
@@ -866,7 +866,7 @@ class TestVariableMappingInitializationUnderPropagation:
             val_it = 2 * cell_val_1d[g]
 
             pp.set_solution_values(
-                name=self.cv1, values=val_sol, data=d, time_step_index=1
+                name=self.cv1, values=val_sol, data=d, time_step_index=0
             )
             pp.set_solution_values(
                 name=self.cv1, values=val_it, data=d, iterate_index=0
@@ -883,7 +883,7 @@ class TestVariableMappingInitializationUnderPropagation:
             val_it = 2 * cell_val_mortar[g]
 
             pp.set_solution_values(
-                name=self.mv, values=val_sol, data=d, time_step_index=1
+                name=self.mv, values=val_sol, data=d, time_step_index=0
             )
             pp.set_solution_values(name=self.mv, values=val_it, data=d, iterate_index=0)
 
@@ -921,7 +921,7 @@ class TestVariableMappingInitializationUnderPropagation:
             # updated
             d = mdg.subdomain_data(g_2d)
             time_step_values_cv2 = pp.get_solution_values(
-                name=self.cv2, data=d, time_step_index=1
+                name=self.cv2, data=d, time_step_index=0
             )
             assert np.all(time_step_values_cv2 == cell_val_2d)
 
@@ -952,7 +952,7 @@ class TestVariableMappingInitializationUnderPropagation:
                 d = mdg.subdomain_data(g)
 
                 time_step_values_cv1 = pp.get_solution_values(
-                    name=self.cv1, data=d, time_step_index=1
+                    name=self.cv1, data=d, time_step_index=0
                 )
                 assert np.all(time_step_values_cv1 == truth_1d)
 
@@ -974,7 +974,7 @@ class TestVariableMappingInitializationUnderPropagation:
                 val_1d_iterate_prev[g] = np.r_[val_1d_iterate_prev[g], extended_1d + 1]
 
                 pp.set_solution_values(
-                    name=self.cv1, values=val_1d_prev[g], data=d, time_step_index=1
+                    name=self.cv1, values=val_1d_prev[g], data=d, time_step_index=0
                 )
                 pp.set_solution_values(
                     name=self.cv1,
@@ -1008,7 +1008,7 @@ class TestVariableMappingInitializationUnderPropagation:
 
                 assert np.all(x_mortar == truth_mortar)
                 assert np.all(
-                    pp.get_solution_values(name=self.mv, data=d, time_step_index=1)
+                    pp.get_solution_values(name=self.mv, data=d, time_step_index=0)
                     == truth_mortar
                 )
                 assert np.all(
@@ -1030,7 +1030,7 @@ class TestVariableMappingInitializationUnderPropagation:
                 ]
 
                 pp.set_solution_values(
-                    name=self.mv, values=val_mortar_prev[g], data=d, time_step_index=1
+                    name=self.mv, values=val_mortar_prev[g], data=d, time_step_index=0
                 )
                 pp.set_solution_values(
                     name=self.mv,

--- a/tests/numerics/fv/test_tpfa.py
+++ b/tests/numerics/fv/test_tpfa.py
@@ -126,7 +126,7 @@ class UnitTestAdTpfaFlux(
                 values=np.array([2, 3], dtype=float),
                 data=data,
                 iterate_index=0,
-                time_step_index=1,
+                time_step_index=0,
             )
 
     def set_geometry(self):

--- a/tests/viz/test_exporter.py
+++ b/tests/viz/test_exporter.py
@@ -225,14 +225,14 @@ def test_mdg(setup: ExporterTestSetup):
             name="dummy_scalar",
             values=np.ones(sd.num_cells) * sd.dim,
             data=sd_data,
-            time_step_index=1,
+            time_step_index=0,
         )
 
         pp.set_solution_values(
             name="dummy_vector",
             values=np.ones((3, sd.num_cells)) * sd.dim,
             data=sd_data,
-            time_step_index=1,
+            time_step_index=0,
         )
 
     for intf, intf_data in mdg.interfaces(return_data=True):
@@ -240,14 +240,14 @@ def test_mdg(setup: ExporterTestSetup):
             name="dummy_scalar",
             values=np.zeros(intf.num_cells),
             data=intf_data,
-            time_step_index=1,
+            time_step_index=0,
         )
 
         pp.set_solution_values(
             name="unique_dummy_scalar",
             values=np.zeros(intf.num_cells),
             data=intf_data,
-            time_step_index=1,
+            time_step_index=0,
         )
 
     # Export data
@@ -432,14 +432,14 @@ def test_mdg_data_selection(setup: ExporterTestSetup):
             name="dummy_scalar",
             values=np.ones(sd.num_cells) * sd.dim,
             data=sd_data,
-            time_step_index=1,
+            time_step_index=0,
         )
 
         pp.set_solution_values(
             name="dummy_vector",
             values=np.ones((3, sd.num_cells)) * sd.dim,
             data=sd_data,
-            time_step_index=1,
+            time_step_index=0,
         )
 
     for intf, intf_data in mdg.interfaces(return_data=True):
@@ -447,14 +447,14 @@ def test_mdg_data_selection(setup: ExporterTestSetup):
             name="dummy_scalar",
             values=np.zeros(intf.num_cells),
             data=intf_data,
-            time_step_index=1,
+            time_step_index=0,
         )
 
         pp.set_solution_values(
             name="unique_dummy_scalar",
             values=np.zeros(intf.num_cells),
             data=intf_data,
-            time_step_index=1,
+            time_step_index=0,
         )
 
     # Fetch separate subdomains

--- a/tests/viz/test_plot_grid.py
+++ b/tests/viz/test_plot_grid.py
@@ -60,7 +60,7 @@ def mdg(request: pytest.FixtureRequest) -> pp.MixedDimensionalGrid:
 
             for i in range(len(variables)):
                 pp.set_solution_values(
-                    name=variables[i], values=values[i], data=data, time_step_index=1
+                    name=variables[i], values=values[i], data=data, time_step_index=0
                 )
 
         else:
@@ -93,10 +93,10 @@ def test_plot_grid_simple_grid(mdg: MixedDimensionalGrid, vector_variable: str):
     The redundant dimensions are filled with zeros."""
     grid, data = mdg.subdomains(return_data=True)[0]
     scalar_data = pp.get_solution_values(
-        name=SCALAR_VARIABLE, data=data, time_step_index=1
+        name=SCALAR_VARIABLE, data=data, time_step_index=0
     )
     vector_data = pp.get_solution_values(
-        name=vector_variable, data=data, time_step_index=1
+        name=vector_variable, data=data, time_step_index=0
     )
     vector_data = vector_data.reshape((mdg.dim_max(), -1), order="F")
     vector_data = np.vstack(

--- a/tutorials/benchmark_simulation.ipynb
+++ b/tutorials/benchmark_simulation.ipynb
@@ -279,7 +279,7 @@
     "        if np.isclose(vals[0], -3.69897001):\n",
     "            vals += 1.5\n",
     "        assert vals.size == 1, \"Normal permeability is not constant.\"\n",
-    "    pp.set_solution_values(\"permeability\", vals, data, time_step_index=1)\n",
+    "    pp.set_solution_values(\"permeability\", vals, data, time_step_index=0)\n",
     "\n",
     "pp.plot_grid(\n",
     "    perm_model.mdg,\n",

--- a/tutorials/equations.ipynb
+++ b/tutorials/equations.ipynb
@@ -528,7 +528,7 @@
     "    values=p_new,\n",
     "    variables=[p],\n",
     "    iterate_index=0,  #   | For a more advanced reader:\n",
-    "    time_step_index=1,  # | We reference method documentation to see what these keyword\n",
+    "    time_step_index=0,  # | We reference method documentation to see what these keyword\n",
     "    additive=False,  #    | arguments do.\n",
     ")\n",
     "\n",

--- a/tutorials/exporting_models.ipynb
+++ b/tutorials/exporting_models.ipynb
@@ -178,7 +178,7 @@
     "        variables = self.equation_system.variables\n",
     "        for var in variables:\n",
     "            # Note that we use iterate_index=0 to get the current solution, whereas\n",
-    "            # the regular exporter uses time_step_index=1.\n",
+    "            # the regular exporter uses time_step_index=0.\n",
     "            scaled_values = self.equation_system.get_variable_values(\n",
     "                variables=[var], iterate_index=0\n",
     "            )\n",


### PR DESCRIPTION
## Proposed changes

DRAFT: @IvarStefansson @keileg  for the indexation issues we discussed after the last user meeting.

Time step indexation reverted to start with 0 for first previous time step.
Time-dependent AD operators have `None` as their time step index, as long as they are at current time.
Iterative operators have always an integer value as iteration index, starting with 0 for the first previous iterate.
The first call to `.previous_iteration()` does not push the iterate index up (stays 0), but flags the instance as as previous iterate, removing it's capability to get a proper AdArray during parsing (`.values_and_jacobian()` will give a trivial `.jac`)


The "flag" for is previous iterate (also for time step) is computed using a PRIVATE index, which starts at -1, and is consistently increased with `+= 1`.

Note also, I propose here to return `iterate_index` as `None` for operators which are both `TimeDependentOperators` and `IterativeOperators`, and at a previous time step.

1. The aim is to make it more clear to users, that there are no iteration indices for previous time steps.
2. Also, code in various parts of the framework will be slightly shorter, because the `get_values` and `set_values` methods do not need an if-branch regarding whether the variable/operator is at previous time. Variables will always have a pair of time step index and iterate index, which are consistent with the intended usage of various get and set values methods in the Ad framework.


## Relevant changes

The essential changes are in the following files:

src/numerics/ad/_ad_utils.py
src/numerics/ad/equation_system.py
src/numerics/ad/operators.py

changes in the other file revert essentially the changes introduced in PR #1166 
