### PR TITLE
STY: Remove type annotation for Enum members

### DIFF
--- a/src/porepy/compositional/_core.py
+++ b/src/porepy/compositional/_core.py
@@ -38,7 +38,7 @@ See Also:
 """
 
 NUMBA_FAST_MATH: bool = False
-"""Flag to instruct the numba compiler to use it's ``fastmath`` functions.
+"""Flag to instruct the numba compiler to use its ``fastmath`` functions.
 
 To be used with care, due to loss in precision.
 
@@ -52,7 +52,7 @@ NUMBA_PARALLEL: bool = True
 
 By default, the parallel backend will be used.
 
-Flag is introduced for developing processes when involving other packages supporing
+Flag is introduced for developing processes when involving other packages supporting
 parallelism such as numpy and PETSc.
 
 Affected numba functionality includes:
@@ -169,5 +169,5 @@ class PhysicalState(Enum):
 
     """
 
-    liquid: int = 0
-    gas: int = 1
+    liquid = 0
+    gas = 1


### PR DESCRIPTION
## Proposed changes

Fixes failing mypy test.
"Members defined within an enum class should not include explicit type annotations.", as per https://typing.readthedocs.io/en/latest/spec/enums.html#defining-members.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [x] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
