### PR TITLE
Upgrade to Python 3.13

### DIFF
--- a/.github/workflows/check_tutorials.yml
+++ b/.github/workflows/check_tutorials.yml
@@ -1,4 +1,4 @@
-# Run unit, integration, and functional tests.
+# Run checks on the tutorials
 name: Check tutorials
 
 # Controls when the action will run. Triggers the workflow on push or pull request
@@ -29,7 +29,7 @@ jobs:
     # https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#specifying-a-python-version
     strategy:
       matrix:
-        # Only run check the latest supported version of Python
+        # Run the test on the latest supported version of Python
         python-version:  ["3.13"]
       # Complete all versions in matrix even if one fails.
       fail-fast: false

--- a/.github/workflows/check_tutorials.yml
+++ b/.github/workflows/check_tutorials.yml
@@ -1,5 +1,5 @@
 # Run unit, integration, and functional tests.
-name: Pytest
+name: Check tutorials
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events for the main and develop branches

--- a/.github/workflows/check_tutorials.yml
+++ b/.github/workflows/check_tutorials.yml
@@ -29,8 +29,8 @@ jobs:
     # https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#specifying-a-python-version
     strategy:
       matrix:
-        # Only check the latest version of 
-        python-version:  ["3.12"]
+        # Only run check the latest supported version of Python
+        python-version:  ["3.13"]
       # Complete all versions in matrix even if one fails.
       fail-fast: false
 

--- a/.github/workflows/run-pytest-all.yml
+++ b/.github/workflows/run-pytest-all.yml
@@ -21,7 +21,7 @@ jobs:
     # https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#specifying-a-python-version
     strategy:
       matrix:
-        python-version:  ["3.12"]  # run only the last python version
+        python-version:  ["3.13"]  # run only the last python version
       # Complete all versions in matrix even if one fails.
       fail-fast: false
 

--- a/.github/workflows/run-pytest.yml
+++ b/.github/workflows/run-pytest.yml
@@ -29,7 +29,7 @@ jobs:
     # https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#specifying-a-python-version
     strategy:
       matrix:
-        python-version:  ["3.11", "3.12"]
+        python-version:  ["3.11", "3.12", "3.13"]
       # Complete all versions in matrix even if one fails.
       fail-fast: false
 

--- a/.github/workflows/run-static-checks.yml
+++ b/.github/workflows/run-static-checks.yml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       matrix:
         # Run the tests only on the latest supported Python version.
-        python-version:  ["3.12"]
+        python-version:  ["3.13"]
       # Complete all versions in matrix even if one fails.
       fail-fast: false
 

--- a/dockerfiles/base/Dockerfile
+++ b/dockerfiles/base/Dockerfile
@@ -6,7 +6,7 @@
 
 # Base the Docker image on the official Python image.
 # For more information, please refer to https://aka.ms/vscode-docker-python
-FROM python:3.12-slim
+FROM python:3.13-slim
 
 
 # Keeps Python from generating .pyc files in the container


### PR DESCRIPTION
## Proposed changes
For now (and likely until the end of April), we will support Python 3.11-3.13.

Changes included:
1. All GH actions run on 3.13.
2. The base docker image is based on Python 3.13

This PR should not be merged until:
1. The GH action running all tests run successfully. EDIT: OK
2. The Docker build on Python 3.13 has been verified to work. EDIT: OK

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [x] Other: Build system

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [x] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
