### PR TITLE
Fix function to refine 1d grids. Improve tests.

### DIFF
--- a/src/porepy/grids/refinement.py
+++ b/src/porepy/grids/refinement.py
@@ -108,7 +108,7 @@ def refine_grid_1d(g: pp.Grid, ratio: int = 2) -> pp.Grid:
 
     # When looping over cells in the old grid, we will hit upon all internal nodes
     # twice, but they should only be added to the refined grid the first time. We
-    # therefore need to keep track of whether an node in the old grid should be added
+    # therefore need to keep track of whether a node in the old grid should be added
     # and, if not, the node index in the new grid by which it is already present.
     #
     # Construct an array that indicates whether an item in the cell-node relation
@@ -172,7 +172,7 @@ def refine_grid_1d(g: pp.Grid, ratio: int = 2) -> pp.Grid:
             + g.nodes[:, end].reshape((-1, 1)) * theta
         )
 
-        # Register the indices of the new nodes and increasen the counter.
+        # Register the indices of the new nodes and increase the counter.
         loc_new_ind += list(node_counter + indices_template)
         node_counter += ratio - 1
 

--- a/src/porepy/grids/refinement.py
+++ b/src/porepy/grids/refinement.py
@@ -86,107 +86,109 @@ def refine_grid_1d(g: pp.Grid, ratio: int = 2) -> pp.Grid:
     # cell-face relation. Since the grid is 1d, nodes and faces are equivalent, and
     # notation used mostly refers to nodes instead of faces.
 
-    # Cell-node relation. Enforce csc format, since this is heavily used below. 
+    # Cell-node relation. Enforce csc format to make sure we use the right data.
     cell_nodes = g.cell_nodes().tocsc()
     nodes, cells, _ = sparse_array_to_row_col_data(cell_nodes)
 
-    # Every cell will contribute (ratio - 1) new nodes
+    # Every cell will contribute (ratio - 1) new nodes.
     num_new_nodes = (ratio - 1) * g.num_cells + g.num_nodes
+
+    # Data structure for the new nodes.
     x = np.zeros((3, num_new_nodes))
-    # Coordinates for splitting of cells
+
+    # Line-length parametrization between 0 and 1. This will be used to define the
+    # coordinates of the new nodes (between nodes in the old grid).
     theta = np.arange(1, ratio) / float(ratio)
-    pos = 0
-    shift = 0
-
-    offset_new_indices = 0
-
-    # Array that indicates whether an item in the cell-node relation represents a node
-    # not listed before (e.g. whether this is the first or second occurrence of the
-    # cell). EK: This does not work if the cells are not linearly ordered.
-    _, first_occ = np.unique(cell_nodes.indices, return_index=True)
-    if_add = np.zeros(cell_nodes.indices.size, dtype=bool)
-    if_add[first_occ] = True
-
-    # Holder for the new indices.
-    new_indices: list[np.ndarray] = []
-
-    # Template array of node indices for refined cells.
-    indices_template = np.vstack((np.arange(ratio), np.arange(ratio) + 1)).ravel("F")
-    indices_template = np.repeat(np.arange(ratio), 2)
-    nd = np.r_[np.diff(cell_nodes.indices)[1::2], 0]
-
-    old_2_new_nodes = {}
+    # Counter used to keep track of how many nodes have been added to the new grid.
+    node_counter = 0
 
     # The refinement must work also for grids that are not equidistant. While it might
     # be possible to do the refinemnet in a vectorized fashion, looping over the cells
     # and refining them one by one is a simpler solution.
 
