### PR TITLE
Reimplemented method cell_face_as_dense in the grid class

### DIFF
--- a/src/porepy/grids/grid.py
+++ b/src/porepy/grids/grid.py
@@ -903,7 +903,7 @@ class Grid:
             ]
         )
 
-    def cell_face_as_dense(self) -> np.ndarray:
+    def cell_faces_as_dense(self) -> np.ndarray:
         """Obtain the cell-face relation in the form of two rows, rather than a
         sparse matrix.
 

--- a/src/porepy/grids/grid.py
+++ b/src/porepy/grids/grid.py
@@ -927,8 +927,8 @@ class Grid:
 
         # Fin the non-zero elements in the cell-face relation.
         fi, ci, sgn = sps.find(self.cell_faces)
-        
-        # Find the sign of the faces. 
+
+        # Find the sign of the faces.
         pos = sgn > 0
         neg = sgn < 0
 
@@ -940,7 +940,6 @@ class Grid:
         cf_dense[1, fi[neg]] = ci[neg]
 
         return cf_dense
-      
 
     def cell_connection_map(self) -> sps.csr_matrix:
         """Get a matrix representation of cell-cell connections, as defined by

--- a/src/porepy/grids/grid.py
+++ b/src/porepy/grids/grid.py
@@ -925,7 +925,7 @@ class Grid:
         if self.num_faces == 0:
             return np.zeros((2, 0))
 
-        # Fin the non-zero elements in the cell-face relation.
+        # Find the non-zero elements in the cell-face relation.
         fi, ci, sgn = sps.find(self.cell_faces)
 
         # Find the sign of the faces.

--- a/src/porepy/numerics/fv/upwind.py
+++ b/src/porepy/numerics/fv/upwind.py
@@ -178,7 +178,7 @@ class Upwind(Discretization):
         upstream_cell_ind = np.zeros(sd.num_faces, dtype=int)
         # Fill the array based on the cell-face relation. By construction, the normal
         # vector of a face points from the first to the second row in this array
-        cf_dense = sd.cell_face_as_dense()
+        cf_dense = sd.cell_faces_as_dense()
         # Positive fluxes point in the same direction as the normal vector, find the
         # upstream cell
         upstream_cell_ind[pos_flux] = cf_dense[0, pos_flux]

--- a/tests/grids/test_grid.py
+++ b/tests/grids/test_grid.py
@@ -67,9 +67,9 @@ def test_closest_cell_out_of_plane():
     assert ind.size == 1
 
 
-def test_cell_face_as_dense():
+def test_cell_faces_as_dense(g):
     g = pp.CartGrid(np.array([2, 1]))
-    cf = g.cell_face_as_dense()
+    cf = g.cell_faces_as_dense()
     known = np.array([[-1, 0, 1, -1, -1, 0, 1], [0, 1, -1, 0, 1, -1, -1]])
     assert np.allclose(cf, known)
 

--- a/tests/grids/test_grid.py
+++ b/tests/grids/test_grid.py
@@ -3,6 +3,7 @@
 * Specific tests for Simplex and Structured Grids
 * Tests for the mortar grid.
 """
+
 import os
 import pickle
 
@@ -68,14 +69,15 @@ def test_closest_cell_out_of_plane():
 
 
 @pytest.mark.parametrize(
-    "g", [
-         pp.PointGrid(np.array([0, 0, 0])),
-         pp.CartGrid(np.array([2])),
-         pp.CartGrid(np.array([2, 2])),
-         pp.CartGrid(np.array([2, 2, 2])),
-         pp.StructuredTriangleGrid(np.array([2, 2])),
-         pp.StructuredTetrahedralGrid(np.array([2, 2, 2]))
-         ]
+    "g",
+    [
+        pp.PointGrid(np.array([0, 0, 0])),
+        pp.CartGrid(np.array([2])),
+        pp.CartGrid(np.array([2, 2])),
+        pp.CartGrid(np.array([2, 2, 2])),
+        pp.StructuredTriangleGrid(np.array([2, 2])),
+        pp.StructuredTetrahedralGrid(np.array([2, 2, 2])),
+    ],
 )
 def test_cell_faces_as_dense(g: pp.Grid):
     """Test that the cell_faces_as_dense method works as expected.
@@ -120,7 +122,9 @@ def test_cell_faces_as_dense(g: pp.Grid):
     # filtering to only catch actual cells.
     cols = np.concatenate([cf_dense[0, internal_cell_0], cf_dense[1, internal_cell_1]])
     # The data is 1 for the first row, and -1 for the second.
-    data = np.concatenate([np.ones(np.sum(internal_cell_0)), -np.ones(np.sum(internal_cell_1))])
+    data = np.concatenate(
+        [np.ones(np.sum(internal_cell_0)), -np.ones(np.sum(internal_cell_1))]
+    )
 
     # Reconstruct the sparse cell-face relation.
     reconstructed = sps.coo_matrix((data, (rows, cols)), shape=(nf, nc)).tocsr()

