### PR TITLE
Deprecation warnings

### DIFF
--- a/src/porepy/fracs/fracture_network_3d.py
+++ b/src/porepy/fracs/fracture_network_3d.py
@@ -1460,8 +1460,8 @@ class FractureNetwork3d(object):
         # local numbering of points
         edges_2d = np.empty_like(edges_loc)
         for ei in range(edges_loc.shape[1]):
-            edges_2d[0, ei] = np.argwhere(p_ind_loc == edges_loc[0, ei])
-            edges_2d[1, ei] = np.argwhere(p_ind_loc == edges_loc[1, ei])
+            edges_2d[0, ei] = np.argmax(p_ind_loc == edges_loc[0, ei])
+            edges_2d[1, ei] = np.argmax(p_ind_loc == edges_loc[1, ei])
 
         assert edges_2d[:2].max() < p_loc.shape[1]
 

--- a/src/porepy/geometry/constrain_geometry.py
+++ b/src/porepy/geometry/constrain_geometry.py
@@ -48,12 +48,7 @@ def lines_by_polygon(
 
     """
     import shapely.geometry as shapely_geometry
-    import shapely.speedups as shapely_speedups
 
-    try:
-        shapely_speedups.enable()
-    except AttributeError:
-        pass
     # it stores the points after the intersection
     int_pts = np.empty((2, 0))
     # define the polygon

--- a/src/porepy/geometry/intersections.py
+++ b/src/porepy/geometry/intersections.py
@@ -1729,12 +1729,6 @@ def triangulations(
     # to other cell shapes. This would require more general data structures, but should
     # not be too much of an effort.
     import shapely.geometry as shapely_geometry
-    import shapely.speedups as shapely_speedups
-
-    try:
-        shapely_speedups.enable()
-    except AttributeError:
-        pass
 
     n_1 = t_1.shape[1]
     n_2 = t_2.shape[1]
@@ -1893,13 +1887,6 @@ def surface_tessellations(
 
     # local imports
     import shapely.geometry as shapely_geometry
-    import shapely.speedups as shapely_speedups
-
-    try:
-        shapely_speedups.enable()
-    except AttributeError:
-        # Nothing to do here, but this may be slow.
-        pass
 
     def _min_max_coord(coord):
         # Convenience function to get max and minimum coordinates for a set of polygons

--- a/src/porepy/grids/simplex.py
+++ b/src/porepy/grids/simplex.py
@@ -12,7 +12,7 @@ from typing import Optional
 
 import numpy as np
 import scipy.sparse as sps
-import scipy.spatial.qhull
+import scipy.spatial
 
 from porepy.grids.grid import Grid
 from porepy.utils import accumarray, setmembership
@@ -55,7 +55,7 @@ class TriangleGrid(Grid):
         self.dim = 2
 
         if tri is None:
-            triangulation = scipy.spatial.qhull.Delaunay(p.transpose())
+            triangulation = scipy.spatial.Delaunay(p.transpose())
             tri = triangulation.simplices
             tri = tri.transpose()
 
@@ -240,7 +240,7 @@ class TetrahedralGrid(Grid):
         # Transform points to column vector if necessary (scipy.Delaunay requires this
         # format)
         if tet is None:
-            tesselation = scipy.spatial.qhull.Delaunay(p.transpose())
+            tesselation = scipy.spatial.Delaunay(p.transpose())
             tet = tesselation.simplices.transpose()
 
         if name is None:

--- a/src/porepy/numerics/linalg/matrix_operations.py
+++ b/src/porepy/numerics/linalg/matrix_operations.py
@@ -296,7 +296,7 @@ def slice_indices(
         array_ind = slice(A.indptr[int(slice_ind)], A.indptr[int(slice_ind + 1)])
         indices: np.ndarray = A.indices[array_ind]
     elif slice_ind.size == 1:
-        array_ind = slice(A.indptr[int(slice_ind)], A.indptr[int(slice_ind + 1)])
+        array_ind = slice(A.indptr[int(slice_ind[0])], A.indptr[int(slice_ind[0] + 1)])
         indices = A.indices[array_ind]
     else:
         array_ind = mcolon(A.indptr[slice_ind], A.indptr[slice_ind + 1])
@@ -342,7 +342,7 @@ def slice_mat(A: sps.spmatrix, ind: np.ndarray) -> sps.spmatrix:
     elif ind.size == 1:
         N = 1
         indptr = np.zeros(2)
-        ind_slice = slice(A.indptr[int(ind)], A.indptr[int(ind + 1)])
+        ind_slice = slice(A.indptr[int(ind[0])], A.indptr[int(ind[0] + 1)])
     else:
         N = ind.size
         indptr = np.zeros(ind.size + 1)

--- a/src/porepy/numerics/linalg/matrix_operations.py
+++ b/src/porepy/numerics/linalg/matrix_operations.py
@@ -288,13 +288,18 @@ def slice_indices(
     assert A.getformat() == "csc" or A.getformat() == "csr"
     if np.asarray(slice_ind).dtype == "bool":
         # Convert to indices.
-        # First check for dimension
+        # First check for dimension.
         if slice_ind.size != A.indptr.size - 1:
             raise IndexError("boolean index did not match indexed array")
         slice_ind = np.where(slice_ind)[0]
-    if isinstance(slice_ind, int) or np.isscalar(slice_ind):
-        array_ind = slice(A.indptr[int(slice_ind)], A.indptr[int(slice_ind + 1)])
+    if isinstance(slice_ind, int):
+        array_ind = slice(A.indptr[slice_ind], A.indptr[slice_ind + 1])
         indices: np.ndarray = A.indices[array_ind]
+    elif isinstance(slice_ind, np.generic):
+        # Special case for single index.
+        assert slice_ind.dtype == int  # For mypy.
+        array_ind = slice(A.indptr[slice_ind], A.indptr[slice_ind + 1])
+        indices = A.indices[array_ind]
     else:
         array_ind = mcolon(A.indptr[slice_ind], A.indptr[slice_ind + 1])
         indices = A.indices[array_ind]

--- a/src/porepy/numerics/linalg/matrix_operations.py
+++ b/src/porepy/numerics/linalg/matrix_operations.py
@@ -297,7 +297,7 @@ def slice_indices(
         indices: np.ndarray = A.indices[array_ind]
     elif isinstance(slice_ind, np.generic):
         # Special case for single index.
-        assert slice_ind.dtype == int  # For mypy.
+        assert isinstance(slice_ind, np.integer)  # For mypy.
         array_ind = slice(A.indptr[slice_ind], A.indptr[slice_ind + 1])
         indices = A.indices[array_ind]
     else:

--- a/src/porepy/numerics/linalg/matrix_operations.py
+++ b/src/porepy/numerics/linalg/matrix_operations.py
@@ -292,12 +292,9 @@ def slice_indices(
         if slice_ind.size != A.indptr.size - 1:
             raise IndexError("boolean index did not match indexed array")
         slice_ind = np.where(slice_ind)[0]
-    if isinstance(slice_ind, int):
+    if isinstance(slice_ind, int) or np.isscalar(slice_ind):
         array_ind = slice(A.indptr[int(slice_ind)], A.indptr[int(slice_ind + 1)])
         indices: np.ndarray = A.indices[array_ind]
-    elif slice_ind.size == 1:
-        array_ind = slice(A.indptr[int(slice_ind[0])], A.indptr[int(slice_ind[0] + 1)])
-        indices = A.indices[array_ind]
     else:
         array_ind = mcolon(A.indptr[slice_ind], A.indptr[slice_ind + 1])
         indices = A.indices[array_ind]


### PR DESCRIPTION
## Proposed changes

Small fixes to take care of deprecation warnings thrown in the following cases:

- The use of scipy.spatial.qhull:

> DeprecationWarning: Please import `Delaunay` from the `scipy.spatial` namespace; the `scipy.spatial.qhull` namespace is deprecated and will be removed in SciPy 2.0.0.

- The use of shapely_speedup.enable():

> DeprecationWarning: This function has no longer any effect, and will be removed in a future release. Starting with Shapely 2.0, equivalent speedups are always available

- Using a single-element array as an int:

> DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [x] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
