### PR TITLE
[MAINT] Integrated dynamic time-stepper into models

### DIFF
--- a/src/porepy/models/solution_strategy.py
+++ b/src/porepy/models/solution_strategy.py
@@ -135,7 +135,7 @@ class SolutionStrategy(abc.ABC):
         self.solid: pp.SolidConstants
         """Solid constants. See also :meth:`set_materials`."""
 
-        self.time_manager = params.get(
+        self.time_manager: pp.TimeManager = params.get(
             "time_manager",
             pp.TimeManager(schedule=[0, 1], dt_init=1, constant_dt=True),
         )
@@ -434,13 +434,22 @@ class SolutionStrategy(abc.ABC):
         )
         self.nonlinear_solver_statistics.num_iteration += 1
 
-    def after_nonlinear_convergence(self) -> None:
+    def after_nonlinear_convergence(self, iteration_counter: int) -> None:
         """Method to be called after every non-linear iteration.
 
         Possible usage is to distribute information on the solution, visualization, etc.
 
+        Parameters:
+            iteration_counter: Number of nonlinear solver iterations before convergence.
+                Used for time step adaptation.
+
         """
         solution = self.equation_system.get_variable_values(iterate_index=0)
+
+        # Update the time step magnitude if the dynamic scheme is used.
+        if not self.time_manager.is_constant:
+            self.time_manager.compute_time_step(iterations=iteration_counter)
+
         self.equation_system.shift_time_step_values(
             max_index=len(self.time_step_indices)
         )
@@ -451,12 +460,24 @@ class SolutionStrategy(abc.ABC):
         self.save_data_time_step()
 
     def after_nonlinear_failure(self) -> None:
-        """Method to be called if the non-linear solver fails to converge."""
+        """Method to be called if the non-linear solver fails to converge.
+
+        Parameters:
+            iteration_counter: Number of nonlinear solver iterations before failure.
+                Used for time step adaptation.
+
+        """
         self.save_data_time_step()
-        if self._is_nonlinear_problem():
+        if not self._is_nonlinear_problem():
+            raise ValueError("Tried solving singular matrix for the linear problem.")
+
+        if self.time_manager.is_constant:
+            # We cannot decrease the constant time step.
             raise ValueError("Nonlinear iterations did not converge.")
         else:
-            raise ValueError("Tried solving singular matrix for the linear problem.")
+            # Update the time step magnitude if the dynamic scheme is used.
+            # Note: It will also raise a ValueError if the minimal time step is reached.
+            self.time_manager.compute_time_step(recompute_solution=True)
 
     def after_simulation(self) -> None:
         """Run at the end of simulation. Can be used for cleanup etc."""

--- a/src/porepy/models/solution_strategy.py
+++ b/src/porepy/models/solution_strategy.py
@@ -460,13 +460,7 @@ class SolutionStrategy(abc.ABC):
         self.save_data_time_step()
 
     def after_nonlinear_failure(self) -> None:
-        """Method to be called if the non-linear solver fails to converge.
-
-        Parameters:
-            iteration_counter: Number of nonlinear solver iterations before failure.
-                Used for time step adaptation.
-
-        """
+        """Method to be called if the non-linear solver fails to converge."""
         self.save_data_time_step()
         if not self._is_nonlinear_problem():
             raise ValueError("Failed to solve linear system for the linear problem.")

