### PR TITLE
FEAT: Hashing

### DIFF
--- a/src/porepy/numerics/ad/_ad_utils.py
+++ b/src/porepy/numerics/ad/_ad_utils.py
@@ -524,6 +524,12 @@ class MergedOperator(operators.Operator):
 
     """
 
+    def _key(self) -> str:
+        return (
+            f"(merged_op, discretization_matrix_key={self._discretization_matrix_key},"
+            f" physics_key={self._physics_key}, domains={[d.id for d in self.domains]})"
+        )
+
     def __init__(
         self,
         discr: pp.discretization_type,

--- a/src/porepy/numerics/ad/grid_operators.py
+++ b/src/porepy/numerics/ad/grid_operators.py
@@ -628,6 +628,10 @@ class Trace:
 class Divergence(Operator):
     """Wrapper class for Ad representations of divergence operators."""
 
+    def _key(self) -> str:
+        subdomain_ids = [sd.id for sd in self.subdomains]
+        return f"(divergence, dim={self.dim}, subdomains={subdomain_ids})"
+
     def __init__(
         self,
         subdomains: list[pp.Grid],

--- a/src/porepy/numerics/ad/operator_functions.py
+++ b/src/porepy/numerics/ad/operator_functions.py
@@ -59,6 +59,8 @@ class AbstractFunction(Operator):
         name: Name of this instance as an AD operator.
 
     """
+    def _key(self) -> str:
+        raise NotImplementedError("Will be covered later.")
 
     def __init__(
         self,

--- a/src/porepy/numerics/ad/operator_functions.py
+++ b/src/porepy/numerics/ad/operator_functions.py
@@ -59,6 +59,7 @@ class AbstractFunction(Operator):
         name: Name of this instance as an AD operator.
 
     """
+
     def _key(self) -> str:
         raise NotImplementedError("Will be covered later.")
 

--- a/src/porepy/numerics/ad/operators.py
+++ b/src/porepy/numerics/ad/operators.py
@@ -1469,9 +1469,19 @@ class SparseArray(Operator):
     def _compute_spmatrix_hash(mat: sps.spmatrix) -> str:
         """Utility function that handles all the sparse formats to compute the hash."""
         # proper handling of all the formats like csr, coo, etc..
-        if isinstance(mat, (sps.csr_matrix, sps.csc_matrix, sps.bsr_matrix)):
+        if isinstance(
+            mat,
+            (
+                sps.csr_matrix,
+                sps.csr_array,
+                sps.csc_matrix,
+                sps.csc_array,
+                sps.bsr_matrix,
+                sps.bsr_array,
+            ),
+        ):
             properties = [mat.data, mat.indices, mat.indptr]
-        elif isinstance(mat, sps.coo_matrix):
+        elif isinstance(mat, (sps.coo_matrix, sps.coo_array)):
             properties = [mat.data, mat.row, mat.col]
         else:
             raise NotImplementedError("Hashing not provided for the format", type(mat))

--- a/src/porepy/numerics/ad/operators.py
+++ b/src/porepy/numerics/ad/operators.py
@@ -1470,9 +1470,9 @@ class SparseArray(Operator):
         """Utility function that handles all the sparse formats to compute the hash.
 
         The hash will match for two sparse arrays with the identical: sparse formats,
-        data arrays, rows and columns arrays. The identical matrices in the different
-        formats will have different hashes. Such behavior is expected, since if two
-        different formats are used, they are likely used for a good (efficiency) reason.
+        shapes, data arrays, rows and columns arrays. The identical matrices in the
+        different formats will have different hashes. Such behavior is expected, since
+        two different formats are likely used for a good reason.
 
         The rows and columns are considered to avoid the collision between, e.g., the
         following rows in the csr format: `[1, 0, 1, 0]` vs `[0, 1, 0, 1]`.
@@ -1506,9 +1506,9 @@ class SparseArray(Operator):
         data_hash = "".join(
             [sha256(array, usedforsecurity=False).hexdigest() for array in properties]
         )
-        # Adding the information about the matrix format. `mat.format` is not used
-        # because it does not distinguish between, e.g., csr_matrix and csr_array.
-        return f"{type(mat).__name__}_{data_hash}"
+        # Adding the information about the matrix format and shape. `mat.format` is not
+        # used because it does not distinguish between, e.g., csr_matrix and csr_array.
+        return f"{type(mat).__name__}_{mat.shape}_{data_hash}"
 
 
 class DenseArray(Operator):

--- a/src/porepy/numerics/ad/operators.py
+++ b/src/porepy/numerics/ad/operators.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import copy
 from enum import Enum
 from functools import reduce
+from hashlib import sha256
 from itertools import count
 from typing import Any, Callable, Literal, Optional, Sequence, TypeVar, Union, overload
 
@@ -1124,6 +1125,32 @@ class Operator:
             name="reverse @ operator",
         )
 
