### PR TITLE
Documentation and test fixes in functional tests

### DIFF
--- a/tests/functional/setups/manu_flow_comp_2d_frac.py
+++ b/tests/functional/setups/manu_flow_comp_2d_frac.py
@@ -3,8 +3,8 @@ This module contains a code verification implementation for a manufactured solut
 the two-dimensional, compressible, single phase flow with a single, fully embedded
 vertical fracture in the middle of the domain.
 
-The exact solution was obtained by extending the solution from the incompressible
-case [1].
+The exact solution is the 2d version of the 3d manufactured solution presented in
+Section 6.1 from [1].
 
 In particular, we have added a pressure-dependent density which obeys the following
 constitutive relationship:
@@ -19,9 +19,9 @@ fluid compressibility.
 
 References:
 
-    - [1] Varela, J., Ahmed, E., Keilegavlen, E., Nordbotten, J. M., & Radu, F. A.
-      (2022). A posteriori error estimates for hierarchical mixed-dimensional
-      elliptic equations. Journal of Numerical Mathematics.
+    - [1] Stefansson, I., Varela, J., Keilegavlen, E., & Berre, I. (2024). Flexible and
+      rigorous numerical modelling of multiphysics processes in fractured porous
+      media using PorePy. Results in Applied Mathematics, 21, 100428.
 
 """
 from __future__ import annotations

--- a/tests/functional/setups/manu_flow_comp_3d_frac.py
+++ b/tests/functional/setups/manu_flow_comp_3d_frac.py
@@ -3,8 +3,7 @@ This module contains a code verification implementation for a manufactured solut
 the three-dimensional, compressible, single-phase flow with a single, fully embedded
 vertical fracture in the middle of the domain.
 
-The exact solution was obtained by extending the solution from the incompressible
-case as given in Appendix D.2 from [1].
+The exact solution is presented in Section 6.1 from [1].
 
 In particular, we have added a pressure-dependent density which obeys the following
 constitutive relationship:
@@ -19,9 +18,9 @@ fluid compressibility.
 
 References:
 
-    - [1] Varela, J., Ahmed, E., Keilegavlen, E., Nordbotten, J. M., & Radu, F. A.
-      (2022). A posteriori error estimates for hierarchical mixed-dimensional
-      elliptic equations. Journal of Numerical Mathematics.
+    - [1] Stefansson, I., Varela, J., Keilegavlen, E., & Berre, I. (2024). Flexible and
+      rigorous numerical modelling of multiphysics processes in fractured porous
+      media using PorePy. Results in Applied Mathematics, 21, 100428.
 
 """
 from __future__ import annotations

--- a/tests/functional/test_manu_flow_comp_frac.py
+++ b/tests/functional/test_manu_flow_comp_frac.py
@@ -3,9 +3,9 @@ This module contains functional tests for approximations to the set of equations
 modeling the 2d and 3d, *compressible* flow with a single, fully embedded vertical
 fracture.
 
-The manufactured solution for the compressible flow verification is obtained as a
-natural extension of the incompressible case, see [1]. The non-linearity is included
-via the dependency of the fluid density with the fluid pressure:
+The manufactured solution for the compressible flow verification is presented in
+Section 6.1 from [1]. The non-linearity is included via the dependency of the fluid
+density with the fluid pressure:
 
 .. math::
 
@@ -19,7 +19,7 @@ values, except for the reference porosity :math:`\\phi_0 = 0.1` and normal perme
 Tests:
 
     [TEST_1] Relative L2-error on Cartesian grids for primary and secondary variables
-      for three different times for 2d and 3d.
+      for two different times for 2d and 3d.
 
     [TEST_2] Observed order of convergence (using four levels of refinement for 2d and
       three levels of refinement for 3d) for primary and secondary variables. Order

--- a/tests/functional/test_manu_flow_comp_frac.py
+++ b/tests/functional/test_manu_flow_comp_frac.py
@@ -393,5 +393,5 @@ def test_order_of_convergence(
                 desired_ooc[dim_idx][grid_type_idx]["ooc_" + var],
                 actual_ooc[dim_idx][grid_type_idx]["ooc_" + var],
                 atol=1e-1,  # allow for an absolute difference of 0.1 in OOC
-                rtol=5e-1,  # allow for 5% of relative difference in OOC
+                rtol=5e-2,  # allow for 5% of relative difference in OOC
             )

