### PR TITLE
1206 test robin approximating dirichlet

### DIFF
--- a/tests/models/test_boundary_condition.py
+++ b/tests/models/test_boundary_condition.py
@@ -253,11 +253,7 @@ class BCValuesFlux:
         """Assigns stress values on top, bottom and right boundary."""
         values = np.zeros((self.nd, bg.num_cells))
         inds = self.not_dir_inds(bg)
-        volumes = bg.cell_volumes
-        values[0, inds] = (
-            42 * (1 - bg.cell_centers[0]) * (volumes * self.params["alpha"])
-        )[inds]
-        values[0, inds] = 24 * (volumes[inds] * self.params["alpha"])
+        values[0, inds] = 24
         return values.ravel("F")
 
 
@@ -283,14 +279,10 @@ class BCDirichletReference:
         """Assigns displacement values in the x-direction of the west boundary."""
         values = super().bc_values_displacement(bg=bg)
         values = values.reshape((self.nd, bg.num_cells), order="F")
-        bounds = self.domain_boundary_sides(bg)
-
         alpha = self.params["alpha"]
         inds = self.not_dir_inds(bg)
         volumes = bg.cell_volumes[inds]
-        values[0, inds] = 42 * (1 - bg.cell_centers[0])[inds]  # / (volumes * alpha)
-        # 24 / (volumes * alpha)
-        values[0, inds] = 24
+        values[0, inds] = 24 / (volumes * alpha)
         return values.ravel("F")
 
     def _bc_values_scalar(self, bg: pp.BoundaryGrid) -> np.ndarray:
@@ -401,6 +393,6 @@ def test_robin_limit_case(rob_class, reference_class, alpha):
     reference_results = run_model(LocalReference, alpha)
 
     assert all(
-        np.allclose(rob_results[key], reference_results[key])
+        np.allclose(rob_results[key], reference_results[key], atol=1e-7)
         for key in rob_results.keys()
     )


### PR DESCRIPTION
## Proposed changes

Addresses issue #1206. Robin conditions are on the form flux + alpha * potential = G. As alpha goes to zero, the Robin conditions approaches Neumann. As alpha goes to infinity, the Robin conditions approaches Dirichlet. This PR includes a test to ensure that the latter happens. The test covers a scalar problem (mass and energy balance) as well as a vector problem (momentum balance). This PR also improves the setup in the approximate-Neumann-conditions-test which was already present. Special thanks to @IvarStefansson for great assistance!

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [x] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
