### PR TITLE
Elasto_plastic_fracture_deformation

### DIFF
--- a/src/porepy/applications/boundary_conditions/model_boundary_conditions.py
+++ b/src/porepy/applications/boundary_conditions/model_boundary_conditions.py
@@ -236,6 +236,7 @@ class BoundaryConditionsMechanicsDirNorthSouth(pp.BoundaryConditionMixin):
         sides = self.domain_boundary_sides(boundary_grid)
         values = np.zeros((self.nd, boundary_grid.num_cells))
         if boundary_grid.dim < self.nd - 1:
+            # No displacement is implemented on grids of co-dimension >= 2.
             return values.ravel("F")
 
         if "uy_north" in self.params or "uy_south" in self.params:

--- a/src/porepy/applications/boundary_conditions/model_boundary_conditions.py
+++ b/src/porepy/applications/boundary_conditions/model_boundary_conditions.py
@@ -267,9 +267,9 @@ class TimeDependentMechanicalBCsDirNorthSouth(BoundaryConditionsMechanicsDirNort
         """Displacement values.
 
         Initial value is u_y = self.solid.fracture_gap() +
-        self.solid.maximum_fracture_closure() at north boundary. Adding it on the
-        boundary ensures a stress-free initial state, as it compensates for those two
-        values corresponding to zero traction contact according to the class
+        self.solid.maximum_elastic_fracture_opening() at north boundary. Adding it on
+        the boundary ensures a stress-free initial state, as it compensates for those
+        two values corresponding to zero traction contact according to the class
         :class:`~porepy.models.constitutive_laws.FractureGap`. For positive times,
         uy_north and uy_south are fetched from parameter dictionary and added,
         defaulting to 0.
@@ -286,7 +286,10 @@ class TimeDependentMechanicalBCsDirNorthSouth(BoundaryConditionsMechanicsDirNort
         values = np.zeros((self.nd, boundary_grid.num_cells))
         # Add fracture width on top if there is a fracture.
         if len(self.mdg.subdomains()) > 1:
-            frac_val = self.solid.fracture_gap() + self.solid.maximum_fracture_closure()
+            frac_val = (
+                self.solid.fracture_gap()
+                + self.solid.maximum_elastic_fracture_opening()
+            )
         else:
             frac_val = 0
         values[1, domain_sides.north] = frac_val

--- a/src/porepy/applications/boundary_conditions/model_boundary_conditions.py
+++ b/src/porepy/applications/boundary_conditions/model_boundary_conditions.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from typing import Any
 
 import numpy as np
@@ -221,8 +222,8 @@ class BoundaryConditionsMechanicsDirNorthSouth(pp.BoundaryConditionMixin):
         """Boundary values for the mechanics problem as a numpy array.
 
         Values for north and south faces are set to zero unless otherwise specified
-        through items ux_north, uy_north, ux_south, uy_south in the parameter dictionary
-        passed on model initialization.
+        through items u_north and u_south in the parameter dictionary passed on model
+        initialization.
 
         Parameters:
             boundary_grid: Boundary grid for which boundary values are to be returned.
@@ -232,20 +233,25 @@ class BoundaryConditionsMechanicsDirNorthSouth(pp.BoundaryConditionMixin):
                 domain, for each face in the subdomain.
 
         """
-        domain_sides = self.domain_boundary_sides(boundary_grid)
+        sides = self.domain_boundary_sides(boundary_grid)
         values = np.zeros((self.nd, boundary_grid.num_cells))
-        values[1, domain_sides.north] = self.solid.convert_units(
-            self.params.get("uy_north", 0), "m"
-        )
-        values[1, domain_sides.south] = self.solid.convert_units(
-            self.params.get("uy_south", 0), "m"
-        )
-        values[0, domain_sides.north] = self.solid.convert_units(
-            self.params.get("ux_north", 0), "m"
-        )
-        values[0, domain_sides.south] = self.solid.convert_units(
-            self.params.get("ux_south", 0), "m"
-        )
+        if boundary_grid.dim < self.nd - 1:
+            return values.ravel("F")
+
+        if "uy_north" in self.params or "uy_south" in self.params:
+            warnings.warn(
+                "uy_north and uy_south are deprecated. Use u_north and u_south instead."
+            )
+        # Wrap as array for convert_units. Thus, the passed values can be scalar or
+        # list. Then tile for correct broadcasting below.
+        u_n = np.tile(
+            self.params.get("u_north", np.zeros(self.nd)), (boundary_grid.num_cells, 1)
+        ).T
+        u_s = np.tile(
+            self.params.get("u_south", np.zeros(self.nd)), (boundary_grid.num_cells, 1)
+        ).T
+        values[:, sides.north] = self.solid.convert_units(u_n, "m")[:, sides.north]
+        values[:, sides.south] = self.solid.convert_units(u_s, "m")[:, sides.south]
         return values.ravel("F")
 
 
@@ -259,8 +265,7 @@ class TimeDependentMechanicalBCsDirNorthSouth(BoundaryConditionsMechanicsDirNort
     def bc_values_displacement(self, boundary_grid: pp.BoundaryGrid) -> np.ndarray:
         """Displacement values.
 
-        Initial value is u_y = 0.042 at north boundary. This is a hard-coded value
-        corresponding to aperture of horizontal fracture used in various tests. Adding
+        Initial value is u_y = self.solid.fracture_gap() at north boundary. Adding
         it on the boundary ensures a stress-free initial state. For positive times,
         uy_north and uy_south are fetched from parameter dictionary and added,
         defaulting to 0.
@@ -277,15 +282,11 @@ class TimeDependentMechanicalBCsDirNorthSouth(BoundaryConditionsMechanicsDirNort
         values = np.zeros((self.nd, boundary_grid.num_cells))
         # Add fracture width on top if there is a fracture.
         if len(self.mdg.subdomains()) > 1:
-            frac_val = self.solid.convert_units(0.042, "m")
+            frac_val = self.solid.fracture_gap()
         else:
             frac_val = 0
         values[1, domain_sides.north] = frac_val
         if self.time_manager.time > 1e-5:
-            values[1, domain_sides.north] += self.solid.convert_units(
-                self.params.get("uy_north", 0), "m"
-            )
-            values[1, domain_sides.south] += self.solid.convert_units(
-                self.params.get("uy_south", 0), "m"
-            )
-        return values.ravel("F")
+            return values.ravel("F") + super().bc_values_displacement(boundary_grid)
+        else:
+            return values.ravel("F")

--- a/src/porepy/applications/boundary_conditions/model_boundary_conditions.py
+++ b/src/porepy/applications/boundary_conditions/model_boundary_conditions.py
@@ -266,8 +266,11 @@ class TimeDependentMechanicalBCsDirNorthSouth(BoundaryConditionsMechanicsDirNort
     def bc_values_displacement(self, boundary_grid: pp.BoundaryGrid) -> np.ndarray:
         """Displacement values.
 
-        Initial value is u_y = self.solid.fracture_gap() at north boundary. Adding
-        it on the boundary ensures a stress-free initial state. For positive times,
+        Initial value is u_y = self.solid.fracture_gap() +
+        self.solid.maximum_fracture_closure() at north boundary. Adding it on the
+        boundary ensures a stress-free initial state, as it compensates for those two
+        values corresponding to zero traction contact according to the class
+        :class:`~porepy.models.constitutive_laws.FractureGap`. For positive times,
         uy_north and uy_south are fetched from parameter dictionary and added,
         defaulting to 0.
 
@@ -283,7 +286,7 @@ class TimeDependentMechanicalBCsDirNorthSouth(BoundaryConditionsMechanicsDirNort
         values = np.zeros((self.nd, boundary_grid.num_cells))
         # Add fracture width on top if there is a fracture.
         if len(self.mdg.subdomains()) > 1:
-            frac_val = self.solid.fracture_gap()
+            frac_val = self.solid.fracture_gap() + self.solid.maximum_fracture_closure()
         else:
             frac_val = 0
         values[1, domain_sides.north] = frac_val

--- a/src/porepy/applications/material_values/solid_values.py
+++ b/src/porepy/applications/material_values/solid_values.py
@@ -176,7 +176,7 @@ extended_granite_values_for_testing.update(
         "dilation_angle": 0.1,  # [rad]
         "fracture_gap": 1e-3,  # [m]
         "fracture_normal_stiffness": 1.1e8,  # [Pa m^-1]
-        "maximum_fracture_closure": 1e-3,  # [m]
+        "maximum_elastic_fracture_opening": 1e-3,  # [m]
         "normal_permeability": 5.0e-15,  # [m^2]
         "residual_aperture": 1e-3,  # [m]
         "skin_factor": 37,  # [-]

--- a/src/porepy/applications/test_utils/models.py
+++ b/src/porepy/applications/test_utils/models.py
@@ -286,7 +286,7 @@ granite_values = {
     "thermal_conductivity": 2.5,
     "thermal_expansion": 1e-5,
     "fracture_normal_stiffness": 1529,
-    "maximum_fracture_closure": 1e-4,
+    "maximum_elastic_fracture_opening": 1e-4,
     "fracture_gap": 1e-4,
     "residual_aperture": 0.01,
 }

--- a/src/porepy/models/constitutive_laws.py
+++ b/src/porepy/models/constitutive_laws.py
@@ -4447,8 +4447,9 @@ class ElastoPlasticFractureDeformation:
         t_t = nd_vec_to_tangential @ self.contact_traction(subdomains)
 
         stiffness = self.fracture_tangential_stiffness(subdomains)
-        stiffness_value = stiffness.value(self.equation_system)
-        if np.any(np.isclose(stiffness_value, -1.0, atol=1e-12, rtol=1e-12)):
+        # Retrieve the *unscaled* stiffness value for the check below.
+        stiffness_value = self.solid.fracture_tangential_stiffness()
+        if np.isclose(stiffness_value, -1.0, atol=1e-12, rtol=1e-12):
             # Stiffness=-1 indicates no elastic tangential deformation. Small tolerances
             # are used to avoid numerical issues, but allowing for a float value.
             num_cells = sum(sd.num_cells for sd in subdomains)

--- a/src/porepy/models/constitutive_laws.py
+++ b/src/porepy/models/constitutive_laws.py
@@ -4314,11 +4314,11 @@ class BartonBandis:
         contact traction and material constants as elaborated in the class documentation.
 
         The returned value depends on the value of the solid constant
-        maximum_elastic_fracture_opening. If its value is zero, the Barton-Bandis model is void,
-        and the method returns a hard-coded pp.ad.Scalar(0) to avoid zero division.
-        Otherwise, an operator which implements the Barton-Bandis model is returned. The
-        special treatment ammounts to a continuous extension in the limit of zero
-        maximum fracture closure.
+        maximum_elastic_fracture_opening. If its value is zero, the Barton-Bandis model
+        is void, and the method returns a hard-coded pp.ad.Scalar(0) to avoid zero
+        division. Otherwise, an operator which implements the Barton-Bandis model is
+        returned. The special treatment ammounts to a continuous extension in the limit
+        of zero maximum fracture closure.
 
         The implementation is based on the paper
 

--- a/src/porepy/models/constitutive_laws.py
+++ b/src/porepy/models/constitutive_laws.py
@@ -4429,8 +4429,10 @@ class ElastoPlasticFractureDeformation:
 
         stiffness = self.fracture_tangential_stiffness(subdomains)
         # Retrieve the *unscaled* stiffness value for the check below.
-        stiffness_value = self.solid.fracture_tangential_stiffness()
-        if np.isclose(stiffness_value, -1.0, atol=1e-12, rtol=1e-12):
+        stiffness_value = self.solid.convert_units(
+            stiffness.value(self.equation_system), "Pa*m^-1", to_si=True
+        )
+        if np.any(np.isclose(stiffness_value, -1.0, atol=1e-12, rtol=1e-12)):
             # Stiffness=-1 indicates no elastic tangential deformation. Small tolerances
             # are used to avoid numerical issues, but allowing for a float value.
             num_cells = sum(sd.num_cells for sd in subdomains)

--- a/src/porepy/models/constitutive_laws.py
+++ b/src/porepy/models/constitutive_laws.py
@@ -4404,11 +4404,7 @@ class ElastoPlasticFractureDeformation:
         u_t = self.elastic_tangential_fracture_deformation(subdomains)
         # Broadcast to number of cells in case elastic normal deformation is scalar, not
         # cell-wise array.
-        nc = sum([sd.num_cells for sd in subdomains])
         u_n = self.elastic_normal_fracture_deformation(subdomains)
-        # * pp.ad.DenseArray(
-        #     np.ones(nc)
-        # )
         return tangential_to_nd @ u_t + normal_to_nd @ u_n
 
     def elastic_tangential_fracture_deformation(
@@ -4443,7 +4439,8 @@ class ElastoPlasticFractureDeformation:
         stiffness_value = stiffness.value(self.equation_system)
         if np.any(stiffness_value < 0):
             # Negative stiffness indicates no elastic tangential deformation.
-            op = pp.ad.DenseArray(np.zeros(sum(sd.num_cells for sd in subdomains)))
+            num_cells = sum(sd.num_cells for sd in subdomains)
+            op = pp.ad.DenseArray(np.zeros((self.nd - 1) * num_cells))
             op.set_name("zero_elastic_tangential_fracture_deformation")
             return op
         scaled_stiffness = stiffness / self.characteristic_contact_traction(subdomains)

--- a/src/porepy/models/constitutive_laws.py
+++ b/src/porepy/models/constitutive_laws.py
@@ -4442,8 +4442,7 @@ class ElastoPlasticFractureDeformation:
         """
         nd_vec_to_tangential = self.tangential_component(subdomains)
         t_t = nd_vec_to_tangential @ self.contact_traction(subdomains)
-        # Since contact traction is nondimensional, the stiffness must be scaled by the
-        # characteristic contact traction.
+
         stiffness = self.fracture_tangential_stiffness(subdomains)
         stiffness_value = stiffness.value(self.equation_system)
         if np.any(stiffness_value < 0):
@@ -4452,6 +4451,8 @@ class ElastoPlasticFractureDeformation:
             zero_u_t = pp.ad.DenseArray(np.zeros((self.nd - 1) * num_cells))
             zero_u_t.set_name("zero_elastic_tangential_fracture_deformation")
             return zero_u_t
+        # Since contact traction is nondimensional, the stiffness must be scaled by the
+        # characteristic contact traction.
         scaled_stiffness = stiffness / self.characteristic_contact_traction(subdomains)
         u_t = t_t / scaled_stiffness
         u_t.set_name("elastic_tangential_fracture_deformation")

--- a/src/porepy/models/constitutive_laws.py
+++ b/src/porepy/models/constitutive_laws.py
@@ -4274,7 +4274,7 @@ class BartonBandis:
     The Barton-Bandis equation is defined in
     :meth:``elastic_normal_fracture_deformation`` while the two parameters
     :math:``\Delta u_n^{max}`` and :math:``K_n`` can be set by the methods
-    :meth:``maximum_fracture_closure`` and :meth:``fracture_normal_stiffness``.
+    :meth:``maximum_elastic_fracture_opening`` and :meth:``fracture_normal_stiffness``.
 
     """
 
@@ -4314,7 +4314,7 @@ class BartonBandis:
         contact traction and material constants as elaborated in the class documentation.
 
         The returned value depends on the value of the solid constant
-        maximum_fracture_closure. If its value is zero, the Barton-Bandis model is void,
+        maximum_elastic_fracture_opening. If its value is zero, the Barton-Bandis model is void,
         and the method returns a hard-coded pp.ad.Scalar(0) to avoid zero division.
         Otherwise, an operator which implements the Barton-Bandis model is returned. The
         special treatment ammounts to a continuous extension in the limit of zero
@@ -4340,7 +4340,7 @@ class BartonBandis:
 
         """
         # The maximum closure of the fracture.
-        maximum_closure = self.maximum_fracture_closure(subdomains)
+        maximum_closure = self.maximum_elastic_fracture_opening(subdomains)
 
         # If the maximum closure is zero, the Barton-Bandis model is not valid in the
         # case of zero normal traction. In this case, we return an empty operator.
@@ -4378,7 +4378,9 @@ class BartonBandis:
         elastic_opening.set_name("Barton-Bandis_elastic_opening")
         return elastic_opening
 
-    def maximum_fracture_closure(self, subdomains: list[pp.Grid]) -> pp.ad.Operator:
+    def maximum_elastic_fracture_opening(
+        self, subdomains: list[pp.Grid]
+    ) -> pp.ad.Operator:
         """The maximum closure of a fracture [m].
 
         Used in the Barton-Bandis model for normal elastic fracture deformation.
@@ -4390,8 +4392,8 @@ class BartonBandis:
             The maximum allowed decrease in fracture opening.
 
         """
-        max_closure = self.solid.maximum_fracture_closure()
-        return Scalar(max_closure, "maximum_fracture_closure")
+        max_closure = self.solid.maximum_elastic_fracture_opening()
+        return Scalar(max_closure, "maximum_elastic_fracture_opening")
 
     def fracture_normal_stiffness(self, subdomains: list[pp.Grid]) -> pp.ad.Operator:
         """The normal stiffness of a fracture [Pa*m^-1].

--- a/src/porepy/models/geometry.py
+++ b/src/porepy/models/geometry.py
@@ -471,7 +471,7 @@ class ModelGeometry:
 
         """
         # TODO: If we ever implement a mapping to reference space for all subdomains,
-        # the present method should be revisiting.
+        # the present method should be revisited.
 
         # For now, assert all subdomains are fractures, i.e. dim == nd - 1.
         # TODO: Extend to all subdomains, not only codimension 1?

--- a/src/porepy/models/material_constants.py
+++ b/src/porepy/models/material_constants.py
@@ -332,6 +332,7 @@ class SolidConstants(MaterialConstants):
             "dilation_angle": 0,
             "fracture_gap": 0,
             "fracture_normal_stiffness": 1,
+            "fracture_tangential_stiffness": -1.0,
             "friction_coefficient": 1,
             "lame_lambda": 1,
             "maximum_fracture_closure": 0,
@@ -549,6 +550,21 @@ class SolidConstants(MaterialConstants):
         """
         return self.convert_units(
             self.constants["fracture_normal_stiffness"], "Pa*m^-1"
+        )
+
+    def fracture_tangential_stiffness(self) -> number:
+        """The tangential stiffness of a fracture [Pa * m^-1].
+
+        Note: The current default value is -1.0, with the convention that negative
+        values correspond to a fracture that does not deform elastically in the
+        tangential direction.
+
+        Returns:
+            The fracture tangential stiffness in converted units.
+
+        """
+        return self.convert_units(
+            self.constants["fracture_tangential_stiffness"], "Pa*m^-1"
         )
 
     def maximum_fracture_closure(self) -> number:

--- a/src/porepy/models/material_constants.py
+++ b/src/porepy/models/material_constants.py
@@ -335,7 +335,7 @@ class SolidConstants(MaterialConstants):
             "fracture_tangential_stiffness": -1.0,
             "friction_coefficient": 1,
             "lame_lambda": 1,
-            "maximum_fracture_closure": 0,
+            "maximum_elastic_fracture_opening": 0,
             "normal_permeability": 1,
             "permeability": 1,
             "porosity": 0.1,
@@ -567,7 +567,7 @@ class SolidConstants(MaterialConstants):
             self.constants["fracture_tangential_stiffness"], "Pa*m^-1"
         )
 
-    def maximum_fracture_closure(self) -> number:
+    def maximum_elastic_fracture_opening(self) -> number:
         """The maximum closure of a fracture [m].
 
         Intended use is in Barton-Bandis-type models for elastic fracture deformation.
@@ -576,7 +576,9 @@ class SolidConstants(MaterialConstants):
             The maximal closure of a fracture.
 
         """
-        return self.convert_units(self.constants["maximum_fracture_closure"], "m")
+        return self.convert_units(
+            self.constants["maximum_elastic_fracture_opening"], "m"
+        )
 
     def open_state_tolerance(self) -> number:
         """Tolerance parameter for the tangential characteristic contact mechanics [-].

--- a/src/porepy/models/material_constants.py
+++ b/src/porepy/models/material_constants.py
@@ -568,12 +568,12 @@ class SolidConstants(MaterialConstants):
         )
 
     def maximum_elastic_fracture_opening(self) -> number:
-        """The maximum closure of a fracture [m].
+        """The maximum opening of a fracture [m].
 
         Intended use is in Barton-Bandis-type models for elastic fracture deformation.
 
         Returns:
-            The maximal closure of a fracture.
+            The maximal opening of a fracture.
 
         """
         return self.convert_units(

--- a/src/porepy/models/momentum_balance.py
+++ b/src/porepy/models/momentum_balance.py
@@ -382,10 +382,12 @@ class MomentumBalanceEquations(pp.BalanceEquation):
             [e_i for e_i in tangential_basis]
         )
 
-        # Variables: The tangential component of the contact traction and the
-        # displacement jump
+        # Variables: The tangential component of the contact traction and the plastic
+        # displacement jump.
         t_t: pp.ad.Operator = nd_vec_to_tangential @ self.contact_traction(subdomains)
-        u_t: pp.ad.Operator = nd_vec_to_tangential @ self.displacement_jump(subdomains)
+        u_t: pp.ad.Operator = nd_vec_to_tangential @ self.plastic_displacement_jump(
+            subdomains
+        )
         # The time increment of the tangential displacement jump
         u_t_increment: pp.ad.Operator = pp.ad.time_increment(u_t)
 
@@ -469,6 +471,7 @@ class MomentumBalanceEquations(pp.BalanceEquation):
 class ConstitutiveLawsMomentumBalance(
     constitutive_laws.ZeroGravityForce,
     constitutive_laws.ElasticModuli,
+    constitutive_laws.ElastoPlasticFractureDeformation,
     constitutive_laws.LinearElasticMechanicalStress,
     constitutive_laws.ConstantSolidDensity,
     constitutive_laws.FractureGap,

--- a/src/porepy/models/momentum_balance.py
+++ b/src/porepy/models/momentum_balance.py
@@ -83,10 +83,15 @@ class MomentumBalanceEquations(pp.BalanceEquation):
     """
     displacement_jump: Callable[[list[pp.Grid]], pp.ad.Operator]
     """Operator giving the displacement jump on fracture grids. Normally defined in a
-    mixin instance of :class:`~porepy.models.models.ModelGeometry`.
+    mixin instance of :class:`~porepy.models.geometry.ModelGeometry`.
 
     """
-    contact_traction: Callable[[list[pp.Grid]], pp.ad.MixedDimensionalVariable]
+    plastic_displacement_jump: Callable[[list[pp.Grid]], pp.ad.Operator]
+    """Operator giving the plastic displacement jump on fracture grids. Normally defined
+    in a mixin instance of
+    :class:`~porepy.models.constitutive_laws.ElastoPlasticFractureDeformation`.
+    """
+    contact_traction: Callable[[list[pp.Grid]], pp.ad.Operator]
     """Contact traction variable. Normally defined in a mixin instance of
     :class:`~porepy.models.momentum_balance.VariablesMomentumBalance`.
 

--- a/src/porepy/models/poromechanics.py
+++ b/src/porepy/models/poromechanics.py
@@ -42,6 +42,7 @@ class ConstitutiveLawsPoromechanics(
     pp.constitutive_laws.ConstantViscosity,
     # Mechanical subproblem
     pp.constitutive_laws.ElasticModuli,
+    pp.constitutive_laws.ElastoPlasticFractureDeformation,
     pp.constitutive_laws.LinearElasticMechanicalStress,
     pp.constitutive_laws.ConstantSolidDensity,
     pp.constitutive_laws.FractureGap,

--- a/src/porepy/models/poromechanics.py
+++ b/src/porepy/models/poromechanics.py
@@ -42,11 +42,12 @@ class ConstitutiveLawsPoromechanics(
     pp.constitutive_laws.ConstantViscosity,
     # Mechanical subproblem
     pp.constitutive_laws.ElasticModuli,
-    pp.constitutive_laws.ElastoPlasticFractureDeformation,
+    pp.constitutive_laws.ElasticTangentialFractureDeformation,
     pp.constitutive_laws.LinearElasticMechanicalStress,
     pp.constitutive_laws.ConstantSolidDensity,
     pp.constitutive_laws.FractureGap,
     pp.constitutive_laws.CoulombFrictionBound,
+    pp.constitutive_laws.DisplacementJump,
 ):
     """Class for the coupling of mass and momentum balance to obtain poromechanics
     equations.

--- a/src/porepy/models/thermoporomechanics.py
+++ b/src/porepy/models/thermoporomechanics.py
@@ -54,11 +54,12 @@ class ConstitutiveLawsThermoporomechanics(
     pp.constitutive_laws.ConstantViscosity,
     # Mechanical subproblem
     pp.constitutive_laws.ElasticModuli,
-    pp.constitutive_laws.ElastoPlasticFractureDeformation,
+    pp.constitutive_laws.ElasticTangentialFractureDeformation,
     pp.constitutive_laws.LinearElasticMechanicalStress,
     pp.constitutive_laws.ConstantSolidDensity,
     pp.constitutive_laws.FractureGap,
     pp.constitutive_laws.CoulombFrictionBound,
+    pp.constitutive_laws.DisplacementJump,
 ):
     """Class for the coupling of energy, mass and momentum balance to obtain
     thermoporomechanics equations.

--- a/src/porepy/models/thermoporomechanics.py
+++ b/src/porepy/models/thermoporomechanics.py
@@ -54,6 +54,7 @@ class ConstitutiveLawsThermoporomechanics(
     pp.constitutive_laws.ConstantViscosity,
     # Mechanical subproblem
     pp.constitutive_laws.ElasticModuli,
+    pp.constitutive_laws.ElastoPlasticFractureDeformation,
     pp.constitutive_laws.LinearElasticMechanicalStress,
     pp.constitutive_laws.ConstantSolidDensity,
     pp.constitutive_laws.FractureGap,

--- a/tests/models/test_constitutive_laws.py
+++ b/tests/models/test_constitutive_laws.py
@@ -268,11 +268,11 @@ reference_arrays = reference_dense_arrays["test_evaluated_values"]
         (
             models.MomentumBalance,
             "elastic_normal_fracture_deformation",
-            # (-normal_traction) * maximum_closure /
+            # maximum_closure + normal_traction * maximum_closure /
             #    (normal_stiffness / characteristic_traction * maximum_closure + (-normal_traction))
             # Here, characteristic_traction = Young's modulus (see implementation of
             # elastic_normal_fracture_deformation in constitutive_laws.py)
-            (1 * 1e-4) / (1.9e8 / youngs * 1e-4 + 1),
+            1e-4 - (1 * 1e-4) / (1.9e8 / youngs * 1e-4 + 1),
             1,
         ),
         (

--- a/tests/models/test_constitutive_laws.py
+++ b/tests/models/test_constitutive_laws.py
@@ -268,8 +268,10 @@ reference_arrays = reference_dense_arrays["test_evaluated_values"]
         (
             models.MomentumBalance,
             "elastic_normal_fracture_deformation",
-            # maximum_closure + normal_traction * maximum_closure /
-            #    (normal_stiffness / characteristic_traction * maximum_closure + (-normal_traction))
+            # maximum_opening + normal_traction * maximum_opening / (
+            #   normal_stiffness / characteristic_traction * maximum_opening
+            #   - normal_traction
+            # )
             # Here, characteristic_traction = Young's modulus (see implementation of
             # elastic_normal_fracture_deformation in constitutive_laws.py)
             1e-4 - (1 * 1e-4) / (1.9e8 / youngs * 1e-4 + 1),

--- a/tests/models/test_constitutive_laws.py
+++ b/tests/models/test_constitutive_laws.py
@@ -39,7 +39,7 @@ solid_values = pp.solid_values.granite
 solid_values.update(
     {
         "fracture_normal_stiffness": 1.9e8,
-        "maximum_fracture_closure": 1e-4,
+        "maximum_elastic_fracture_opening": 1e-4,
         "fracture_gap": 1e-4,
         "residual_aperture": 0.01,
     }

--- a/tests/models/test_momentum_balance.py
+++ b/tests/models/test_momentum_balance.py
@@ -298,7 +298,7 @@ def test_lithostatic(dim: int):
 """Tests for elastoplastic split of fracture deformation below."""
 
 
-class LinearModel(
+class ElastoplasticModel2d(
     SquareDomainOrthogonalFractures,
     pp.model_boundary_conditions.BoundaryConditionsMechanicsDirNorthSouth,
     pp.models.momentum_balance.MomentumBalance,
@@ -319,10 +319,11 @@ solid_vals_elastoplastic = {
 
 
 def verify_elastoplastic_deformation(
-    setup: LinearModel,
+    setup: pp.models.MomentumBalance,
     u_e_expected: list[pp.number],
     u_p_expected: list[pp.number],
     u_top_expected: list[pp.number],
+    traction_expected: list[pp.number],
     tols: list[float],
     compare_means: bool = False,
 ):
@@ -344,7 +345,7 @@ def verify_elastoplastic_deformation(
             Expected value of displacement in the cells above the fracture. nan values
             are ignored, i.e., the test will pass if all computed values match the
             corresponding non-nan expected values.
-        tols: ``len=3``
+        tols: ``len=4``
 
             Tolerances for the comparisons. The first two are for the elastic and
             plastic displacement jumps, respectively, the third is for the displacement
@@ -352,6 +353,10 @@ def verify_elastoplastic_deformation(
             fracture.
         compare_means: Whether to compare the means of the computed values to the
             expected values. If False, the values are compared element-wise.
+
+    Returns:
+        Tuple of the computed elastic displacement jump, plastic displacement jump,
+        displacement in the cells above the fracture and traction on the fracture.
 
 
     """
@@ -437,23 +442,26 @@ def verify_elastoplastic_deformation(
     )
     # Check that open cells have zero traction.
     assert np.allclose(traction[:, open_cells], 0, atol=1e-10)
+    # Compare to expected values.
+    assert np.allclose(traction, np.reshape(traction_expected, (nd, 1)), rtol=tols[3])
+
     return u_e, u_p, u_top, traction
 
 
 @pytest.mark.parametrize(
     "u_north, u_e_expected,u_p_expected,u_expected,traction_expected",
     [
-        # Compression and elastic shear. -1e6 is the expected value of the normal
+        # Compression and elastic shear. -2e6 is the expected value of the normal
         # traction, which is the negative (sign convention) and dominated by the shear
-        # modulus (1e6). 1e1 is the expected value of the traction in the x direction,
-        # which is computed from the tangential stiffness (1e-5) and the normal
-        # traction.
-        ([1.0, -1.0], [1, 0], [0, 0], [1, np.nan], [1e1, -1e6]),
+        # modulus (1e6, remember factor 2 for \mu in Hooke's law!). 1e-5 is the expected
+        # value of the traction in the x direction, which is computed from the
+        # tangential stiffness (1e-5) and the tangential displacement (1).
+        ([1.0, -1.0], [1, 0], [0, 0], [1, np.nan], [1e-5, -2e6]),
         # Extension and plastic shear.
         ([1.0, 1.0], [0, 0], [1, 1], [1, 1], [0, 0]),
     ],
 )
-def test_2d_single_fracture(
+def test_elastoplastic_2d_single_fracture(
     u_north: list[pp.number],
     u_e_expected: list[pp.number],
     u_p_expected: list[pp.number],
@@ -482,21 +490,23 @@ def test_2d_single_fracture(
         "material_constants": {"solid": solid},
         "u_north": u_north,
         "fracture_indices": [1],  # Single fracture with constant y coordinate.
+        # "meshing_arguments": {"cell_size": 0.2},
     }
 
     # Create model and run simulation.
-    setup = LinearModel(params)
+    setup = ElastoplasticModel2d(params)
     pp.run_time_dependent_model(setup, params)
     verify_elastoplastic_deformation(
         setup,
         u_e_expected,
         u_p_expected,
         u_expected,
-        [1e-3, 1e-10, 1e-3, 1e2],
+        traction_expected,
+        [1e-3, 1e-10, 1e-3, 1e-3],
     )
 
 
-class LinearModel3D(
+class ElastoplasticModel3d(
     CubeDomainOrthogonalFractures,
     pp.model_boundary_conditions.BoundaryConditionsMechanicsDirNorthSouth,
     pp.models.momentum_balance.MomentumBalance,
@@ -518,7 +528,7 @@ cases_3d = [
         [2, 0, 3],
         [0, 0, 0],
         [2, np.nan, 3],
-        [2e1 / np.sqrt(13), -1e7, 3e1 / np.sqrt(13)],
+        [2e-5, -2e6, 3e-5],
     ),
     # Shear and, since u_y_north is positive, extension. With opening, no elastic
     # deformation occurs, and the displacement is entirely plastic, identically 0
@@ -531,7 +541,7 @@ cases_3d = [
     "u_north,u_e_expected,u_p_expected,u_expected,traction_expected",
     cases_3d,
 )
-def test_3d_single_fracture(
+def test_elastoplastic_3d_single_fracture(
     u_north: list[pp.number],
     u_e_expected: list[pp.number],
     u_p_expected: list[pp.number],
@@ -566,14 +576,15 @@ def test_3d_single_fracture(
     }
 
     # Create model and run simulation
-    setup = LinearModel3D(params)
+    setup = ElastoplasticModel3d(params)
     pp.run_time_dependent_model(setup, params)
-    verify_elastoplastic_deformation(
+    *_, traction = verify_elastoplastic_deformation(
         setup,
         u_e_expected,
         u_p_expected,
         u_expected,
-        [1e-3, 1e-10, 1e-3, 1e-2],
+        traction_expected,
+        [1e-3, 1e-10, 1e-3, 1e-3],
     )
 
 
@@ -616,7 +627,7 @@ class TimeDependentBCs(
         return values.ravel("F")
 
 
-class LinearModelTimeDependentBCs(
+class ElastoplasticModelTimeDependentBCs(
     CubeDomainOrthogonalFractures,
     TimeDependentBCs,
     pp.models.momentum_balance.MomentumBalance,
@@ -641,15 +652,17 @@ def test_time_dependent_bc():
     }
 
     # Create model and run simulation. The north displacement is 1, -1, 1.
-    setup = LinearModelTimeDependentBCs(params)
+    setup = ElastoplasticModelTimeDependentBCs(params)
     pp.run_time_dependent_model(setup, params)
+    tols = [5e-2, 1e-10, 1e-3, 5e-2]
+
     verify_elastoplastic_deformation(
         setup,
         [0.86, 0, 0.86],
         [0, 0, 0],
         [np.nan, np.nan, np.nan],
-        [1, -1, 1],
-        [5e-2, 1e-10, 1e-3, 5e-2],
+        [0.086, -2.54, 0.086],
+        tols,
     )
     # Continue for one more time step. This time, the north displacement is 1, -1, 2.
     setup.time_manager = pp.TimeManager([1.0, 2.0], 1.0, True)
@@ -657,8 +670,10 @@ def test_time_dependent_bc():
 
     # Fixed values from a previous run. Both normal value (u_y=0) and ratio of
     # tangential displacements (1/50, see BC class) are correct.
-    u_e = [0.50754939, 0.0, 25.37756547]
+    u_e = np.array([0.50754939, 0.0, 25.37756547])
     u_p = [0.40916401, 0.0, 20.45818325]
+    traction = u_e * 1e-1
+    traction[1] = -2.54
     # Same goes here. We expect -0.75, since the top coordinate is 0.75.
     u_top = [0.97917835, -0.75, 48.95893718]
     pp.run_time_dependent_model(setup, params)
@@ -667,6 +682,7 @@ def test_time_dependent_bc():
         u_e,
         u_p,
         u_top,
-        np.ones(3) * 1e-10,
+        traction,
+        tols,
         compare_means=True,
     )

--- a/tests/models/test_momentum_balance.py
+++ b/tests/models/test_momentum_balance.py
@@ -360,11 +360,11 @@ def verify_elastoplastic_deformation(
 
 
     """
+    nd = setup.nd  # Shorthand for number of dimensions.
     # Get the indices of the tangential components in global coordinates. Hardcoded
     # based on the assumption that the fracture has constant y-coordinate.
     fracture_ind = 1
     tang_ind = np.setdiff1d(np.arange(nd), fracture_ind)
-    nd = setup.nd  # Shorthand for number of dimensions.
     matrix = setup.mdg.subdomains(dim=nd)[0]
     fractures = setup.mdg.subdomains(dim=nd - 1)
     assert len(fractures) == 1  # Below code assumes a single fracture.

--- a/tests/models/test_momentum_balance.py
+++ b/tests/models/test_momentum_balance.py
@@ -25,7 +25,7 @@ class LinearModel(
 @pytest.mark.parametrize(
     "solid_vals,north_displacement",
     [
-        ({}, 0),
+        ({}, 0.0),
         ({"characteristic_displacement": 42}, -0.1),
         ({"porosity": 0.5}, 0.2),
     ],
@@ -46,7 +46,7 @@ def test_2d_single_fracture(solid_vals, north_displacement):
     params = {
         "times_to_export": [],  # Suppress output for tests
         "material_constants": {"solid": solid},
-        "uy_north": north_displacement,
+        "u_north": [0.0, north_displacement],
     }
 
     # Create model and run simulation
@@ -127,7 +127,7 @@ def test_unit_conversion(units, uy_north):
         "times_to_export": [],  # Suppress output for tests
         "fracture_indices": [0, 1],
         "cartesian": True,
-        "uy_north": uy_north,
+        "u_north": [0, uy_north],
         "material_constants": {"solid": solid},
     }
     reference_params = copy.deepcopy(params)

--- a/tests/models/test_momentum_balance.py
+++ b/tests/models/test_momentum_balance.py
@@ -13,6 +13,10 @@ from porepy.applications.test_utils.models import (
     compare_scaled_model_quantities,
     compare_scaled_primary_variables,
 )
+from porepy.applications.md_grids.model_geometries import (
+    SquareDomainOrthogonalFractures,
+    CubeDomainOrthogonalFractures,
+)
 
 
 class LinearModel(
@@ -112,13 +116,13 @@ def test_2d_single_fracture(solid_vals, north_displacement):
 
 @pytest.mark.parametrize("units", [{"m": 0.29, "kg": 0.31, "K": 4.1}])
 @pytest.mark.parametrize("uy_north", [2e-4, -1e-4])
-def test_unit_conversion(units, uy_north):
+def test_unit_conversion(units: dict, uy_north: float):
     """Test that solution is independent of units.
 
     Parameters:
-        units (dict): Dictionary with keys as those in
+        units: Dictionary with keys as those in
             :class:`~pp.models.material_constants.MaterialConstants`.
-        uy_north (float): Value of displacement on the north boundary.
+        uy_north: Value of y displacement on the north boundary.
 
     """
     solid = pp.SolidConstants(pp.solid_values.extended_granite_values_for_testing)
@@ -127,7 +131,7 @@ def test_unit_conversion(units, uy_north):
         "times_to_export": [],  # Suppress output for tests
         "fracture_indices": [0, 1],
         "cartesian": True,
-        "u_north": [0, uy_north],
+        "u_north": [0.0, uy_north],
         "material_constants": {"solid": solid},
     }
     reference_params = copy.deepcopy(params)
@@ -289,3 +293,380 @@ def test_lithostatic(dim: int):
     # The stress at the bottom of the domain should be equal to the weight of the
     # column.
     assert np.allclose(bottom_traction, -rho * g * sd.cell_volumes.sum())
+
+
+"""Tests for elastoplastic split of fracture deformation below."""
+
+
+class LinearModel(
+    SquareDomainOrthogonalFractures,
+    pp.model_boundary_conditions.BoundaryConditionsMechanicsDirNorthSouth,
+    pp.models.momentum_balance.MomentumBalance,
+):
+
+    pass
+
+
+# We set a high shear modulus to make the domain stiff (especially for shear), and a
+# low tangential fracture stiffness to make the fracture weak. This will make the
+# fracture deform significantly more than the surrounding domain. Still, the domain
+# will deform slightly, requiring a tolerance when comparing the results.
+solid_vals_elastoplastic = {
+    "fracture_tangential_stiffness": 1e-5,
+    "shear_modulus": 1e6,
+    "lame_lambda": 1e2,
+}
+
+
+def verify_elastoplastic_deformation(
+    setup: LinearModel,
+    u_e_expected: list[pp.number],
+    u_p_expected: list[pp.number],
+    u_top_expected: list[pp.number],
+    tols: list[float],
+    compare_means: bool = False,
+):
+    """Verify the results of a simulation.
+
+    The function will raise an assertion error if the results do not match the expected
+    values within the given tolerances.
+
+    Parameters:
+        setup: The model setup.
+        u_e_expected: ``len=nd``
+
+            Expected values of the elastic displacement jump in the x and y directions.
+        u_p_expected: ``len=nd``
+
+            Expected values of the plastic displacement jump in the x and y directions.
+        u_top_expected: ``len=nd``
+
+            Expected value of displacement in the cells above the fracture. nan values
+            are ignored, i.e., the test will pass if all computed values match the
+            corresponding non-nan expected values.
+        tols: ``len=3``
+
+            Tolerances for the comparisons. The first two are for the elastic and
+            plastic displacement jumps, respectively, the third is for the displacement
+            in the cells above the fracture and the fourth is for the traction on the
+            fracture.
+        compare_means: Whether to compare the means of the computed values to the
+            expected values. If False, the values are compared element-wise.
+
+
+    """
+    nd = setup.nd  # Shorthand for number of dimensions.
+    matrix = setup.mdg.subdomains(dim=nd)[0]
+    fractures = setup.mdg.subdomains(dim=nd - 1)
+    assert len(fractures) == 1  # Below code assumes a single fracture.
+    fracture = fractures[0]
+
+    # Get plastic and elastic displacement jumps on the fracture in local coordinates.
+    u_p_loc = setup.plastic_displacement_jump(fractures).value(setup.equation_system)
+    u_e_loc = setup.elastic_displacement_jump(fractures).value(setup.equation_system)
+
+    # Transform the jumps to global coordinates and corresponding to the j side of the
+    # fracture being the one with the lower y-coordinate (jumps are k-j).
+
+    # First, rotate the local displacements to global coordinates. Then, switch sign if
+    # the fracture normal points downwards. This is needed to counteract the cases when
+    # the j ("left") side of the fracture is the one with the higher y-coordinate, i.e.
+    # the upper half of the domain.
+    proj = setup.mdg.subdomain_data(fracture)["tangential_normal_projection"]
+    n = proj.normals
+    rot = proj.project_tangential_normal().T
+    u_p = rot @ u_p_loc
+    u_e = rot @ u_e_loc
+
+    sign = np.tile(np.sign(n[1]), (setup.nd, 1)).ravel("F")
+    u_p = (sign * u_p).reshape((nd, -1), order="F")
+    u_e = (sign * u_e).reshape((nd, -1), order="F")
+
+    u_domain = (
+        setup.displacement([matrix])
+        .value(setup.equation_system)
+        .reshape((nd, -1), order="F")
+    )
+    u_top = u_domain[:, matrix.cell_centers[1] > 0.5]
+    # Compare the computed values to the expected values.
+    if compare_means:
+        assert np.allclose(np.mean(u_e, axis=1), u_e_expected, rtol=tols[0])
+    else:
+        assert np.allclose(u_e, np.reshape(u_e_expected, (nd, 1)), rtol=tols[0])
+
+    if compare_means:
+        assert np.allclose(np.mean(u_p, axis=1), u_p_expected, rtol=tols[1])
+    else:
+        assert np.allclose(u_p, np.reshape(u_p_expected, (nd, 1)), rtol=tols[1])
+
+    # Matrix displacement above the fracture. We only compare those values that are not
+    # nan in the expected values.
+    mask_u = np.logical_not(np.isnan(u_top_expected))
+    if compare_means:
+        expected = np.array(u_top_expected)[mask_u]
+        assert np.allclose(np.mean(u_top, axis=1)[mask_u], expected, rtol=tols[2])
+    else:
+        expected = np.reshape(u_top_expected, (nd, 1))[mask_u]
+        assert np.allclose(u_top[mask_u], expected, rtol=tols[2])
+
+    # Traction on the fracture. We check that the traction is zero for open cells and
+    # that tangential traction is equal to the normal traction times the tangential
+    # stiffness for closed cells.
+    open_cells = u_p[1] > 1e-10
+    traction = (
+        setup.characteristic_contact_traction([fracture])
+        * setup.contact_traction([fracture])
+    ).value(setup.equation_system)
+    # Rotate to global coordinates.
+    traction = rot @ traction
+    traction = (sign * traction).reshape((nd, -1), order="F")
+    # Get the indices of the tangential components. Hardcoded based on the assumption
+    # that the fracture has constant y-coordinate.
+    if nd == 3:
+        tang_ind = np.array([0, 2])
+    else:
+        tang_ind = np.array([0])
+    # The two next assertions should hold for all cells. Thus, we use a very low
+    # tolerance and don't compare means.
+    # Check that tangential part of traction and u_e are parallel and have relative
+    # magnitudes equal to stiffness for closed cells.
+    assert np.allclose(
+        traction[tang_ind][:, ~open_cells] / u_e[tang_ind][:, ~open_cells],
+        setup.solid.fracture_tangential_stiffness(),
+        atol=1e-10,
+    )
+    # Check that open cells have zero traction.
+    assert np.allclose(traction[:, open_cells], 0, atol=1e-10)
+    return u_e, u_p, u_top, traction
+
+
+@pytest.mark.parametrize(
+    "u_north, u_e_expected,u_p_expected,u_expected,traction_expected",
+    [
+        # Compression and elastic shear. -1e6 is the expected value of the normal
+        # traction, which is the negative (sign convention) and dominated by the shear
+        # modulus (1e6). 1e1 is the expected value of the traction in the x direction,
+        # which is computed from the tangential stiffness (1e-5) and the normal
+        # traction.
+        ([1.0, -1.0], [1, 0], [0, 0], [1, np.nan], [1e1, -1e6]),
+        # Extension and plastic shear.
+        ([1.0, 1.0], [0, 0], [1, 1], [1, 1], [0, 0]),
+    ],
+)
+def test_2d_single_fracture(
+    u_north: list[pp.number],
+    u_e_expected: list[pp.number],
+    u_p_expected: list[pp.number],
+    u_expected: list[pp.number],
+    traction_expected: list[pp.number],
+):
+    """Test that the solution is qualitatively sound.
+
+    Parameters:
+        north_displacement: Value of displacement on the north boundary.
+        u_e_expected: Expected values of the elastic displacement jump in global
+            coordinates.
+        u_p_expected: Expected values of the plastic displacement jump in global
+            coordinates.
+        u_expected: Expected value of displacement in the x direction of cells above the
+            fracture.
+        traction_expected: Expected value of traction on the fracture in global
+            coordinates.
+
+    """
+    # Instantiate constants and store in params.
+
+    solid = pp.SolidConstants(solid_vals_elastoplastic)
+    params = {
+        "times_to_export": [],  # Suppress output for tests
+        "material_constants": {"solid": solid},
+        "u_north": u_north,
+        "fracture_indices": [1],  # Single fracture with constant y coordinate.
+    }
+
+    # Create model and run simulation.
+    setup = LinearModel(params)
+    pp.run_time_dependent_model(setup, params)
+    verify_elastoplastic_deformation(
+        setup,
+        u_e_expected,
+        u_p_expected,
+        u_expected,
+        [1e-3, 1e-10, 1e-3, 1e2],
+    )
+
+
+class LinearModel3D(
+    CubeDomainOrthogonalFractures,
+    pp.model_boundary_conditions.BoundaryConditionsMechanicsDirNorthSouth,
+    pp.models.momentum_balance.MomentumBalance,
+):
+
+    pass
+
+
+cases_3d = [
+    # Shear and, since u_y_north is negative, compression. With low tangential
+    # stiffness, the fracture will deform elastically, accounting for almost all of the
+    # displacement (very little in the matrix). The normal traction is dominated by the
+    # shear modulus. The tangential traction is computed from the normal traction and
+    # the tangential stiffness (see also test_2d_single_fracture). The relative
+    # magnitude of the two tangential components is computed from the Pythagorean
+    # theorem.
+    (
+        [2.0, -1.0, 3],
+        [2, 0, 3],
+        [0, 0, 0],
+        [2, np.nan, 3],
+        [2e1 / np.sqrt(13), -1e7, 3e1 / np.sqrt(13)],
+    ),
+    # Shear and, since u_y_north is positive, extension. With opening, no elastic
+    # deformation occurs, and the displacement is entirely plastic, identically 0
+    # in the matrix.
+    ([2.0, 1.0, 3], [0, 0, 0], [2, 1, 3], [2, 1, 3], [0, 0, 0]),
+]
+
+
+@pytest.mark.parametrize(
+    "u_north,u_e_expected,u_p_expected,u_expected,traction_expected",
+    cases_3d,
+)
+def test_3d_single_fracture(
+    u_north: list[pp.number],
+    u_e_expected: list[pp.number],
+    u_p_expected: list[pp.number],
+    u_expected: list[pp.number],
+    traction_expected: list[pp.number],
+):
+    """Test that the solution is qualitatively sound.
+
+    The fracture is in the x-z plane, with constant y coordinate. Thus, x and z are the
+    (global) tangential directions, and y is the normal direction.
+
+    Parameters:
+        u_north: Value of displacement on the north boundary.
+        u_e_expected: Expected values of the elastic displacement jump in the x and y
+            directions.
+        u_p_expected: Expected values of the plastic displacement jump in the x and y
+            directions.
+        u_expected: Expected values of displacement in the x and z directions of cells
+            above the fracture.
+        traction_expected: Expected values of traction on the fracture in global
+            coordinates.
+
+    """
+    # Instantiate constants and store in params.
+    solid = pp.SolidConstants(solid_vals_elastoplastic)
+    params = {
+        "times_to_export": [],  # Suppress output for tests
+        "material_constants": {"solid": solid},
+        "fracture_indices": [1],
+        "u_north": u_north,
+        # "nd": 3,
+    }
+
+    # Create model and run simulation
+    setup = LinearModel3D(params)
+    pp.run_time_dependent_model(setup, params)
+    verify_elastoplastic_deformation(
+        setup,
+        u_e_expected,
+        u_p_expected,
+        u_expected,
+        [1e-3, 1e-10, 1e-3, 1e-2],
+    )
+
+
+class TimeDependentBCs(
+    pp.model_boundary_conditions.BoundaryConditionsMechanicsDirNorthSouth,
+):
+
+    def bc_values_displacement(self, bg: pp.BoundaryGrid) -> np.ndarray:
+        """Displacement values.
+
+        Initial value is u_y = self.solid.fracture_gap() at north boundary. Adding it on
+        the boundary ensures a stress-free initial state. For positive times, a tailored
+        displacement is imposed on the north boundary. The south boundary is fixed.
+
+        Parameters:
+            boundary_grid: Boundary grid for which boundary values are to be returned.
+
+        Returns:
+            Array of boundary values, with one value for each dimension of the problem,
+            for each face in the subdomain.
+
+        """
+        sides = self.domain_boundary_sides(bg)
+        values = np.zeros((self.nd, bg.num_cells))
+
+        # Add fracture width on top if there is a fracture.
+        if len(self.mdg.subdomains()) > 1:
+            frac_val = self.solid.fracture_gap()
+        else:
+            frac_val = 0
+        values[1, sides.north] = frac_val
+
+        if bg.dim < self.nd - 1:
+            return values.ravel("F")
+        if self.time_manager.time > 1e-5:
+            # Create slip for second time step.
+            u_z = 50.0 if self.time_manager.time > 1.1 else 1.0
+            u_n = np.tile([1, -1, u_z], (bg.num_cells, 1)).T
+            values[:, sides.north] += self.solid.convert_units(u_n, "m")[:, sides.north]
+        return values.ravel("F")
+
+
+class LinearModelTimeDependentBCs(
+    CubeDomainOrthogonalFractures,
+    TimeDependentBCs,
+    pp.models.momentum_balance.MomentumBalance,
+):
+
+    pass
+
+
+def test_time_dependent_bc():
+    solid = pp.SolidConstants(
+        {
+            "fracture_tangential_stiffness": 1e-1,
+            "shear_modulus": 1e0,
+            "lame_lambda": 1e0,
+        }
+    )
+    params = {
+        "times_to_export": [],  # Suppress output for tests
+        "material_constants": {"solid": solid},
+        "fracture_indices": [1],
+        "time_manager": pp.TimeManager([0.0, 1.0], 1.0, True),
+    }
+
+    # Create model and run simulation. The north displacement is 1, -1, 1.
+    setup = LinearModelTimeDependentBCs(params)
+    pp.run_time_dependent_model(setup, params)
+    verify_elastoplastic_deformation(
+        setup,
+        [0.86, 0, 0.86],
+        [0, 0, 0],
+        [np.nan, np.nan, np.nan],
+        [1, -1, 1],
+        [5e-2, 1e-10, 1e-3, 5e-2],
+    )
+    # Continue for one more time step. This time, the north displacement is 1, -1, 2.
+    setup.time_manager = pp.TimeManager([1.0, 2.0], 1.0, True)
+    params["prepare_simulation"] = False
+
+    # Fixed values from a previous run. Both normal value (u_y=0) and ratio of
+    # tangential displacements (1/50, see BC class) are correct.
+    u_e = [0.50754939, 0.0, 25.37756547]
+    u_p = [0.40916401, 0.0, 20.45818325]
+    # Same goes here. We expect -0.75, since the top coordinate is 0.75.
+    u_top = [0.97917835, -0.75, 48.95893718]
+    pp.run_time_dependent_model(setup, params)
+    verify_elastoplastic_deformation(
+        setup,
+        u_e,
+        u_p,
+        u_top,
+        np.ones(3) * 1e-10,
+        compare_means=True,
+    )

--- a/tests/models/test_poromechanics.py
+++ b/tests/models/test_poromechanics.py
@@ -1,9 +1,8 @@
 """Tests for poromechanics.
 
-The positive fracture gap value of 0.042 ensures positive aperture for all simulation.
-This is needed to avoid degenerate mass balance equation in fracture.
+The positive fracture gap value ensures positive aperture for all simulation. This is
+needed to avoid degenerate mass balance equation in fracture.
 
-TODO: Clean up.
 """
 
 from __future__ import annotations
@@ -82,7 +81,9 @@ class NonzeroFractureGapPoromechanics:
 
             # Set mortar displacement to zero on bottom and fracture gap value on top
             vals = np.zeros((self.nd, intf.num_cells))
-            vals[1, top_cells] = self.solid.fracture_gap()
+            vals[1, top_cells] = (
+                self.solid.fracture_gap() + self.solid.maximum_fracture_closure()
+            )
             self.equation_system.set_variable_values(
                 vals.ravel("F"),
                 [self.interface_displacement_variable],

--- a/tests/models/test_poromechanics.py
+++ b/tests/models/test_poromechanics.py
@@ -1,6 +1,6 @@
 """Tests for poromechanics.
 
-The hardcoded fracture gap value of 0.042 ensures positive aperture for all simulation.
+The positive fracture gap value of 0.042 ensures positive aperture for all simulation.
 This is needed to avoid degenerate mass balance equation in fracture.
 
 TODO: Clean up.
@@ -39,9 +39,9 @@ class NonzeroFractureGapPoromechanics:
     def initial_condition(self):
         """Set initial condition.
 
-        Set initial displacement compatible with fracture gap of 0.042 for matrix
-        subdomain and matrix-fracture interface. Also initialize boundary conditions
-        to 0.042 on top side.
+        Set initial displacement compatible with fracture gap for matrix subdomain and
+        matrix-fracture interface. Also initialize boundary conditions to fracture gap
+        value on top half of the matrix.
 
         """
         super().initial_condition()
@@ -57,7 +57,7 @@ class NonzeroFractureGapPoromechanics:
         if len(self.mdg.subdomains()) > 1:
             top_cells = sd.cell_centers[1] > self.fluid.convert_units(0.5, "m")
             vals = np.zeros((self.nd, sd.num_cells))
-            vals[1, top_cells] = self.fluid.convert_units(0.042, "m")
+            vals[1, top_cells] = self.solid.fracture_gap()
             self.equation_system.set_variable_values(
                 vals.ravel("F"),
                 [self.displacement_variable],
@@ -80,9 +80,9 @@ class NonzeroFractureGapPoromechanics:
             intf_normals = normals[:, faces_primary]
             top_cells = intf_normals[1, :] < 0
 
-            # Set mortar displacement to zero on bottom and 0.042 on top
+            # Set mortar displacement to zero on bottom and fracture gap value on top
             vals = np.zeros((self.nd, intf.num_cells))
-            vals[1, top_cells] = self.fluid.convert_units(0.042, "m")
+            vals[1, top_cells] = self.solid.fracture_gap()
             self.equation_system.set_variable_values(
                 vals.ravel("F"),
                 [self.interface_displacement_variable],
@@ -155,15 +155,15 @@ class TailoredPoromechanics(
     pass
 
 
-def create_fractured_setup(solid_vals, fluid_vals, uy_north):
+def create_fractured_setup(solid_vals: dict, fluid_vals: dict, uy_north: float):
     """Create a setup for a fractured domain.
 
     The domain is a unit square with two intersecting fractures.
 
     Parameters:
-        solid_vals (dict): Parameters for the solid mechanics model.
-        fluid_vals (dict): Parameters for the fluid mechanics model.
-        uy_north (float): Displacement in y-direction on the north boundary.
+        solid_vals: Parameters for the solid mechanics model.
+        fluid_vals: Parameters for the fluid mechanics model.
+        uy_north: Displacement in y-direction on the north boundary.
 
     Returns:
         TailoredPoromechanics: A setup for a fractured domain.
@@ -180,7 +180,7 @@ def create_fractured_setup(solid_vals, fluid_vals, uy_north):
     params = {
         "times_to_export": [],  # Suppress output for tests
         "material_constants": {"solid": solid, "fluid": fluid},
-        "uy_north": uy_north,
+        "u_north": [0, uy_north],  # Note: List of length nd. Extend if used in 3d.
         "max_iterations": 20,
     }
     setup = TailoredPoromechanics(params)
@@ -270,7 +270,7 @@ def test_2d_single_fracture(solid_vals, north_displacement):
         assert np.allclose(u_vals[:, bottom], 0)
         # Zero x and nonzero y displacement in top
         assert np.allclose(u_vals[0, top], 0)
-        assert np.allclose(u_vals[1, top], 0.042)
+        assert np.allclose(u_vals[1, top], setup.solid.fracture_gap())
         # Zero displacement relative to initial value implies zero pressure
         assert np.allclose(p_vals, 0)
     elif north_displacement < 0.0:
@@ -306,7 +306,7 @@ def test_2d_single_fracture(solid_vals, north_displacement):
     else:
         # Displacement jump should be equal to initial displacement.
         assert np.allclose(jump[0], 0.0)
-        assert np.allclose(jump[1], 0.042)
+        assert np.allclose(jump[1], setup.solid.fracture_gap())
         # Normal traction should be non-positive. Zero if north_displacement equals
         # initial gap, negative otherwise.
         if north_displacement < 0.0:
@@ -331,7 +331,7 @@ def test_without_fracture(biot_coefficient):
     params = {
         "fracture_indices": [],
         "material_constants": {"fluid": fluid, "solid": solid},
-        "uy_north": 0.001,
+        "u_north": [0, 0.001],
         "cartesian": True,
     }
     m = TailoredPoromechanics(params)
@@ -381,8 +381,8 @@ def test_pull_north_positive_opening():
 def test_pull_south_positive_opening():
     """Check solution for a pull on the south side with one horizontal fracture."""
 
-    setup = create_fractured_setup({}, {}, 0)
-    setup.params["uy_south"] = -0.001
+    setup = create_fractured_setup({}, {}, 0.0)
+    setup.params["u_south"] = [0.0, -0.001]
     pp.run_time_dependent_model(setup, {})
     u_vals, p_vals, p_frac, jump, traction = get_variables(setup)
 
@@ -408,7 +408,7 @@ def test_push_north_zero_opening():
     u_vals, p_vals, p_frac, jump, traction = get_variables(setup)
 
     # All components should be closed in the normal direction
-    assert np.allclose(jump[1], 0.042)
+    assert np.allclose(jump[1], setup.solid.fracture_gap())
 
     # Contact force in normal direction should be negative
     assert np.all(traction[1] < 0)
@@ -418,13 +418,13 @@ def test_push_north_zero_opening():
 
 
 def test_positive_p_frac_positive_opening():
-    setup = create_fractured_setup({}, {}, 0)
+    setup = create_fractured_setup({}, {}, 0.0)
     setup.params["fracture_source_value"] = 0.001
     pp.run_time_dependent_model(setup, {})
     _, _, p_frac, jump, traction = get_variables(setup)
 
     # All components should be open in the normal direction
-    assert np.all(jump[1] > 0.042)
+    assert np.all(jump[1] > setup.solid.fracture_gap())
 
     # By symmetry (reasonable to expect from this grid), the jump in tangential
     # deformation should be zero.
@@ -442,17 +442,17 @@ def test_positive_p_frac_positive_opening():
 
 def test_pull_south_positive_reference_pressure():
     """Compare with and without nonzero reference (and initial) solution."""
-    setup_ref = create_fractured_setup({}, {}, 0)
+    setup_ref = create_fractured_setup({}, {}, 0.0)
     setup_ref.subtract_p_frac = False
-    setup_ref.params["uy_south"] = -0.001
+    setup_ref.params["u_south"] = [0.0, -0.001]
     pp.run_time_dependent_model(setup_ref, {})
     u_vals_ref, p_vals_ref, p_frac_ref, jump_ref, traction_ref = get_variables(
         setup_ref
     )
 
-    setup = create_fractured_setup({}, {"pressure": 1}, 0)
+    setup = create_fractured_setup({}, {"pressure": 1}, 0.0)
     setup.subtract_p_frac = False
-    setup.params["uy_south"] = -0.001
+    setup.params["u_south"] = [0.0, -0.001]
     pp.run_time_dependent_model(setup, {})
     u_vals, p_vals, p_frac, jump, traction = get_variables(setup)
 
@@ -485,7 +485,7 @@ def test_unit_conversion(units):
         "times_to_export": [],  # Suppress output for tests
         "num_fracs": 1,
         "cartesian": True,
-        "uy_north": 1e-5,
+        "u_north": [0.0, 1e-5],
         "material_constants": {"solid": solid, "fluid": fluid},
     }
     reference_params = copy.deepcopy(params)

--- a/tests/models/test_poromechanics.py
+++ b/tests/models/test_poromechanics.py
@@ -82,7 +82,8 @@ class NonzeroFractureGapPoromechanics:
             # Set mortar displacement to zero on bottom and fracture gap value on top
             vals = np.zeros((self.nd, intf.num_cells))
             vals[1, top_cells] = (
-                self.solid.fracture_gap() + self.solid.maximum_fracture_closure()
+                self.solid.fracture_gap()
+                + self.solid.maximum_elastic_fracture_opening()
             )
             self.equation_system.set_variable_values(
                 vals.ravel("F"),

--- a/tests/models/test_solution_strategy.py
+++ b/tests/models/test_solution_strategy.py
@@ -170,7 +170,7 @@ def test_restart(solid_vals: dict, north_displacement: float):
     # Remove temporary visualization folder.
     shutil.rmtree(visualization_dir)
 
-    # Clean up the reference data/
+    # Clean up the reference data.
     for f in pvd_files + vtu_files + json_files:
         src = reference_dir / Path(f.stem + f.suffix)
         src.unlink()

--- a/tests/models/test_solution_strategy.py
+++ b/tests/models/test_solution_strategy.py
@@ -77,7 +77,7 @@ def create_restart_model(
         ({"porosity": 0.5}, 0.1),
     ],
 )
-def test_restart(solid_vals, north_displacement):
+def test_restart(solid_vals: dict, north_displacement: float):
     """Restart version of .test_poromechanics.test_2d_single_fracture.
 
     Provided the exported data from a previous time step, restart the simulaton,
@@ -88,11 +88,9 @@ def test_restart(solid_vals, north_displacement):
     practical situation.
 
     Parameters:
-        solid_vals (dict): Dictionary with keys as those in :class:`pp.SolidConstants`
-            and corresponding values.
-        north_displacement (float): Value of displacement on the north boundary.
-        expected_x_y (tuple): Expected values of the displacement in the x and y.
-            directions. The values are used to infer sign of displacement solution.
+        solid_vals: Dictionary with keys as those in :class:`pp.SolidConstants` and
+            corresponding values.
+        north_displacement: Value of displacement on the north boundary.
 
     """
     # Setup and run model for full time interval. With this generate reference files
@@ -112,10 +110,10 @@ def test_restart(solid_vals, north_displacement):
 
     # Now use the reference data to restart the simulation. Note, the restart
     # capabilities of the models automatically use the last available time step for
-    # restart, here the restart files contain information on the initial and first
-    # time step. Thus, the simulation is restarted from the first time step.
-    # Recompute the second time step which will serve as foundation for the comparison
-    # to the above computed reference files.
+    # restart, here the restart files contain information on the initial and first time
+    # step. Thus, the simulation is restarted from the first time step. Recompute the
+    # second time step which will serve as foundation for the comparison to the above
+    # computed reference files.
     setup = create_restart_model(solid_vals, {}, north_displacement, restart=True)
     pp.run_time_dependent_model(setup, {})
 
@@ -169,10 +167,10 @@ def test_restart(solid_vals, north_displacement):
     restarted_times_json.close()
     reference_times_json.close()
 
-    # Remove temporary visualization folder
+    # Remove temporary visualization folder.
     shutil.rmtree(visualization_dir)
 
-    # Clean up the reference data
+    # Clean up the reference data/
     for f in pvd_files + vtu_files + json_files:
         src = reference_dir / Path(f.stem + f.suffix)
         src.unlink()
@@ -336,8 +334,8 @@ def test_parse_equations(
     """Test that equation parsing works as expected.
 
     Currently tested are the relevant equations in the mass balance and momentum balance
-    models. To add a new model, add a new class in setup_utils.py and expand the
-    test parameterization accordingly.
+    models. To add a new model, add a new class in setup_utils.py and expand the test
+    parameterization accordingly.
 
     Parameters:
         model_type: Type of model to test. Currently supported are "mass_balance" and

--- a/tests/models/test_thermoporomechanics.py
+++ b/tests/models/test_thermoporomechanics.py
@@ -3,7 +3,6 @@
 The positive fracture gap value ensures positive aperture for all simulation. This is
 needed to avoid degenerate mass and energy balance equations in the fracture.
 
-TODO: Clean up.
 """
 
 from __future__ import annotations

--- a/tests/models/test_thermoporomechanics.py
+++ b/tests/models/test_thermoporomechanics.py
@@ -1,7 +1,7 @@
 """Tests for thermoporomechanics.
 
-The hardcoded fracture gap value of 0.042 ensures positive aperture for all simulation.
-This is needed to avoid degenerate mass and energy balance equations in the fracture.
+The positive fracture gap value ensures positive aperture for all simulation. This is
+needed to avoid degenerate mass and energy balance equations in the fracture.
 
 TODO: Clean up.
 """
@@ -109,7 +109,7 @@ def test_2d_single_fracture(solid_vals: dict, uy_north: float):
     """
 
     # Create model and run simulation
-    setup = create_fractured_setup(solid_vals, {}, {"uy_north": uy_north})
+    setup = create_fractured_setup(solid_vals, {}, {"u_north": [0.0, uy_north]})
     pp.run_time_dependent_model(setup, {})
 
     # Check that the pressure is linear
@@ -123,7 +123,7 @@ def test_2d_single_fracture(solid_vals: dict, uy_north: float):
         assert np.allclose(u_vals[:, bottom], 0)
         # Zero x and nonzero y displacement in top
         assert np.allclose(u_vals[0, top], 0)
-        assert np.allclose(u_vals[1, top], 0.042)
+        assert np.allclose(u_vals[1, top], setup.solid.fracture_gap())
         # Zero displacement relative to initial value implies zero pressure and
         # temperature
         assert np.allclose(p_vals, 0)
@@ -163,7 +163,7 @@ def test_2d_single_fracture(solid_vals: dict, uy_north: float):
     else:
         # Displacement jump should be equal to initial displacement.
         assert np.allclose(jump[0], 0.0)
-        assert np.allclose(jump[1], 0.042)
+        assert np.allclose(jump[1], setup.solid.fracture_gap())
         # Normal traction should be non-positive. Zero if uy_north equals
         # initial gap, negative otherwise.
         if uy_north < 0:
@@ -184,9 +184,9 @@ def test_thermoporomechanics_model_no_modification():
 
 
 def test_pull_north_positive_opening():
-    setup = create_fractured_setup({}, {}, {"uy_north": 0.001})
+    setup = create_fractured_setup({}, {}, {"u_north": [0.0, 0.001]})
     pp.run_time_dependent_model(setup, {})
-    u_vals, p_vals, p_frac, jump, traction, t_vals, t_frac = get_variables(setup)
+    _, _, p_frac, jump, traction, _, t_frac = get_variables(setup)
 
     # All components should be open in the normal direction
     assert np.all(jump[1] > 0)
@@ -206,7 +206,7 @@ def test_pull_north_positive_opening():
 
 
 def test_pull_south_positive_opening():
-    setup = create_fractured_setup({}, {}, {"uy_south": -0.001})
+    setup = create_fractured_setup({}, {}, {"u_south": [0.0, -0.001]})
     pp.run_time_dependent_model(setup, {})
     u_vals, p_vals, p_frac, jump, traction, t_vals, t_frac = get_variables(setup)
 
@@ -228,12 +228,12 @@ def test_pull_south_positive_opening():
 
 
 def test_push_north_zero_opening():
-    setup = create_fractured_setup({}, {}, {"uy_north": -0.001})
+    setup = create_fractured_setup({}, {}, {"u_north": [0.0, -0.001]})
     pp.run_time_dependent_model(setup, {})
     u_vals, p_vals, p_frac, jump, traction, t_vals, t_frac = get_variables(setup)
 
     # All components should be closed in the normal direction
-    assert np.allclose(jump[1], 0.042)
+    assert np.allclose(jump[1], setup.solid.fracture_gap())
 
     # Contact force in normal direction should be negative
     assert np.all(traction[1] < 0)
@@ -249,7 +249,7 @@ def test_positive_p_frac_positive_opening():
     _, _, p_frac, jump, traction, _, t_frac = get_variables(setup)
 
     # All components should be open in the normal direction.
-    assert np.all(jump[1] > 0.042)
+    assert np.all(jump[1] > setup.solid.fracture_gap())
 
     # By symmetry (reasonable to expect from this grid), the jump in tangential
     # deformation should be zero.
@@ -382,7 +382,7 @@ def test_unit_conversion(units):
         "times_to_export": [],  # Suppress output for tests
         "fracture_indices": [0],
         "cartesian": True,
-        "uy_north": -1e-5,
+        "u_north": [0.0, -1e-5],
         "material_constants": {"solid": solid, "fluid": fluid},
     }
     reference_params = copy.deepcopy(params)

--- a/tutorials/conventions.ipynb
+++ b/tutorials/conventions.ipynb
@@ -41,7 +41,16 @@
     "\n",
     "This can be used to obtain the outwards pointing normal vector of a cell. We simply multiply with the value ($\\pm 1$) of sd.cell_faces. For instance, for cell `c` and face `f` we have\n",
     "\n",
-    "`outward_normal = sd.cell_faces[f, c] * sd.face_normals[:, f]`"
+    "`outward_normal = sd.cell_faces[f, c] * sd.face_normals[:, f]`\n",
+    "### Local coordinates and internal boundaries \n",
+    "In [mixed-dimensional grids](./mixed_dimensional_grids.ipynb) (TODO: Move there? Or create fracture deformation tutorial?), fractures define internal boundaries for the matrix.\n",
+    "Each fracture is assigned a local basis with a normal vector and one or two tangential vectors for ambient dimension of 2 and 3, respectively. \n",
+    "The fracture's normal vector coincides with the outwards normal vector of the matrix on the \"j side\"/\"left side\" of the fracture (the other side is referred to as the \"k side\" or the \"right side\").\n",
+    "The fracture is assigned a `TangentialNormalProjection` with methods to rotate between global and local coordinates.\n",
+    "\n",
+    "In some settings, it is important to distinguish between the two sides of a fracture.\n",
+    "This information is contained in the `sign_of_mortar_sides` method of the `MortarGrid` representing the fracture-matrix interface.\n",
+    "The method returns a matrix with $-1$ and $+1$ entries corresponding to the j and k side, respectively.\n"
    ]
   },
   {
@@ -49,7 +58,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Boundaries\n",
+    "## External boundaries\n",
     "### Flow\n",
     "Outflow values are considered positive for Neumann type boundary conditions, i.e. outward pointing normal vectors are assumed.\n",
     "\n",
@@ -60,7 +69,7 @@
     "For a 2d  domain, this means that a prescribed boundary value of $\\mathbf{u}_b = [1, -2]$ signifies a unitary displacement to the right, and downwards with magnitude 2. \n",
     "Similarly, $\\sigma\\cdot \\mathbf{n} = [-1, 0]$ implies a unitary force to the left.\n",
     "\n",
-    "Displacements defined on inner boundaries are also in global coordinates."
+    "Displacements defined on inner boundaries are also in global coordinates.\n"
    ]
   },
   {


### PR DESCRIPTION
## Proposed changes

Introduces a elasto-plastic split of the displacement jump, i.e., [u] = [u]^p + [u]^e. The plastic part is the shear and separation ("full opening") we're familiar with. The elastic part is e.g. Barton-Bandis in the normal direction. In the tangential direction, one may use a linear elastic relation introduced as part of this PR . By choosing the default value of -1 for the elastic tangential stiffness, zero tangential deformation is allowed. 

Breaking and notable changes:
1. maximum_fracture_closure renamed to maximum_elastic_fracture_opening
2. elastic_normal_fracture_deformation now returns the positive value maximum_elastic_fracture_opening-closure, instead of the negative value closure.
3. Introduces elastic_displacement_jump and plastic_displacement_jump in new class DisplacementJump.  Some places where displacement_jump was previously called, including in the tangential deformation equation, now require the plastic part.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected):
- [x] Testing (contribution related to testing of existing or new functionality).
- [x] Documentation (contribution related to adding, improving, or fixing documentation): Some information added to Conventions tutorial
- [x] Maintenance (e.g., improve logic and performance, remove obsolete code): Various minor fixes.
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR): Please verify during review.
- [x] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
