### PR TITLE
1250 purge granite and water

### DIFF
--- a/src/porepy/applications/material_values/fluid_values.py
+++ b/src/porepy/applications/material_values/fluid_values.py
@@ -31,6 +31,7 @@ conductivity between 290K (16.85C) and 295K (21.85C).
 """
 
 water = {
+    "name": "water",
     "compressibility": 4.559 * 1e-10,  # [Pa^-1], isentropic compressibility
     "density": 998.2,  # [kg m^-3]
     "specific_heat_capacity": 4182.0,  # [J kg^-1 K^-1], isochoric specific heat

--- a/src/porepy/applications/material_values/solid_values.py
+++ b/src/porepy/applications/material_values/solid_values.py
@@ -70,6 +70,7 @@ S_s = 4.65e-6 m^-1 = 4.65e-6 / (rho_water * g) Pa^-1 = 4.74e-10 Pa^-1.
 """
 
 granite = {
+    "name": "granite",
     "biot_coefficient": 0.47,  # [-]
     "density": 2683.0,  # [kg * m^-3]
     "friction_coefficient": 0.6,  # [-]
@@ -148,6 +149,7 @@ Chose the average value of the estimate provided in table 6.
 """
 
 basalt = {
+    "name": "basalt",
     "biot_coefficient": 0.35,  # [-]
     "density": 2950.0,  # [kg * m^-3]
     "friction_coefficient": 0.7,  # [-]
@@ -184,4 +186,8 @@ extended_granite_values_for_testing.update(
     }
 )
 for n in ["lame_lambda", "shear_modulus"]:
-    extended_granite_values_for_testing[n] *= 1e-3  # Improve conditioning
+    # Because the dict contains a string value, mypy complains about multiplying an
+    # object with a float. The multiplied values are floats, so we can safely ignore.
+    extended_granite_values_for_testing[  # type: ignore
+        n
+    ] *= 1e-3  # Improve conditioning

--- a/src/porepy/applications/test_utils/models.py
+++ b/src/porepy/applications/test_utils/models.py
@@ -279,32 +279,6 @@ def _add_mixin(mixin, parent):
     return cls
 
 
-# TODO: Purge in favour of pp.solid_values.granite
-granite_values = {
-    "biot_coefficient": 0.8,
-    "permeability": 1e-20,
-    "density": 2700,
-    "porosity": 7e-3,
-    "shear_modulus": 16.67 * pp.GIGA,
-    "lame_lambda": 11.11 * pp.GIGA,
-    "specific_heat_capacity": 790,
-    "thermal_conductivity": 2.5,
-    "thermal_expansion": 1e-5,
-    "fracture_normal_stiffness": 1529,
-    "maximum_elastic_fracture_opening": 1e-4,
-    "fracture_gap": 1e-4,
-    "residual_aperture": 0.01,
-}
-water_values = {
-    "specific_heat_capacity": 4180,
-    "compressibility": 4e-10,
-    "viscosity": 1e-3,
-    "density": 1000,
-    "thermal_conductivity": 0.6,
-    "thermal_expansion": 2.1e-4,
-}
-
-
 def compare_scaled_primary_variables(
     setup_0: pp.SolutionStrategy,
     setup_1: pp.SolutionStrategy,

--- a/tests/models/test_fluid_mass_balance.py
+++ b/tests/models/test_fluid_mass_balance.py
@@ -157,7 +157,7 @@ def test_tested_vs_testable_methods_single_phase_flow(
         all_testable_methods: List of all testable methods.
 
     """
-    # Failure here could be mean two things:
+    # Failure here could mean two things:
     #
     #   (1) The `all_tested_methods` fixture is an empty list due to the tests
     #       from `test_ad_operator_methods_single_phase_flow` not being collected (see
@@ -175,12 +175,12 @@ def test_tested_vs_testable_methods_single_phase_flow(
     assert all_tested_methods == all_testable_methods
 
 
-# NOTE: The tests for darcy_flux, fluid_flux, fluid_source,
+# NOTE: The tests for darcy_flux, fluid_flux, fluid_flux, fluid_source,
 # interface_darcy_flux_equation, interface_fluid_flux, interface_flux_equation,
 # mass_balance_equation, normal_permeability, skin_factor, and pressure_trace were based
 # on different water fluid values in PorePy 1.10.0 and prior. The new expected values
-# for each test are copied from the test's output. We rely on the tests working
-# correctly previously for this.
+# for each test are copied from the test's output. We rely on the correctness of the
+# previous tests for this choice.
 @pytest.mark.parametrize(
     "method_name, expected_value, dimension_restriction",
     [
@@ -261,8 +261,19 @@ def test_tested_vs_testable_methods_single_phase_flow(
         # fluid_mass = rho * phi * specific_volume
         (
             "fluid_mass",
-            granite_values["porosity"]
-            / (np.exp(water_values["compressibility"] * 200 * pp.BAR)),
+            np.array(
+                [
+                    3.27386543e00,
+                    3.27386543e00,
+                    3.27386543e00,
+                    3.27386543e00,
+                    6.54773085e-03,
+                    6.54773085e-03,
+                    6.54773085e-03,
+                    6.54773085e-03,
+                    1.30954617e-05,
+                ]
+            ),
             None,
         ),
         # Only sources from interface fluxes are non-zero. External sources are zero.
@@ -306,9 +317,9 @@ def test_tested_vs_testable_methods_single_phase_flow(
             ),
             None,
         ),
-        # Mobility = rho / mu
-        ("mobility", water_values["density"] / (water_values["viscosity"]), None),
-        # Combination of mobility and fluid density = rho/mu
+        # Mobility = 1 / mu
+        ("mobility", 1.0 / (water_values["viscosity"]), None),
+        # Combination of mobility and fluid density = rho / mu
         # Mobility_rho = rho_ref * exp(c_f * (p - p_ref)) / mu
         (
             "mobility_rho",
@@ -317,9 +328,9 @@ def test_tested_vs_testable_methods_single_phase_flow(
             / water_values["viscosity"],
             None,
         ),
-        ("normal_permeability", 5e-15, None),
-        ("permeability", 5.0e-18, None),
-        ("porosity", 1.3e-2, None),
+        ("normal_permeability", granite_values["normal_permeability"], None),
+        ("permeability", granite_values["permeability"], None),
+        ("porosity", granite_values["porosity"], None),
         ("pressure", 200 * pp.BAR, None),
         # pressure_exponential = exp(c_f * (p - p_ref))
         (
@@ -360,11 +371,11 @@ def test_tested_vs_testable_methods_single_phase_flow(
             None,
         ),
         # ("reference_pressure", 0, None),
-        ("skin_factor", 37.0, None),
+        ("skin_factor", granite_values["skin_factor"], None),
         ("tangential_component", np.array([[1.0, 0.0]]), 0),  # Check only for 0d.
         ("well_fluid_flux", 0, 2),  # Use dim_restriction=2 to ignore well flux.
         ("well_flux_equation", 0, 2),  # Use dim_restriction=2 to ignore well equation.
-        ("well_radius", 0.1, None),
+        ("well_radius", granite_values["well_radius"], None),
         # Testing of methods with deeper namespace.
         # rho = rho_ref * exp(c_f * (p - p_ref))
         (


### PR DESCRIPTION
## Proposed changes

Removes water and granite values for testing in ``applications.test_utils`` in favor of the values in ``applications.material_values``.

## Types of changes

What types of changes does this PR introduce to PorePy?

- [x] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
