### PR TITLE
MAINT: Remove use of deprecated .add() in FractureNetwork3d

### DIFF
--- a/src/porepy/fracs/fracture_network_3d.py
+++ b/src/porepy/fracs/fracture_network_3d.py
@@ -1662,7 +1662,8 @@ class FractureNetwork3d(object):
                 # points should not be sorted. Splitting of non-convex fractures into
                 # convex subparts is handled below.
                 new_frac = pp.PlaneFracture(constrained_polys[sub_i], sort_points=False)
-                self.add(new_frac)
+                new_frac.index = len(self.fractures)
+                self.fractures.append(new_frac)
                 ind_map = np.hstack((ind_map, fi))
 
         # Now, we may modify the fractures for two reasons:
@@ -1989,7 +1990,9 @@ class FractureNetwork3d(object):
                 # thus a linear ordering should be fine also for a subpolygon.
                 verts = np.unique(triangles[tris])
                 # To be sure, check the convexity of the polygon.
-                self.add(pp.PlaneFracture(f.pts[:, verts], check_convexity=False))
+                new_frac = pp.PlaneFracture(f.pts[:, verts], check_convexity=False)
+                new_frac.index = len(self.fractures)
+                self.fractures.append(new_frac)
                 ind_map = np.hstack((ind_map, fi))
 
             # Finally, increase pointer to ind_map array


### PR DESCRIPTION
## Proposed changes
Response to #1298. Thanks, @wmboon, and sorry for the inconvenience.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [x] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