+    def __hash__(self):
+        return hash(self._key())
+
+    def _key(self) -> str:
+        """String representation for hashing.
+
+        Provides a representation of the operator tree which grows from the current
+        operator meant for hashing. Different AD objects that represent the identical
+        trees defined on the same domains must have identical keys. Otherwise, the keys
+        must be different.
+
+        All the leave operators (which are the subclasses) must override this method.
+        Calling super is not expected.
+
+        Returns:
+            The key string.
+
+        Raises:
+            ValueError: If this method is called from the leave AD object.
+
+        """
+        if self.operation == Operator.Operations.void or len(self.children) == 0:
+            raise ValueError("Base class operator must represent an operation.")
+        tmp = [self.operation.value] + [child._key() for child in self.children]
+        return " ".join(tmp)
+
     def _parse_other(self, other):
         if isinstance(other, float) or isinstance(other, int):
             return [self, Scalar(other)]
@@ -1388,6 +1415,13 @@ class SparseArray(Operator):
         self._shape = mat.shape
         """Shape of the wrapped matrix."""
 
+        # TODO: Make readonly, see https://github.com/pmgbergen/porepy/issues/1214
+        self._hash_value: str = self._compute_spmatrix_hash(mat)
+        """String to uniquly identify the contents of the matrix."""
+
+    def _key(self) -> str:
+        return f"(sparse_array, hash={self._hash_value})"
+
     def __repr__(self) -> str:
         return f"Matrix with shape {self._mat.shape} and {self._mat.data.size} elements"
 
@@ -1431,6 +1465,20 @@ class SparseArray(Operator):
         """Shape of the wrapped matrix."""
         return self._shape
 
+    @staticmethod
+    def _compute_spmatrix_hash(mat: sps.spmatrix) -> str:
+        """Utility function that handles all the sparse formats to compute the hash."""
+        # proper handling of all the formats like csr, coo, etc..
+        if isinstance(mat, (sps.csr_matrix, sps.csc_matrix, sps.bsr_matrix)):
+            properties = [mat.data, mat.indices, mat.indptr]
+        elif isinstance(mat, sps.coo_matrix):
+            properties = [mat.data, mat.row, mat.col]
+        else:
+            raise NotImplementedError("Hashing not provided for the format", type(mat))
+        return "".join(
+            [sha256(array, usedforsecurity=False).hexdigest() for array in properties]
+        )
+
 
 class DenseArray(Operator):
     """AD representation of a constant numpy array.
@@ -1457,6 +1505,15 @@ class DenseArray(Operator):
         # Force the data to be float, so that we limit the number of combinations of
         # data types that we need to consider in parsing.
         self._values = values.astype(float, copy=False)
+
+        # TODO: Make readonly, see https://github.com/pmgbergen/porepy/issues/1214
+        self._hash_value: str = sha256(
+            self._values, usedforsecurity=False  # type: ignore[arg-type]
+        ).hexdigest()
+        """String to uniquly identify the array."""
+
+    def _key(self) -> str:
+        return f"(dense_array, hash={self._hash_value})"
 
     def __repr__(self) -> str:
         return f"Wrapped numpy array of size {self._values.size}."
@@ -1534,6 +1591,10 @@ class TimeDependentDenseArray(TimeDependentOperator):
     ):
         super().__init__(name=name, domains=domains)
 
+    def _key(self) -> str:
+        domain_ids = [domain.id for domain in self.domains]
+        return f"(time_dependent_dense_array, name={self.name}, domains={domain_ids})"
+
     def parse(self, mdg: pp.MixedDimensionalGrid) -> np.ndarray:
         """Convert this array into numerical values.
 