-    # TODO: To cover permuted indices of nodes and cells, we will need a more general
-    # way of tracking nodes (in the coarse grid) that have been added to the new grid.
-    # To this end, make a dictionary of old-to-new nodes and use this to define the
-    # indices in the assignment to new_indices. The new nodes (refined ones) can still
-    # be done as now, nodes also in the coarse grid have the current implementation if
-    # if_add_loc is true for the relevant item, and fetch the index from the dictionary
-    # otherwise. What to do with the mysterious shift variable is still unclear (note
-    # that the current implementation is probably incorrect even for unpermuted
-    # indices), it will take some thinking of how many nodes have really been added,
-    # what happens to the start and end note etc.
+    # When looping over cells in the old grid, we will hit upon all internal nodes
+    # twice, but they should only be added to the refined grid the first time. We
+    # therefore need to keep track of whether an node in the old grid should be added
+    # and, if not, the node index in the new grid by which it is already present.
+    #
+    # Construct an array that indicates whether an item in the cell-node relation
+    # represents a node not listed before (e.g. whether this is the first or second
+    # occurrence of the cell).
+    _, first_occ = np.unique(cell_nodes.indices, return_index=True)
+    # By default, the nodes should not be added; overwrite this for the first
+    # occurrence.
+    node_to_be_added = np.zeros(cell_nodes.indices.size, dtype=bool)
+    node_to_be_added[first_occ] = True
+    # Map node indices from the old to the new grid.
+    old_2_new_nodes = {}
+
+    # Holder for the new indices.
+    new_indices: list[np.ndarray] = []
+
+    # Template array of node indices for refined nodes (those not present in the old
+    # grid). The actual node indices are found by adding node_counter as an offset, see
+    # below code. Splitting a cell into 'ratio' parts requires 'ratio'-1 new nodes (not
+    # counting the existing nodes of the old grid), hence the size of the template.
+    indices_template = np.repeat(np.arange(ratio - 1), 2)
 
     # Loop over all old cells and refine them.
     for c in np.arange(g.num_cells):
         # Find start and end nodes of the old cell. First the location in the sparse
         # storage.
         loc = slice(cell_nodes.indptr[c], cell_nodes.indptr[c + 1])
-        # Then the actual indices. This will be correct also if the nodes are not
-        # ordered linearly (start+1 != end).
+        # Then the actual indices. EK note to self: This will be correct also if the
+        # nodes are not ordered linearly (start+1 != end).
         start, end = cell_nodes.indices[loc]
 
         # Flags for whether this is the first occurrences of the nodes of the old cell.
-        # If so, they should be added to the new node array
-        if_add_loc = if_add[loc]
+        # If so, they should be added to the new node array.
+        node_to_be_added_loc = node_to_be_added[loc]
 
-        # Local cell-node (thus cell-face) relations of the new grid. This will give a
-        # linear ordering of the new nodes.
-        #offset_new_indices = new_indices[-1][-1]
-        
+        # Local cell-node (thus cell-face) relations of the new grid.
         loc_new_ind = []
 
-        # Add coordinate of the startpoint to the node array if relevant
-        if if_add_loc[0]:
-            x[:, pos] = g.nodes[:, start]
-            old_2_new_nodes[start] = pos
-            loc_new_ind.append(pos)
-            pos += 1
+        # Add coordinate of the startpoint to the node array if relevant.
+        if node_to_be_added_loc[0]:
+            # Register the new coordinate.
+            x[:, node_counter] = g.nodes[:, start]
+            # Associate the node index 'start' in the old grid with the index
+            # 'node_counter' in the new grid.
+            old_2_new_nodes[start] = node_counter
+            # Add the node index to the local new indices.
+            loc_new_ind.append(node_counter)
+            # Increase node counter.
+            node_counter += 1
         else:
+            # This node has already been added to the refined grid. Use the node map to
+            # find the right index.
             loc_new_ind.append(old_2_new_nodes[start])
 
