### PR TITLE
Issue with Cartesian grid and MandelSetup

### DIFF
--- a/src/porepy/examples/mandel_biot.py
+++ b/src/porepy/examples/mandel_biot.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Callable, Literal, Union, cast
+import warnings
 
 import matplotlib.colors as mcolors  # type: ignore
 import matplotlib.pyplot as plt
@@ -1022,6 +1023,18 @@ class MandelUtils(VerificationUtils):
             color_map: listed color map object.
 
         """
+        if self.grid_type() == "cartesian":
+            # A division by zero was discovered while running the Mandel-problem on a
+            # Cartesian grid. The issue was related to plotting, and the current
+            # solution is to skip the troublesome plotting if the grid type is
+            # Cartesian. The GitHub-issue for this is found at:
+            # https://github.com/pmgbergen/porepy/issues/1137
+            warnings.warn(
+                """Division by x-component of the normal vector for internal faces of
+                cells adjacent to the southern boundary causes division by zero for
+                cartesian grids."""
+            )
+            return
         sd = self.mdg.subdomains()[0]
         xf = sd.face_centers[0]
         nx = sd.face_normals[0]

--- a/src/porepy/examples/mandel_biot.py
+++ b/src/porepy/examples/mandel_biot.py
@@ -23,9 +23,9 @@ References:
 
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass
 from typing import Callable, Literal, Union, cast
-import warnings
 
 import matplotlib.colors as mcolors  # type: ignore
 import matplotlib.pyplot as plt


### PR DESCRIPTION
## Proposed changes

Addresses issue #1137. The issue reports a possible functional error in mandels_problem.py. The only problem @IvarStefansson and I found while trying to reproduce the issue was some division by zero while plotting (if Cartesian grids were used). A user warning is now implemented and the problematic plotting is skipped in the case of Mandel's problem being run with a Cartesian grid. Please refer to the issue for more detailed breakdown of the problem. 

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [x] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
