### PR TITLE
Remove iteration counter and norms that are already covered by SolverStatistics

### DIFF
--- a/src/porepy/models/solution_strategy.py
+++ b/src/porepy/models/solution_strategy.py
@@ -519,8 +519,8 @@ class SolutionStrategy(abc.ABC):
             nonlinear_increment: Newly obtained solution increment vector
             residual: Residual vector of non-linear system, evaluated at the newly
             obtained solution vector.
-            reference_residual: Reference residual vector of non-linear system, evaluated
-                for the initial guess at current time step.
+            reference_residual: Reference residual vector of non-linear system,
+                evaluated for the initial guess at current time step.
             nl_params: Dictionary of parameters used for the convergence check.
                 Which items are required will depend on the convergence test to be
                 implemented.

--- a/src/porepy/numerics/linear_solvers.py
+++ b/src/porepy/numerics/linear_solvers.py
@@ -53,7 +53,7 @@ class LinearSolver:
         residual = setup.equation_system.assemble(evaluate_jacobian=False)
         nonlinear_increment = setup.solve_linear_system()
 
-        _, _, is_converged, _ = setup.check_convergence(
+        is_converged, _ = setup.check_convergence(
             nonlinear_increment, residual, residual.copy(), self.params
         )
 
@@ -68,7 +68,7 @@ class LinearSolver:
             # the case for ContactMechanics and possibly others). Thus, we first call
             # after_nonlinear_iteration(), and then after_nonlinear_convergence()
             setup.after_nonlinear_iteration(nonlinear_increment)
-            setup.after_nonlinear_convergence(iteration_counter=1)
+            setup.after_nonlinear_convergence()
         else:
             setup.after_nonlinear_failure()
         return is_converged

--- a/src/porepy/numerics/nonlinear/nonlinear_solvers.py
+++ b/src/porepy/numerics/nonlinear/nonlinear_solvers.py
@@ -48,7 +48,7 @@ class NewtonSolver:
         # loop or inside a stationary problem (default).
         self.progress_bar_position: int = params.get("progress_bar_position", 0)
 
-    def solve(self, model) -> tuple[bool, int]:
+    def solve(self, model) -> bool:
         """Solve the nonlinear problem.
 
         Parameters:
@@ -59,8 +59,6 @@ class NewtonSolver:
 
             bool:
                 True if the solution is converged.
-            int:
-                Number of iterations used.
 
         """
         model.before_nonlinear_loop()
@@ -142,7 +140,6 @@ class NewtonSolver:
                         "Newton iteration number "
                         + f"{model.nonlinear_solver_statistics.num_iteration + 1} of \t"
                         + f"{self.params['max_iterations']}"
-                        ""
                     )
                     newton_step()
 
@@ -167,7 +164,7 @@ class NewtonSolver:
         if not is_converged:
             model.after_nonlinear_failure()
 