-        loc_new_ind += list(pos + indices_template[:-2])
-        
-        # Add coordinates of the internal nodes. The coordinates added here run from
-        # closest to the start node to closest to the end node. Reshape is needed since
-        # we may add more than one node at a time (in contrast to the assignments in the
-        # if-statements above and below).
-        x[:, pos : (pos + ratio - 1)] = g.nodes[:, start].reshape((-1, 1)) * (1 - theta) + g.nodes[
-            :, end
-        ].reshape((-1, 1)) * theta
-        # Shift the position
-        pos += ratio - 1
-        shift += ratio + (2 - np.sum(if_add_loc) * (1 - nd[c])) - nd[c]
+        # Add coordinates of the internal nodes (those not present in the old grid). The
+        # coordinates added here run from closest to the start node to closest to the
+        # end node. Reshape is needed since we may add more than one node at a time (in
+        # contrast to the assignments in the if-statements above and below).
+        x[:, node_counter : (node_counter + ratio - 1)] = (
+            g.nodes[:, start].reshape((-1, 1)) * (1 - theta)
+            + g.nodes[:, end].reshape((-1, 1)) * theta
+        )
 
-        # Add coordinate of the endpoint of this interval if relevant
-        if if_add_loc[-1]:
-            x[:, pos] = g.nodes[:, end]
-            old_2_new_nodes[end] = pos
-            loc_new_ind.append(pos)
-            pos += 1
+        # Register the indices of the new nodes and increasen the counter.
+        loc_new_ind += list(node_counter + indices_template)
+        node_counter += ratio - 1
+
+        # Add coordinate of the endpoint of this interval if relevant. See corresponding
+        # if-statement above for comments.
+        if node_to_be_added_loc[-1]:
+            x[:, node_counter] = g.nodes[:, end]
+            old_2_new_nodes[end] = node_counter
+            loc_new_ind.append(node_counter)
+            node_counter += 1
         else:
             loc_new_ind.append(old_2_new_nodes[end])
 
-        new_indices.append(np.array(loc_new_ind))          
-        debug = True
-        #assert shift == offset_new_indices
+        new_indices.append(np.array(loc_new_ind))
 
-    # For 1d grids, there is a 1-1 relation between faces and nodes
+    # For 1d grids, there is a 1-1 relation between faces and nodes.
     face_nodes = sps.identity(x.shape[1], format="csc")
 
     # The grid is 1d, so the face indices are the same as the node indices stored in
@@ -195,6 +197,7 @@ def refine_grid_1d(g: pp.Grid, ratio: int = 2) -> pp.Grid:
 
     # The signs are -1 for the first node of each cell, and 1 for the second. Other
     # possibilities would be possible, but this should work.
+    #
     # Find the first occurrence of each node.
     _, first_occurrences = np.unique(cell_face_ind, return_index=True)
     # Initialize the signs array with -1, and set the first occurrences to 1.
@@ -202,7 +205,7 @@ def refine_grid_1d(g: pp.Grid, ratio: int = 2) -> pp.Grid:
     signs[first_occurrences] = 1
 
     # We have the cell-face relation. The index pointer assigns two indices to each
-    # cell, again, this is 1d.s
+    # cell, as will always be the case for a 1d grid.
     cell_faces = sps.csc_matrix(
         (
             signs,
@@ -210,6 +213,7 @@ def refine_grid_1d(g: pp.Grid, ratio: int = 2) -> pp.Grid:
             np.arange(0, cell_face_ind.size + 1, 2),
         )
     )
+    # Construct grid, compute geometry, done.
     g = Grid(1, x, face_nodes, cell_faces, "Refined 1d grid")
     g.compute_geometry()
 

--- a/tests/grids/test_refinement.py
+++ b/tests/grids/test_refinement.py
@@ -42,12 +42,8 @@ class TestGridPerturbation:
 class TestGridRefinement1D:
     """Tests for the 1D grid refinement functions.
 
-    The test focuses on the topology of the refined grid, also in cases with non-uniform
-    grid spacing, permuted node/cell orderings and split nodes.
-
-    Geometric aspects (whatever that would be, perhaps grids not aligned with the
-    x-axis) are not tested, as the chance of errors in the geometric computations is
-    considered low.
+    The test are in effect sanity checks on the refined grid, also in cases with
+    non-uniform grid spacing, permuted node/cell orderings and split nodes.
 
     """
 