@@ -1608,6 +1669,9 @@ class Scalar(Operator):
         # Force the data to be float, so that we limit the number of combinations of
         # data types that we need to consider in parsing.
         self._value = float(value)
+
+    def _key(self) -> str:
+        return f"(scalar, {self._value})"
 
     def __repr__(self) -> str:
         return f"Wrapped scalar with value {self._value}"
@@ -1723,6 +1787,10 @@ class Variable(TimeDependentOperator, IterativeOperator):
 
         # tag
         self._tags: dict[str, Any] = tags if tags is not None else {}
+
+    def _key(self):
+        # The names are unique for variables.
+        return f"(var, name={self.name}, domain={str(self.domain.id)})"
 
     @property
     def id(self) -> int:
@@ -1843,6 +1911,13 @@ class MixedDimensionalVariable(Variable):
         AssertionError: If one of the above assumptions is violated.
 
     """
+
+    def _key(self) -> str:
+        # The MixedDimensionalVariable is not stored in the equation system but
+        # constructed every time when needed. Thus, its id is updated and cannot be
+        # relied on. Instead, we rely on the name, which is guaranteed to be unique.
+        domain_ids = [domain.id for domain in self.domains]
+        return f"(mdvar, name={self.name}, domains={domain_ids})"
 
     def __init__(self, variables: list[Variable]) -> None:
         # IMPLEMENTATION NOTE VL

--- a/tests/numerics/ad/test_operators.py
+++ b/tests/numerics/ad/test_operators.py
@@ -2078,7 +2078,7 @@ def test_hashing(generate_ad_list):
     """
 
     class Model(SquareDomainOrthogonalFractures, SinglePhaseFlow):
-    """Mock-up model."""
+        """Mock-up model."""
 
     # With the default parameters, the model contains one fracture.
     model = Model({})

--- a/tests/numerics/ad/test_operators.py
+++ b/tests/numerics/ad/test_operators.py
@@ -19,6 +19,7 @@ Checks performed include the following:
     test_arithmetic_operations_on_ad_objects: Basic Ad operators combined with standard
         arithmetic operations are tested.
     test_hashing: Expectations for the hash function to work correctly with AD objects.
