### PR TITLE
MAINT: Change misleading names related to restarting simulations

### DIFF
--- a/src/porepy/numerics/time_step_control.py
+++ b/src/porepy/numerics/time_step_control.py
@@ -399,7 +399,7 @@ class TimeManager:
         self._recomp_sol: bool = False
         self._iters: Union[int, None] = None
 
-        # Book keeping of saved time steps for restarting purposes.
+        # Bookkeeping of saved time steps for restarting purposes.
         self.exported_dt: list[pp.number] = []
         """A list of time steps for the simulation states that were saved on disk with
         `write_time_information` for restarting purposes. Completeness and lack of
@@ -735,7 +735,7 @@ class TimeManager:
 
         """
 
-        # Book keeping
+        # Bookkeeping
         self.exported_times.append(
             int(self.time) if isinstance(self.time, np.integer) else float(self.time)
         )

--- a/src/porepy/viz/data_saving_model_mixin.py
+++ b/src/porepy/viz/data_saving_model_mixin.py
@@ -217,7 +217,7 @@ class DataSavingMixin:
 
         # Load time and time step size
         self.time_manager.load_time_information(times_file)
-        self.time_manager.set_from_history(time_index)
+        self.time_manager.set_time_and_dt_from_exported_steps(time_index)
         self.exporter._time_step_counter = time_index
 
     def load_data_from_pvd(
@@ -251,7 +251,7 @@ class DataSavingMixin:
 
         # Load time and time step size
         self.time_manager.load_time_information(times_file)
-        self.time_manager.set_from_history(time_index)
+        self.time_manager.set_time_and_dt_from_exported_steps(time_index)
         self.exporter._time_step_counter = time_index
 
 


### PR DESCRIPTION
## Proposed changes

Changes proposed by @pschultzendorff and I. Addresses issue #1199. 

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [x] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
