### PR TITLE
Make the code compatible with numpy v2.0, scipy v1.14

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,9 @@ matplotlib
 meshio >= 5.0
 networkx
 numba >= 0.57
-numpy < 2.0
+numpy
 requests
-scipy < 1.14
+scipy
 seaborn
 shapely
 six

--- a/src/porepy/applications/test_utils/common_xpfa_tests.py
+++ b/src/porepy/applications/test_utils/common_xpfa_tests.py
@@ -140,7 +140,7 @@ def _test_laplacian_stencil_cart_2d(discr_matrices_func):
     g, perm, bound = _setup_cart_2d(nx, dir_faces)
     div, flux, bound_flux, _ = discr_matrices_func(g, perm, bound)
     A = div * flux
-    b = -(div * bound_flux).A
+    b = -(div * bound_flux).toarray()
 
     # Checks on interior cell
     mid = 4
@@ -183,7 +183,7 @@ def _test_laplacian_stensil_cart_2d_periodic_bcs(discr_matrices_func):
     bound = pp.BoundaryCondition(g)
     div, flux, bound_flux, _ = discr_matrices_func(g, perm, bound)
     a = div * flux
-    b = -(div * bound_flux).A
+    b = -(div * bound_flux).toarray()
 
     # Create laplace matrix
     A_lap = np.array(
@@ -199,7 +199,7 @@ def _test_laplacian_stensil_cart_2d_periodic_bcs(discr_matrices_func):
             [0.0, 0.0, -1.0, 0.0, 0.0, -1.0, -1.0, -1.0, 4.0],
         ]
     )
-    assert np.allclose(a.A, A_lap)
+    assert np.allclose(a.toarray(), A_lap)
     assert np.allclose(b, 0)
 
 
@@ -604,8 +604,8 @@ def _test_gravity_2d_horizontal_periodic_ambient_dim_2(method):
         )
     )
 
-    assert np.allclose(A.A, A_known)
-    assert np.allclose(vector_source_discr.A, vct_src_known)
+    assert np.allclose(A.toarray(), A_known)
+    assert np.allclose(vector_source_discr.toarray(), vct_src_known)
 
 
 class XpfaBoundaryPressureTests:
@@ -941,8 +941,9 @@ def test_split_discretization_into_subproblems(
                     # stored in a dictionary, compare the individual matrices.
                     for sub_key in data_with:
                         assert np.allclose(
-                            data_with[sub_key].A, data_without[sub_key].A
+                            data_with[sub_key].toarray(),
+                            data_without[sub_key].toarray(),
                         )
                 else:
                     # The matrices are stored directly in the data dictionary.
-                    assert np.allclose(data_with.A, data_without.A)
+                    assert np.allclose(data_with.toarray(), data_without.toarray())

--- a/src/porepy/fracs/fracture_network_2d.py
+++ b/src/porepy/fracs/fracture_network_2d.py
@@ -501,7 +501,7 @@ class FractureNetwork2d:
 
         # map the constraint index
         index_map = np.where(np.logical_not(to_delete))[0]
-        mapped_constraints = np.arange(index_map.size)[np.in1d(index_map, constraints)]
+        mapped_constraints = np.arange(index_map.size)[np.isin(index_map, constraints)]
 
         # update the tags
         for key, value in self.tags.items():

--- a/src/porepy/fracs/fracture_network_3d.py
+++ b/src/porepy/fracs/fracture_network_3d.py
@@ -522,13 +522,13 @@ class FractureNetwork3d(object):
             if has_boundary:
                 is_boundary = np.array(self.tags["boundary"])[unique_fracs]
                 is_frac = np.logical_not(
-                    np.logical_or(np.in1d(unique_fracs, constraints), is_boundary)
+                    np.logical_or(np.isin(unique_fracs, constraints), is_boundary)
                 )
                 is_frac_or_boundary = np.logical_not(
-                    np.in1d(unique_fracs, constraints),
+                    np.isin(unique_fracs, constraints),
                 )
             else:
-                is_frac = np.logical_not(np.in1d(unique_fracs, constraints))
+                is_frac = np.logical_not(np.isin(unique_fracs, constraints))
                 is_frac_or_boundary = is_frac
 
             # If more than one fracture share this point, it is an intersection
@@ -2149,7 +2149,7 @@ class FractureNetwork3d(object):
         # Loop over edges, and the polygons to which the edge belongs
         for e, e2f in enumerate(edges_2_frac):
             # Check if the polygons are on the boundary
-            edge_of_domain_boundary = np.in1d(e2f, boundary_polygons)
+            edge_of_domain_boundary = np.isin(e2f, boundary_polygons)
 
             if any(edge_of_domain_boundary):
                 # If all associated polygons are boundary, this is simple

--- a/src/porepy/fracs/meshing.py
+++ b/src/porepy/fracs/meshing.py
@@ -286,7 +286,7 @@ def _tag_faces(grids, check_highest_dim=True):
                 nodes_glb = g.global_point_ind[nodes_loc]
                 # We then tag each node as a tip node if it is not a global
                 # boundary node
-                node_on_tip_not_global_bnd = np.in1d(
+                node_on_tip_not_global_bnd = np.isin(
                     nodes_glb, bnd_nodes_glb, invert=True
                 )
 

--- a/src/porepy/fracs/split_grid.py
+++ b/src/porepy/fracs/split_grid.py
@@ -971,7 +971,7 @@ def _duplicate_nodes_with_offset(g: pp.Grid, nodes: np.ndarray, offset: float) -
             assert isinstance(all_faces, np.ndarray)  # Appease mypy
             colored_faces = np.unique(all_faces)
 
-            is_colored = np.in1d(faces_of_node_t, colored_faces, assume_unique=True)
+            is_colored = np.isin(faces_of_node_t, colored_faces, assume_unique=True)
 
             faces = np.append(faces, faces_of_node_t[is_colored])
 
@@ -1141,7 +1141,7 @@ def remove_nodes(g: pp.Grid, rem: np.ndarray) -> pp.Grid:
 
     """
     all_rows = np.arange(g.face_nodes.shape[0])
-    rows_to_keep = np.where(np.logical_not(np.in1d(all_rows, rem)))[0]
+    rows_to_keep = np.where(np.logical_not(np.isin(all_rows, rem)))[0]
     g.face_nodes = g.face_nodes[rows_to_keep, :]
     g.nodes = g.nodes[:, rows_to_keep]
     return g

--- a/src/porepy/grids/coarsening.py
+++ b/src/porepy/grids/coarsening.py
@@ -182,7 +182,7 @@ def generate_seeds(mdg: Union[pp.Grid, pp.MixedDimensionalGrid]) -> np.ndarray:
     for g in gs:
         tips = np.where(g.tags["tip_faces"])[0]
         faces, cells, _ = sparse_array_to_row_col_data(g.cell_faces)
-        index = np.in1d(faces, tips).nonzero()[0]
+        index = np.isin(faces, tips).nonzero()[0]
         cells = np.unique(cells[index])
 
         # recover the mapping between the secondary and the primary grid
@@ -193,8 +193,8 @@ def generate_seeds(mdg: Union[pp.Grid, pp.MixedDimensionalGrid]) -> np.ndarray:
         face_cells = secondary_to_mortar.T * primary_to_mortar
 
         interf_cells, interf_faces, _ = sparse_array_to_row_col_data(face_cells)
-        index = np.in1d(interf_cells, cells).nonzero()[0]
-        index = np.in1d(g_h_faces, interf_faces[index]).nonzero()[0]
+        index = np.isin(interf_cells, cells).nonzero()[0]
+        index = np.isin(g_h_faces, interf_faces[index]).nonzero()[0]
         seeds = np.concatenate((seeds, g_h_cells[index]))
 
     return seeds
@@ -704,7 +704,7 @@ def _generate_coarse_grid_mdg(
 
                 # Map indices
                 mask = np.argsort(indices)
-                indices = np.in1d(face_map[0, :], indices[mask]).nonzero()[0]
+                indices = np.isin(face_map[0, :], indices[mask]).nonzero()[0]
                 # Reverse the ordering
                 indices = indices[np.argsort(mask)]
 
@@ -727,7 +727,7 @@ def _generate_coarse_grid_mdg(
 
             # map indices
             mask = np.argsort(indices)
-            indices = np.in1d(face_map[0, :], indices[mask]).nonzero()[0]
+            indices = np.isin(face_map[0, :], indices[mask]).nonzero()[0]
             face_cells.indices = indices[np.argsort(mask)]
 
             # update the map

--- a/src/porepy/grids/mortar_grid.py
+++ b/src/porepy/grids/mortar_grid.py
@@ -880,7 +880,7 @@ class MortarGrid:
             and (face_duplicate_ind is not None)
             and self.codim < 2
         ):
-            is_second_side = np.in1d(primary_f, face_duplicate_ind)
+            is_second_side = np.isin(primary_f, face_duplicate_ind)
             secondary_f = np.r_[
                 secondary_f[~is_second_side], secondary_f[is_second_side]
             ]

--- a/src/porepy/grids/partition.py
+++ b/src/porepy/grids/partition.py
@@ -637,7 +637,7 @@ def _extract_cells_from_faces_2d(
     cell_faces_indices = cell_nodes.indices
     data = -1 * cell_nodes.data
     _, ix = np.unique(cell_faces_indices, return_index=True)
-    data[ix] *= -1
+    data[ix.ravel()] *= -1
 
     cell_faces = sps.csc_matrix((data, cell_faces_indices, cell_nodes.indptr))
 
@@ -735,6 +735,7 @@ def _extract_cells_from_faces_3d(
     _, IA, IC = np.unique(
         face_nodes_sorted, return_index=True, return_inverse=True, axis=1
     )
+    IC = IC.ravel()
 
     face_nodes_indices = face_nodes_indices[:, IA].ravel("F")
     num_face_nodes = face_nodes_indices.size
@@ -749,7 +750,7 @@ def _extract_cells_from_faces_3d(
 
     data = np.ones(IC.shape)
     _, ix = np.unique(IC, return_index=True)
-    data[ix] *= -1
+    data[ix.ravel()] *= -1
 
     cell_faces = sps.coo_matrix((data, (IC, cell_idx))).tocsc()
 

--- a/src/porepy/numerics/fracture_deformation/conforming_propagation.py
+++ b/src/porepy/numerics/fracture_deformation/conforming_propagation.py
@@ -704,7 +704,7 @@ class ConformingFracturePropagation(FracturePropagation):
             for i in range(local_nodes.size - 1):
                 e = [local_nodes[i + j] for j in range(sd_secondary.dim)]
 
-                if np.all(np.in1d(e, edge_primary)):
+                if np.all(np.isin(e, edge_primary)):
                     # The edge which we are splitting
                     continue
                 # Identify whether the edge is on a fracture. If so, remove the

--- a/src/porepy/numerics/fracture_deformation/propagate_fracture.py
+++ b/src/porepy/numerics/fracture_deformation/propagate_fracture.py
@@ -358,7 +358,7 @@ def _update_mortar_grid(
         # Pick those of the other faces that were not added during splitting
         old_other_faces = np.setdiff1d(other_faces, new_faces_h)
 
-        if np.any(np.in1d(old_other_faces, other_side_old)):
+        if np.any(np.isin(old_other_faces, other_side_old)):
             other_side_new = np.append(other_side_new, loc_faces[0])
         else:
             other_side_new = np.append(other_side_new, loc_faces[1])
@@ -684,7 +684,7 @@ def _update_connectivity_fracture_grid(
         # Faces that existed before the cell loop
         ind_in_original = existing_faces_l[are_in_original]
         # Index of these faces in cf_val_loc
-        indata_secondaryocal = np.in1d(all_local_faces, ind_in_original)
+        indata_secondaryocal = np.isin(all_local_faces, ind_in_original)
 
         if sd_secondary.cell_faces[ind_in_original].data.size != ind_in_original.size:
             # This situation can happen in 3d (perhaps also 2d).
@@ -704,7 +704,7 @@ def _update_connectivity_fracture_grid(
         # of the cell loop
         ind_not_in_original = existing_faces_l[~are_in_original]
         # Index of these faces in cf_val_loc
-        ind_not_local = np.in1d(all_local_faces, ind_not_in_original)
+        ind_not_local = np.isin(all_local_faces, ind_not_in_original)
         # These are assigned the value -1; since it was given +1 when first added
         # to cf_val (see call cf_val_loc[~exist] above)
         cf_val_loc[ind_not_local] = -1
@@ -780,7 +780,7 @@ def _update_nodes_fracture_grid(
     # Some of the nodes of the face to be split will be in sd_secondary already (as tip nodes)
     # Find which are present, and which should be added
     # NOTE: This comparison must be done in terms of global_point_ind
-    are_old_global_nodes_in_l = np.in1d(
+    are_old_global_nodes_in_l = np.isin(
         unique_global_nodes, sd_secondary.global_point_ind
     )
     are_new_global_nodes_in_l = np.logical_not(are_old_global_nodes_in_l)

--- a/src/porepy/numerics/fv/biot.py
+++ b/src/porepy/numerics/fv/biot.py
@@ -470,7 +470,7 @@ class Biot(pp.Mpsa):
             # interaction regions may be structured so that some faces have previously
             # been partially discretized even if it has not been their turn until now)
             eliminate_face = np.where(
-                np.logical_not(np.in1d(l2g_faces, faces_in_subgrid))
+                np.logical_not(np.isin(l2g_faces, faces_in_subgrid))
             )[0]
             pp.fvutils.remove_nonlocal_contribution(
                 eliminate_face,
@@ -484,7 +484,7 @@ class Biot(pp.Mpsa):
             )
 
             eliminate_cell = np.where(
-                np.logical_not(np.in1d(l2g_cells, cells_in_subgrid))
+                np.logical_not(np.isin(l2g_cells, cells_in_subgrid))
             )[0]
             pp.fvutils.remove_nonlocal_contribution(
                 eliminate_cell,

--- a/src/porepy/numerics/fv/fvutils.py
+++ b/src/porepy/numerics/fv/fvutils.py
@@ -256,7 +256,7 @@ def compute_dist_face_cell(sd, subcell_topology, eta, return_paired=True):
     elif np.asarray(eta).size == 1:
         eta_vec = eta * np.ones(subcell_topology.fno.size)
         # Set eta values to zero at the boundary
-        bnd = np.in1d(subcell_topology.fno, sd.get_all_boundary_faces())
+        bnd = np.isin(subcell_topology.fno, sd.get_all_boundary_faces())
         eta_vec[bnd] = 0
     else:
         raise ValueError("size of eta must either be 1 or number of subfaces")

--- a/src/porepy/numerics/fv/mpfa.py
+++ b/src/porepy/numerics/fv/mpfa.py
@@ -294,7 +294,7 @@ class Mpfa(pp.FVElliptic):
             # interaction regions may be structured so that some faces have previously
             # been partially discretized even if it has not been their turn until now)
             eliminate_face = np.where(
-                np.logical_not(np.in1d(l2g_faces, faces_in_subgrid))
+                np.logical_not(np.isin(l2g_faces, faces_in_subgrid))
             )[0]
             pp.fvutils.remove_nonlocal_contribution(eliminate_face, 1, *discr_fields)
 

--- a/src/porepy/numerics/fv/mpsa.py
+++ b/src/porepy/numerics/fv/mpsa.py
@@ -310,7 +310,7 @@ class Mpsa(Discretization):
             # interaction regions may be structured so that some faces have previously
             # been partially discretized even if it has not been their turn until now)
             eliminate_face = np.where(
-                np.logical_not(np.in1d(l2g_faces, faces_in_subgrid))
+                np.logical_not(np.isin(l2g_faces, faces_in_subgrid))
             )[0]
             pp.fvutils.remove_nonlocal_contribution(
                 eliminate_face,

--- a/src/porepy/params/bc.py
+++ b/src/porepy/params/bc.py
@@ -154,7 +154,7 @@ class BoundaryCondition(AbstractBoundaryCondition):
                                         array must match number of faces"""
                     )
                 faces = np.argwhere(faces)
-            if not np.all(np.in1d(faces, self.bf)):
+            if not np.all(np.isin(faces, self.bf)):
                 raise ValueError(
                     "Give boundary condition only on the \
                                  boundary"
@@ -162,7 +162,7 @@ class BoundaryCondition(AbstractBoundaryCondition):
             domain_boundary_and_tips = np.argwhere(
                 np.logical_or(sd.tags["domain_boundary_faces"], sd.tags["tip_faces"])
             )
-            if not np.all(np.in1d(faces, domain_boundary_and_tips)):
+            if not np.all(np.isin(faces, domain_boundary_and_tips)):
                 warnings.warn(
                     "You are now specifying conditions on internal \
                               boundaries. Be very careful!"
@@ -393,7 +393,7 @@ class BoundaryConditionVectorial(AbstractBoundaryCondition):
                     )
                 faces = np.argwhere(faces)
 
-            if not np.all(np.in1d(faces, self.bf)):
+            if not np.all(np.isin(faces, self.bf)):
                 raise ValueError("Give boundary condition only on the boundary")
             if isinstance(cond, str):
                 cond = [cond] * faces.size

--- a/src/porepy/utils/array_operations.py
+++ b/src/porepy/utils/array_operations.py
@@ -97,6 +97,7 @@ class SparseNdArray:
             return_inverse=True,
             return_counts=True,
         )
+        all_2_unique = all_2_unique.ravel()
 
         # Next, consolidate the values for duplicate coordinates.
         if additive:

--- a/src/porepy/utils/graph.py
+++ b/src/porepy/utils/graph.py
@@ -31,7 +31,7 @@ class Graph:
         else:
             self.node_connections = node_connections
         self.regions = 0
-        self.color = np.array([np.NaN] * node_connections.shape[1])
+        self.color = np.array([np.nan] * node_connections.shape[1])
 
     def color_nodes(self):
         """

--- a/src/porepy/utils/setmembership.py
+++ b/src/porepy/utils/setmembership.py
@@ -15,8 +15,7 @@ def unique_rows(data: np.ndarray[Any, np.dtype[np.float64]]) -> Tuple[
     np.ndarray[Any, np.dtype[np.int64]],
     np.ndarray[Any, np.dtype[np.int64]],
 ]:
-    """
-    Function similar to Matlab's unique(...,'rows')
+    """Function similar to Matlab's unique(...,'rows')
 
     See also function unique_columns in this module; this is likely slower, but
     is understandable, documented, and has a tolerance option.
@@ -26,14 +25,30 @@ def unique_rows(data: np.ndarray[Any, np.dtype[np.float64]]) -> Tuple[
     (summary pretty far down on the page)
     Note: I have no idea what happens here
 
+    Parameters:
+        data ``shape=(n, m)``.
+
+            Array to be uniquified along its first array.
+
+    Returns:
+        Uniquified array.
+
+        np.ndarray: ``shape=(n, r), r \leq m``. Unique rows.
+        
+        np.ndarray: ``shape=(r)`` Indexes that map from the unique to the original
+            array.
+
+        np.ndarray: ``shape=(m)`` Indexes that map from the original to the unique
+            array.
+
     """
     b = np.ascontiguousarray(data).view(
         np.dtype((np.void, data.dtype.itemsize * data.shape[1]))
     )
     _, ia = np.unique(b, return_index=True)
     _, ic = np.unique(b, return_inverse=True)
-    #    return np.unique(b).view(data.dtype).reshape(-1, data.shape[1]), ia, ic
-    return data[ia], ia, ic
+    # Ravel index data to get 1d output
+    return data[ia], ia.ravel(), ic.ravel()
 
 
 def ismember_rows(
@@ -94,6 +109,7 @@ def ismember_rows(
     # the indices which maps the unique array back to the original c
     if a.ndim > 1:
         _, ind = np.unique(c, axis=1, return_inverse=True)
+        ind = ind.ravel()
     else:
         _, ind = np.unique(c, return_inverse=True)
 
@@ -175,7 +191,8 @@ def unique_columns_tol(
         un_ar, new_2_old, old_2_new = np.unique(
             mat, return_index=True, return_inverse=True, axis=1
         )
-        return un_ar, new_2_old, old_2_new
+        # Ravel index arrays to get 1d output
+        return un_ar, new_2_old.ravel(), old_2_new.ravel()
 
     @numba.jit("Tuple((b1[:],i8[:],i8[:]))(f8[:, :],f8)", nopython=True, cache=True)
     def _numba_distance(mat, tol):
@@ -227,7 +244,6 @@ def unique_columns_tol(
     # practice failed.
 
     keep, new_2_old, old_2_new = _numba_distance(mat_t, tol)
-
     return mat[:, keep], new_2_old, old_2_new
 
 

--- a/src/porepy/utils/setmembership.py
+++ b/src/porepy/utils/setmembership.py
@@ -15,7 +15,7 @@ def unique_rows(data: np.ndarray[Any, np.dtype[np.float64]]) -> Tuple[
     np.ndarray[Any, np.dtype[np.int64]],
     np.ndarray[Any, np.dtype[np.int64]],
 ]:
-    """Function similar to Matlab's unique(...,'rows')
+    r"""Function similar to Matlab's unique(...,'rows')
 
     See also function unique_columns in this module; this is likely slower, but
     is understandable, documented, and has a tolerance option.
@@ -34,7 +34,7 @@ def unique_rows(data: np.ndarray[Any, np.dtype[np.float64]]) -> Tuple[
         Uniquified array.
 
         np.ndarray: ``shape=(n, r), r \leq m``. Unique rows.
-        
+
         np.ndarray: ``shape=(r)`` Indexes that map from the unique to the original
             array.
 

--- a/tests/fracs/test_wells.py
+++ b/tests/fracs/test_wells.py
@@ -218,7 +218,7 @@ def test_add_one_well_with_matrix(get_mdg) -> None:
         # compared.
         assert np.isclose(
             np.linalg.norm(known),
-            np.linalg.norm(intf.mortar_to_primary_int().A.flatten()),
+            np.linalg.norm(intf.mortar_to_primary_int().toarray().flatten()),
             rtol=1e-5,
             atol=1e-8,
         )

--- a/tests/grids/test_grid.py
+++ b/tests/grids/test_grid.py
@@ -605,10 +605,10 @@ def test_merge_single_grid():
 
     assert intf.num_cells == 1
     assert intf.num_sides() == 1
-    assert np.all(intf.primary_to_mortar_avg().A == [1, 0, 0])
-    assert np.all(intf.primary_to_mortar_int().A == [1, 0, 0])
-    assert np.all(intf.secondary_to_mortar_avg().A == [0, 0, 1])
-    assert np.all(intf.secondary_to_mortar_int().A == [0, 0, 1])
+    assert np.all(intf.primary_to_mortar_avg().toarray() == [1, 0, 0])
+    assert np.all(intf.primary_to_mortar_int().toarray() == [1, 0, 0])
+    assert np.all(intf.secondary_to_mortar_avg().toarray() == [0, 0, 1])
+    assert np.all(intf.secondary_to_mortar_int().toarray() == [0, 0, 1])
 
 
 def test_merge_two_grids():
@@ -632,10 +632,10 @@ def test_merge_two_grids():
 
     assert intf.num_cells == 1
     assert intf.num_sides() == 1
-    assert np.all(intf.primary_to_mortar_avg().A == [0, 1, 0])
-    assert np.all(intf.primary_to_mortar_int().A == [0, 1, 0])
-    assert np.all(intf.secondary_to_mortar_avg().A == [0, 1])
-    assert np.all(intf.secondary_to_mortar_int().A == [0, 1])
+    assert np.all(intf.primary_to_mortar_avg().toarray() == [0, 1, 0])
+    assert np.all(intf.primary_to_mortar_int().toarray() == [0, 1, 0])
+    assert np.all(intf.secondary_to_mortar_avg().toarray() == [0, 1])
+    assert np.all(intf.secondary_to_mortar_int().toarray() == [0, 1])
 
 
 def test_boundary_grid():

--- a/tests/grids/test_mortar_grid.py
+++ b/tests/grids/test_mortar_grid.py
@@ -145,8 +145,8 @@ def test_2d_domain_replace_2d_grid_with_coarse_grid():
     # Columns in integrated projection sum to either 0 or 1
     assert np.all(
         np.logical_or(
-            new_projection_int.A.sum(axis=0) == 1,
-            new_projection_int.A.sum(axis=0) == 0,
+            new_projection_int.toarray().sum(axis=0) == 1,
+            new_projection_int.toarray().sum(axis=0) == 0,
         ),
     )
 
@@ -189,8 +189,8 @@ def test_2d_domain_replace_2d_grid_with_fine_perturbed_grid():
     # Columns in integrated projection sum to either 0 or 1.
     assert np.all(
         np.logical_or(
-            new_projection_int.A.sum(axis=0) == 1,
-            new_projection_int.A.sum(axis=0) == 0,
+            new_projection_int.toarray().sum(axis=0) == 1,
+            new_projection_int.toarray().sum(axis=0) == 0,
         ),
     )
 
@@ -233,8 +233,8 @@ def test_2d_domain_replace_2d_grid_with_perturbed_grid():
     # Columns in integrated projection sum to either 0 or 1.
     assert np.all(
         np.logical_or(
-            new_projection_int.A.sum(axis=0) == 1,
-            new_projection_int.A.sum(axis=0) == 0,
+            new_projection_int.toarray().sum(axis=0) == 1,
+            new_projection_int.toarray().sum(axis=0) == 0,
         ),
     )
 
@@ -294,8 +294,8 @@ def test_2d_domain_replace_2d_grid_with_permuted_nodes():
     # Columns in integrated projection sum to either 0 or 1.
     assert np.all(
         np.logical_or(
-            new_projection_int.A.sum(axis=0) == 1,
-            new_projection_int.A.sum(axis=0) == 0,
+            new_projection_int.toarray().sum(axis=0) == 1,
+            new_projection_int.toarray().sum(axis=0) == 0,
         ),
     )
     fi = np.where(sd_new.face_centers[1] == 0.5)[0]
@@ -341,8 +341,8 @@ def test_2d_domain_replace_2d_grid_with_permuted_and_perturbed_nodes():
     # Columns in integrated projection sum to either 0 or 1.
     assert np.all(
         np.logical_or(
-            new_projection_int.A.sum(axis=0) == 1,
-            new_projection_int.A.sum(axis=0) == 0,
+            new_projection_int.toarray().sum(axis=0) == 1,
+            new_projection_int.toarray().sum(axis=0) == 0,
         ),
     )
 

--- a/tests/grids/test_refinement.py
+++ b/tests/grids/test_refinement.py
@@ -287,21 +287,21 @@ class TestRefinementMortarGrid:
             # The ordering of the cells in the new 1d grid may be flipped on
             # some systems; therefore allow two configurations
             assert np.logical_or(
-                np.allclose(low_to_mortar_known_avg, intf.secondary_to_mortar_avg().A),
+                np.allclose(low_to_mortar_known_avg, intf.secondary_to_mortar_avg().toarray()),
                 np.allclose(
                     low_to_mortar_known_avg,
-                    intf.secondary_to_mortar_avg().A[::-1],
+                    intf.secondary_to_mortar_avg().toarray()[::-1],
                 ),
             )
 
             if low_to_mortar_known_int is not None:
                 assert np.logical_or(
                     np.allclose(
-                        low_to_mortar_known_int, intf.secondary_to_mortar_int().A
+                        low_to_mortar_known_int, intf.secondary_to_mortar_int().toarray()
                     ),
                     np.allclose(
                         low_to_mortar_known_int,
-                        intf.secondary_to_mortar_int().A[::-1],
+                        intf.secondary_to_mortar_int().toarray()[::-1],
                     ),
                 )
 

--- a/tests/models/test_constitutive_laws.py
+++ b/tests/models/test_constitutive_laws.py
@@ -650,7 +650,7 @@ def test_derivatives_darcy_flux_potential_trace(base_discr: str):
     # match the ordering of the 2d cells (which was used to set 'true_derivatives').
     dt_du_computed = computed_flux.jac[
         1, (model.mortar_to_high_cell @ model.global_dof_u_mortar_y).astype(int)
-    ].A.ravel()
+    ].toarray().ravel()
 
     assert np.allclose(dt_du_computed, true_derivatives)
 
@@ -708,14 +708,14 @@ def test_derivatives_darcy_flux_potential_trace(base_discr: str):
     # ordering.
     assert np.allclose(
         true_jac_dp,
-        potential_trace.jac[fracture_faces_cart_ordering][:, model.global_p_2d_ind].A,
+        potential_trace.jac[fracture_faces_cart_ordering][:, model.global_p_2d_ind].toarray(),
     )
 
     # The computed Jacobian. Here we also need to reorder the columns from mortar to
     # high-dimensional cell ordering.
     computed_dp_dl = potential_trace.jac[fracture_faces_cart_ordering][
         :, model.mortar_to_high_cell @ model.global_intf_ind
-    ].A
+    ].toarray()
     # The true Jacobian with respect to the interface flux is found by differentiating
     # p_reconstructed with respect to the interface flux.
     true_dp_dl = np.diag(-dist / k_yy)

--- a/tests/models/test_fluid_mass_balance.py
+++ b/tests/models/test_fluid_mass_balance.py
@@ -391,7 +391,7 @@ def test_ad_operator_methods_single_phase_flow(
     val = operator.value(model_setup.equation_system)
 
     if isinstance(val, sps.bsr_matrix):  # needed for `tangential_component`
-        val = val.A
+        val = val.toarray()
 
     # Compare the actual and expected values.
     assert np.allclose(val, expected_value, rtol=1e-8, atol=1e-15)

--- a/tests/models/test_geometry.py
+++ b/tests/models/test_geometry.py
@@ -325,7 +325,7 @@ def test_internal_boundary_normal_to_outwards(
         cf = sd.cell_faces
         # Summing is a trick to get the sign of the cell-face relation for the boundary
         # faces (we don't care about internal faces).
-        cf_sum = np.sum(cf, axis=1)
+        cf_sum = np.asarray(np.sum(cf, axis=1))
         # Only compare for fracture faces
         fracture_faces = np.where(sd.tags["fracture_faces"])[0]
         # The matrix constrained to this subdomain
@@ -338,7 +338,7 @@ def test_internal_boundary_normal_to_outwards(
             dim_ind = np.arange(i, loc_size, dim)
             dim_vals = loc_vals[dim_ind]
             assert np.allclose(
-                dim_vals[fracture_faces], cf_sum[fracture_faces].toarray().ravel()
+                dim_vals[fracture_faces], cf_sum[fracture_faces].ravel()
             )
         # Update offset, needed to test for multiple subdomains.
         offset += sd.num_faces * dim

--- a/tests/models/test_geometry.py
+++ b/tests/models/test_geometry.py
@@ -338,7 +338,7 @@ def test_internal_boundary_normal_to_outwards(
             dim_ind = np.arange(i, loc_size, dim)
             dim_vals = loc_vals[dim_ind]
             assert np.allclose(
-                dim_vals[fracture_faces], cf_sum[fracture_faces].A.ravel()
+                dim_vals[fracture_faces], cf_sum[fracture_faces].toarray().ravel()
             )
         # Update offset, needed to test for multiple subdomains.
         offset += sd.num_faces * dim

--- a/tests/models/test_geometry.py
+++ b/tests/models/test_geometry.py
@@ -90,9 +90,9 @@ def test_boundary_sides(geometry_class, num_fracs):
 
         # Check that only valid boundaries are picked
         domain_or_internal_bf = np.where(np.sum(np.abs(sd.cell_faces), axis=1) == 1)
-        assert np.all(np.in1d(all_bf, domain_or_internal_bf))
+        assert np.all(np.isin(all_bf, domain_or_internal_bf))
         frac_faces = sd.tags["fracture_faces"].nonzero()[0]
-        assert np.all(np.logical_not(np.in1d(all_bf, frac_faces)))
+        assert np.all(np.logical_not(np.isin(all_bf, frac_faces)))
         assert np.all(all_bool == (east + west + north + south + top + bottom))
 
         # Check that the coordinates of the

--- a/tests/models/test_solution_strategy.py
+++ b/tests/models/test_solution_strategy.py
@@ -287,7 +287,7 @@ def test_targeted_rediscretization(model_class):
         A_targeted, b_targeted = model_targeted.stored_linear_system[i]
 
         # Convert to dense array to ensure the matrices are identical.
-        assert np.allclose(A_full.A, A_targeted.A)
+        assert np.allclose(A_full.toarray(), A_targeted.toarray())
         assert np.allclose(b_full, b_targeted)
 
     # Check that the discretization matrix changes between iterations. Without this

--- a/tests/numerics/ad/test_equation_system.py
+++ b/tests/numerics/ad/test_equation_system.py
@@ -77,7 +77,7 @@ def test_evaluate_variables():
         ad_array = var.value_and_jacobian(eq_system)
         assert isinstance(ad_array, pp.ad.AdArray)
         assert np.allclose(ad_array.val, 2)
-        assert np.allclose(ad_array.jac.A, known_jac)
+        assert np.allclose(ad_array.jac.toarray(), known_jac)
 
         # Now create the variable at the previous iterate. This should also give the
         # most recent value in pp.ITERATE_SOLUTIONS, but it should not yield an AdArray.
@@ -85,7 +85,7 @@ def test_evaluate_variables():
         ad_array_prev_iter = var_prev_iter.value_and_jacobian(eq_system)
         assert isinstance(ad_array_prev_iter, pp.ad.AdArray)
         assert np.allclose(ad_array_prev_iter.val, 2)
-        assert np.allclose(ad_array_prev_iter.jac.A, np.zeros(known_jac.shape))
+        assert np.allclose(ad_array_prev_iter.jac.toarray(), np.zeros(known_jac.shape))
 
         # Create the variable at the previous time step. This should give the most
         # recent value in pp.TIME_STEP_SOLUTIONS.
@@ -93,7 +93,7 @@ def test_evaluate_variables():
         ad_array_prev_timestep = var_prev_timestep.value_and_jacobian(eq_system)
         assert isinstance(ad_array_prev_timestep, pp.ad.AdArray)
         assert np.allclose(ad_array_prev_timestep.val, 1)
-        assert np.allclose(ad_array_prev_timestep.jac.A, np.zeros(known_jac.shape))
+        assert np.allclose(ad_array_prev_timestep.jac.toarray(), np.zeros(known_jac.shape))
 
         # Use the ad machinery to define the difference between the current and previous
         # time step. This should give an AdArray with the same value as that obtained by
@@ -104,7 +104,7 @@ def test_evaluate_variables():
         assert np.allclose(
             ad_array_increment.val, ad_array.val - ad_array_prev_timestep.val
         )
-        assert np.allclose(ad_array_increment.jac.A, known_jac)
+        assert np.allclose(ad_array_increment.jac.toarray(), known_jac)
 
 
 def test_variable_creation():
@@ -1337,7 +1337,7 @@ def test_schur_complement(eq_var_to_exclude):
             var for var in setup.all_variable_names if var not in var_to_exclude
         ]
 
-    inverter = lambda A: sps.csr_matrix(np.linalg.inv(A.A))
+    inverter = lambda A: sps.csr_matrix(np.linalg.inv(A.toarray()))
 
     # Rows and columns to keep
     rows_keep = np.sort(np.hstack([setup.eq_ind(name) for name in eq_names]))

--- a/tests/numerics/ad/test_forward_mode.py
+++ b/tests/numerics/ad/test_forward_mode.py
@@ -20,7 +20,7 @@ def test_quadratic_function():
     x, y = initAdArrays([np.array([1]), np.array([2])])
     z = 1 * x + 2 * y + 3 * x * y + 4 * x * x + 5 * y * y
     val = 35
-    assert z.val == val and np.all(z.jac.A == [15, 25])
+    assert z.val == val and np.all(z.jac.toarray() == [15, 25])
 
 
 def test_vector_quadratic():
@@ -46,34 +46,34 @@ def test_mapping_m_to_n():
 def test_add_two_ad_variables_init():
     a, b = initAdArrays([np.array([1]), np.array([-10])])
     c = a + b
-    assert c.val == -9 and np.all(c.jac.A == [1, 1])
-    assert a.val == 1 and np.all(a.jac.A == [1, 0])
-    assert b.val == -10 and np.all(b.jac.A == [0, 1])
+    assert c.val == -9 and np.all(c.jac.toarray() == [1, 1])
+    assert a.val == 1 and np.all(a.jac.toarray() == [1, 0])
+    assert b.val == -10 and np.all(b.jac.toarray() == [0, 1])
 
 
 def test_sub_var_init_with_var_init():
     a, b = initAdArrays([np.array([3]), np.array([2])])
     c = b - a
-    assert np.allclose(c.val, -1) and np.all(c.jac.A == [-1, 1])
-    assert a.val == 3 and np.all(a.jac.A == [1, 0])
-    assert b.val == 2 and np.all(b.jac.A == [0, 1])
+    assert np.allclose(c.val, -1) and np.all(c.jac.toarray() == [-1, 1])
+    assert a.val == 3 and np.all(a.jac.toarray() == [1, 0])
+    assert b.val == 2 and np.all(b.jac.toarray() == [0, 1])
 
 
 def test_mul_ad_var_init():
     a, b = initAdArrays([np.array([3]), np.array([2])])
     c = a * b
-    assert a.val == 3 and np.all(a.jac.A == [1, 0])
-    assert b.val == 2 and np.all(b.jac.A == [0, 1])
-    assert c.val == 6 and np.all(c.jac.A == [2, 3])
+    assert a.val == 3 and np.all(a.jac.toarray() == [1, 0])
+    assert b.val == 2 and np.all(b.jac.toarray() == [0, 1])
+    assert c.val == 6 and np.all(c.jac.toarray() == [2, 3])
 
 
 def test_mul_scal_ad_var_init():
     a, b = initAdArrays([np.array([3]), np.array([2])])
     d = 3.0
     c = d * a
-    assert c.val == 9 and np.all(c.jac.A == [3, 0])
-    assert a.val == 3 and np.all(a.jac.A == [1, 0])
-    assert b.val == 2 and np.all(b.jac.A == [0, 1])
+    assert c.val == 9 and np.all(c.jac.toarray() == [3, 0])
+    assert a.val == 3 and np.all(a.jac.toarray() == [1, 0])
+    assert b.val == 2 and np.all(b.jac.toarray() == [0, 1])
 
 
 def test_mul_sps_advar_init():
@@ -82,7 +82,7 @@ def test_mul_sps_advar_init():
 
     f = A @ x
     assert np.all(f.val == [14, 32, 50])
-    assert np.all((f.jac == A).A)
+    assert np.all((f.jac == A).toarray())
 
 
 def test_advar_init_diff_len():
@@ -98,9 +98,9 @@ def test_advar_init_diff_len():
     jac_f = sps.hstack((A, zero_32))
     jac_g = sps.hstack((zero_23, B))
     assert np.all(f.val == [14, 32, 50])
-    assert np.all((f.jac == jac_f).A)
+    assert np.all((f.jac == jac_f).toarray())
     assert np.all(g.val == [5, 14])
-    assert np.all((g.jac == jac_g).A)
+    assert np.all((g.jac == jac_g).toarray())
 
 
 def test_advar_init_cross_jacobi():
@@ -109,7 +109,7 @@ def test_advar_init_cross_jacobi():
     z = x * y
     J = np.array([[1, 0, -1, 0], [0, 5, 0, 4]])
     assert np.all(z.val == [-1, 20])
-    assert np.all((z.jac == J).A)
+    assert np.all((z.jac.toarray() == J))
 
 
 def test_advar_mul_vec():
@@ -132,9 +132,9 @@ def test_advar_m_mul_vec_n():
     Jy = np.array([[3, 0, 1], [0, 2, 0]])
     Jz = np.array([[1, 0, 3], [0, 4, 0]])
     assert np.all(y.val == [4, 2])
-    assert np.sum(y.jac.A - Jy) == 0
+    assert np.sum(y.jac.toarray() - Jy) == 0
     assert np.all(z.val == [4, 4])
-    assert np.sum(z.jac.A - Jz) == 0
+    assert np.sum(z.jac.toarray() - Jz) == 0
 
 
 def test_mul_sps_advar():
@@ -144,7 +144,7 @@ def test_mul_sps_advar():
     f = A @ x
 
     assert np.all(f.val == [14, 32, 50])
-    assert np.all(f.jac == A * J.A)
+    assert np.all(f.jac == A * J.toarray())
 
 
 def test_mul_advar_vectors():
@@ -157,7 +157,7 @@ def test_mul_advar_vectors():
     f = A @ a + b
 
     assert np.all(f.val == [15, 33, 51])
-    assert np.sum(f.jac.A != A * Ja + Jb) == 0
+    assert np.sum(f.jac.toarray() != A * Ja + Jb) == 0
     assert (
         np.sum(Ja != sps.csc_matrix(np.array([[1, 3, 1], [5, 0, 0], [5, 1, 2]]))) == 0
     )
@@ -181,11 +181,11 @@ def test_copy_vector():
     a = AdArray(np.ones(3), sps.csr_matrix(np.diag(np.ones((3)))))
     b = a.copy()
     assert np.allclose(a.val, b.val)
-    assert np.allclose(a.jac.A, b.jac.A)
+    assert np.allclose(a.jac.toarray(), b.jac.toarray())
     a.val[0] = 3
     a.jac[2] = 4
     assert np.allclose(b.val, np.ones(3))
-    assert np.allclose(b.jac.A, sps.csr_matrix(np.diag(np.ones((3)))).A)
+    assert np.allclose(b.jac.toarray(), sps.csr_matrix(np.diag(np.ones((3)))).toarray())
 
 
 def test_exp_scalar_times_ad_var():
@@ -198,8 +198,8 @@ def test_exp_scalar_times_ad_var():
     zero = sps.csc_matrix((3, 3))
     jac = sps.hstack([c * sps.diags(np.exp(c * val)) * J, zero, zero])
     jac_a = sps.hstack([J, zero, zero])
-    assert np.allclose(b.val, np.exp(c * val)) and np.allclose(b.jac.A, jac.A)
-    assert np.all(a.val == [1, 2, 3]) and np.all(a.jac.A == jac_a.A)
+    assert np.allclose(b.val, np.exp(c * val)) and np.allclose(b.jac.toarray(), jac.toarray())
+    assert np.all(a.val == [1, 2, 3]) and np.all(a.jac.toarray() == jac_a.toarray())
 
 
 @pytest.mark.parametrize(
@@ -242,10 +242,10 @@ def test_get_set_slice_ad_var(index, index_c):
     a_copy = a.copy()
     a[index] = b
     assert np.all(a[index].val == b.val)
-    assert np.all(a[index].jac.A == b.jac.A)
+    assert np.all(a[index].jac.toarray() == b.jac.toarray())
     # complement should not be affected
     assert np.all(a[index_c].val == a_copy[index_c].val)
-    assert np.all(a[index_c].jac.A == a_copy[index_c].jac.A)
+    assert np.all(a[index_c].jac.toarray() == a_copy[index_c].jac.toarray())
 
     # setting a numpy array should only modify the values of the ad array
     b = target_val * 10.
@@ -253,7 +253,7 @@ def test_get_set_slice_ad_var(index, index_c):
     a[index] = b
     assert np.all(a[index].val == b)
     assert np.all(a[index_c].val == a_copy[index_c].val)
-    assert np.all(a.jac.A == a_copy.jac.A)
+    assert np.all(a.jac.toarray() == a_copy.jac.toarray())
 
 
 @pytest.mark.parametrize(

--- a/tests/numerics/ad/test_functions.py
+++ b/tests/numerics/ad/test_functions.py
@@ -47,7 +47,7 @@ def test_exp_sparse_jac():
     J = sps.csc_matrix(np.array([[3, 2, 1], [5, 6, 1], [2, 3, 5]]))
     a = AdArray(val, J)
     b = af.exp(a)
-    jac = np.dot(np.diag(np.exp(val)), J.A)
+    jac = np.dot(np.diag(np.exp(val)), J.toarray())
     assert np.all(b.val == np.exp(val)) and np.all(b.jac == jac)
 
 
@@ -59,8 +59,8 @@ def test_exp_scalar_times_ad_var():
     b = af.exp(c * a)
     jac = c * sps.diags(np.exp(c * val)) * J
 
-    assert np.allclose(b.val, np.exp(c * val)) and np.allclose(b.jac.A, jac.A)
-    assert np.all(a.val == [1, 2, 3]) and np.all(a.jac.A == J.A)
+    assert np.allclose(b.val, np.exp(c * val)) and np.allclose(b.jac.toarray(), jac.toarray())
+    assert np.all(a.val == [1, 2, 3]) and np.all(a.jac.toarray() == J.toarray())
 
 
 # Function: log
@@ -85,7 +85,7 @@ def test_log_vector():
     b = af.log(a)
     jac = sps.diags(1 / val) * J
 
-    assert np.all(b.val == np.log(val)) and np.all(b.jac.A == jac)
+    assert np.all(b.val == np.log(val)) and np.all(b.jac.toarray() == jac)
 
 
 def test_log_sparse_jac():
@@ -93,7 +93,7 @@ def test_log_sparse_jac():
     J = sps.csc_matrix(np.array([[3, 2, 1], [5, 6, 1], [2, 3, 5]]))
     a = AdArray(val, J)
     b = af.log(a)
-    jac = np.dot(np.diag(1 / val), J.A)
+    jac = np.dot(np.diag(1 / val), J.toarray())
     assert np.all(b.val == np.log(val)) and np.all(b.jac == jac)
 
 
@@ -105,8 +105,8 @@ def test_log_scalar_times_ad_var():
     b = af.log(c * a)
     jac = sps.diags(1 / val) * J
 
-    assert np.allclose(b.val, np.log(c * val)) and np.allclose(b.jac.A, jac.A)
-    assert np.all(a.val == [1, 2, 3]) and np.all(a.jac.A == J.A)
+    assert np.allclose(b.val, np.log(c * val)) and np.allclose(b.jac.toarray(), jac.toarray())
+    assert np.all(a.val == [1, 2, 3]) and np.all(a.jac.toarray() == J.toarray())
 
 
 # Function: abs
@@ -137,7 +137,7 @@ def test_abs_advar():
         ),
     )
     assert np.allclose(a_abs.val, [1, 10, 3, np.pi])
-    assert np.allclose(a_abs.jac.A, J_abs)
+    assert np.allclose(a_abs.jac.toarray(), J_abs)
 
 
 # Function: sin
@@ -171,7 +171,7 @@ def test_sin_sparse_jac():
     J = sps.csc_matrix(np.array([[3, 2, 1], [5, 6, 1], [2, 3, 5]]))
     a = AdArray(val, J)
     b = af.sin(a)
-    jac = np.dot(np.diag(np.cos(val)), J.A)
+    jac = np.dot(np.diag(np.cos(val)), J.toarray())
     assert np.all(b.val == np.sin(val)) and np.all(b.jac == jac)
 
 
@@ -183,8 +183,8 @@ def test_sin_scalar_times_ad_var():
     b = af.sin(c * a)
     jac = c * sps.diags(np.cos(c * val)) * J
 
-    assert np.allclose(b.val, np.sin(c * val)) and np.allclose(b.jac.A, jac.A)
-    assert np.all(a.val == [1, 2, 3]) and np.all(a.jac.A == J.A)
+    assert np.allclose(b.val, np.sin(c * val)) and np.allclose(b.jac.toarray(), jac.toarray())
+    assert np.all(a.val == [1, 2, 3]) and np.all(a.jac.toarray() == J.toarray())
 
 
 # Function: cos
@@ -218,7 +218,7 @@ def test_cos_sparse_jac():
     J = sps.csc_matrix(np.array([[3, 2, 1], [5, 6, 1], [2, 3, 5]]))
     a = AdArray(val, J)
     b = af.cos(a)
-    jac = np.dot(-np.diag(np.sin(val)), J.A)
+    jac = np.dot(-np.diag(np.sin(val)), J.toarray())
     assert np.all(b.val == np.cos(val)) and np.all(b.jac == jac)
 
 
@@ -230,8 +230,8 @@ def test_cos_scalar_times_ad_var():
     b = af.cos(c * a)
     jac = -c * sps.diags(np.sin(c * val)) * J
 
-    assert np.allclose(b.val, np.cos(c * val)) and np.allclose(b.jac.A, jac.A)
-    assert np.all(a.val == [1, 2, 3]) and np.all(a.jac.A == J.A)
+    assert np.allclose(b.val, np.cos(c * val)) and np.allclose(b.jac.toarray(), jac.toarray())
+    assert np.all(a.val == [1, 2, 3]) and np.all(a.jac.toarray() == J.toarray())
 
 
 # Function: tan
@@ -265,7 +265,7 @@ def test_tan_sparse_jac():
     J = sps.csc_matrix(np.array([[3, 2, 1], [5, 6, 1], [2, 3, 5]]))
     a = AdArray(val, J)
     b = af.tan(a)
-    jac = np.dot(np.diag((np.cos(val) ** 2) ** (-1)), J.A)
+    jac = np.dot(np.diag((np.cos(val) ** 2) ** (-1)), J.toarray())
     assert np.all(b.val == np.tan(val)) and np.all(b.jac == jac)
 
 
@@ -277,8 +277,8 @@ def test_tan_scalar_times_ad_var():
     b = af.tan(c * a)
     jac = c * sps.diags((np.cos(c * val) ** 2) ** (-1)) * J
 
-    assert np.allclose(b.val, np.tan(c * val)) and np.allclose(b.jac.A, jac.A)
-    assert np.all(a.val == [1, 2, 3]) and np.all(a.jac.A == J.A)
+    assert np.allclose(b.val, np.tan(c * val)) and np.allclose(b.jac.toarray(), jac.toarray())
+    assert np.all(a.val == [1, 2, 3]) and np.all(a.jac.toarray() == J.toarray())
 
 
 # Function: arcsin
@@ -312,7 +312,7 @@ def test_arcsin_sparse_jac():
     J = sps.csc_matrix(np.array([[0.3, 0.2, 0.1], [0.5, 0.6, 0.1], [0.2, 0.3, 0.5]]))
     a = AdArray(val, J)
     b = af.arcsin(a)
-    jac = np.dot(np.diag((1 - val**2) ** (-0.5)), J.A)
+    jac = np.dot(np.diag((1 - val**2) ** (-0.5)), J.toarray())
     assert np.all(b.val == np.arcsin(val)) and np.all(b.jac == jac)
 
 
@@ -324,8 +324,8 @@ def test_arcsin_scalar_times_ad_var():
     b = af.arcsin(c * a)
     jac = sps.diags(c * (1 - (c * val) ** 2) ** (-0.5)) * J
 
-    assert np.allclose(b.val, np.arcsin(c * val)) and np.allclose(b.jac.A, jac.A)
-    assert np.all(a.val == [0.1, 0.2, 0.3]) and np.all(a.jac.A == J.A)
+    assert np.allclose(b.val, np.arcsin(c * val)) and np.allclose(b.jac.toarray(), jac.toarray())
+    assert np.all(a.val == [0.1, 0.2, 0.3]) and np.all(a.jac.toarray() == J.toarray())
 
 
 # Function: arccos
@@ -359,7 +359,7 @@ def test_arccos_sparse_jac():
     J = sps.csc_matrix(np.array([[0.3, 0.2, 0.1], [0.5, 0.6, 0.1], [0.2, 0.3, 0.5]]))
     a = AdArray(val, J)
     b = af.arccos(a)
-    jac = np.dot(-np.diag((1 - val**2) ** (-0.5)), J.A)
+    jac = np.dot(-np.diag((1 - val**2) ** (-0.5)), J.toarray())
     assert np.all(b.val == np.arccos(val)) and np.all(b.jac == jac)
 
 
@@ -371,8 +371,8 @@ def test_arccos_scalar_times_ad_var():
     b = af.arccos(c * a)
     jac = -sps.diags(c * (1 - (c * val) ** 2) ** (-0.5)) * J
 
-    assert np.allclose(b.val, np.arccos(c * val)) and np.allclose(b.jac.A, jac.A)
-    assert np.all(a.val == [0.1, 0.2, 0.3]) and np.all(a.jac.A == J.A)
+    assert np.allclose(b.val, np.arccos(c * val)) and np.allclose(b.jac.toarray(), jac.toarray())
+    assert np.all(a.val == [0.1, 0.2, 0.3]) and np.all(a.jac.toarray() == J.toarray())
 
 
 # Function: arctan
@@ -406,7 +406,7 @@ def test_arctan_sparse_jac():
     J = sps.csc_matrix(np.array([[0.3, 0.2, 0.1], [0.5, 0.6, 0.1], [0.2, 0.3, 0.5]]))
     a = AdArray(val, J)
     b = af.arctan(a)
-    jac = np.dot(np.diag((1 + val**2) ** (-1)), J.A)
+    jac = np.dot(np.diag((1 + val**2) ** (-1)), J.toarray())
     assert np.all(b.val == np.arctan(val)) and np.all(b.jac == jac)
 
 
@@ -418,8 +418,8 @@ def test_arctan_scalar_times_ad_var():
     b = af.arctan(c * a)
     jac = sps.diags(c * (1 + (c * val) ** 2) ** (-1)) * J
 
-    assert np.allclose(b.val, np.arctan(c * val)) and np.allclose(b.jac.A, jac.A)
-    assert np.all(a.val == [0.1, 0.2, 0.3]) and np.all(a.jac.A == J.A)
+    assert np.allclose(b.val, np.arctan(c * val)) and np.allclose(b.jac.toarray(), jac.toarray())
+    assert np.all(a.val == [0.1, 0.2, 0.3]) and np.all(a.jac.toarray() == J.toarray())
 
 
 # Function: sinh
@@ -453,7 +453,7 @@ def test_sinh_sparse_jac():
     J = sps.csc_matrix(np.array([[3, 2, 1], [5, 6, 1], [2, 3, 5]]))
     a = AdArray(val, J)
     b = af.sinh(a)
-    jac = np.dot(np.diag(np.cosh(val)), J.A)
+    jac = np.dot(np.diag(np.cosh(val)), J.toarray())
     assert np.all(b.val == np.sinh(val)) and np.all(b.jac == jac)
 
 
@@ -465,8 +465,8 @@ def test_sinh_scalar_times_ad_var():
     b = af.sinh(c * a)
     jac = c * sps.diags(np.cosh(c * val)) * J
 
-    assert np.allclose(b.val, np.sinh(c * val)) and np.allclose(b.jac.A, jac.A)
-    assert np.all(a.val == [1, 2, 3]) and np.all(a.jac.A == J.A)
+    assert np.allclose(b.val, np.sinh(c * val)) and np.allclose(b.jac.toarray(), jac.toarray())
+    assert np.all(a.val == [1, 2, 3]) and np.all(a.jac.toarray() == J.toarray())
 
 
 # Function: cosh
@@ -500,7 +500,7 @@ def test_cosh_sparse_jac():
     J = sps.csc_matrix(np.array([[3, 2, 1], [5, 6, 1], [2, 3, 5]]))
     a = AdArray(val, J)
     b = af.cosh(a)
-    jac = np.dot(np.diag(np.sinh(val)), J.A)
+    jac = np.dot(np.diag(np.sinh(val)), J.toarray())
     assert np.all(b.val == np.cosh(val)) and np.all(b.jac == jac)
 
 
@@ -512,8 +512,8 @@ def test_cosh_scalar_times_ad_var():
     b = af.cosh(c * a)
     jac = c * sps.diags(np.sinh(c * val)) * J
 
-    assert np.allclose(b.val, np.cosh(c * val)) and np.allclose(b.jac.A, jac.A)
-    assert np.all(a.val == [1, 2, 3]) and np.all(a.jac.A == J.A)
+    assert np.allclose(b.val, np.cosh(c * val)) and np.allclose(b.jac.toarray(), jac.toarray())
+    assert np.all(a.val == [1, 2, 3]) and np.all(a.jac.toarray() == J.toarray())
 
 
 # Function: tanh
@@ -547,7 +547,7 @@ def test_tanh_sparse_jac():
     J = sps.csc_matrix(np.array([[3, 2, 1], [5, 6, 1], [2, 3, 5]]))
     a = AdArray(val, J)
     b = af.tanh(a)
-    jac = np.dot(np.diag((np.cosh(val) ** 2) ** (-1)), J.A)
+    jac = np.dot(np.diag((np.cosh(val) ** 2) ** (-1)), J.toarray())
     assert np.all(b.val == np.tanh(val)) and np.all(b.jac == jac)
 
 
@@ -559,8 +559,8 @@ def test_tanh_scalar_times_ad_var():
     b = af.tanh(c * a)
     jac = c * sps.diags((np.cosh(c * val) ** 2) ** (-1)) * J
 
-    assert np.allclose(b.val, np.tanh(c * val)) and np.allclose(b.jac.A, jac.A)
-    assert np.all(a.val == [1, 2, 3]) and np.all(a.jac.A == J.A)
+    assert np.allclose(b.val, np.tanh(c * val)) and np.allclose(b.jac.toarray(), jac.toarray())
+    assert np.all(a.val == [1, 2, 3]) and np.all(a.jac.toarray() == J.toarray())
 
 
 # Function: arcsinh
@@ -575,7 +575,7 @@ def test_arcsinh_advar():
     a = AdArray(np.array([0.2]), sps.csr_matrix(np.array([0.3])))
     b = af.arcsinh(a)
     assert np.isclose(b.val, np.arcsinh(0.2)) and np.isclose(
-        b.jac.A, (1 + 0.2**2) ** (-0.5) * 0.3
+        b.jac.toarray(), (1 + 0.2**2) ** (-0.5) * 0.3
     )
     assert a.val == 0.2 and a.jac == 0.3
 
@@ -587,7 +587,7 @@ def test_arcsinh_vector():
     b = af.arcsinh(a)
     jac = np.dot(np.diag((1 + val**2) ** (-0.5)), J)
 
-    assert np.allclose(b.val, np.arcsinh(val)) and np.allclose(b.jac.A, jac)
+    assert np.allclose(b.val, np.arcsinh(val)) and np.allclose(b.jac.toarray(), jac)
     assert np.all(J == np.array([[0.3, 0.2, 0.1], [0.5, 0.6, 0.1], [0.2, 0.3, 0.5]]))
 
 
@@ -596,8 +596,8 @@ def test_arcsinh_sparse_jac():
     J = sps.csc_matrix(np.array([[0.3, 0.2, 0.1], [0.5, 0.6, 0.1], [0.2, 0.3, 0.5]]))
     a = AdArray(val, J)
     b = af.arcsinh(a)
-    jac = np.dot(np.diag((1 + val**2) ** (-0.5)), J.A)
-    assert np.allclose(b.val, np.arcsinh(val)) and np.allclose(b.jac.A, jac)
+    jac = np.dot(np.diag((1 + val**2) ** (-0.5)), J.toarray())
+    assert np.allclose(b.val, np.arcsinh(val)) and np.allclose(b.jac.toarray(), jac)
 
 
 def test_arcsinh_scalar_times_ad_var():
@@ -608,8 +608,8 @@ def test_arcsinh_scalar_times_ad_var():
     b = af.arcsinh(c * a)
     jac = sps.diags(c * (1 + (c * val) ** 2) ** (-0.5)) * J
 
-    assert np.allclose(b.val, np.arcsinh(c * val)) and np.allclose(b.jac.A, jac.A)
-    assert np.all(a.val == [0.1, 0.2, 0.3]) and np.all(a.jac.A == J.A)
+    assert np.allclose(b.val, np.arcsinh(c * val)) and np.allclose(b.jac.toarray(), jac.toarray())
+    assert np.all(a.val == [0.1, 0.2, 0.3]) and np.all(a.jac.toarray() == J.toarray())
 
 
 # Function: arccosh
@@ -637,7 +637,7 @@ def test_arccosh_vector():
     b = af.arccosh(a)
     jac = np.dot(np.diag((val - 1) ** (-0.5) * (val + 1) ** (-0.5)), J)
 
-    assert np.allclose(b.val, np.arccosh(val)) and np.allclose(b.jac.A, jac)
+    assert np.allclose(b.val, np.arccosh(val)) and np.allclose(b.jac.toarray(), jac)
     assert np.all(J == np.array([[3, 2, 1], [5, 6, 1], [2, 3, 5]]))
 
 
@@ -646,8 +646,8 @@ def test_arccosh_sparse_jac():
     J = sps.csc_matrix(np.array([[3, 2, 1], [5, 6, 1], [2, 3, 5]]))
     a = AdArray(val, J)
     b = af.arccosh(a)
-    jac = np.dot(np.diag((val - 1) ** (-0.5) * (val + 1) ** (-0.5)), J.A)
-    assert np.allclose(b.val, np.arccosh(val)) and np.allclose(b.jac.A, jac)
+    jac = np.dot(np.diag((val - 1) ** (-0.5) * (val + 1) ** (-0.5)), J.toarray())
+    assert np.allclose(b.val, np.arccosh(val)) and np.allclose(b.jac.toarray(), jac)
 
 
 def test_arccosh_scalar_times_ad_var():
@@ -658,8 +658,8 @@ def test_arccosh_scalar_times_ad_var():
     b = af.arccosh(c * a)
     jac = sps.diags(c * (c * val - 1) ** (-0.5) * (c * val + 1) ** (-0.5)) * J
 
-    assert np.allclose(b.val, np.arccosh(c * val)) and np.allclose(b.jac.A, jac.A)
-    assert np.all(a.val == [1, 2, 3]) and np.all(a.jac.A == J.A)
+    assert np.allclose(b.val, np.arccosh(c * val)) and np.allclose(b.jac.toarray(), jac.toarray())
+    assert np.all(a.val == [1, 2, 3]) and np.all(a.jac.toarray() == J.toarray())
 
 
 # Function: arctanh
@@ -674,7 +674,7 @@ def test_arctanh_advar():
     a = AdArray(np.array([0.2]), sps.csr_matrix(np.array([0.3])))
     b = af.arctanh(a)
     assert np.isclose(b.val, np.arctanh(0.2)) and np.isclose(
-        b.jac.A, (1 - 0.2**2) ** (-1) * 0.3
+        b.jac.toarray(), (1 - 0.2**2) ** (-1) * 0.3
     )
     assert a.val == 0.2 and a.jac == 0.3
 
@@ -686,7 +686,7 @@ def test_arctanh_vector():
     b = af.arctanh(a)
     jac = np.dot(np.diag((1 - val**2) ** (-1)), J)
 
-    assert np.allclose(b.val, np.arctanh(val)) and np.allclose(b.jac.A, jac)
+    assert np.allclose(b.val, np.arctanh(val)) and np.allclose(b.jac.toarray(), jac)
     assert np.all(J == np.array([[0.3, 0.2, 0.1], [0.5, 0.6, 0.1], [0.2, 0.3, 0.5]]))
 
 
@@ -695,8 +695,8 @@ def test_arctanh_sparse_jac():
     J = sps.csc_matrix(np.array([[0.3, 0.2, 0.1], [0.5, 0.6, 0.1], [0.2, 0.3, 0.5]]))
     a = AdArray(val, J)
     b = af.arctanh(a)
-    jac = np.dot(np.diag((1 - val**2) ** (-1)), J.A)
-    assert np.allclose(b.val, np.arctanh(val)) and np.allclose(b.jac.A, jac)
+    jac = np.dot(np.diag((1 - val**2) ** (-1)), J.toarray())
+    assert np.allclose(b.val, np.arctanh(val)) and np.allclose(b.jac.toarray(), jac)
 
 
 def test_arctanh_scalar_times_ad_var():
@@ -707,8 +707,8 @@ def test_arctanh_scalar_times_ad_var():
     b = af.arctanh(c * a)
     jac = sps.diags(c * (1 - (c * val) ** 2) ** (-1)) * J
 
-    assert np.allclose(b.val, np.arctanh(c * val)) and np.allclose(b.jac.A, jac.A)
-    assert np.all(a.val == [0.1, 0.2, 0.3]) and np.all(a.jac.A == J.A)
+    assert np.allclose(b.val, np.arctanh(c * val)) and np.allclose(b.jac.toarray(), jac.toarray())
+    assert np.all(a.val == [0.1, 0.2, 0.3]) and np.all(a.jac.toarray() == J.toarray())
 
 
 # Function: heaviside_smooth
@@ -725,7 +725,7 @@ def test_heaviside_smooth_advar():
     b = af.heaviside_smooth(a)
     val = 0.5 * (1 + (2 / np.pi) * np.arctan(0.2 / 1e-3))
     der = (1 / np.pi) * (1e-3 / (1e-3**2 + 0.2**2))
-    assert np.isclose(b.val, val) and np.isclose(b.jac.A, der * 0.3)
+    assert np.isclose(b.val, val) and np.isclose(b.jac.toarray(), der * 0.3)
     assert a.val == 0.2 and a.jac == 0.3
 
 
@@ -740,7 +740,7 @@ def test_heaviside_smooth_vector():
         np.diag(np.pi ** (-1) * (1e-3 * (1e-3**2 + val**2) ** (-1))), J
     )
 
-    assert np.allclose(b.val, true_val) and np.allclose(b.jac.A, true_jac)
+    assert np.allclose(b.val, true_val) and np.allclose(b.jac.toarray(), true_jac)
     assert np.all(J == np.array([[3, -2, 1], [-5, 6, 1], [2, 3, -5]]))
 
 
@@ -752,10 +752,10 @@ def test_heaviside_smooth_sparse_jac():
 
     true_val = 0.5 * (1 + 2 * np.pi ** (-1) * np.arctan(val * 1e3))
     true_jac = np.dot(
-        np.diag(np.pi ** (-1) * (1e-3 * (1e-3**2 + val**2) ** (-1))), J.A
+        np.diag(np.pi ** (-1) * (1e-3 * (1e-3**2 + val**2) ** (-1))), J.toarray()
     )
 
-    assert np.allclose(b.val, true_val) and np.allclose(b.jac.A, true_jac)
+    assert np.allclose(b.val, true_val) and np.allclose(b.jac.toarray(), true_jac)
 
 
 def test_heaviside_smooth_times_ad_var():
@@ -770,5 +770,5 @@ def test_heaviside_smooth_times_ad_var():
         sps.diags(c * np.pi ** (-1) * (1e-3 * (1e-3**2 + (c * val) ** 2) ** (-1))) * J
     )
 
-    assert np.allclose(b.val, true_val) and np.allclose(b.jac.A, true_jac.A)
-    assert np.all(a.val == [1, -2, -3]) and np.all(a.jac.A == J.A)
+    assert np.allclose(b.val, true_val) and np.allclose(b.jac.toarray(), true_jac.toarray())
+    assert np.all(a.val == [1, -2, -3]) and np.all(a.jac.toarray() == J.toarray())

--- a/tests/numerics/ad/test_operator_functions.py
+++ b/tests/numerics/ad/test_operator_functions.py
@@ -55,26 +55,26 @@ def test_ad_function():
     val_ad = F_var.value_and_jacobian(eqsys)
     # test values at current time step
     assert np.all(val_ad.val == 1.)
-    assert np.all(val_ad.jac.A == np.eye(mdg.num_subdomain_cells()))
+    assert np.all(val_ad.jac.toarray() == np.eye(mdg.num_subdomain_cells()))
 
     # vals at previous iter and zero Jacobian
     # previous iterate has the same values as the original operator, but no Jacobian
     F_var_pi = F_var.previous_iteration()
     val = F_var_pi.value_and_jacobian(eqsys)
     assert np.all(val.val == val_ad.val)
-    assert np.all(val.jac.A == 0.)
+    assert np.all(val.jac.toarray() == 0.)
 
     # 1 iterate before has the respective values
     F_var_pii = F_var_pi.previous_iteration()
     val = F_var_pii.value_and_jacobian(eqsys)
     assert np.all(val.val == 2.)
-    assert np.all(val.jac.A == 0.)
+    assert np.all(val.jac.toarray() == 0.)
 
     # Analogously for prev time
     F_var_pt = F_var.previous_timestep()
     val = F_var_pt.value_and_jacobian(eqsys)
     assert np.all(val.val == 10.)
-    assert np.all(val.jac.A == 0.)
+    assert np.all(val.jac.toarray() == 0.)
 
     # when evaluating with values only, the result should be a numpy array
     val = F_var.value(eqsys)

--- a/tests/numerics/ad/test_operators.py
+++ b/tests/numerics/ad/test_operators.py
@@ -695,7 +695,7 @@ def test_ad_variable_prev_time_and_iter(prev_time):
 
         # prev var has no Jacobian
         ad_i = var_i.value_and_jacobian(eqsys)
-        assert np.all(ad_i.jac.A == 0.)
+        assert np.all(ad_i.jac.toarray() == 0.)
 
     # Test creating with explicit stepping and recursive stepping
     vars_exp = [getattr(var, get_prev_key)(steps=i) for i in range(1, depth)]
@@ -1641,9 +1641,9 @@ def _expected_value(
                 2
                 * np.vstack(
                     (
-                        var_1.val[0] * var_1.jac[0].A,
-                        var_1.val[1] * var_1.jac[1].A,
-                        var_1.val[2] * var_1.jac[2].A,
+                        var_1.val[0] * var_1.jac[0].toarray(),
+                        var_1.val[1] * var_1.jac[1].toarray(),
+                        var_1.val[2] * var_1.jac[2].toarray(),
                     )
                 ),
             )
@@ -1680,9 +1680,9 @@ def _expected_value(
             jac = sps.csr_matrix(
                 np.vstack(
                     (
-                        -2 / var_2.val[0] ** 2 * var_2.jac[0].A,
-                        -2 / var_2.val[1] ** 2 * var_2.jac[1].A,
-                        -2 / var_2.val[2] ** 2 * var_2.jac[2].A,
+                        -2 / var_2.val[0] ** 2 * var_2.jac[0].toarray(),
+                        -2 / var_2.val[1] ** 2 * var_2.jac[1].toarray(),
+                        -2 / var_2.val[2] ** 2 * var_2.jac[2].toarray(),
                     )
                 ),
             )
@@ -1694,9 +1694,9 @@ def _expected_value(
             jac = sps.csr_matrix(
                 np.vstack(
                     (
-                        np.log(2.0) * (2 ** var_2.val[0]) * var_2.jac[0].A,
-                        np.log(2.0) * (2 ** var_2.val[1]) * var_2.jac[1].A,
-                        np.log(2.0) * (2 ** var_2.val[2]) * var_2.jac[2].A,
+                        np.log(2.0) * (2 ** var_2.val[0]) * var_2.jac[0].toarray(),
+                        np.log(2.0) * (2 ** var_2.val[1]) * var_2.jac[1].toarray(),
+                        np.log(2.0) * (2 ** var_2.val[2]) * var_2.jac[2].toarray(),
                     )
                 ),
             )
@@ -1728,9 +1728,9 @@ def _expected_value(
             jac = sps.csr_matrix(
                 np.vstack(
                     (
-                        var_1.jac[0].A / var_2[0],
-                        var_1.jac[1].A / var_2[1],
-                        var_1.jac[2].A / var_2[2],
+                        var_1.jac[0].toarray() / var_2[0],
+                        var_1.jac[1].toarray() / var_2[1],
+                        var_1.jac[2].toarray() / var_2[2],
                     )
                 )
             )
@@ -1743,9 +1743,9 @@ def _expected_value(
             jac = sps.csr_matrix(
                 np.vstack(
                     (
-                        var_2[0] * (var_1.val[0] ** (var_2[0] - 1.0)) * var_1.jac[0].A,
-                        var_2[1] * (var_1.val[1] ** (var_2[1] - 1.0)) * var_1.jac[1].A,
-                        var_2[2] * (var_1.val[2] ** (var_2[2] - 1.0)) * var_1.jac[2].A,
+                        var_2[0] * (var_1.val[0] ** (var_2[0] - 1.0)) * var_1.jac[0].toarray(),
+                        var_2[1] * (var_1.val[1] ** (var_2[1] - 1.0)) * var_1.jac[1].toarray(),
+                        var_2[2] * (var_1.val[2] ** (var_2[2] - 1.0)) * var_1.jac[2].toarray(),
                     )
                 )
             )
@@ -1776,9 +1776,9 @@ def _expected_value(
             jac = sps.csr_matrix(
                 np.vstack(
                     (
-                        -var_1[0] * var_2.jac[0].A / var_2.val[0] ** 2,
-                        -var_1[1] * var_2.jac[1].A / var_2.val[1] ** 2,
-                        -var_1[2] * var_2.jac[2].A / var_2.val[2] ** 2,
+                        -var_1[0] * var_2.jac[0].toarray() / var_2.val[0] ** 2,
+                        -var_1[1] * var_2.jac[1].toarray() / var_2.val[1] ** 2,
+                        -var_1[2] * var_2.jac[2].toarray() / var_2.val[2] ** 2,
                     )
                 )
             )
@@ -1789,9 +1789,9 @@ def _expected_value(
             jac = sps.csr_matrix(
                 np.vstack(
                     (
-                        var_1[0] ** var_2.val[0] * np.log(var_1[0]) * var_2.jac[0].A,
-                        var_1[1] ** var_2.val[1] * np.log(var_1[1]) * var_2.jac[1].A,
-                        var_1[2] ** var_2.val[2] * np.log(var_1[2]) * var_2.jac[2].A,
+                        var_1[0] ** var_2.val[0] * np.log(var_1[0]) * var_2.jac[0].toarray(),
+                        var_1[1] ** var_2.val[1] * np.log(var_1[1]) * var_2.jac[1].toarray(),
+                        var_1[2] ** var_2.val[2] * np.log(var_1[2]) * var_2.jac[2].toarray(),
                     )
                 )
             )
@@ -1828,9 +1828,9 @@ def _expected_value(
             jac = sps.csr_matrix(
                 np.vstack(
                     (
-                        var_1.jac[0].A * var_2.val[0] + var_1.val[0] * var_2.jac[0].A,
-                        var_1.jac[1].A * var_2.val[1] + var_1.val[1] * var_2.jac[1].A,
-                        var_1.jac[2].A * var_2.val[2] + var_1.val[2] * var_2.jac[2].A,
+                        var_1.jac[0].toarray() * var_2.val[0] + var_1.val[0] * var_2.jac[0].toarray(),
+                        var_1.jac[1].toarray() * var_2.val[1] + var_1.val[1] * var_2.jac[1].toarray(),
+                        var_1.jac[2].toarray() * var_2.val[2] + var_1.val[2] * var_2.jac[2].toarray(),
                     )
                 )
             )
@@ -1842,12 +1842,12 @@ def _expected_value(
             jac = sps.csr_matrix(
                 np.vstack(  # NBNB
                     (
-                        var_1.jac[0].A / var_2.val[0]
-                        - var_1.val[0] * var_2.jac[0].A / var_2.val[0] ** 2,
-                        var_1.jac[1].A / var_2.val[1]
-                        - var_1.val[1] * var_2.jac[1].A / var_2.val[1] ** 2,
-                        var_1.jac[2].A / var_2.val[2]
-                        - var_1.val[2] * var_2.jac[2].A / var_2.val[2] ** 2,
+                        var_1.jac[0].toarray() / var_2.val[0]
+                        - var_1.val[0] * var_2.jac[0].toarray() / var_2.val[0] ** 2,
+                        var_1.jac[1].toarray() / var_2.val[1]
+                        - var_1.val[1] * var_2.jac[1].toarray() / var_2.val[1] ** 2,
+                        var_1.jac[2].toarray() / var_2.val[2]
+                        - var_1.val[2] * var_2.jac[2].toarray() / var_2.val[2] ** 2,
                     )
                 )
             )
@@ -1863,22 +1863,22 @@ def _expected_value(
                     (
                         var_2.val[0]
                         * var_1.val[0] ** (var_2.val[0] - 1.0)
-                        * var_1.jac[0].A
+                        * var_1.jac[0].toarray()
                         + np.log(var_1.val[0])
                         * (var_1.val[0] ** var_2.val[0])
-                        * var_2.jac[0].A,
+                        * var_2.jac[0].toarray(),
                         var_2.val[1]
                         * var_1.val[1] ** (var_2.val[1] - 1.0)
-                        * var_1.jac[1].A
+                        * var_1.jac[1].toarray()
                         + np.log(var_1.val[1])
                         * (var_1.val[1] ** var_2.val[1])
-                        * var_2.jac[1].A,
+                        * var_2.jac[1].toarray(),
                         var_2.val[2]
                         * var_1.val[2] ** (var_2.val[2] - 1.0)
-                        * var_1.jac[2].A
+                        * var_1.jac[2].toarray()
                         + np.log(var_1.val[2])
                         * (var_1.val[2] ** var_2.val[2])
-                        * var_2.jac[2].A,
+                        * var_2.jac[2].toarray(),
                     )
                 )
             )

--- a/tests/numerics/ad/test_surrogate_operator.py
+++ b/tests/numerics/ad/test_surrogate_operator.py
@@ -251,7 +251,7 @@ def test_secondary_operators(
         jac_.data = d
         jacs.append(jac_)
 
-    assert np.all(sop_val.jac.A == sum(jacs).A)
+    assert np.all(sop_val.jac.toarray() == sum(jacs).toarray())
 
     # progress values in time and check that only values are progressed, and that
     # they are correct, i.e. current iter is set as previous time
@@ -277,11 +277,11 @@ def test_secondary_operators(
         assert np.all(sop_pt_val.val == expr.interface_values)
     else:
         assert np.all(sop_pt_val.val == expr.subdomain_values)
-    assert np.all(sop_pt_val.jac.A == 0.0)
+    assert np.all(sop_pt_val.jac.toarray() == 0.0)
 
     sop_pi_val = sop_pi.value_and_jacobian(eqsys)
     assert np.all(sop_pi_val.val == np.ones(nc))
-    assert np.all(sop_pi_val.jac.A == 0.0)
+    assert np.all(sop_pi_val.jac.toarray() == 0.0)
 
     ## Test that the user cannot set values of unexpected shape
     if on_intf:

--- a/tests/numerics/fv/test_fvutils.py
+++ b/tests/numerics/fv/test_fvutils.py
@@ -48,7 +48,7 @@ def test_subcell_topology_2d_cart():
     usubfno = np.unique(subcell_topology.subfno)
     assert usubfno.size == subcell_topology.subfno.size
 
-    assert np.all(np.in1d(subcell_topology.subfno, subcell_topology.subhfno))
+    assert np.all(np.isin(subcell_topology.subfno, subcell_topology.subhfno))
 
 
 def test_subcell_mapping_2d_simplex():

--- a/tests/numerics/fv/test_fvutils.py
+++ b/tests/numerics/fv/test_fvutils.py
@@ -295,7 +295,7 @@ def test_bound_exclusion():
     neu_ind = np.argsort(subfno_neu)
     neu_ind = neu_ind[is_neu_nd[neu_ind]]
     reference = reference_dense_arrays.test_fvutils["test_bound_exclusion"]
-    assert np.alltrue(neu_ind == reference["neu_inds"])
+    assert np.all(neu_ind == reference["neu_inds"])
 
     subfno_dir = bound_exclusion.exclude_neumann_robin(subfno_nd.ravel("C")).ravel("F")
     is_dir_nd = (
@@ -307,4 +307,4 @@ def test_bound_exclusion():
     dir_ind = np.argsort(subfno_dir)
     dir_ind = dir_ind[is_dir_nd[dir_ind]]
 
-    assert np.alltrue(dir_ind == reference["dir_inds"])
+    assert np.all(dir_ind == reference["dir_inds"])

--- a/tests/numerics/fv/test_mpfa.py
+++ b/tests/numerics/fv/test_mpfa.py
@@ -1167,7 +1167,7 @@ class TestRobinBoundaryCondition:
         a = div * flux
         b = -div * bound_flux * u_bound
 
-        p = np.linalg.solve(a.A, b)
+        p = np.linalg.solve(a.toarray(), b)
 
         u_ex = [
             np.dot(g.face_normals[:, f], np.array([0, -1, 0]))
@@ -1198,7 +1198,7 @@ class TestRobinBoundaryCondition:
         a = div * flux
         b = -div * bound_flux * u_bound
 
-        p = np.linalg.solve(a.A, b)
+        p = np.linalg.solve(a.toarray(), b)
         assert np.allclose(p, p_ex)
         assert np.allclose(flux * p + bound_flux * u_bound, u_ex)
 

--- a/tests/numerics/fv/test_mpsa.py
+++ b/tests/numerics/fv/test_mpsa.py
@@ -267,7 +267,7 @@ class TestMpsaExactReproduction:
         discr.discretize(g, data)
         A, b = discr.assemble_matrix_rhs(g, data)
 
-        d = np.linalg.solve(A.A, b)
+        d = np.linalg.solve(A.toarray(), b)
 
         stress = data[pp.DISCRETIZATION_MATRICES][keyword][discr.stress_matrix_key]
         bound_stress = data[pp.DISCRETIZATION_MATRICES][keyword][
@@ -592,7 +592,7 @@ class MpsaReconstructBoundaryDisplacement(TestUpdateMpsaDiscretization):
         grad_bound = matrix_dictionary[discr.bound_displacement_face_matrix_key]
 
         hf2f = pp.fvutils.map_hf_2_f(sd=g)
-        num_subfaces = hf2f.sum(axis=1).A.ravel()
+        num_subfaces = hf2f.sum(axis=1).toarray().ravel()
         scaling = sps.dia_matrix(
             (1.0 / num_subfaces, 0), shape=(hf2f.shape[0], hf2f.shape[0])
         )
@@ -740,7 +740,7 @@ class TestCreateBoundRhs:
         bound_rhs_b = pp.Mpsa("")._create_bound_rhs(bc_sub, be, st, g, True)
 
         # rhs should not be affected by basis transform
-        assert np.allclose(bound_rhs_b.A, bound_rhs.A)
+        assert np.allclose(bound_rhs_b.toarray(), bound_rhs.toarray())
 
 
 class TestMpsaRotation:
@@ -1183,7 +1183,7 @@ class TestAsymmetricNeumann:
 
         expected_igrad = self.reference_sparse_arrays["test_cart_2d"]["igrad"]
 
-        assert np.all(np.abs(igrad - expected_igrad).A < 1e-12)
+        assert np.all(np.abs(igrad - expected_igrad).toarray() < 1e-12)
 
     def test_cart_3d(self):
         g = pp.CartGrid([1, 1, 1], physdims=(1, 1, 1))
@@ -1205,7 +1205,7 @@ class TestAsymmetricNeumann:
             g, k, subcell_topology, bound_exclusion, 0, "python"
         )
         expected_igrad = self.reference_sparse_arrays["test_cart_3d"]["igrad"]
-        assert np.all(np.abs(igrad - expected_igrad).A < 1e-12)
+        assert np.all(np.abs(igrad - expected_igrad).toarray() < 1e-12)
 
 
 class TestMpsaReproduceKnownValues:

--- a/tests/numerics/fv/test_tpfa.py
+++ b/tests/numerics/fv/test_tpfa.py
@@ -453,7 +453,7 @@ def test_transmissibility_calculation(vector_source: bool, base_discr: str):
             assert np.isclose(flux, computed_flux.val[fi])
 
         # Fetch the transmissibility from the base discretization.
-        diff = base_flux[fi].A.ravel()
+        diff = base_flux[fi].toarray().ravel()
         # Add tpfa-style contribution from the derivative of the transmissibility.
         diff[ci] += trm_diff * p
 
@@ -465,7 +465,7 @@ def test_transmissibility_calculation(vector_source: bool, base_discr: str):
 
         diff[ci] += projected_vs * trm_diff
 
-        assert np.allclose(diff, computed_flux.jac[fi].A.ravel())
+        assert np.allclose(diff, computed_flux.jac[fi].toarray().ravel())
 
     # On Neumann faces, the computed flux should equal the boundary condition. The
     # derivative should be zero.
@@ -473,7 +473,7 @@ def test_transmissibility_calculation(vector_source: bool, base_discr: str):
         computed_flux.val[model._neumann_face]
         == model._neumann_flux * div[1, model._neumann_face]
     )
-    assert np.allclose(computed_flux.jac[model._neumann_face].A, 0)
+    assert np.allclose(computed_flux.jac[model._neumann_face].toarray(), 0)
 
     # Test flux calculation on internal face. This is a bit more involved, as we need to
     # compute the harmonic mean of the two transmissibilities and its derivative.
@@ -501,7 +501,7 @@ def test_transmissibility_calculation(vector_source: bool, base_discr: str):
     vs_diff = (projected_vs_1 - projected_vs_0) * div[1, fi]
 
     # Fetch the transmissibility from the base discretization.
-    trm_full = base_flux[fi].A.ravel()
+    trm_full = base_flux[fi].toarray().ravel()
     # The derivative of the full transmissibility with respect to the two cell center
     # pressures, by the product rule.
     trm_diff_p0 = (
@@ -527,7 +527,7 @@ def test_transmissibility_calculation(vector_source: bool, base_discr: str):
     vector_source_diff = np.array(
         [trm_diff_p0 * vs_diff, -trm_diff_p1 * vs_diff]
     ).ravel()
-    assert np.allclose(trm_diff + vector_source_diff, computed_flux.jac[fi].A)
+    assert np.allclose(trm_diff + vector_source_diff, computed_flux.jac[fi].toarray())
 
     ####
     # Test the potential trace calculation
@@ -574,12 +574,12 @@ def test_transmissibility_calculation(vector_source: bool, base_discr: str):
 
     # Check the derivative of the potential trace reconstruction: Fetch the cell
     # contribution from the base discretization.
-    cell_contribution = base_bound_pressure_cell[model._neumann_face].A.ravel()
+    cell_contribution = base_bound_pressure_cell[model._neumann_face].toarray().ravel()
     # For the cell next to the Neumann face, there is an extra contribution from the
     # derivative of the transmissibility.
     cell_contribution[ci] += dp_diff * model._neumann_flux
 
-    assert np.allclose(potential_trace.jac[model._neumann_face].A, cell_contribution)
+    assert np.allclose(potential_trace.jac[model._neumann_face].toarray(), cell_contribution)
 
     # On a Dirichlet face, the potential trace should be equal to the Dirichlet value.
     assert np.isclose(
@@ -588,7 +588,7 @@ def test_transmissibility_calculation(vector_source: bool, base_discr: str):
     # The derivative of the potential trace with respect to the pressure should be zero,
     # as the potential trace is constant.
     assert np.allclose(
-        potential_trace.jac[model._nonzero_dirichlet_face].A, 0, atol=1e-15
+        potential_trace.jac[model._nonzero_dirichlet_face].toarray(), 0, atol=1e-15
     )
 
 
@@ -764,7 +764,7 @@ def test_diff_tpfa_and_standard_tpfa_give_same_linear_system(base_discr: str):
         matrix.append(mod.linear_system[0])
         vector.append(mod.linear_system[1])
 
-    assert np.allclose(matrix[0].A, matrix[1].A)
+    assert np.allclose(matrix[0].toarray(), matrix[1].toarray())
     assert np.allclose(vector[0], vector[1])
 
 

--- a/tests/utils/test_setmembership.py
+++ b/tests/utils/test_setmembership.py
@@ -112,8 +112,8 @@ def test_unique_columns_tol_no_common_points():
     p_unique, new_2_old, old_2_new = setmembership.unique_columns_tol(p)
 
     assert np.allclose(p, p_unique)
-    assert np.alltrue(old_2_new == np.arange(3))
-    assert np.alltrue(old_2_new == new_2_old)
+    assert np.all(old_2_new == np.arange(3))
+    assert np.all(old_2_new == new_2_old)
 
 
 def test_unique_columns_tol_remove_one_point():
@@ -121,8 +121,8 @@ def test_unique_columns_tol_remove_one_point():
     _, new_2_old, old_2_new = setmembership.unique_columns_tol(p)
 
     assert np.allclose(p, np.ones((2, 1)))
-    assert np.alltrue(old_2_new == np.zeros(2))
-    assert np.alltrue(new_2_old == np.zeros(1))
+    assert np.all(old_2_new == np.zeros(2))
+    assert np.all(new_2_old == np.zeros(1))
 
 
 def test_unique_columns_tol_remove_one_of_tree():
@@ -133,11 +133,11 @@ def test_unique_columns_tol_remove_one_of_tree():
     # (see unique_columns_tol for the various options that may be applied).
     # Do a simple sort to ensure we're safe.
     if p_unique[0, 0] == 0:
-        assert np.alltrue(np.sort(old_2_new) == np.array([0, 1, 1]))
-        assert np.alltrue(np.sort(new_2_old) == np.array([0, 2]))
+        assert np.all(np.sort(old_2_new) == np.array([0, 1, 1]))
+        assert np.all(np.sort(new_2_old) == np.array([0, 2]))
     else:
-        assert np.alltrue(np.sort(old_2_new) == np.array([0, 0, 1]))
-        assert np.alltrue(np.sort(new_2_old) == np.array([0, 2]))
+        assert np.all(np.sort(old_2_new) == np.array([0, 0, 1]))
+        assert np.all(np.sort(new_2_old) == np.array([0, 2]))
 
     p_known = np.array([[0, 1], [0, 1]])
 

--- a/tutorials/stress_discretization.ipynb
+++ b/tutorials/stress_discretization.ipynb
@@ -151,7 +151,7 @@
     "mpsa_class.discretize(g, data)\n",
     "A, b = mpsa_class.assemble_matrix_rhs(g, data)\n",
     "\n",
-    "u = np.linalg.solve(A.A, b)"
+    "u = np.linalg.solve(A.toarray(), b)"
    ]
   },
   {


### PR DESCRIPTION
## Proposed changes
Though this PR changes a lot of lines, they are limited to the following cases:
* To convert a  `scipy.sparse.spmatrix` to a dense array, use `A.toarray()` instead of `A.A` (the latter is deprecated)
* The output from `numpy.unique(..., return_inverse=True)` can now be 2d. The code was updated to reflect this.
* Use `numpy.isin` rather than the deprecated `numpy.in1d`.
* Use `numpy.nan` instead of `numpy.NaN` (changed a single occurence)
* Updated documentation of a single function in `utils/setmembership.py`. This is the only change that was not directly linked to the updates of numpy and scipy versions.

Notes:
* The code should be compatible with both `numpy 1.X` and `2.X`
* While the test suite would benefit from `black` formatting, I did not do so in this PR, since this would have made it very difficult to get an overview of the changes. Instead I suggest to do this in a dedicated PR, and then probably require that the test folders are compatible with `black`  as part of the static tests.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Testing (contribution related to testing of existing or new functionality).
- [x] Documentation (contribution related to adding, improving, or fixing documentation).
- [x] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [ ] Static typing is included in the update. NOT RELEVANT
- [x] This PR does not duplicate existing functionality. 
- [x] The update is covered by the test suite (including tests added in the PR).
- [x] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
