### PR TITLE
BUG: Set nonzero color map range for constant data.

### DIFF
--- a/src/porepy/viz/plot_grid.py
+++ b/src/porepy/viz/plot_grid.py
@@ -527,7 +527,16 @@ def _color_map(
     """
     cmap = plt.get_cmap(cmap_type)
     scalar_map = mpl.cm.ScalarMappable(cmap=cmap)
+    # For constant data, perturb the data slightly to generate a color map.
+    if extr_value[0] == extr_value[1]:
+        if extr_value[0] == 0:
+            eps = 1e-6  # Arbitrary small value.
+        else:
+            eps = 1e-1 * extr_value[0]  # 10% of the value.
+        extr_value[0] -= eps
+        extr_value[1] += eps
     scalar_map.set_array(extr_value)
+    # Set the limits of the color map.
     scalar_map.set_clim(vmin=extr_value[0], vmax=extr_value[1])
     return scalar_map
 


### PR DESCRIPTION
## Proposed changes

Avoid mapping errors for plotting of constant data caused by setting a color map with empty range.
Resolves #1278.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [x] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
