### PR TITLE
BUG: Safeguard against wrong "scaling" passed

### DIFF
--- a/src/porepy/grids/match_grids.py
+++ b/src/porepy/grids/match_grids.py
@@ -132,6 +132,10 @@ def match_2d(
 
             Control weights of the returned matrix, see return values for specification.
 
+    Raises:
+        ValueError if an unknown scaling is passed.
+
+
     Returns:
         Mapping from the cells in the old to the new grid.
 
@@ -220,6 +224,8 @@ def match_2d(
         new_g_ind = new_g_ind[mask]
         old_g_ind = old_g_ind[mask]
         weights = np.ones_like(new_g_ind)
+    else:
+        raise ValueError("Unknown scaling option passed.")
 
     return sps.coo_matrix(
         (weights, (new_g_ind, old_g_ind)), shape=(new_g.num_cells, old_g.num_cells)

--- a/src/porepy/grids/match_grids.py
+++ b/src/porepy/grids/match_grids.py
@@ -225,7 +225,7 @@ def match_2d(
         old_g_ind = old_g_ind[mask]
         weights = np.ones_like(new_g_ind)
     else:
-        raise ValueError("Unknown scaling option passed.")
+        raise ValueError(f"Unknown scaling option {scaling} passed.")
 
     return sps.coo_matrix(
         (weights, (new_g_ind, old_g_ind)), shape=(new_g.num_cells, old_g.num_cells)


### PR DESCRIPTION
## Proposed changes

Passing of wrong parameter caused unwanted behaviour due to the last elif in the function being False.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [x] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