+    test_hashing_sparse_array: Edge cases for the hash function of SparseArray.
 
 """
 
@@ -634,7 +635,7 @@ def test_ad_variable_evaluation():
     assert np.allclose(true_state[ind1], v1_prev.value(eq_system, true_iterate))
 
 
-@pytest.mark.parametrize('prev_time', [True, False])
+@pytest.mark.parametrize("prev_time", [True, False])
 def test_ad_variable_prev_time_and_iter(prev_time):
     # Test only 1 variable, the rest should be covered by other tests
     mdg, _ = pp.mdg_library.square_with_orthogonal_fractures(
@@ -646,12 +647,10 @@ def test_ad_variable_prev_time_and_iter(prev_time):
 
     # Integer to test the depth of prev _*, could be a test parameter, but no need
     depth = 4
-    var_name = 'foo'
+    var_name = "foo"
     vec = np.ones(mdg.num_subdomain_cells())
 
-    eqsys.create_variables(
-        var_name, dof_info={"cells": 1}, subdomains=mdg.subdomains()
-    )
+    eqsys.create_variables(var_name, dof_info={"cells": 1}, subdomains=mdg.subdomains())
     var = eqsys.md_variable(var_name)
 
     # Starting point is time step index is None, iterate index is 0
@@ -660,23 +659,23 @@ def test_ad_variable_prev_time_and_iter(prev_time):
     assert var.iterate_index == 0
 
     # For AD to work, we need at least values at iterate_index = 0
-    eqsys.set_variable_values(vec * 0., [var], iterate_index = 0)
+    eqsys.set_variable_values(vec * 0.0, [var], iterate_index=0)
 
     # Test configuration dependent on whether prev iter or prev time is tested.
     # Code is analogous
     if prev_time:
-        index_key = 'time_step_index'
-        other_index_key = 'iterate_index'
-        get_prev_key = 'previous_timestep'
+        index_key = "time_step_index"
+        other_index_key = "iterate_index"
+        get_prev_key = "previous_timestep"
 
         # prohibit prev time step variable to also be prev iter
         with pytest.raises(ValueError):
             var_pt = var.previous_timestep()
             _ = var_pt.previous_iteration()
     else:
-        index_key = 'iterate_index'
-        other_index_key = 'time_step_index'
-        get_prev_key = 'previous_iteration'
+        index_key = "iterate_index"
+        other_index_key = "time_step_index"
+        get_prev_key = "previous_iteration"
 
         # prohibit prev iter variable to also be prev time
         with pytest.raises(ValueError):
@@ -689,18 +688,18 @@ def test_ad_variable_prev_time_and_iter(prev_time):
 
     # Evaluating the last step, should raise a key error because no values set
     with pytest.raises(KeyError):
-        var_prev = getattr(var, get_prev_key)(steps = depth)
+        var_prev = getattr(var, get_prev_key)(steps=depth)
         _ = var_prev.value(eqsys)
 
     # Evaluate prev var and check that the values are what they're supposed to be.
     for i in range(depth - 1):
-        var_i = getattr(var, get_prev_key)(steps = i + 1)
+        var_i = getattr(var, get_prev_key)(steps=i + 1)
         val_i = var_i.value(eqsys)
         assert np.allclose(val_i, i)
 
         # prev var has no Jacobian
         ad_i = var_i.value_and_jacobian(eqsys)
-        assert np.all(ad_i.jac.toarray() == 0.)
+        assert np.all(ad_i.jac.toarray() == 0.0)
 
     # Test creating with explicit stepping and recursive stepping
     vars_exp = [getattr(var, get_prev_key)(steps=i) for i in range(1, depth)]
@@ -1748,9 +1747,15 @@ def _expected_value(
             jac = sps.csr_matrix(
                 np.vstack(
                     (
-                        var_2[0] * (var_1.val[0] ** (var_2[0] - 1.0)) * var_1.jac[0].toarray(),
-                        var_2[1] * (var_1.val[1] ** (var_2[1] - 1.0)) * var_1.jac[1].toarray(),
-                        var_2[2] * (var_1.val[2] ** (var_2[2] - 1.0)) * var_1.jac[2].toarray(),
+                        var_2[0]
+                        * (var_1.val[0] ** (var_2[0] - 1.0))
+                        * var_1.jac[0].toarray(),
+                        var_2[1]
+                        * (var_1.val[1] ** (var_2[1] - 1.0))
+                        * var_1.jac[1].toarray(),
+                        var_2[2]
+                        * (var_1.val[2] ** (var_2[2] - 1.0))
+                        * var_1.jac[2].toarray(),
                     )
                 )
             )
@@ -1794,9 +1799,15 @@ def _expected_value(
             jac = sps.csr_matrix(
                 np.vstack(
                     (
-                        var_1[0] ** var_2.val[0] * np.log(var_1[0]) * var_2.jac[0].toarray(),
-                        var_1[1] ** var_2.val[1] * np.log(var_1[1]) * var_2.jac[1].toarray(),
-                        var_1[2] ** var_2.val[2] * np.log(var_1[2]) * var_2.jac[2].toarray(),
+                        var_1[0] ** var_2.val[0]
+                        * np.log(var_1[0])
+                        * var_2.jac[0].toarray(),
+                        var_1[1] ** var_2.val[1]
+                        * np.log(var_1[1])
+                        * var_2.jac[1].toarray(),
+                        var_1[2] ** var_2.val[2]
+                        * np.log(var_1[2])
+                        * var_2.jac[2].toarray(),
                     )
                 )
             )
@@ -1833,9 +1844,12 @@ def _expected_value(
             jac = sps.csr_matrix(
                 np.vstack(
                     (
-                        var_1.jac[0].toarray() * var_2.val[0] + var_1.val[0] * var_2.jac[0].toarray(),
-                        var_1.jac[1].toarray() * var_2.val[1] + var_1.val[1] * var_2.jac[1].toarray(),
-                        var_1.jac[2].toarray() * var_2.val[2] + var_1.val[2] * var_2.jac[2].toarray(),
+                        var_1.jac[0].toarray() * var_2.val[0]
+                        + var_1.val[0] * var_2.jac[0].toarray(),
+                        var_1.jac[1].toarray() * var_2.val[1]
+                        + var_1.val[1] * var_2.jac[1].toarray(),
+                        var_1.jac[2].toarray() * var_2.val[2]
+                        + var_1.val[2] * var_2.jac[2].toarray(),
                     )
                 )
             )
@@ -2101,3 +2115,29 @@ def test_hashing(generate_ad_list):
                 assert hash(ad1) != hash(ad2)
             else:
                 assert hash(ad1) == hash(ad2)
+
+
+@pytest.mark.parametrize(
+    "two_spmatrices",
+    [
+        # *_matrix and *_array must have different hashes.
+        [sps.coo_matrix(np.eye(2, 2)), sps.coo_array(np.eye(2, 2))],
+        # Different sparse formats must have different hashes.
+        [sps.csc_matrix(np.eye(2, 2)), sps.dia_matrix(np.eye(2, 2))],
+        # Csr matrices with different `data` fields must have different hashes.
+        [sps.csr_matrix([1, 0, 1, 0]), sps.csr_matrix([2, 0, 2, 0])],
+        # Csr matrices with different `indices` fields must have different hashes.
+        [sps.csr_matrix([1, 0, 1, 0]), sps.csr_matrix([0, 1, 0, 1])],
+        # Csr matrices with different `indptr` fields must have different hashes.
+        [sps.csr_matrix([[1], [0], [1], [0]]), sps.csr_matrix([[1], [1], [0], [0]])],
+        # Csr matrices with different `shape` fields must have different hashes.
+        [sps.csr_matrix([1, 0]), sps.csr_matrix([1, 0, 0])],
+    ],
+)
+def test_hashing_sparse_array(two_spmatrices):
+    """The hash function should account for these edge cases, when two matrices are
+    almost identical, but it is crucial to distinguish between them.
+
+    """
+    m1, m2 = [pp.ad.SparseArray(mat) for mat in two_spmatrices]
+    assert hash(m1) != hash(m2)

--- a/tests/numerics/ad/test_operators.py
+++ b/tests/numerics/ad/test_operators.py
@@ -2057,7 +2057,7 @@ def test_arithmetic_operations_on_ad_objects(
                 model.interface_darcy_flux_variable, model.mdg.interfaces()
             ),
         ],
-        # Some randomly selected operators: Leaves and trees.
+        # Some randomly selected operators: Leaves and trees in the Ad operator graph sense.
         lambda model: [
             model.ad_time_step,
             model.permeability(model.mdg.subdomains()),
@@ -2078,7 +2078,7 @@ def test_hashing(generate_ad_list):
     """
 
     class Model(SquareDomainOrthogonalFractures, SinglePhaseFlow):
-        """Mock-up model."""
+    """Mock-up model."""
 
     # With the default parameters, the model contains one fracture.
     model = Model({})


### PR DESCRIPTION
## Proposed changes

This addresses #1179. Note that I have not implement hashing for the AD functions, since they are not used by the basic models. This however should not break anything, since right now nothing relies on the hashes.

Sidenote: I considered the original idea to name the new method `__key` with double underscore, however, it leads to the issue. Consider the following code: 
```
class Parent:

    def __hash__(self) -> int:
        return hash(self.__key())

    def __key(self):
        return 'hi from parent'
    

class Child(Parent):

    def __key(self):
        return 'hi from child'
    

p = Parent()
print(hash(p))

c = Child()
print(hash(c))
```

The hashes of the parent and the child will be the same (not as we want). This is because the method `__hash__` defined only for the parent always calls the parent's `__key` due to [name mangling in Python](https://stackoverflow.com/a/1301369). The workaround would be either to repeat the `__hash__` method for each child class or to replace the double underscore with the single one. I have chosen the latter. Please let me know if I understood the idea incorrectly.


## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