--- a/src/porepy/models/solution_strategy.py
+++ b/src/porepy/models/solution_strategy.py
@@ -469,7 +469,7 @@ class SolutionStrategy(abc.ABC):
         """
         self.save_data_time_step()
         if not self._is_nonlinear_problem():
-            raise ValueError("Tried solving singular matrix for the linear problem.")
+            raise ValueError("Failed to solve linear system for the linear problem.")
 
         if self.time_manager.is_constant:
             # We cannot decrease the constant time step.

--- a/src/porepy/numerics/linear_solvers.py
+++ b/src/porepy/numerics/linear_solvers.py
@@ -68,7 +68,7 @@ class LinearSolver:
             # the case for ContactMechanics and possibly others). Thus, we first call
             # after_nonlinear_iteration(), and then after_nonlinear_convergence()
             setup.after_nonlinear_iteration(nonlinear_increment)
-            setup.after_nonlinear_convergence()
+            setup.after_nonlinear_convergence(iteration_counter=1)
         else:
             setup.after_nonlinear_failure()
         return is_converged

--- a/src/porepy/numerics/nonlinear/nonlinear_solvers.py
+++ b/src/porepy/numerics/nonlinear/nonlinear_solvers.py
@@ -121,10 +121,11 @@ class NewtonSolver:
                 newton_step()
 
                 if is_diverged:
-                    model.after_nonlinear_failure()
                     break
                 elif is_converged:
-                    model.after_nonlinear_convergence()
+                    model.after_nonlinear_convergence(
+                        iteration_counter=iteration_counter
+                    )
                     break
 
                 iteration_counter += 1
@@ -160,11 +161,12 @@ class NewtonSolver:
                         # If the process finishes early, the tqdm bar needs to be
                         # manually closed. See https://stackoverflow.com/a/73175351.
                         solver_progressbar.close()
-                        model.after_nonlinear_failure()
                         break
                     elif is_converged:
                         solver_progressbar.close()
-                        model.after_nonlinear_convergence()
+                        model.after_nonlinear_convergence(
+                            iteration_counter=iteration_counter
+                        )
                         break
 
                     iteration_counter += 1

--- a/src/porepy/numerics/nonlinear/nonlinear_solvers.py
+++ b/src/porepy/numerics/nonlinear/nonlinear_solvers.py
@@ -121,6 +121,7 @@ class NewtonSolver:
                 newton_step()
 
                 if is_diverged:
+                    # The nonlinear solver failure is handled after the loop.
                     break
                 elif is_converged:
                     model.after_nonlinear_convergence(
@@ -161,6 +162,7 @@ class NewtonSolver:
                         # If the process finishes early, the tqdm bar needs to be
                         # manually closed. See https://stackoverflow.com/a/73175351.
                         solver_progressbar.close()
+                        # The nonlinear solver failure is handled after the loop.
                         break
                     elif is_converged:
                         solver_progressbar.close()

--- a/src/porepy/numerics/time_step_control.py
+++ b/src/porepy/numerics/time_step_control.py
@@ -620,11 +620,21 @@ class TimeManager:
     def _correction_based_on_schedule(self) -> None:
         """Correct time step if time + dt > scheduled_time."""
         schedule_time = self.schedule[self._scheduled_idx]
-        if (self.time + self.dt) > schedule_time:
-            self.dt = schedule_time - self.time  # correct  time step
+        if self.time + self.dt > schedule_time:
+            self._scheduled_idx += 1  # Increaing index to catch next scheduled time.
+
+            if np.isclose(self.time, schedule_time, rtol=self.rtol, atol=self.atol):
+                # Scheduled time will be reached within tol, no need for correction.
+                if self._print_info:
+                    print(
+                        f"Not correcting time step to match scheduled time. Next dt ="
+                        f" {self.dt}."
+                    )
+                return
+
+            self.dt = schedule_time - self.time  # Correcting time step.
 
             if self._scheduled_idx < len(self.schedule) - 1:
-                self._scheduled_idx += 1  # increase index to catch next scheduled time
                 if self._print_info:
                     print(
                         f"Correcting time step to match scheduled time. Next dt ="

--- a/src/porepy/numerics/time_step_control.py
+++ b/src/porepy/numerics/time_step_control.py
@@ -621,7 +621,7 @@ class TimeManager:
         """Correct time step if time + dt > scheduled_time."""
         schedule_time = self.schedule[self._scheduled_idx]
         if self.time + self.dt > schedule_time:
-            self._scheduled_idx += 1  # Increaing index to catch next scheduled time.
+            self._scheduled_idx += 1  # Increase index to catch next scheduled time.
 
             if np.isclose(self.time, schedule_time, rtol=self.rtol, atol=self.atol):
                 # Scheduled time will be reached within tol, no need for correction.

--- a/tests/numerics/test_time_step_control.py
+++ b/tests/numerics/test_time_step_control.py
@@ -832,7 +832,8 @@ MAX_NONLINEAR_ITER = 10
             # iterations, etc. "unreachable" means that the convergence check should not
             # be called due to exceeding the iteration limit.
             "time_step_converged": [False, True, "unreachable"] + [True] * 5,
-            # Time step magnitudes to compare with.
+            # Time step magnitudes to compare with. These are known values produced with the settings
+            # of the TimeStepper found in the test function below.
             "dt_history_expected": [1, 0.3, 0.6, 0.18, 0.36, 0.36, 0.144, 0.006],
         },
         # Case 2: constant_dt. Should fail after nonlinear divergence.

--- a/tests/numerics/test_time_step_control.py
+++ b/tests/numerics/test_time_step_control.py
@@ -750,7 +750,7 @@ class TestTimeControl:
         pth.unlink()
 
 
-class DynamicTimeStepTestCaseModel(SquareDomainOrthogonalFractures, SinglePhaseFlow):
+class DynamicTimeStepTestCaseModel(SinglePhaseFlow):
     """A mockup model that overrides `check_convergence` and predefines convergence
     behavior after each nonlinear iteration.
 
@@ -764,7 +764,7 @@ class DynamicTimeStepTestCaseModel(SquareDomainOrthogonalFractures, SinglePhaseF
         time_step_converged: list,
         params: dict,
     ):
-        super().__init__(params | {"fracture_indices": []})
+        super().__init__(params)
         self.time_step_idx: int = -1
         self.nonlinear_iter_idx: int = 0
         self.num_nonlinear_iterations: list[int] = num_nonlinear_iterations
@@ -832,8 +832,8 @@ MAX_NONLINEAR_ITER = 10
             # iterations, etc. "unreachable" means that the convergence check should not
             # be called due to exceeding the iteration limit.
             "time_step_converged": [False, True, "unreachable"] + [True] * 5,
-            # Time step magnitudes to compare with. These are known values produced with the settings
-            # of the TimeStepper found in the test function below.
+            # Time step magnitudes to compare with. These are known values produced with
+            # the settings of the TimeStepper found in the test function below.
             "dt_history_expected": [1, 0.3, 0.6, 0.18, 0.36, 0.36, 0.144, 0.006],
         },
         # Case 2: constant_dt. Should fail after nonlinear divergence.


### PR DESCRIPTION
## Proposed changes

Dynamic time stepping is a feature of `TimeManager` which was not supported by the models #739. This also fixes the bug mentioned in #1152 and fixes the newly found bug which caused to call `after_nonlinear_failure` twice. I'll point on it at the review.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [x] Bugfix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
