### PR TITLE
BUG: Fix keep-output command line argument in profiling script

### DIFF
--- a/src/porepy/applications/profiling/run_profiling.py
+++ b/src/porepy/applications/profiling/run_profiling.py
@@ -198,7 +198,7 @@ def run_model_with_tracer(args, model) -> None:
             refinement.
             - min_duration (int): Minimum duration in microseconds for a function to be
             recorded by VizTracer.
-            - keep_output (bool): Whether to keep the output file after viewing it.
+            - clear_output (bool): Whether to clear the output file after viewing it.
         model: The model to be run and profiled.
 
     Raises:
@@ -249,7 +249,7 @@ def run_model_with_tracer(args, model) -> None:
     results_path = pathlib.Path(__file__).parent / save_file
     tracer.save(str(results_path))
     subprocess.run(["vizviewer", "--port", "9002", results_path])
-    if not args.keep_output:
+    if args.clear_output:
         results_path.unlink()
 
 
@@ -288,10 +288,10 @@ if __name__ == "__main__":
         + " named after the chosen physics, geometry, and grid refinement.",
     )
     parser.add_argument(
-        "--keep_output",
+        "--clear_output",
         action="store_true",
-        default=True,
-        help="Keep viztracer output after running.",
+        help="Clear viztracer output after running. By default, the log files are"
+        + " kept.",
     )
     parser.add_argument(
         "--min_duration",


### PR DESCRIPTION
## Proposed changes
The `argparse` argument `--keep_output` in the profiler was initiated with `action="store_true"` and `default=True`. This meant it couldn't be set to `False`. I changed the argument to `--clear_output` with `action="store_true"`, which is automatically initiated with `default=False`. Everything stays the same, except one can now actually use the flag.

## Types of changes
- [ ] Minor change (e.g., dependency bumps, broken links).
- [x] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist
- [x] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
