### PR TITLE
BUG: Increase digits of integer arrays

### DIFF
--- a/src/porepy/fracs/fracture.py
+++ b/src/porepy/fracs/fracture.py
@@ -32,7 +32,7 @@ class Fracture(abc.ABC):
 
             Array containing the start- and end point/the corner points for
             line/plane fractures.
-        tags: ``shape=(num_tags, ), dtype=np.int8, default=None``
+        tags: ``shape=(num_tags, ), dtype=np.int32, default=None``
 
             All the tags of the fracture. A tag value of ``-1`` equals to the tag not
             existing at all.
@@ -107,9 +107,9 @@ class Fracture(abc.ABC):
 
         """
         if tags is None:
-            self.tags = np.full((0,), -1, dtype=np.int8)
+            self.tags = np.full((0,), -1, dtype=np.int32)
         else:
-            self.tags = np.asarray(tags, dtype=np.int8)
+            self.tags = np.asarray(tags, dtype=np.int32)
 
     def __repr__(self) -> str:
         """Representation is same as str-representation."""

--- a/src/porepy/fracs/fracture_importer.py
+++ b/src/porepy/fracs/fracture_importer.py
@@ -231,7 +231,7 @@ def network_2d_from_csv(
 
     Parameters:
         f_name: Path to the CSV file.
-        tagcols: ``dtype=np.int8, default=None``
+        tagcols: ``dtype=np.int32, default=None``
 
             Column index where fracture tags are stored. 0-offset. Defaults to no
             columns.

--- a/src/porepy/fracs/fracture_network_2d.py
+++ b/src/porepy/fracs/fracture_network_2d.py
@@ -261,7 +261,7 @@ class FractureNetwork2d:
             do_snap: ``default=True``
 
                 Whether to snap lines to avoid small segments.
-            constraints: ``dtype=np.int8, default=None``
+            constraints: ``dtype=np.int32, default=None``
 
                 Indices of fractures that should not generate lower-dimensional
                 meshes, but only act as constraints in the meshing algorithm. Useful
@@ -391,7 +391,7 @@ class FractureNetwork2d:
             do_snap: ``default=True``
 
                 Whether to snap lines to avoid small segments.
-            constraints: ``dtype=np.int8, default=None``
+            constraints: ``dtype=np.int32, default=None``
 
                 Indices of fractures that should not generate lower-dimensional
                 meshes, but only act as constraints in the meshing algorithm.
@@ -593,7 +593,7 @@ class FractureNetwork2d:
         """Unified description of points and lines for domain and fractures.
 
         Parameters:
-            constraints: ``dtype=np.int8``
+            constraints: ``dtype=np.int32``
 
                 Indices of fractures which should be considered meshing constraints,
                 not as physical objects.
@@ -1296,7 +1296,7 @@ class FractureNetwork2d:
         to_keep[np.setdiff1d(all_pts_id, pts_id, assume_unique=True)] = False
 
         # create the map between the old and new
-        new_pts_id = -np.ones(all_pts_id.size, dtype=np.int8)
+        new_pts_id = -np.ones(all_pts_id.size, dtype=np.int32)
         new_pts_id[to_keep] = np.arange(pts_id.size)
 
         # update the edges numeration

--- a/src/porepy/fracs/fracture_network_3d.py
+++ b/src/porepy/fracs/fracture_network_3d.py
@@ -253,7 +253,7 @@ class FractureNetwork3d(object):
 
                 Name of the output Gmsh file(s). If not given, ``gmsh_frac_file``
                 will be assigned.
-            constraints: ``dtype=np.int8, default=None``
+            constraints: ``dtype=np.int32, default=None``
 
                 Indices of fractures that should not generate lower-dimensional
                 meshes, but only act as constraints in the meshing algorithm. Useful
@@ -355,7 +355,7 @@ class FractureNetwork3d(object):
                 Whether the fracture network is of the DFN (Discrete Fracture Network)
                 type. If ``True``, a DFN mesh, where only the network (and not the
                 surrounding matrix) is created.