--- a/tests/grids/test_refinement.py
+++ b/tests/grids/test_refinement.py
@@ -7,6 +7,7 @@
 - :func:`porepy.fracs.meshing.cart_grid`
 
 """
+
 from __future__ import division
 
 import numpy as np
@@ -18,6 +19,7 @@ from porepy.grids import refinement
 from porepy.grids.simplex import TriangleGrid
 from porepy.grids.structured import TensorGrid
 from porepy.applications.test_utils.arrays import compare_arrays
+import scipy.sparse as sps
 
 
 class TestGridPerturbation:
@@ -38,25 +40,88 @@ class TestGridPerturbation:
 
 
 class TestGridRefinement1D:
-    @pytest.mark.parametrize(
-        "g,target_nodes",
-        [
-            (TensorGrid(np.array([0, 2, 4])), np.arange(5)),  # uniform
-            (TensorGrid(np.array([0, 2, 6])), np.array([0, 1, 2, 4, 6])),  # non-uniform
-        ],
-    )
-    def test_refinement_grid_1D(self, g, target_nodes):
-        h = refinement.refine_grid_1d(g, ratio=2)
-        assert np.allclose(h.nodes[0], target_nodes)
+    """Tests for the 1D grid refinement functions.
 
-    def test_refinement_grid_1d_general_orientation(self):
-        x = np.array([0, 2, 6]) * np.ones((3, 1))
-        g = TensorGrid(x[0])
-        g.nodes = x
-        h = refinement.refine_grid_1d(g, ratio=2)
-        assert np.allclose(
-            h.nodes, np.array([[0, 1, 2, 4, 6], [0, 1, 2, 4, 6], [0, 1, 2, 4, 6]])
+    The test focuses on the topology of the refined grid, also in cases with non-uniform
+    grid spacing, permuted node/cell orderings and split nodes.
+
+    Geometric aspects (whatever that would be, perhaps grids not aligned with the
+    x-axis) are not tested, as the chance of errors in the geometric computations is
+    considered low.
+
+    """
+
+    def compare_refined_grids(self, g: pp.Grid, g_ref: pp.Grid, ratio: int) -> None:
+        """Helper function to compare the refined grid with the original grid.
+
+        See comments in the below code for which properties are compared.
+
+        Parameters:
+            g: The original grid.
+            g_ref: The refined grid.
+            ratio: The ratio of the number of cells in the refined grid to the original
+                grid.
+
+        """
+
+        # The two grids should cover the same domain.
+        assert np.sum(g.cell_volumes) == np.sum(g_ref.cell_volumes)
+
+        # If the ratio is given, all cells should be refined by this ratio.
+        if ratio is not None:
+            assert np.allclose(g_ref.num_cells / g.num_cells, ratio)
+
+        # There should be as many faces as nodes in a 1d grid. Check that the face-node
+        # map is 1-1, and that there are as many node coordinates as there are nodes.
+        assert g_ref.face_nodes.shape[0] == g_ref.face_nodes.shape[1]
+        assert g_ref.face_nodes.shape[0] == g_ref.nodes.shape[1]
+
+        # These are 1d grids, thus the number of boundary faces should be the same in
+        # the two grids. Exploit this to check the refined cell-face mapping, which has
+        # a somewhat non-trivial construction.
+        num_boundary_g = np.sum(np.sum(g.cell_faces, axis=1) != 0)
+        num_boundary_g_ref = np.sum(np.sum(g_ref.cell_faces, axis=1) != 0)
+        assert num_boundary_g == num_boundary_g_ref
+
+    @pytest.mark.parametrize("ratio", [2, 3])
+    def test_refinement_grid_1D(self, ratio: int):
+        """Test the refinement of a 1D grid
+
+        Parameters:
+            ratio: The ratio of the number of cells in the refined grid to the original
+                grid.
+
+        """
+        # First create four grids with increasing complexity, then refine each of them
+        # and verify that the refined grid has the expected properties.
+
+        # A simple uniform grid.
+        g_0 = pp.TensorGrid(np.array([0, 1, 2, 3, 4]))
+
+        # A grid with non-uniform spacing.
+        g_1 = pp.TensorGrid(np.array([0, 1, 2, 2.5, 3, 4]))
+
+        # A grid with a permuted node/face (they can be considered identical in 1d) and
+        # cell ordering: The nodes lie along the x-axis, but in the order [1, 0, 2, 3].
+        # The cells are ordered (with increasing x-coordinates) [1, 0, 2].
+        x = np.array([[1, 0, 2, 3], [0, 0, 0, 0], [0, 0, 0, 0]])
+        fn = sps.identity(4, format="csr")
+        cf = sps.csc_array(np.array([[-1, 1, 0], [0, -1, 0], [1, 0, -1], [0, 0, -1]]))
+        g_2 = pp.Grid(dim=1, nodes=x, face_nodes=fn, cell_faces=cf, name="")
+
+        # A grid where one node (coordinate x=2) has been split, as would happen if two
+        # 1d grids representing fractures intersect.
+        x = np.array([[0, 1, 2, 2, 3], [0, 0, 0, 0, 0], [0, 0, 0, 0, 0]])
+        fn = sps.identity(5, format="csr")
+        cf = sps.csc_array(
+            np.array([[-1, 1, 0, 0, 0], [0, -1, 1, 0, 0], [0, 0, 0, -1, 1]]).T
         )
+        g_3 = pp.Grid(dim=1, nodes=x, face_nodes=fn, cell_faces=cf, name="")
+
+        for g in [g_0, g_1, g_2, g_3]:
+            g.compute_geometry()
+            g_ref = pp.refinement.refine_grid_1d(g, ratio)
+            self.compare_refined_grids(g, g_ref, ratio)
 
 
 class TestGridRefinement2DSimplex:
@@ -287,7 +352,9 @@ class TestRefinementMortarGrid:
             # The ordering of the cells in the new 1d grid may be flipped on
             # some systems; therefore allow two configurations
             assert np.logical_or(
-                np.allclose(low_to_mortar_known_avg, intf.secondary_to_mortar_avg().toarray()),
+                np.allclose(
+                    low_to_mortar_known_avg, intf.secondary_to_mortar_avg().toarray()
+                ),
                 np.allclose(
                     low_to_mortar_known_avg,
                     intf.secondary_to_mortar_avg().toarray()[::-1],
@@ -297,7 +364,8 @@ class TestRefinementMortarGrid:
             if low_to_mortar_known_int is not None:
                 assert np.logical_or(
                     np.allclose(
-                        low_to_mortar_known_int, intf.secondary_to_mortar_int().toarray()
+                        low_to_mortar_known_int,
+                        intf.secondary_to_mortar_int().toarray(),
                     ),
                     np.allclose(
                         low_to_mortar_known_int,


### PR DESCRIPTION
## Proposed changes
The function `pp.refinement.refine_grid_1d` returned grids with non-sensical topology (the cell-face map was clearly wrong), however this was not covered by the tests.

This PR fixes that issue, and also improves the implementation of the function so that it can be used for grids with non-trivial topology (ordering of cells, faces and nodes which are not linear). The new implementation is also much better documented.

The tests have also been improved. I decided to only test grids that are aligned with the x-axis. This is seemingly a poorer coverage than what used to be the case, however, I found the old tests' focus on geometry misguided; the chances of getting the geometry wrong are miniscule, while the topology is more complex.

Resolves #1277 

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [x] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Testing (contribution related to testing of existing or new functionality).
- [x] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
