### PR TITLE
Freeze scipy < 1.14

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ networkx
 numba >= 0.57
 numpy < 2.0
 requests
-scipy
+scipy < 1.14
 seaborn
 shapely
 six


### PR DESCRIPTION
## Proposed changes
Scipy v 1.14 introduces changes that make the tests fail. This PR freezes scipy to a safe version.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [x] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