-            constraints: ``dtype=np.int8, default=None``
+            constraints: ``dtype=np.int32, default=None``
 
                 Indices of fractures that should not generate lower-dimensional
                 meshes, but only act as constraints in the meshing algorithm. Useful
@@ -2041,7 +2041,7 @@ class FractureNetwork3d(object):
         Returns:
             Tuple with 3 elements.
 
-            :obj:`numpy.ndarray`: ``dtype=np.int8``
+            :obj:`numpy.ndarray`: ``dtype=np.int32``
 
                 Tag of the edges, using the values in GmshConstants. Note that
                 auxiliary points will not be tagged (these are also ignored in
@@ -2120,7 +2120,7 @@ class FractureNetwork3d(object):
         Returns:
             Tuple with two elements.
 
-            :obj:`numpy.ndarray`: ``dtype=np.int8``
+            :obj:`numpy.ndarray`: ``dtype=np.int32``
 
                 For all points in the decomposition, the value is ``0`` if the point
                 is in the interior, ``constants.FRACTURE_TAG`` if the point is on a
@@ -2128,7 +2128,7 @@ class FractureNetwork3d(object):
                 and ``constants.DOMAIN_BOUNDARY_TAG`` if the point is part of the
                 boundary specification.
 
-            :obj:`numpy.ndarray`: ``dtype=np.int8``
+            :obj:`numpy.ndarray`: ``dtype=np.int32``
 
                 For all edges in the decomposition, tags identifying the edge as on a
                 fracture or boundary.
@@ -2253,7 +2253,7 @@ class FractureNetwork3d(object):
             Add description of **kwargs**.
 
         Parameters:
-            point_tags: ``dtype=np.int8``
+            point_tags: ``dtype=np.int32``
 
                 Tags of the points. Refers to values listed in ``GmshInterfaceTags``.
 
@@ -2895,7 +2895,7 @@ class FractureNetwork3d(object):
 
                     2D coordinates of fracture intersection points.
 
-                :obj:`numpy.ndarray`: ``shape=(2, num_intersection), dtype=np.int8``
+                :obj:`numpy.ndarray`: ``shape=(2, num_intersection), dtype=np.int32``
 
                     Index of the intersecting fractures.
 

--- a/src/porepy/fracs/utils.py
+++ b/src/porepy/fracs/utils.py
@@ -165,7 +165,7 @@ def linefractures_to_pts_edges(
     # the rest of the rows with tags where they exist. All other tags keep their
     # initial value of ``-1``, which is equal to the tag not existing. This seemingly
     # complicated procedure is done to ensure that the ``edges`` array is not ragged.
-    edges = np.full((max_edge_dim, len(fractures)), -1, dtype=np.int8)
+    edges = np.full((max_edge_dim, len(fractures)), -1, dtype=np.int32)
     for row_index, edge in enumerate(edges_list):
         edges[: edge.shape[0], row_index] = edge
 

--- a/tests/fracs/test_fracture_network_2d.py
+++ b/tests/fracs/test_fracture_network_2d.py
@@ -1,4 +1,5 @@
 """Testing functionality related to FractureNetwork2d."""
+
 import numpy as np
 import pytest
 
@@ -247,8 +248,9 @@ def test_add_networks_preserve_tags(fracs: list[LineFracture]):
 
     # Assign tags to network1
     tag1 = 2
-    # Had to change this to ensure that edges still has ``dtype np.int8``
-    network_1._edges = np.vstack((network_1._edges, tag1 * np.ones(2, dtype=np.int8)))
+    # Had to change this to ensure that edges still has ``dtype np.int32``.
+    # Used to be int8. Not sure if this is important.
+    network_1._edges = np.vstack((network_1._edges, tag1 * np.ones(2, dtype=np.int32)))
     together = network_1.add_network(network_2)
     known_tags = np.array([tag1, tag1, tag2, tag2])
     assert np.all(together._edges[2] == known_tags)


### PR DESCRIPTION
## Proposed changes

2d domains with 64 fractures did not work due to the `edges` array being int8. This PR increases to int32 throughout the code (all inside fracs, mostly related to tagging). Thanks to @jwboth for provoking the bug!

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [x] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
