### PR TITLE
TST: Improved TimeManager integration test

### DIFF
--- a/tests/numerics/test_time_step_control.py
+++ b/tests/numerics/test_time_step_control.py
@@ -772,12 +772,18 @@ class DynamicTimeStepTestCaseModel(SinglePhaseFlow):
         self.time_step_history: list = []
 
     def before_nonlinear_loop(self) -> None:
+        super().before_nonlinear_loop()  # The AD time step is expected to update here.
         self.time_step_idx += 1
         self.nonlinear_iter_idx = -1
         self.time_step_history.append(self.time_manager.dt)
 
     def before_nonlinear_iteration(self):
+        super().before_nonlinear_iteration()
         self.nonlinear_iter_idx += 1
+        # The AD time step should not change throughout the Newton iterations.
+        assert (
+            self.ad_time_step.value(self.equation_system) == self.time_manager.dt
+        ), "The AD time step value conflicts with the value from the time_manager."
 
     def _is_nonlinear_problem(self):
         return True


### PR DESCRIPTION
## Proposed changes

Following @IvarStefansson's suggestion [here](https://github.com/pmgbergen/porepy/pull/1188#pullrequestreview-2115306343), I add one more check to the test. It checks that the AD time step scalar actually receives the updated value of the time step.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