--- a/tests/grids/test_grid.py
+++ b/tests/grids/test_grid.py
@@ -67,11 +67,65 @@ def test_closest_cell_out_of_plane():
     assert ind.size == 1
 
 
-def test_cell_faces_as_dense(g):
-    g = pp.CartGrid(np.array([2, 1]))
-    cf = g.cell_faces_as_dense()
-    known = np.array([[-1, 0, 1, -1, -1, 0, 1], [0, 1, -1, 0, 1, -1, -1]])
-    assert np.allclose(cf, known)
+@pytest.mark.parametrize(
+    "g", [
+         pp.PointGrid(np.array([0, 0, 0])),
+         pp.CartGrid(np.array([2])),
+         pp.CartGrid(np.array([2, 2])),
+         pp.CartGrid(np.array([2, 2, 2])),
+         pp.StructuredTriangleGrid(np.array([2, 2])),
+         pp.StructuredTetrahedralGrid(np.array([2, 2, 2]))
+         ]
+)
+def test_cell_faces_as_dense(g: pp.Grid):
+    """Test that the cell_faces_as_dense method works as expected.
+
+    The test is based on constructing the dense version of the cell-face relation, using
+    the relevant method in the grid class, and reconstructing the sparse version from
+    the dense version using the known (or supposed, in case of bugs) structure of the
+    dense version.
+
+    Parameters:
+        g: The grid for which the test should be run.
+
+    """
+    # Get the sparse and dense versions of the cell-face relation.
+    cf_sparse = g.cell_faces
+    cf_dense = g.cell_faces_as_dense()
+
+    # Number of faces in the grid.
+    nf, nc = g.num_faces, g.num_cells
+
+    # All (possible) face indices. All of these will occur at least once (or else
+    # something is wrong, but the test should still work).
+    face_ind = np.arange(nf)
+
+    # In the dense cell-face relation, there are as many columns as there are faces, and
+    # the elements in the faces are the indices of the cells neighboring the face. The
+    # cells in the first row have positive sign in the sparse cell-face relation (that
+    # is, the face normal vectors point out of the cells), while the row contains cells
+    # with negative sign. A negative number in the dense cell-face relation signifies
+    # that the face is on the boundary, and that there is no neighboring cell on that
+    # side of the face.
+
+    # Logical array to identify actual cells in the first and second row
+    internal_cell_0 = cf_dense[0] >= 0
+    internal_cell_1 = cf_dense[1] >= 0
+
+    # Form the rows, columns and data for the reconstructed sparse cell-face relation.
+    # The rows are the indices of those faces that are internal. Pick indices from the
+    # first row of the dense relation, then the second.
+    rows = np.concatenate([face_ind[internal_cell_0], face_ind[internal_cell_1]])
+    # The columns are the indices of the cells that are neighbors to the faces. Again do
+    # filtering to only catch actual cells.
+    cols = np.concatenate([cf_dense[0, internal_cell_0], cf_dense[1, internal_cell_1]])
+    # The data is 1 for the first row, and -1 for the second.
+    data = np.concatenate([np.ones(np.sum(internal_cell_0)), -np.ones(np.sum(internal_cell_1))])
+
+    # Reconstruct the sparse cell-face relation.
+    reconstructed = sps.coo_matrix((data, (rows, cols)), shape=(nf, nc)).tocsr()
+    # The original and reconstructed cell-face relations should be the same.
+    assert np.allclose(reconstructed.toarray(), cf_sparse.toarray())
 
 
 # ----- Boundary tests ----- #

--- a/tutorials/grid_topology.ipynb
+++ b/tutorials/grid_topology.ipynb
@@ -329,7 +329,7 @@
     }
    ],
    "source": [
-    "g.cell_face_as_dense()"
+    "g.cell_faces_as_dense()"
    ]
   },
   {


### PR DESCRIPTION
## Proposed changes
Changes:
1. Replaced the (8 year old!) implementation of `cell_face_as_dense` in the `Grid` class. The new implementation is much more transparent, and documented.
2. Renamed the method `cell_face_as_dense` -> `cell_faces_as_dense`.
3. Improved the test for this method.

@IvarStefansson @IngridKJ: Although the test suite is much improved, the old implementation did not fail on this expanded set. I am not sure which grid you used to make the method fail today, but could you test the new version and see if it works? If so, I am not sure if we should expand the test suite with the previously failing grid, so let me know what you think. If it still fails, we will definitely add it.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Testing (contribution related to testing of existing or new functionality).
- [x] Documentation (contribution related to adding, improving, or fixing documentation).
- [x] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
