### PR TITLE
Improvements and fixes for the dynamic time stepper

### DIFF
--- a/src/porepy/models/solution_strategy.py
+++ b/src/porepy/models/solution_strategy.py
@@ -498,6 +498,11 @@ class SolutionStrategy(abc.ABC):
             # Note: It will also raise a ValueError if the minimal time step is reached.
             self.time_manager.compute_time_step(recompute_solution=True)
 
+            # Reset the iterate values. This ensures that the initial guess for an
+            # unknown time step equals the known time step.
+            prev_solution = self.equation_system.get_variable_values(time_step_index=0)
+            self.equation_system.set_variable_values(prev_solution, iterate_index=0)
+
     def after_simulation(self) -> None:
         """Run at the end of simulation. Can be used for cleanup etc."""
         pass

--- a/src/porepy/numerics/time_step_control.py
+++ b/src/porepy/numerics/time_step_control.py
@@ -467,7 +467,7 @@ class TimeManager:
         self._recomp_sol = recompute_solution
         self._iters = iterations
 
-        # First, check if we reach final simulation time
+        # First, check if we reach final simulation time with a valid solution
         if not recompute_solution and self.final_time_reached():
             return None
 

--- a/src/porepy/numerics/time_step_control.py
+++ b/src/porepy/numerics/time_step_control.py
@@ -97,6 +97,8 @@ from typing import Optional, Union
 import numpy as np
 from numpy.typing import ArrayLike
 
+import porepy as pp
+
 __all__ = ["TimeManager"]
 
 
@@ -343,6 +345,9 @@ class TimeManager:
         self.schedule = schedule
         self.time_init = schedule[0]
         self.time_final = schedule[-1]
+        self._is_about_to_hit_schedule: bool = False
+        """This flag indicates that we expect the current time step to step over the
+        schedule point. Used to step back in the schedule if we did not converge."""
 
         # Initial time step
         self.dt_init = dt_init
@@ -393,6 +398,23 @@ class TimeManager:
         # Keep track of recomputed solutions and current number of iterations
         self._recomp_sol: bool = False
         self._iters: Union[int, None] = None
+
+        # Book keeping of saved time steps for restarting purposes.
+        self.dt_history: list[pp.number] = []
+        """A list of time steps for the simulation states that were saved on disk with
+        `write_time_information` for restarting purposes. Completeness and lack of
+        duplication are NOT guaranteed.
+
+        NOTE: This property cannot be inferred from `time_history`, consider the case
+        when not every time step is saved.
+
+        """
+        self.time_history: list[pp.number] = []
+        """A list of time points for the simulation states that were saved on disk with
+        `write_time_information` for restarting purposes. Completeness and lack of
+        duplication are NOT guaranteed.
+
+        """
 
     def __repr__(self) -> str:
         s = "Time-stepping control object with attributes:\n"
@@ -446,7 +468,7 @@ class TimeManager:
         self._iters = iterations
 
         # First, check if we reach final simulation time
-        if self.final_time_reached():
+        if not recompute_solution and self.final_time_reached():
             return None
 
         # If the time step is constant, always return that value
@@ -570,6 +592,8 @@ class TimeManager:
             #   (S3) Decrease time step multiplying it by the recomputing factor < 1.
             #   (S4) Increase counter that keeps track of the number of times the
             #        solution was recomputed.
+            #   (S5) Step back in the schedule if we expected to meet the next schedule
+            #        point.
 
             # Note that iterations is not really used here. So, as long as
             # recompute_solution = True and recomputation_attempts <
@@ -582,6 +606,9 @@ class TimeManager:
             self.time_index -= 1  # (S2)
             self.dt *= self.recomp_factor  # (S3)
             self._recomp_num += 1  # (S4)
+            if self._is_about_to_hit_schedule:  # (S5)
+                self._scheduled_idx -= 1
+
             if self._print_info:
                 msg = (
                     "Solution did not converge and will be recomputed."
@@ -620,7 +647,11 @@ class TimeManager:
     def _correction_based_on_schedule(self) -> None:
         """Correct time step if time + dt > scheduled_time."""
         schedule_time = self.schedule[self._scheduled_idx]
+
+        self._is_about_to_hit_schedule = False
+
         if self.time + self.dt > schedule_time:
+            self._is_about_to_hit_schedule = True
             self._scheduled_idx += 1  # Increase index to catch next scheduled time.
 
             if np.isclose(self.time, schedule_time, rtol=self.rtol, atol=self.atol):
@@ -703,13 +734,6 @@ class TimeManager:
                 a default path within the default 'visualization' folder is used.
 
         """
-        # Initialization
-        if not hasattr(self, "time_history"):
-            self.time_history = []
-            """Collection of all visited physical times."""
-        if not hasattr(self, "dt_history"):
-            self.dt_history = []
-            """Collection of all used time step sizes."""
 
         # Book keeping
         self.time_history.append(
@@ -746,6 +770,8 @@ class TimeManager:
     def set_from_history(self, time_index: int = -1) -> None:
         """Load previous visited history for resuming, and cut-off afterward
         history.
+
+        NOTE: This method by itself does NOT update the simulation state arrays.
 
         NOTE: It is implicitly assumed that the first entry of the history corresponds
         to the initial solution.

--- a/tests/numerics/test_time_step_control.py
+++ b/tests/numerics/test_time_step_control.py
@@ -387,22 +387,30 @@ class TestParameterInputs:
 
 
 class TestTimeControl:
-    """The following tests are written to check the overall behavior of the time-stepping
-    algorithm"""
+    """The following tests are written to check the overall behavior of the
+    time-stepping algorithm"""
 
-    def test_final_simulation_time(self):
-        """Test if final simulation time returns None, irrespectively of parameters
-        passed in next_time_step()."""
+    @pytest.mark.parametrize("recompute_solution", [False, True])
+    @pytest.mark.parametrize(
+        "time",
+        [
+            1,  # We reach the final time
+            2,  # We are above the final time
+        ],
+    )
+    def test_final_simulation_time(self, recompute_solution: bool, time: int):
+        """Test if final simulation time returns None if we do not ask to recompute the
+        solution"""
         # Assume we reach the final time
         time_manager = pp.TimeManager(schedule=[0, 1], dt_init=0.1)
-        time_manager.time = 1
-        dt = time_manager.compute_time_step(iterations=1000, recompute_solution=True)
-        assert dt is None
-        # Now, assume we are above the final time
-        time_manager = pp.TimeManager(schedule=[0, 1], dt_init=0.1)
-        time_manager.time = 2
-        dt = time_manager.compute_time_step(iterations=0, recompute_solution=False)
-        assert dt is None
+        time_manager.time = time
+        dt = time_manager.compute_time_step(
+            iterations=1000, recompute_solution=recompute_solution
+        )
+        if recompute_solution:
+            assert dt is not None
+        else:
+            assert dt is None
 
     @pytest.mark.parametrize(
         "schedule, dt_init, time, time_index, iters, recomp_sol",


### PR DESCRIPTION
## Proposed changes

Fixed a bug of dynamic time stepping when a time step failed right before meeting the schedule. Also improved documentation a bit.

Update: This also addresses the issue with resetting the iterate values after an unsuccessful time step.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [x] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Testing (contribution related to testing of existing or new functionality).
- [x] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
