### PR TITLE
Optimizing test exectution for test geometry

### DIFF
--- a/tests/models/test_geometry.py
+++ b/tests/models/test_geometry.py
@@ -37,27 +37,27 @@ geometry_list = [
 
 num_fracs_list = [0, 1, 2, 3]
 
+
 @pytest.fixture(scope="module")
 def geometries():
     geometries = {}
     for geometry_class in geometry_list:
         for num_fracs in num_fracs_list:
-            geometry= geometry_class()
-            geometry.params = {
-                "fracture_indices": [i for i in range(num_fracs)]
-            }
+            geometry = geometry_class()
+            geometry.params = {"fracture_indices": [i for i in range(num_fracs)]}
             geometry.units = pp.Units()
             geometry.set_geometry()
-            
+
             geometries[(geometry_class, num_fracs)] = geometry
-            
+
     return geometries
+
 
 @pytest.mark.parametrize("geometry_class", geometry_list)
 def test_set_geometry(geometry_class, geometries):
     """Test the method set_geometry."""
     # Testing with a single fracture should be sufficient here.
-    geometry = geometries[geometry_class,1]
+    geometry = geometries[geometry_class, 1]
     for attr in [
         "mdg",
         "domain",
@@ -117,8 +117,7 @@ def test_boundary_sides(geometries, geometry_class: type[pp.ModelGeometry], num_
 @pytest.mark.parametrize("geometry_class", geometry_list)
 @pytest.mark.parametrize("num_fracs", [0, 3])
 def test_wrap_grid_attributes(
-    geometries,
-    geometry_class: type[pp.ModelGeometry], num_fracs
+    geometries, geometry_class: type[pp.ModelGeometry], num_fracs
 ) -> None:
     """Test that the grid attributes are wrapped correctly.
 
@@ -126,7 +125,7 @@ def test_wrap_grid_attributes(
     wrap a number of attributes, and check that the attributes are wrapped correctly.
 
     """
-    geometry  = geometries[geometry_class, num_fracs]
+    geometry = geometries[geometry_class, num_fracs]
     nd: int = geometry.nd
 
     # Various combinations of single and many subdomains
@@ -216,7 +215,9 @@ def test_wrap_grid_attributes(
 
 
 @pytest.mark.parametrize("geometry_class", geometry_list)
-def test_subdomain_interface_methods(geometries, geometry_class: type[pp.ModelGeometry]) -> None:
+def test_subdomain_interface_methods(
+    geometries, geometry_class: type[pp.ModelGeometry]
+) -> None:
     """Test interfaces_to_subdomains and subdomains_to_interfaces.
 
     Parameters:
@@ -258,11 +259,11 @@ def test_subdomain_interface_methods(geometries, geometry_class: type[pp.ModelGe
 
 @pytest.mark.parametrize("geometry_class", geometry_list)
 @pytest.mark.parametrize("num_fracs", [0, 1, 2, 3])
-def test_internal_boundary_normal_to_outwards(geometries,
-    geometry_class: type[pp.ModelGeometry], num_fracs
+def test_internal_boundary_normal_to_outwards(
+    geometries, geometry_class: type[pp.ModelGeometry], num_fracs
 ) -> None:
     # Define the geometry
-    
+
     geometry = geometries[geometry_class, num_fracs]
     dim = geometry.nd
 
@@ -328,7 +329,9 @@ def test_internal_boundary_normal_to_outwards(geometries,
 
 @pytest.mark.parametrize("geometry_class", geometry_list)
 @pytest.mark.parametrize("num_fracs", [0, 1, 2, 3])
-def test_outwards_normals(geometries, geometry_class: type[pp.ModelGeometry], num_fracs) -> None:
+def test_outwards_normals(
+    geometries, geometry_class: type[pp.ModelGeometry], num_fracs
+) -> None:
     """Test :meth:`pp.ModelGeometry.outwards_internal_boundary_normals`.
 
     Parameters:

--- a/tests/models/test_geometry.py
+++ b/tests/models/test_geometry.py
@@ -39,7 +39,7 @@ num_fracs_list = [0, 1, 2, 3]
 
 
 @pytest.fixture(scope="module")
-def geometries():
+def geometries() -> dict[tuple[type[pp.ModelGeometry], int], pp.ModelGeometry]:
     geometries = {}
     for geometry_class in geometry_list:
         for num_fracs in num_fracs_list:
@@ -54,7 +54,10 @@ def geometries():
 
 
 @pytest.mark.parametrize("geometry_class", geometry_list)
-def test_set_geometry(geometry_class, geometries):
+def test_set_geometry(
+    geometries: dict[tuple[type[pp.ModelGeometry], int], pp.ModelGeometry],
+    geometry_class: type[pp.ModelGeometry],
+) -> None:
     """Test the method set_geometry."""
     # Testing with a single fracture should be sufficient here.
     geometry = geometries[geometry_class, 1]
@@ -71,7 +74,11 @@ def test_set_geometry(geometry_class, geometries):
 
 @pytest.mark.parametrize("geometry_class", geometry_list)
 @pytest.mark.parametrize("num_fracs", [0, 3])
-def test_boundary_sides(geometries, geometry_class: type[pp.ModelGeometry], num_fracs):
+def test_boundary_sides(
+    geometries: dict[tuple[type[pp.ModelGeometry], int], pp.ModelGeometry],
+    geometry_class: type[pp.ModelGeometry],
+    num_fracs: int,
+) -> None:
     geometry = geometries[geometry_class, num_fracs]
 
     # Fetch the bounding box for the domain.
@@ -117,7 +124,9 @@ def test_boundary_sides(geometries, geometry_class: type[pp.ModelGeometry], num_
 @pytest.mark.parametrize("geometry_class", geometry_list)
 @pytest.mark.parametrize("num_fracs", [0, 3])
 def test_wrap_grid_attributes(
-    geometries, geometry_class: type[pp.ModelGeometry], num_fracs
+    geometries: dict[tuple[type[pp.ModelGeometry], int], pp.ModelGeometry],
+    geometry_class: type[pp.ModelGeometry],
+    num_fracs: int,
 ) -> None:
     """Test that the grid attributes are wrapped correctly.
 
@@ -216,7 +225,8 @@ def test_wrap_grid_attributes(
 
 @pytest.mark.parametrize("geometry_class", geometry_list)
 def test_subdomain_interface_methods(
-    geometries, geometry_class: type[pp.ModelGeometry]
+    geometries: dict[tuple[type[pp.ModelGeometry], int], pp.ModelGeometry],
+    geometry_class: type[pp.ModelGeometry],
 ) -> None:
     """Test interfaces_to_subdomains and subdomains_to_interfaces.
 
@@ -260,7 +270,9 @@ def test_subdomain_interface_methods(
 @pytest.mark.parametrize("geometry_class", geometry_list)
 @pytest.mark.parametrize("num_fracs", [0, 1, 2, 3])
 def test_internal_boundary_normal_to_outwards(
-    geometries, geometry_class: type[pp.ModelGeometry], num_fracs
+    geometries: dict[tuple[type[pp.ModelGeometry], int], pp.ModelGeometry],
+    geometry_class: type[pp.ModelGeometry],
+    num_fracs: int,
 ) -> None:
     # Define the geometry
 
@@ -330,7 +342,9 @@ def test_internal_boundary_normal_to_outwards(
 @pytest.mark.parametrize("geometry_class", geometry_list)
 @pytest.mark.parametrize("num_fracs", [0, 1, 2, 3])
 def test_outwards_normals(
-    geometries, geometry_class: type[pp.ModelGeometry], num_fracs
+    geometries: dict[tuple[type[pp.ModelGeometry], int], pp.ModelGeometry],
+    geometry_class: type[pp.ModelGeometry],
+    num_fracs: int,
 ) -> None:
     """Test :meth:`pp.ModelGeometry.outwards_internal_boundary_normals`.
 
@@ -434,7 +448,7 @@ def test_outwards_normals(
 
 @pytest.mark.parametrize("geometry_class", geometry_list)
 def test_basis_normal_tangential_components(
-    geometries,
+    geometries: dict[tuple[type[pp.ModelGeometry], int], pp.ModelGeometry],
     geometry_class: type[pp.ModelGeometry],
 ) -> None:
     """Test that methods to compute basis vectors and extract normal and tangential
@@ -536,7 +550,10 @@ def test_basis_normal_tangential_components(
 
 
 @pytest.mark.parametrize("geometry_class", geometry_list)
-def test_local_coordinates(geometries, geometry_class: type[pp.ModelGeometry]) -> None:
+def test_local_coordinates(
+    geometries: dict[tuple[type[pp.ModelGeometry], int], pp.ModelGeometry],
+    geometry_class: type[pp.ModelGeometry],
+) -> None:
     """Test the method to compute local fracture coordinates.
 
     The actual generation of the local coordinates is tested in

--- a/tests/models/test_geometry.py
+++ b/tests/models/test_geometry.py
@@ -15,7 +15,6 @@ Testing covers:
         local_coordinates
 
 """
-
 from __future__ import annotations
 
 import numpy as np
@@ -27,7 +26,8 @@ import porepy.applications.md_grids.model_geometries
 from porepy.applications.test_utils import models
 
 
-geometry_list = [
+# List of geometry classes to test.
+geometry_list: list[pp.ModelGeometry] = [
     porepy.applications.md_grids.model_geometries.RectangularDomainThreeFractures,
     models._add_mixin(
         porepy.applications.md_grids.model_geometries.OrthogonalFractures3d,
@@ -35,540 +35,595 @@ geometry_list = [
     ),
 ]
 
-num_fracs_list = [0, 1, 2, 3]
 
-
-@pytest.fixture(scope="module")
-def geometries() -> dict[tuple[type[pp.ModelGeometry], int], pp.ModelGeometry]:
-    geometries = {}
-    for geometry_class in geometry_list:
-        for num_fracs in num_fracs_list:
-            geometry = geometry_class()
-            geometry.params = {"fracture_indices": [i for i in range(num_fracs)]}
-            geometry.units = pp.Units()
-            geometry.set_geometry()
-
-            geometries[(geometry_class, num_fracs)] = geometry
-
-    return geometries
-
-
+# Parametrization of the goemetry class is common for all tests.
 @pytest.mark.parametrize("geometry_class", geometry_list)
-def test_set_geometry(
-    geometries: dict[tuple[type[pp.ModelGeometry], int], pp.ModelGeometry],
-    geometry_class: type[pp.ModelGeometry],
-) -> None:
-    """Test the method set_geometry."""
-    # Testing with a single fracture should be sufficient here.
-    geometry = geometries[geometry_class, 1]
-    for attr in [
-        "mdg",
-        "domain",
-        "nd",
-        "fracture_network",
-        "well_network",
-        "fractures",
-    ]:
-        assert hasattr(geometry, attr)
+class TestGeometry:
 
+    @classmethod
+    def setup_class(self):
+        """Classmethod for setting up parameters for the test.
 
-@pytest.mark.parametrize("geometry_class", geometry_list)
-@pytest.mark.parametrize("num_fracs", [0, 3])
-def test_boundary_sides(
-    geometries: dict[tuple[type[pp.ModelGeometry], int], pp.ModelGeometry],
-    geometry_class: type[pp.ModelGeometry],
-    num_fracs: int,
-) -> None:
-    geometry = geometries[geometry_class, num_fracs]
+        Implementation note: We could also have used a fixture for this, combined with
+        pytest.requests, but this solution seems to be the recommended one.
 
-    # Fetch the bounding box for the domain.
-    box_min, box_max = pp.domain.mdg_minmax_coordinates(geometry.mdg)
+        Generate a dictionary of geometries based on different geometry classes and
+        number of fractures. The individual tests will then pick some or all of these
+        geometries.
 
-    for sd in geometry.mdg.subdomains():
-        all_bf, east, west, north, south, top, bottom = geometry.domain_boundary_sides(
-            sd
-        )
-        all_bool = np.zeros(sd.num_faces, dtype=bool)
-        all_bool[all_bf] = 1
+        This function iterates over a list of geometry classes and a list of fracture
+        counts to create instances of geometries. Each geometry instance is configured
+        with fracture indices and units, and its geometry is set.
 
-        # Check that only valid boundaries are picked.
-        domain_or_internal_bf = np.where(np.sum(np.abs(sd.cell_faces), axis=1) == 1)
-        assert np.all(np.isin(all_bf, domain_or_internal_bf))
-        frac_faces = sd.tags["fracture_faces"].nonzero()[0]
-        assert np.all(np.logical_not(np.isin(all_bf, frac_faces)))
-        assert np.all(all_bool == (east + west + north + south + top + bottom))
+        """
+        # List of number of fractures to test.
+        num_fracs_list = [0, 1, 2, 3]
+        # Dictionary to store the geometry information.
+        self.geometries: dict[tuple[type[pp.ModelGeometry], int], pp.ModelGeometry] = {}
 
-        # Check that the coordinates of the face centers are at the boundary.
-        for side, dim in zip([east, north, top], [0, 1, 2]):
-            assert np.all(np.isclose(sd.face_centers[dim, side], box_max[dim]))
-        for side, dim in zip([west, south, bottom], [0, 1, 2]):
-            assert np.all(np.isclose(sd.face_centers[dim, side], box_min[dim]))
+        for geometry_class in geometry_list:
+            for num_fracs in num_fracs_list:
+                # Create an instance of the geometry class.
+                geometry = geometry_class()
+                geometry.params = {"fracture_indices": [i for i in range(num_fracs)]}
+                # Assign units to the geometry.
+                geometry.units = pp.Units()
+                # Set the geometry configuration.
+                geometry.set_geometry()
 
-    # The same for boundary grids.
-    bg: pp.BoundaryGrid
-    for bg in geometry.mdg.boundaries():
-        all_bf, east, west, north, south, top, bottom = geometry.domain_boundary_sides(
-            bg
-        )
-        all_bool = np.ones(bg.num_cells, dtype=bool)
+                self.geometries[(geometry_class, num_fracs)] = geometry
 
-        assert np.all(all_bool == (east + west + north + south + top + bottom))
+    def test_set_geometry(
+        self,
+        geometry_class: type[pp.ModelGeometry],
+    ) -> None:
+        """Test the method set_geometry.
 
-        # Check that the coordinates of the cell centers are at the boundary.
-        for side, dim in zip([east, north, top], [0, 1, 2]):
-            assert np.all(np.isclose(bg.cell_centers[dim, side], box_max[dim]))
-        for side, dim in zip([west, south, bottom], [0, 1, 2]):
-            assert np.all(np.isclose(bg.cell_centers[dim, side], box_min[dim]))
+        Parameters:
+            geometry_class: Class to test.
 
+        """
+        # Testing with a single fracture should be sufficient here.
+        num_fracs = 1
+        geometry = self.geometries[geometry_class, num_fracs]
+        for attr in [
+            "mdg",
+            "domain",
+            "nd",
+            "fracture_network",
+            "well_network",
+            "fractures",
+        ]:
+            assert hasattr(geometry, attr)
 
-@pytest.mark.parametrize("geometry_class", geometry_list)
-@pytest.mark.parametrize("num_fracs", [0, 3])
-def test_wrap_grid_attributes(
-    geometries: dict[tuple[type[pp.ModelGeometry], int], pp.ModelGeometry],
-    geometry_class: type[pp.ModelGeometry],
-    num_fracs: int,
-) -> None:
-    """Test that the grid attributes are wrapped correctly.
+    @pytest.mark.parametrize("num_fracs", [0, 3])
+    def test_boundary_sides(
+        self,
+        geometry_class: type[pp.ModelGeometry],
+        num_fracs: int,
+    ) -> None:
+        """Test the method domain_boundary_sides.
 
-    The test is based on sending in a list of grids (both subdomains and interfaces)
-    wrap a number of attributes, and check that the attributes are wrapped correctly.
+        Parameters:
+            geometry_class: Class to test.
+            num_fracs: Number of fractures to include in the test.
 
-    """
-    geometry = geometries[geometry_class, num_fracs]
-    nd: int = geometry.nd
+        """
+        geometry = self.geometries[geometry_class, num_fracs]
 
-    # Various combinations of single and many subdomains
-    all_subdomains = geometry.mdg.subdomains()
-    top_subdomain = geometry.mdg.subdomains(dim=geometry.nd)
-    some_subdomains = top_subdomain + geometry.mdg.subdomains(dim=geometry.nd - 1)
-    # An empty list
-    empty_subdomains: list[pp.Grid] = []
+        # Fetch the bounding box for the domain.
+        box_min, box_max = pp.domain.mdg_minmax_coordinates(geometry.mdg)
 
-    # Various combinations of single and many interfaces
-    all_interfaces = geometry.mdg.interfaces()
-    top_interfaces = geometry.mdg.interfaces(dim=geometry.nd - 1)
-    some_interfaces = top_interfaces + geometry.mdg.interfaces(dim=geometry.nd - 2)
+        for sd in geometry.mdg.subdomains():
+            all_bf, east, west, north, south, top, bottom = (
+                geometry.domain_boundary_sides(sd)
+            )
+            all_bool = np.zeros(sd.num_faces, dtype=bool)
+            all_bool[all_bf] = 1
 
-    # Gather all lists of subdomains and all lists of interfaces
-    test_subdomains = [all_subdomains, top_subdomain, some_subdomains, empty_subdomains]
-    test_interfaces = [all_interfaces, top_interfaces, some_interfaces]
+            # Check that only valid boundaries are picked.
+            domain_or_internal_bf = np.where(np.sum(np.abs(sd.cell_faces), axis=1) == 1)
+            assert np.all(np.isin(all_bf, domain_or_internal_bf))
+            frac_faces = sd.tags["fracture_faces"].nonzero()[0]
+            assert np.all(np.logical_not(np.isin(all_bf, frac_faces)))
+            assert np.all(all_bool == (east + west + north + south + top + bottom))
 
-    # Equation system, needed for evaluation.
-    eq_system = pp.ad.EquationSystem(geometry.mdg)
+            # Check that the coordinates of the face centers are at the boundary.
+            for side, dim in zip([east, north, top], [0, 1, 2]):
+                assert np.all(np.isclose(sd.face_centers[dim, side], box_max[dim]))
+            for side, dim in zip([west, south, bottom], [0, 1, 2]):
+                assert np.all(np.isclose(sd.face_centers[dim, side], box_min[dim]))
 
-    # Test that an error is raised if the grid does not have such an attribute
-    with pytest.raises(ValueError):
-        geometry.wrap_grid_attribute(top_subdomain, "no_such_attribute", dim=1)
+        # The same for boundary grids.
+        bg: pp.BoundaryGrid
+        for bg in geometry.mdg.boundaries():
+            all_bf, east, west, north, south, top, bottom = (
+                geometry.domain_boundary_sides(bg)
+            )
+            all_bool = np.ones(bg.num_cells, dtype=bool)
 
-    # Test that the an error is raised if we try to wrap a field which is not an
-    # ndarray.
-    with pytest.raises(ValueError):
-        # This will return a string
-        geometry.wrap_grid_attribute(top_subdomain, "name", dim=1)
+            assert np.all(all_bool == (east + west + north + south + top + bottom))
 
-    # One loop for both subdomains and interfaces.
-    for grids in test_subdomains + test_interfaces:
-        # Which attributes to test depends on whether the grids are subdomains or
-        # interfaces.
-        if len(grids) == 0 or isinstance(grids[0], pp.MortarGrid):
-            # Also include the empty list here, one attribute should be sufficient to
-            # test that a zero matrix is returned.
-            attr_list = ["cell_centers"]
-            dim_list = [nd]
+            # Check that the coordinates of the cell centers are at the boundary.
+            for side, dim in zip([east, north, top], [0, 1, 2]):
+                assert np.all(np.isclose(bg.cell_centers[dim, side], box_max[dim]))
+            for side, dim in zip([west, south, bottom], [0, 1, 2]):
+                assert np.all(np.isclose(bg.cell_centers[dim, side], box_min[dim]))
+
+    @pytest.mark.parametrize("num_fracs", [0, 3])
+    def test_wrap_grid_attributes(
+        self,
+        geometry_class: type[pp.ModelGeometry],
+        num_fracs: int,
+    ) -> None:
+        """Test that the grid attributes are wrapped correctly.
+
+        The test is based on sending in a list of grids (both subdomains and interfaces)
+        wrap a number of attributes, and check that the attributes are wrapped
+        correctly.
+
+        Parameters:
+            geometry_class: Class to test.
+            num_fracs: Number of fractures to include in the test.
+
+        """
+        geometry = self.geometries[geometry_class, num_fracs]
+        nd: int = geometry.nd
+
+        # Various combinations of single and many subdomains.
+        all_subdomains = geometry.mdg.subdomains()
+        top_subdomain = geometry.mdg.subdomains(dim=geometry.nd)
+        some_subdomains = top_subdomain + geometry.mdg.subdomains(dim=geometry.nd - 1)
+        # An empty list
+        empty_subdomains: list[pp.Grid] = []
+
+        # Various combinations of single and many interfaces.
+        all_interfaces = geometry.mdg.interfaces()
+        top_interfaces = geometry.mdg.interfaces(dim=geometry.nd - 1)
+        some_interfaces = top_interfaces + geometry.mdg.interfaces(dim=geometry.nd - 2)
+
+        # Gather all lists of subdomains and all lists of interfaces.
+        test_subdomains = [
+            all_subdomains,
+            top_subdomain,
+            some_subdomains,
+            empty_subdomains,
+        ]
+        test_interfaces = [all_interfaces, top_interfaces, some_interfaces]
+
+        # Equation system, needed for evaluation.
+        eq_system = pp.ad.EquationSystem(geometry.mdg)
+
+        # Test that an error is raised if the grid does not have such an attribute.
+        with pytest.raises(ValueError):
+            geometry.wrap_grid_attribute(top_subdomain, "no_such_attribute", dim=1)
+
+        # Test that the an error is raised if we try to wrap a field which is not an
+        # ndarray.
+        with pytest.raises(ValueError):
+            # This will return a string.
+            geometry.wrap_grid_attribute(top_subdomain, "name", dim=1)
+
+        # One loop for both subdomains and interfaces.
+        for grids in test_subdomains + test_interfaces:
+            # Which attributes to test depends on whether the grids are subdomains or
+            # interfaces.
+            if len(grids) == 0 or isinstance(grids[0], pp.MortarGrid):
+                # Also include the empty list here, one attribute should be sufficient
+                # to test that a zero matrix is returned.
+                attr_list = ["cell_centers"]
+                dim_list = [nd]
+            else:
+                # All relevant attributes for subdomain grids
+                attr_list = [
+                    "cell_centers",
+                    "face_centers",
+                    "face_normals",
+                    "cell_volumes",
+                    "face_areas",
+                ]
+                # List of dimensions, corresponding to the order in attr_list.
+                dim_list = [nd, nd, nd, 1, 1]
+
+            # Loop over attributes and corresponding dimensions.
+            for attr, dim in zip(attr_list, dim_list):
+                # Get hold of the wrapped attribute and the wrapping.
+                wrapped_value = geometry.wrap_grid_attribute(
+                    grids, attr, dim=dim
+                ).value(eq_system)
+
+                # Check that the wrapped attribute is a matrix.
+                assert isinstance(wrapped_value, np.ndarray)
+
+                # Check that the matrix have the expected size, which depends on the
+                # type of attribute wrapped (cell or face) and the dimension of the
+                # field.
+                size_key = "num_cells" if "cell" in attr else "num_faces"
+                tot_size = sum([getattr(sd, size_key) for sd in grids])
+
+                assert wrapped_value.shape == (tot_size * dim,)
+
+                # Counter for the current position in the wrapped attribute.
+                ind_cc = 0
+
+                # Loop over the grids (be they subdomains or interfaces).
+                for grid in grids:
+                    # Get hold of the actual attribute values straight from the grid.
+                    size = getattr(grid, size_key)
+                    # Note the use of 2d here, or else the below accessing of [:dim]
+                    # would not work.
+                    actual_value = np.atleast_2d(getattr(grid, attr))
+                    # Compare values with the wrapped attribute, both usual and inverse.
+                    assert np.allclose(
+                        wrapped_value[ind_cc : ind_cc + size * dim],
+                        actual_value[:dim].ravel("F"),
+                    )
+                    # Move to the new position in the wrapped attribute.
+                    ind_cc += size * dim
+
+    def test_subdomain_interface_methods(
+        self,
+        geometry_class: type[pp.ModelGeometry],
+    ) -> None:
+        """Test interfaces_to_subdomains and subdomains_to_interfaces.
+
+        Parameters:
+            geometry_class: Class to test.
+
+        """
+        # Use two fractures, that should be enough to test the methods.
+        num_fracs = 2
+        geometry = self.geometries[geometry_class, num_fracs]
+
+        all_subdomains = geometry.mdg.subdomains()
+        all_interfaces = geometry.mdg.interfaces()
+
+        returned_subdomains = geometry.interfaces_to_subdomains(all_interfaces)
+        returned_interfaces = geometry.subdomains_to_interfaces(all_subdomains, [1])
+        if all_interfaces == []:
+            assert returned_subdomains == []
+            assert returned_interfaces == []
         else:
-            # All relevant attributes for subdomain grids
-            attr_list = [
-                "cell_centers",
-                "face_centers",
-                "face_normals",
-                "cell_volumes",
-                "face_areas",
-            ]
-            #  List of dimensions, corresponding to the order in attr_list
-            dim_list = [nd, nd, nd, 1, 1]
+            assert all_subdomains == returned_subdomains
+            assert all_interfaces == returned_interfaces
 
-        # Loop over attributes and corresponding dimensions.
-        for attr, dim in zip(attr_list, dim_list):
-            # Get hold of the wrapped attribute and the wrapping.
-            wrapped_value = geometry.wrap_grid_attribute(grids, attr, dim=dim).value(
-                eq_system
+        # Empty list passed should return empty list for both methods.
+        no_subdomains = geometry.interfaces_to_subdomains([])
+        no_interfaces = geometry.subdomains_to_interfaces([], [1])
+        assert no_subdomains == []
+        assert no_interfaces == []
+        if getattr(geometry, "num_fracs", 0) > 1:
+            # Matrix and two fractures.
+            two_fractures = all_subdomains[1:3]
+            # Only those interfaces involving one of the two fractures are expected.
+            interfaces = []
+            for sd in two_fractures:
+                interfaces += geometry.mdg.subdomain_to_interfaces(sd, [1])
+            sorted_interfaces = geometry.mdg.sort_interfaces(interfaces)
+            assert sorted_interfaces == geometry.subdomains_to_interfaces(
+                two_fractures, [1]
             )
 
-            # Check that the wrapped attribute is a matrix
-            assert isinstance(wrapped_value, np.ndarray)
+    @pytest.mark.parametrize("num_fracs", [0, 1, 2, 3])
+    def test_internal_boundary_normal_to_outwards(
+        self,
+        geometry_class: type[pp.ModelGeometry],
+        num_fracs: int,
+    ) -> None:
+        """Test that the method internal_boundary_normal_to_outwards works as expected.
 
-            # Check that the matrix have the expected size, which depends on the type
-            # of attribute wrapped (cell or face) and the dimension of the field.
-            size_key = "num_cells" if "cell" in attr else "num_faces"
-            tot_size = sum([getattr(sd, size_key) for sd in grids])
+        Parameters:
+            geometry_class: Class to test.
+            num_fracs: Number of fractures to include in the test
 
-            assert wrapped_value.shape == (tot_size * dim,)
+        """
 
-            # Counter for the current position in the wrapped attribute
-            ind_cc = 0
+        # Get the geometry.
+        geometry = self.geometries[geometry_class, num_fracs]
+        dim = geometry.nd
 
-            # Loop over the grids (be they subdomains or interfaces)
-            for grid in grids:
-                # Get hold of the actual attribute values straight from the grid
-                size = getattr(grid, size_key)
-                # Note the use of 2d here, or else the below accessing of [:dim] would
-                # not work.
-                actual_value = np.atleast_2d(getattr(grid, attr))
-                # Compare values with the wrapped attribute, both usual and inverse.
+        # Make an equation system, which is needed for parsing of the Ad operator
+        # representations of the geometry.
+        eq_sys = pp.EquationSystem(geometry.mdg)
+
+        # The function to be tested only accepts the top level subdomain(s).
+        # NOTE: This test does not cover the case of multiple subdomains on the top
+        # level, as could happen if we implement a domain decomposition approach. We
+        # could make a partitioning of the top dimensional grid and thereby test the
+        # functionality, but this has not been prioritized. Passing in the same
+        # subdomain twice will not work, since the function will uniquify the input.
+        subdomains = [
+            geometry.mdg.interface_to_subdomain_pair(intf)[0]
+            for intf in geometry.mdg.interfaces()
+        ]
+
+        # Get hold of the matrix to be tested, parse it to numerical format.
+        sign_switcher = geometry.internal_boundary_normal_to_outwards(
+            subdomains, dim=dim
+        )
+        mat = sign_switcher.value(eq_sys)
+
+        # Check that the wrapped attribute is a matrix.
+        assert isinstance(mat, sps.spmatrix)
+        # Check that the matrix have the expected size.
+        expected_size = sum([sd.num_faces for sd in subdomains]) * dim
+        assert mat.shape == (expected_size, expected_size)
+
+        # All values are stored on the main diagonal, fetch these.
+        mat_vals = mat.diagonal()
+
+        # Offset, needed to deal with the case of several subdomains. It is not relevant
+        # for now (see comment above), but we keep it.
+        offset = 0
+
+        # Loop over subdomains (at the time of writing, there will only be one) and
+        # check that the values are as expected.
+        for sd in subdomains:
+            # We get the expected values from the cell-face relation of the subdomain:
+            # By assumptions in the mesh construction, the normal vector of a boundary
+            # face is pointing outwards for those faces that have a positive cell-face
+            # item (note that on boundary faces, there is only one non-zero entry in the
+            # cell-face for each row, ie., each face).
+            cf = sd.cell_faces
+            # Summing is a trick to get the sign of the cell-face relation for the
+            # boundary faces (we don't care about internal faces).
+            cf_sum = np.asarray(np.sum(cf, axis=1))
+            # Only compare for fracture faces
+            fracture_faces = np.where(sd.tags["fracture_faces"])[0]
+            # The matrix constrained to this subdomain
+            loc_vals = mat_vals[offset : offset + sd.num_faces * dim]
+            loc_size = loc_vals.size
+            # The matrix will have one row for each face for each dimension. Loop over
+            # the dimensions; the sign should be the same for all dimensions.
+            for i in range(dim):
+                # Indices belonging to the current dimension.
+                dim_ind = np.arange(i, loc_size, dim)
+                dim_vals = loc_vals[dim_ind]
                 assert np.allclose(
-                    wrapped_value[ind_cc : ind_cc + size * dim],
-                    actual_value[:dim].ravel("F"),
+                    dim_vals[fracture_faces], cf_sum[fracture_faces].ravel()
                 )
-                # Move to the new position in the wrapped attribute
-                ind_cc += size * dim
+            # Update offset, needed to test for multiple subdomains.
+            offset += sd.num_faces * dim
 
+    @pytest.mark.parametrize("num_fracs", [0, 1, 2, 3])
+    def test_outwards_normals(
+        self,
+        geometry_class: type[pp.ModelGeometry],
+        num_fracs: int,
+    ) -> None:
+        """Test :meth:`pp.ModelGeometry.outwards_internal_boundary_normals`.
 
-@pytest.mark.parametrize("geometry_class", geometry_list)
-def test_subdomain_interface_methods(
-    geometries: dict[tuple[type[pp.ModelGeometry], int], pp.ModelGeometry],
-    geometry_class: type[pp.ModelGeometry],
-) -> None:
-    """Test interfaces_to_subdomains and subdomains_to_interfaces.
+        Parameters:
+            geometry_class: Class to test.
+            num_fracs: Number of fractures to include in the test.
 
-    Parameters:
-        geometry_class: Class to test.
+        """
+        # Define the geometry.
+        geometry = self.geometries[geometry_class, num_fracs]
+        dim = geometry.nd
+        # Make an equation system, which is needed for parsing of the Ad operator
+        # representations of the geometry.
+        eq_sys = pp.EquationSystem(geometry.mdg)
 
-    """
-    # Use two fractures, that should be enough to test the methods.
-    geometry = geometries[geometry_class, 2]
+        # First check the method to compute.
+        interfaces = geometry.mdg.interfaces()
+        normal_op = geometry.outwards_internal_boundary_normals(
+            interfaces, unitary=True
+        )
+        normals = normal_op.value(eq_sys)
 
-    all_subdomains = geometry.mdg.subdomains()
-    all_interfaces = geometry.mdg.interfaces()
+        # The result should be a dense array.
+        assert isinstance(normals, np.ndarray)
 
-    returned_subdomains = geometry.interfaces_to_subdomains(all_interfaces)
-    returned_interfaces = geometry.subdomains_to_interfaces(all_subdomains, [1])
-    if all_interfaces == []:
-        assert returned_subdomains == []
-        assert returned_interfaces == []
-    else:
-        assert all_subdomains == returned_subdomains
-        assert all_interfaces == returned_interfaces
+        if len(interfaces) == 0:
+            # We have checked that the method can handle empty lists (parsable
+            # operator). Check the entry and exit.
+            assert np.allclose(normals, 0)
+            return
 
-    # Empty list passed should return empty list for both methods.
-    no_subdomains = geometry.interfaces_to_subdomains([])
-    no_interfaces = geometry.subdomains_to_interfaces([], [1])
-    assert no_subdomains == []
-    assert no_interfaces == []
-    if getattr(geometry, "num_fracs", 0) > 1:
-        # Matrix and two fractures.
-        two_fractures = all_subdomains[1:3]
-        # Only those interfaces involving one of the two fractures are expected.
-        interfaces = []
-        for sd in two_fractures:
-            interfaces += geometry.mdg.subdomain_to_interfaces(sd, [1])
-        sorted_interfaces = geometry.mdg.sort_interfaces(interfaces)
-        assert sorted_interfaces == geometry.subdomains_to_interfaces(
-            two_fractures, [1]
+        # Convert the normals into a nd x num_faces array.
+        normals_reshaped = np.reshape(normals, (dim, -1), order="F")
+
+        # Check that the normals are unit vectors.
+        assert np.allclose(np.linalg.norm(normals_reshaped, axis=0), 1)
+
+        # Also construct the normal vectors without normalization, and check that their
+        # norms are equal to the volumes of the interface cells.
+        normal_op_not_unitary = geometry.outwards_internal_boundary_normals(
+            interfaces, unitary=False
+        )
+        normals_not_unitary = normal_op_not_unitary.value(eq_sys)
+        normals_reshaped_not_unitary = np.reshape(
+            normals_not_unitary, (dim, -1), order="F"
         )
 
+        volumes = np.hstack([intf.cell_volumes for intf in interfaces])
+        assert np.allclose(
+            np.linalg.norm(normals_reshaped_not_unitary, axis=0), volumes
+        )
 
-@pytest.mark.parametrize("geometry_class", geometry_list)
-@pytest.mark.parametrize("num_fracs", [0, 1, 2, 3])
-def test_internal_boundary_normal_to_outwards(
-    geometries: dict[tuple[type[pp.ModelGeometry], int], pp.ModelGeometry],
-    geometry_class: type[pp.ModelGeometry],
-    num_fracs: int,
-) -> None:
-    # Define the geometry
+        # Check that the normals are outward. This is done by checking that the dot
+        # product of the normal and the vector from the center of the interface to the
+        # center of the neighboring subdomain cell is positive.
+        offset = 0
+        for intf in interfaces:
+            sd = geometry.mdg.interface_to_subdomain_pair(intf)[0]
 
-    geometry = geometries[geometry_class, num_fracs]
-    dim = geometry.nd
+            loc_normals = normals_reshaped[:, offset : offset + intf.num_cells]
 
-    # Make an equation system, which is needed for parsing of the Ad operator
-    # representations of the geometry
-    eq_sys = pp.EquationSystem(geometry.mdg)
+            fracture_faces = intf.mortar_to_primary_avg().tocsc().indices
+            proj_normals = (intf.mortar_to_primary_avg() * loc_normals.T)[
+                fracture_faces
+            ]
 
-    # The function to be tested only accepts the top level subdomain(s)
-    # NOTE: This test does not cover the case of multiple subdomains on the top level,
-    # as could happen if we implement a domain decomposition approach. We could make
-    # a partitioning of the top dimensional grid and thereby test the functionality,
-    # but this has not been prioritized. Passing in the same subdomain twice will not
-    # work, since the function will uniquify the input.
-    subdomains = [
-        geometry.mdg.interface_to_subdomain_pair(intf)[0]
-        for intf in geometry.mdg.interfaces()
-    ]
+            cc = sd.cell_centers
+            fc = sd.face_centers
 
-    # Get hold of the matrix to be tested, parse it to numerical format.
-    sign_switcher = geometry.internal_boundary_normal_to_outwards(subdomains, dim=dim)
-    mat = sign_switcher.value(eq_sys)
+            fracture_cells = sd.cell_faces[fracture_faces].tocsr().indices
 
-    # Check that the wrapped attribute is a matrix
-    assert isinstance(mat, sps.spmatrix)
-    # Check that the matrix have the expected size.
-    expected_size = sum([sd.num_faces for sd in subdomains]) * dim
-    assert mat.shape == (expected_size, expected_size)
+            vec = cc[:, fracture_cells] - fc[:, fracture_faces]
 
-    # All values are stored on the main diagonal, fetch these.
-    mat_vals = mat.diagonal()
+            nrm1 = np.linalg.norm(proj_normals, axis=1)
 
-    # Offset, needed to deal with the case of several subdomains. It is not relevant
-    # for now (see comment above), but we keep it.
-    offset = 0
+            nrm2 = np.linalg.norm(proj_normals + 1e-3 * vec[:dim].T, axis=1)
 
-    # Loop over subdomains (at the time of writing, there will only be one) and check
-    # that the values are as expected.
-    for sd in subdomains:
-        # We get the expected values from the cell-face relation of the subdomain:
-        # By assumptions in the mesh construction, the normal vector of a boundary
-        # face is pointing outwards for those faces that have a positive cell-face
-        # item (note that on boundary faces, there is only one non-zero entry in the
-        # cell-face for each row, ie., each face).
-        cf = sd.cell_faces
-        # Summing is a trick to get the sign of the cell-face relation for the boundary
-        # faces (we don't care about internal faces).
-        cf_sum = np.asarray(np.sum(cf, axis=1))
-        # Only compare for fracture faces
-        fracture_faces = np.where(sd.tags["fracture_faces"])[0]
-        # The matrix constrained to this subdomain
-        loc_vals = mat_vals[offset : offset + sd.num_faces * dim]
-        loc_size = loc_vals.size
-        # The matrix will have one row for each face for each dimension. Loop over the
-        # dimensions; the sign should be the same for all dimensions.
-        for i in range(dim):
-            # Indices belonging to the current dimension
-            dim_ind = np.arange(i, loc_size, dim)
-            dim_vals = loc_vals[dim_ind]
-            assert np.allclose(dim_vals[fracture_faces], cf_sum[fracture_faces].ravel())
-        # Update offset, needed to test for multiple subdomains.
-        offset += sd.num_faces * dim
+            assert np.all(nrm1 > nrm2)
+            offset += intf.num_cells
 
+        # Left multiply with dim-vector defined on the interface. This should give a
+        # vector of length dim * num_intf_cells.
+        size = dim * sum([intf.num_cells for intf in interfaces])
+        dim_vec = pp.ad.DenseArray(np.ones(size))
 
-@pytest.mark.parametrize("geometry_class", geometry_list)
-@pytest.mark.parametrize("num_fracs", [0, 1, 2, 3])
-def test_outwards_normals(
-    geometries: dict[tuple[type[pp.ModelGeometry], int], pp.ModelGeometry],
-    geometry_class: type[pp.ModelGeometry],
-    num_fracs: int,
-) -> None:
-    """Test :meth:`pp.ModelGeometry.outwards_internal_boundary_normals`.
+        # Left multiply with the normal operator; in essense this extracts the normal
+        # vector (in the geometric sense) as a vector (in the algebraic sense).
+        product = (normal_op * dim_vec).value(eq_sys)
+        assert product.shape == (size,)
 
-    Parameters:
-        geometry_class: Class to test.
+        # Each vector should have unit length, as is checked by by the lines below.
+        inner_product = np.linalg.norm(product.reshape((dim, -1), order="F"), axis=0)
+        assert np.allclose(np.abs(inner_product), 1)
 
-    """
-    # Define the geometry
-    geometry = geometries[geometry_class, num_fracs]
-    dim = geometry.nd
-    # Make an equation system, which is needed for parsing of the Ad operator
-    # representations of the geometry
-    eq_sys = pp.EquationSystem(geometry.mdg)
+        # Also sum the components of the normal vector. This is equivalent to taking the
+        # dot product between the normal vector and a vector of ones.
+        dot_product = np.sum(product.reshape((dim, -1), order="F"), axis=0)
 
-    # First check the method to compute
-    interfaces = geometry.mdg.interfaces()
-    normal_op = geometry.outwards_internal_boundary_normals(interfaces, unitary=True)
-    normals = normal_op.value(eq_sys)
+        # The summing can also be done by constructing an nd-to-scalar mapping, using
+        # the basis vectors. A similar operation (actually the transpose, scalar-to-nd)
+        # is used in the model classes to expand scalars to vectors (e.g., pressure as a
+        # potential to pressure as a force).
+        basis = geometry.basis(interfaces, dim)
+        nd_to_scalar_sum = pp.ad.sum_operator_list([e.T for e in basis])
+        inner_op = nd_to_scalar_sum * (normal_op * dim_vec)
 
-    # The result should be a dense array
-    assert isinstance(normals, np.ndarray)
+        # The two operations should give the same result
+        assert np.allclose(inner_op.value(eq_sys), dot_product)
 
-    if len(interfaces) == 0:
-        # We have checked that the method can handle empty lists (parsable operator).
-        # Check the entry and exit.
-        assert np.allclose(normals, 0)
-        return
+    def test_basis_normal_tangential_components(
+        self,
+        geometry_class: type[pp.ModelGeometry],
+    ) -> None:
+        """Test that methods to compute basis vectors and extract normal and tangential
+        components work as expected.
 
-    # Convert the normals into a nd x num_faces array
-    normals_reshaped = np.reshape(normals, (dim, -1), order="F")
+        Parameters:
+            geometry_class: List of classes to test.
 
-    # Check that the normals are unit vectors
-    assert np.allclose(np.linalg.norm(normals_reshaped, axis=0), 1)
+        """
+        num_fracs = 2
+        geometry = self.geometries[geometry_class, num_fracs]
+        dim = geometry.nd
 
-    # Also construct the normal vectors without normalization, and check that their
-    # norms are equal to the volumes of the interface cells.
-    normal_op_not_unitary = geometry.outwards_internal_boundary_normals(
-        interfaces, unitary=False
-    )
-    normals_not_unitary = normal_op_not_unitary.value(eq_sys)
-    normals_reshaped_not_unitary = np.reshape(normals_not_unitary, (dim, -1), order="F")
+        # List of subdomains and interfaces. The latter are only needed for one test.
+        subdomains = geometry.mdg.subdomains()
+        interfaces = geometry.mdg.interfaces()
 
-    volumes = np.hstack([intf.cell_volumes for intf in interfaces])
-    assert np.allclose(np.linalg.norm(normals_reshaped_not_unitary, axis=0), volumes)
+        # Count the number of cells
+        num_subdomain_cells = sum([sd.num_cells for sd in subdomains])
+        num_cells_total = num_subdomain_cells + sum(
+            [intf.num_cells for intf in interfaces]
+        )
 
-    # Check that the normals are outward. This is done by checking that the dot product
-    # of the normal and the vector from the center of the interface to the center of the
-    # neighboring subdomain cell is positive.
-    offset = 0
-    for intf in interfaces:
-        sd = geometry.mdg.interface_to_subdomain_pair(intf)[0]
+        # Make an equation system, which is needed for parsing of the Ad operator
+        # representations of the geometry.
+        eq_sys = pp.EquationSystem(geometry.mdg)
 
-        loc_normals = normals_reshaped[:, offset : offset + intf.num_cells]
-
-        fracture_faces = intf.mortar_to_primary_avg().tocsc().indices
-        proj_normals = (intf.mortar_to_primary_avg() * loc_normals.T)[fracture_faces]
-
-        cc = sd.cell_centers
-        fc = sd.face_centers
-
-        fracture_cells = sd.cell_faces[fracture_faces].tocsr().indices
-
-        vec = cc[:, fracture_cells] - fc[:, fracture_faces]
-
-        nrm1 = np.linalg.norm(proj_normals, axis=1)
-
-        nrm2 = np.linalg.norm(proj_normals + 1e-3 * vec[:dim].T, axis=1)
-
-        assert np.all(nrm1 > nrm2)
-        offset += intf.num_cells
-
-    # Left multiply with dim-vector defined on the interface. This should give a vector
-    # of length dim*num_intf_cells.
-    size = dim * sum([intf.num_cells for intf in interfaces])
-    dim_vec = pp.ad.DenseArray(np.ones(size))
-
-    # Left multiply with the normal operator; in essense this extracts the normal vector
-    # (in the geometric sense) as a vector (in the algebraic sense).
-    product = (normal_op * dim_vec).value(eq_sys)
-    assert product.shape == (size,)
-
-    # Each vector should have unit length, as is checked by by the lines below.
-    inner_product = np.linalg.norm(product.reshape((dim, -1), order="F"), axis=0)
-    assert np.allclose(np.abs(inner_product), 1)
-
-    # Also sum the components of the normal vector. This is equivalent to taking the dot
-    # product between the normal vector and a vector of ones.
-    dot_product = np.sum(product.reshape((dim, -1), order="F"), axis=0)
-
-    # The summing can also be done by constructing an nd-to-scalar mapping, using the
-    # basis vectors. A similar operation (actually the transpose, scalar-to-nd) is used
-    # in the model classes to expand scalars to vectors (e.g., pressure as a potential
-    # to pressure as a force).
-    basis = geometry.basis(interfaces, dim)
-    nd_to_scalar_sum = pp.ad.sum_operator_list([e.T for e in basis])
-    inner_op = nd_to_scalar_sum * (normal_op * dim_vec)
-
-    # The two operations should give the same result
-    assert np.allclose(inner_op.value(eq_sys), dot_product)
-
-
-@pytest.mark.parametrize("geometry_class", geometry_list)
-def test_basis_normal_tangential_components(
-    geometries: dict[tuple[type[pp.ModelGeometry], int], pp.ModelGeometry],
-    geometry_class: type[pp.ModelGeometry],
-) -> None:
-    """Test that methods to compute basis vectors and extract normal and tangential
-    components work as expected.
-
-    Parameters:
-        geometry_list: List of classes to test.
-
-    """
-    geometry = geometries[geometry_class, 2]
-    dim = geometry.nd
-
-    # List of subdomains and interfaces. The latter are only needed for one test.
-    subdomains = geometry.mdg.subdomains()
-    interfaces = geometry.mdg.interfaces()
-
-    # Count the number of cells
-    num_subdomain_cells = sum([sd.num_cells for sd in subdomains])
-    num_cells_total = num_subdomain_cells + sum([intf.num_cells for intf in interfaces])
-
-    # Make an equation system, which is needed for parsing of the Ad operator
-    # representations of the geometry
-    eq_sys = pp.EquationSystem(geometry.mdg)
-
-    # First test the method e_i (and thereby also the method basis, since the latter
-    # is just a shallow wrapper around the former).
-    # Loop over dimension of the basis vectors and of dimensions, construct the basis
-    # vectors and check that they have the expected components.
-    for basis_dim in range(dim + 1):
-        for i in range(basis_dim):
-            # Consider both subdomains and interfaces here, since the method allows it.
-            e_i = geometry.e_i(subdomains + interfaces, i=i, dim=basis_dim).value(
-                eq_sys
-            )
-            # Expected values
-            rows = np.arange(i, num_cells_total * basis_dim, basis_dim)
-            cols = np.arange(num_cells_total)
-            data = np.ones(num_cells_total)
-            mat = sps.coo_matrix(
-                (data, (rows, cols)),
-                shape=(num_cells_total * basis_dim, num_cells_total),
-            )
-            assert np.allclose((mat - e_i).data, 0)
-
-            if basis_dim == dim:
-                # the dimension of the basis vector space is not specified, the value
-                # should be the same as for basis_dim = dim
-                e_None = geometry.e_i(subdomains + interfaces, i=i, dim=dim).value(
+        # First test the method e_i (and thereby also the method basis, since the latter
+        # is just a shallow wrapper around the former). Loop over dimension of the basis
+        # vectors and of dimensions, construct the basis vectors and check that they
+        # have the expected components.
+        for basis_dim in range(dim + 1):
+            for i in range(basis_dim):
+                # Consider both subdomains and interfaces here, since the method allows
+                # it.
+                e_i = geometry.e_i(subdomains + interfaces, i=i, dim=basis_dim).value(
                     eq_sys
                 )
-                assert np.allclose((e_None - e_i).data, 0)
+                # Expected values
+                rows = np.arange(i, num_cells_total * basis_dim, basis_dim)
+                cols = np.arange(num_cells_total)
+                data = np.ones(num_cells_total)
+                mat = sps.coo_matrix(
+                    (data, (rows, cols)),
+                    shape=(num_cells_total * basis_dim, num_cells_total),
+                )
+                assert np.allclose((mat - e_i).data, 0)
 
-    # Next, test the methods to extract normal and tangential components.
-    # The normal component is straightforward, the tangential component requires a bit
-    # of work to deal with the difference between 2d and 3d.
-    normal_component = geometry.normal_component(subdomains).value(eq_sys)
+                if basis_dim == dim:
+                    # the dimension of the basis vector space is not specified, the
+                    # value should be the same as for basis_dim = dim.
+                    e_None = geometry.e_i(subdomains + interfaces, i=i, dim=dim).value(
+                        eq_sys
+                    )
+                    assert np.allclose((e_None - e_i).data, 0)
 
-    # The normal component should, for each row, have 1 in the column corresponding to
-    # the normal component, so [(0, dim-1), (1, 2*dim-1), ...)] should be non-zero.
-    # Note that the number of rows is smaller than the number of columns, since the
-    # matrix will multiply a full vector and extract the normal component.
-    rows_normal_component = np.arange(num_subdomain_cells)
-    cols_normal_component = np.arange(dim - 1, dim * num_subdomain_cells, dim)
-    data_normal_component = np.ones(num_subdomain_cells)
+        # Next, test the methods to extract normal and tangential components. The normal
+        # component is straightforward, the tangential component requires a bit of work
+        # to deal with the difference between 2d and 3d.
+        normal_component = geometry.normal_component(subdomains).value(eq_sys)
 
-    known_normal_component = sps.coo_matrix(
-        (data_normal_component, (rows_normal_component, cols_normal_component)),
-        shape=(num_subdomain_cells, dim * num_subdomain_cells),
-    )
+        # The normal component should, for each row, have 1 in the column corresponding
+        # to the normal component, so [(0, dim - 1), (1, 2 * dim - 1), ...)] should be
+        # non-zero. Note that the number of rows is smaller than the number of columns,
+        # since the matrix will multiply a full vector and extract the normal component.
+        rows_normal_component = np.arange(num_subdomain_cells)
+        cols_normal_component = np.arange(dim - 1, dim * num_subdomain_cells, dim)
+        data_normal_component = np.ones(num_subdomain_cells)
 
-    assert np.allclose((known_normal_component - normal_component).data, 0)
-
-    # For the tangential component, the expected value depends on dimension.
-    tangential_component = geometry.tangential_component(subdomains).value(eq_sys)
-    if dim == 2:
-        # Here we need [(0, 0), (1, 2), (2, 4), ...] to be non-zero
-        rows_tangential_component = np.arange(num_subdomain_cells)
-        cols_tangential_component = np.arange(0, dim * num_subdomain_cells, dim)
-        data_tangential_component = np.ones(num_subdomain_cells)
-    elif dim == 3:
-        # Here we need [(0, 0), (1, 1), (2, 3), (3, 4), (4, 6), ..] to be non-zero
-        rows_tangential_component = np.arange(num_subdomain_cells * (dim - 1))
-        cols_tangential_component_ext = np.arange(0, dim * num_subdomain_cells)
-        cols_tangential_component = np.setdiff1d(
-            cols_tangential_component_ext,
-            np.arange(dim - 1, dim * num_subdomain_cells, dim),
+        known_normal_component = sps.coo_matrix(
+            (data_normal_component, (rows_normal_component, cols_normal_component)),
+            shape=(num_subdomain_cells, dim * num_subdomain_cells),
         )
-        data_tangential_component = np.ones(num_subdomain_cells * (dim - 1))
 
-    known_tangential_component = sps.coo_matrix(
-        (
-            data_tangential_component,
-            (rows_tangential_component, cols_tangential_component),
-        ),
-        shape=((dim - 1) * num_subdomain_cells, dim * num_subdomain_cells),
-    )
+        assert np.allclose((known_normal_component - normal_component).data, 0)
 
-    assert np.allclose((known_tangential_component - tangential_component).data, 0)
+        # For the tangential component, the expected value depends on dimension.
+        tangential_component = geometry.tangential_component(subdomains).value(eq_sys)
+        if dim == 2:
+            # Here we need [(0, 0), (1, 2), (2, 4), ...] to be non-zero.
+            rows_tangential_component = np.arange(num_subdomain_cells)
+            cols_tangential_component = np.arange(0, dim * num_subdomain_cells, dim)
+            data_tangential_component = np.ones(num_subdomain_cells)
+        elif dim == 3:
+            # Here we need [(0, 0), (1, 1), (2, 3), (3, 4), (4, 6), ..] to be non-zero.
+            rows_tangential_component = np.arange(num_subdomain_cells * (dim - 1))
+            cols_tangential_component_ext = np.arange(0, dim * num_subdomain_cells)
+            cols_tangential_component = np.setdiff1d(
+                cols_tangential_component_ext,
+                np.arange(dim - 1, dim * num_subdomain_cells, dim),
+            )
+            data_tangential_component = np.ones(num_subdomain_cells * (dim - 1))
 
+        known_tangential_component = sps.coo_matrix(
+            (
+                data_tangential_component,
+                (rows_tangential_component, cols_tangential_component),
+            ),
+            shape=((dim - 1) * num_subdomain_cells, dim * num_subdomain_cells),
+        )
 
-@pytest.mark.parametrize("geometry_class", geometry_list)
-def test_local_coordinates(
-    geometries: dict[tuple[type[pp.ModelGeometry], int], pp.ModelGeometry],
-    geometry_class: type[pp.ModelGeometry],
-) -> None:
-    """Test the method to compute local fracture coordinates.
+        assert np.allclose((known_tangential_component - tangential_component).data, 0)
 
-    The actual generation of the local coordinates is tested in
-    test_tangential_normal_projection.py, so we only do a simple test here.
+    def test_local_coordinates(
+        self,
+        geometry_class: type[pp.ModelGeometry],
+    ) -> None:
+        """Test the method to compute local fracture coordinates.
 
-    Parameters:
-        geometry_class: Class to test.
+        The actual generation of the local coordinates is tested in
+        test_tangential_normal_projection.py, so we only do a simple test here.
 
-    """
-    geometry = geometries[geometry_class, 2]
-    global_to_local = geometry.local_coordinates(
-        geometry.mdg.subdomains(dim=geometry.nd - 1)
-    )
-    # The global to local operator should be a rotation matrix, and the inverse should
-    # be the transpose. This is checked by multiplying the matrix with its transpose,
-    # which should give the identity matrix.
-    val = global_to_local.value(pp.EquationSystem(geometry.mdg)).todense()
-    assert np.allclose(val @ val.T, np.eye(val.shape[0]))
+        Parameters:
+            geometry_class: Class to test.
+
+        """
+        num_fracs = 2
+        geometry = self.geometries[geometry_class, num_fracs]
+        global_to_local = geometry.local_coordinates(
+            geometry.mdg.subdomains(dim=geometry.nd - 1)
+        )
+        # The global to local operator should be a rotation matrix, and the inverse
+        # should be the transpose. This is checked by multiplying the matrix with its
+        # transpose, which should give the identity matrix.
+        val = global_to_local.value(pp.EquationSystem(geometry.mdg)).todense()
+        assert np.allclose(val @ val.T, np.eye(val.shape[0]))


### PR DESCRIPTION
## Proposed changes

Based on issue #1303, we optimized the test to go from 13s to 6s, using `@fixture` for geometry. In this way we only constructed the object once instead of for every test.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [x] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [x] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