-        return is_converged, model.nonlinear_solver_statistics.num_iteration
+        return is_converged
 
     def iteration(self, model) -> np.ndarray:
         """A single nonlinear iteration.

--- a/tests/models/test_solution_strategy.py
+++ b/tests/models/test_solution_strategy.py
@@ -197,7 +197,7 @@ class RediscretizationTest:
 
     def check_convergence(self, *args, **kwargs):
         if self.nonlinear_solver_statistics.num_iteration > 1:
-            return 0.0, 0.0, True, False
+            return True, False
         else:
             # Call to super is okay here, since the full model used in the tests is
             # known to have a method of this name.

--- a/tests/numerics/nonlinear/test_nonlinear_solvers.py
+++ b/tests/numerics/nonlinear/test_nonlinear_solvers.py
@@ -1,0 +1,61 @@
+import porepy as pp
+import numpy as np
+from typing import Any
+
+from porepy.models.fluid_mass_balance import SinglePhaseFlow
+
+
+class NonlinearSinglePhaseFlow(SinglePhaseFlow):
+    """Class setup which forces a set number of nonlinear iterations to be run for
+    testing."""
+
+    def _is_nonlinear_problem(self):
+        """Method for stating that the problem is nonlinear."""
+        return True
+
+    def check_convergence(
+        self,
+        nonlinear_increment: np.ndarray,
+        residual: np.ndarray,
+        reference_residual: np.ndarray,
+        nl_params: dict[str, Any],
+    ) -> tuple[bool, bool]:
+        """Method for checking convergence.
+
+        This method is only used for testing. It returns not converged if the iteration
+        count is smaller than a pre set value.
+
+        """
+        diverged = False
+        if (
+            self.nonlinear_solver_statistics.num_iteration
+            < self.expected_number_of_iterations
+        ):
+            converged = False
+            return converged, diverged
+        converged = True
+        return converged, diverged
+
+    def after_nonlinear_failure(self) -> None:
+        """Method which is called if the non-linear solver fails to converge."""
+        self.save_data_time_step()
+        prev_solution = self.equation_system.get_variable_values(time_step_index=0)
+        self.equation_system.set_variable_values(prev_solution, iterate_index=0)
+
+
+def test_nonlinear_iteration_count():
+    """Test for checking if the nonlinear iterations are counted as expected.
+
+    A pre set value of expected iterations is set, and the test checks that the
+    iteration count matches the pre set value after convergence is obtained.
+
+    """
+    params = {"max_iterations": 96}
+    model = NonlinearSinglePhaseFlow()
+    model.expected_number_of_iterations = 13
+    pp.run_time_dependent_model(model, params)
+
+    assert (
+        model.nonlinear_solver_statistics.num_iteration
+        == model.expected_number_of_iterations
+    )

--- a/tests/numerics/nonlinear/test_nonlinear_solvers.py
+++ b/tests/numerics/nonlinear/test_nonlinear_solvers.py
@@ -9,10 +9,6 @@ class NonlinearSinglePhaseFlow(SinglePhaseFlow):
     """Class setup which forces a set number of nonlinear iterations to be run for
     testing."""
 
-    def _is_nonlinear_problem(self):
-        """Method for stating that the problem is nonlinear."""
-        return True
-
     def check_convergence(
         self,
         nonlinear_increment: np.ndarray,
@@ -36,12 +32,6 @@ class NonlinearSinglePhaseFlow(SinglePhaseFlow):
         converged = True
         return converged, diverged
 
-    def after_nonlinear_failure(self) -> None:
-        """Method which is called if the non-linear solver fails to converge."""
-        self.save_data_time_step()
-        prev_solution = self.equation_system.get_variable_values(time_step_index=0)
-        self.equation_system.set_variable_values(prev_solution, iterate_index=0)
-
 
 def test_nonlinear_iteration_count():
     """Test for checking if the nonlinear iterations are counted as expected.
@@ -52,7 +42,7 @@ def test_nonlinear_iteration_count():
     """
     params = {"max_iterations": 96}
     model = NonlinearSinglePhaseFlow()
-    model.expected_number_of_iterations = 13
+    model.expected_number_of_iterations = 3
     pp.run_time_dependent_model(model, params)
 
     assert (

--- a/tests/numerics/test_time_step_control.py
+++ b/tests/numerics/test_time_step_control.py
@@ -813,16 +813,16 @@ class DynamicTimeStepTestCaseModel(SinglePhaseFlow):
         residual: np.ndarray,
         reference_residual: np.ndarray,
         nl_params: dict[str, Any],
-    ) -> tuple[float, float, bool, bool]:
+    ) -> tuple[bool, bool]:
         if self.num_nonlinear_iters < self.num_nonlinear_iterations[self.time_step_idx]:
             # Neither converged nor diverged
-            return 0.5, 0.5, False, False
+            return False, False
         if self.time_step_converged[self.time_step_idx] is True:
             # Converged
-            return 0, 0.5, True, False
+            return True, False
         if self.time_step_converged[self.time_step_idx] is False:
             # Diverged
-            return 1, 0.5, False, True
+            return False, True
         assert (
             False
         ), "Nonlinear solver did not stop iterating after the iteration limit."


### PR DESCRIPTION
Changes proposed by @IngridKJ and I. 

## Proposed changes

Adresses issues #1219 and #1200.

``model.nonlinar_solver_statistics`` already keeps track of the number of nonlinear iterations, residual norms, and nonlinear increment norms. Thus, any explicit passes of these values between ``SolutionStrategy.after_nonlinear_convergence``, ``SolutionStrategy.check_convergence``, and ``NewtonSolver.solve`` are removed. Conveniently, this fixes ``iteration_counter`` lagging behind by one step. ``NewtonSolver.solve`` only returns one boolean value ``converged`` now.

On an additional note, we noticed that the test suite does not cover the case of divergence due to nan values in ``SolutionStrategy.check_convergence``, i.e., lines 547-551 in ``solution_strategy.py``. We only noticed a mistake in our changes due to flake complaining, not the tests. Any opinions on that would be welcome :)

We added tests for ``SolutionStrategy.check_convergence`` and ``NewtonSolver.solve``.

## Types of changes

What types of changes does this PR introduce to PorePy?

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [x] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

Not quite sure how to categorize this, as it is only code cleanup, but any custom scripts depending on ``iteration_counter`` and ``check_convergence`` will break.

## Checklist

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.