--- a/tests/functional/test_manu_flow_incomp_frac.py
+++ b/tests/functional/test_manu_flow_incomp_frac.py
@@ -328,5 +328,5 @@ def test_order_of_convergence(
                 desired_ooc[dim_idx][grid_type_idx]["ooc_" + var],
                 actual_ooc[dim_idx][grid_type_idx]["ooc_" + var],
                 atol=1e-1,  # allow for an absolute difference of 0.1 in OOC
-                rtol=5e-1,  # allow for 5% of relative difference in OOC
+                rtol=5e-2,  # allow for 5% of relative difference in OOC
             )

--- a/tests/functional/test_manu_flow_incomp_frac.py
+++ b/tests/functional/test_manu_flow_incomp_frac.py
@@ -9,8 +9,8 @@ from [1] (i.e., the bubble function is scaled to obtain a better conditioned sys
 
 Tests:
 
-    [TEST_1] Relative L2-error on Cartesian grids for primary and secondary variables
-      for three different times for 2d and 3d.
+    [TEST_1] Relative L2-errors on Cartesian grids for primary and secondary variables
+      for 2d and 3d.
 
     [TEST_2] Observed order of convergence (using four levels of refinement for 2d and
       three levels of refinement for 3d) for primary and secondary variables. Order

--- a/tests/functional/test_manu_poromech_nofrac.py
+++ b/tests/functional/test_manu_poromech_nofrac.py
@@ -20,7 +20,7 @@ the exact pressure and displacement solutions, we use the ones employed in [3].
 Tests:
 
     [TEST_1] Relative L2-error on Cartesian grids for primary and secondary variables
-      for three different times for 2d and 3d.
+      for two different times for 2d and 3d.
 
     [TEST_2] Observed order of convergence (using four levels of refinement for 2d and
       three levels of refinement for 3d) for primary and secondary variables. Order

--- a/tests/functional/test_manu_poromech_nofrac.py
+++ b/tests/functional/test_manu_poromech_nofrac.py
@@ -360,5 +360,5 @@ def test_order_of_convergence(
                 desired_ooc[dim_idx][grid_type_idx]["ooc_" + var],
                 actual_ooc[dim_idx][grid_type_idx]["ooc_" + var],
                 atol=1e-1,  # allow for an absolute difference of 0.1 in OOC
-                rtol=5e-1,  # allow for 5% of relative difference in OOC
+                rtol=5e-2,  # allow for 5% of relative difference in OOC
             )

--- a/tests/functional/test_manu_thermoporomech_nofrac.py
+++ b/tests/functional/test_manu_thermoporomech_nofrac.py
@@ -369,5 +369,5 @@ def test_order_of_convergence(
                 desired_ooc[dim_idx][grid_type_idx]["ooc_" + var],
                 actual_ooc[dim_idx][grid_type_idx]["ooc_" + var],
                 atol=1e-1,  # allow for an absolute difference of 0.1 in OOC
-                rtol=5e-1,  # allow for 5% of relative difference in OOC
+                rtol=5e-2,  # allow for 5% of relative difference in OOC
             )

--- a/tests/functional/test_manu_thermoporomech_nofrac.py
+++ b/tests/functional/test_manu_thermoporomech_nofrac.py
@@ -5,7 +5,7 @@ modeling the 2d and 3d flow in non-isothermal deformable porous media.
 Tests:
 
     [TEST_1] Relative L2-error on Cartesian grids for primary and secondary variables
-      for three different times for 2d and 3d.
+      for two different times for 2d and 3d.
 
     [TEST_2] Observed order of convergence (using four levels of refinement for 2d and
       three levels of refinement for 3d) for primary and secondary variables. Order of


### PR DESCRIPTION
## Proposed changes

This PR introduces some documentation updates in functional tests. In addition, some relative errors were corrected (from 50% tolerance to the desired 5% relative tolerance).
These only affected skipped tests. All tests passed locally in my machine.


## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Testing (contribution related to testing of existing or new functionality).
- [x] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [x] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
