### PR TITLE
1196-adaptivity-of-solutionstatistics

### DIFF
--- a/src/porepy/models/solution_strategy.py
+++ b/src/porepy/models/solution_strategy.py
@@ -68,6 +68,8 @@ class SolutionStrategy(abc.ABC):
     :class:`~porepy.viz.exporter.Exporter`.
 
     """
+    nonlinear_solver_statistics: pp.SolverStatistics
+    """Solver statistics for the nonlinear solver."""
     update_all_boundary_conditions: Callable[[], None]
     """Set the values of the boundary conditions for the new time step.
     Defined in :class:`~porepy.models.abstract_equations.BoundaryConditionsMixin`.

--- a/src/porepy/models/solution_strategy.py
+++ b/src/porepy/models/solution_strategy.py
@@ -12,7 +12,7 @@ import logging
 import time
 import warnings
 from pathlib import Path
-from typing import Any, Callable, Optional, Type
+from typing import Any, Callable, Optional
 
 import numpy as np
 import scipy.sparse as sps

--- a/src/porepy/models/solution_strategy.py
+++ b/src/porepy/models/solution_strategy.py
@@ -8,11 +8,12 @@ keep them separate, to avoid breaking existing code (legacy models).
 from __future__ import annotations
 
 import abc
+from dataclasses import dataclass
 import logging
 import time
 import warnings
 from pathlib import Path
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Optional, Type
 
 import numpy as np
 import scipy.sparse as sps
@@ -183,11 +184,7 @@ class SolutionStrategy(abc.ABC):
         is adjusted during simulation. See :meth:`before_nonlinear_loop`.
 
         """
-
-        self.nonlinear_solver_statistics = self.params.get(
-            "nonlinear_solver_statistics", pp.SolverStatistics
-        )()
-        """Statistics object for non-linear solver loop."""
+        self.set_solver_statistics()
 
     def prepare_simulation(self) -> None:
         """Run at the start of simulation. Used for initialization etc."""
@@ -229,6 +226,17 @@ class SolutionStrategy(abc.ABC):
         the permeability, the porosity, etc.
 
         """
+
+    def set_solver_statistics(self) -> None:
+        """Set the solver statistics object.
+
+        This method is called at initialization. It is intended to be used to
+        set the solver statistics object(s). Currently, the solver statistics
+        object is related to nonlinearity only. Statistics on linear solvers
+        may be added in the future.
+
+        """
+        self.nonlinear_solver_statistics = pp.SolverStatistics()
 
     def initial_condition(self) -> None:
         """Set the initial condition for the problem.

--- a/src/porepy/models/solution_strategy.py
+++ b/src/porepy/models/solution_strategy.py
@@ -184,7 +184,9 @@ class SolutionStrategy(abc.ABC):
 
         """
 
-        self.nonlinear_solver_statistics = pp.SolverStatistics()
+        self.nonlinear_solver_statistics = self.params.get(
+            "nonlinear_solver_statistics", pp.SolverStatistics
+        )()
         """Statistics object for non-linear solver loop."""
 
     def prepare_simulation(self) -> None:

--- a/src/porepy/models/solution_strategy.py
+++ b/src/porepy/models/solution_strategy.py
@@ -233,24 +233,25 @@ class SolutionStrategy(abc.ABC):
 
         This method is called at initialization. It is intended to be used to
         set the solver statistics object(s). Currently, the solver statistics
-        object is related to nonlinearity only. Statistics on linear solvers
-        may be added in the future.
+        object is related to nonlinearity only. Statistics on other parts of the
+        solution process, such as linear solvers, may be added in the future.
+
+        Raises:
+            ValueError: If the solver statistics object is not a subclass of
+                pp.SolverStatistics.
 
         """
         # Retrieve the value with a default of pp.SolverStatistics
-        statistics_candidate = self.params.get(
-            "nonlinear_solver_statistics",
-        )
+        statistics = self.params.get("nonlinear_solver_statistics", pp.SolverStatistics)
         # Explicitly check if the retrieved value is a class and a subclass of
         # pp.SolverStatistics for type checking.
-        if isinstance(statistics_candidate, type) and issubclass(
-            statistics_candidate, pp.SolverStatistics
-        ):
-            statistics: Type[pp.SolverStatistics] = statistics_candidate
+        if isinstance(statistics, type) and issubclass(statistics, pp.SolverStatistics):
+            self.nonlinear_solver_statistics = statistics()
+
         else:
-            # Default to pp.SolverStatistics if the check fails
-            statistics = pp.SolverStatistics
-        self.nonlinear_solver_statistics = statistics()
+            raise ValueError(
+                f"Expected a subclass of pp.SolverStatistics, got {statistics}."
+            )
 
     def initial_condition(self) -> None:
         """Set the initial condition for the problem.

--- a/src/porepy/models/solution_strategy.py
+++ b/src/porepy/models/solution_strategy.py
@@ -236,7 +236,20 @@ class SolutionStrategy(abc.ABC):
         may be added in the future.
 
         """
-        self.nonlinear_solver_statistics = pp.SolverStatistics()
+        # Retrieve the value with a default of pp.SolverStatistics
+        statistics_candidate = self.params.get(
+            "nonlinear_solver_statistics",
+        )
+        # Explicitly check if the retrieved value is a class and a subclass of
+        # pp.SolverStatistics for type checking.
+        if isinstance(statistics_candidate, type) and issubclass(
+            statistics_candidate, pp.SolverStatistics
+        ):
+            statistics: Type[pp.SolverStatistics] = statistics_candidate
+        else:
+            # Default to pp.SolverStatistics if the check fails
+            statistics = pp.SolverStatistics
+        self.nonlinear_solver_statistics = statistics()
 
     def initial_condition(self) -> None:
         """Set the initial condition for the problem.

--- a/src/porepy/models/solution_strategy.py
+++ b/src/porepy/models/solution_strategy.py
@@ -8,7 +8,6 @@ keep them separate, to avoid breaking existing code (legacy models).
 from __future__ import annotations
 
 import abc
-from dataclasses import dataclass
 import logging
 import time
 import warnings

--- a/src/porepy/numerics/nonlinear/nonlinear_solvers.py
+++ b/src/porepy/numerics/nonlinear/nonlinear_solvers.py
@@ -120,6 +120,8 @@ class NewtonSolver:
             ):
                 newton_step()
 
+                iteration_counter += 1
+
                 if is_diverged:
                     # The nonlinear solver failure is handled after the loop.
                     break
@@ -128,8 +130,6 @@ class NewtonSolver:
                         iteration_counter=iteration_counter
                     )
                     break
-
-                iteration_counter += 1
 
         # Progressbars turned on:
         else:
@@ -153,6 +153,8 @@ class NewtonSolver:
                         f"""{self.params['max_iterations']}"""
                     )
                     newton_step()
+                    iteration_counter += 1
+
                     solver_progressbar.update(n=1)
                     solver_progressbar.set_postfix_str(
                         f"Increment {nonlinear_increment_norm:.3E}"
@@ -170,8 +172,6 @@ class NewtonSolver:
                             iteration_counter=iteration_counter
                         )
                         break
-
-                    iteration_counter += 1
 
         if not is_converged:
             model.after_nonlinear_failure()


### PR DESCRIPTION
## Proposed changes

This PR resolves #1196 by allowing passing of a solver statistics class, which can be a tailored version of `SolverStatistics`. Also resolves #1200 by swapping order of operations inside a Newton iteration.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [x] Bugfix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
