### PR TITLE
MOD: Replacing l2_error with general lp_error in ConvergenceAnalysis.

### DIFF
--- a/src/porepy/applications/convergence_analysis.py
+++ b/src/porepy/applications/convergence_analysis.py
@@ -633,8 +633,7 @@ class ConvergenceAnalysis:
                 Order of the norm. Allows ``p==numpy.inf``.
 
         Raises:
-            ValueError: If ``p`` is not strictly positive when ``integration_weights``
-                are given.
+            ValueError: If ``p < 1`` when ``integration_weights`` are given.
 
         Returns:
             The norm value.
@@ -652,7 +651,7 @@ class ConvergenceAnalysis:
             if p == np.inf:
                 return np.max(integration_weights * x)
             else:
-                if not (isinstance(p, (int, float)) and p > 0):
+                if not (isinstance(p, (int, float)) and p >= 1):
                     raise ValueError(
                         "Order p must be a positive float or numpy.inf,"
                         + f" not {p, type(p)}."

--- a/src/porepy/applications/convergence_analysis.py
+++ b/src/porepy/applications/convergence_analysis.py
@@ -477,22 +477,25 @@ class ConvergenceAnalysis:
         return "%2.2e"
 
     @staticmethod
-    def l2_error(
+    def lp_error(
         grid: pp.GridLike,
         true_array: np.ndarray,
         approx_array: np.ndarray,
         is_scalar: bool,
         is_cc: bool,
+        p: pp.number = 2,
         relative: bool = False,
         parameter_weight: Optional[np.ndarray] = None,
     ) -> pp.number:
-        """Compute discrete L2-error as given in [1].
+        """Computes the discrete :math:`L_p`-error as given in [1].
 
         It is possible to compute the absolute error (default) or the relative error.
 
-        Raises:
-            NotImplementedError if a mortar grid is given and ``is_cc=False``.
-            ZeroDivisionError if the denominator in the relative error is zero.
+        References:
+
+            - [1] Nordbotten and Keilegavlen, Two-point stress approximation: A simple
+              and robust finite volume method for linearized (poro-)elasticity and
+              Stokes flow.
 
         Parameters:
             grid: Either a subdomain grid or a mortar grid.
@@ -504,27 +507,24 @@ class ConvergenceAnalysis:
             is_cc: Whether the variable is associated to cell centers. Use ``False``
                 for variables associated to face centers. For example, ``is_cc=True``
                 for pressures, whereas ``is_cc=False`` for subdomain fluxes.
-            relative: Compute the relative error (if True) or the absolute error (if
-                False).
+            p: ``default=2``.
+
+                Order of the norm. Can take the value ``numpy.inf``.
+            relative: ``default=False``
+
+                If True, computes the relative error by dividing the error by the
+                respective norm of ``true_array``.
             parameter_weight: Array containing the parameter weight, producing a
                 weighted norm. If given, the array size must equal the number of faces
                 or cells in the grid.
-
-
-        Returns:
-            Discrete L2-error between the true and approximated arrays.
 
         Raises:
             NotImplementedError: If a mortar grid is given and is_cc is False.
             ZeroDivisionError: If the denominator in the relative error is zero.
             ValueError: If the parameter weight has an invalid size.
 
-        References:
-
-            - [1] Nordbotten and Keilegavlen, Two-point stress approximation: A simple
-              and robust finite volume method for linearized (poro-)elasticity and
-              Stokes flow.
-
+        Returns:
+            (Discrete) :math:`L_p`-error between the true and approximated arrays.
 
         """
         # Sanity check.
@@ -566,9 +566,15 @@ class ConvergenceAnalysis:
             meas = meas.repeat(grid.dim)
 
         # Obtain numerator and denominator to determine the error.
-        numerator = np.sqrt(np.sum(meas * np.abs(true_array - approx_array) ** 2))
+        numerator = ConvergenceAnalysis.lp_norm(
+            true_array - approx_array,
+            integration_weights=meas,
+            p=p,
+        )
         denominator = (
-            np.sqrt(np.sum(meas * np.abs(true_array) ** 2)) if relative else 1.0
+            ConvergenceAnalysis.lp_norm(true_array, integration_weights=meas, p=p)
+            if relative
+            else 1.0
         )
 
         # Deal with the case when the denominator is zero when computing the relative
@@ -577,3 +583,92 @@ class ConvergenceAnalysis:
             raise ZeroDivisionError("Attempted division by zero.")
 
         return numerator / denominator
+
+    @staticmethod
+    def lp_norm(
+        vec: np.ndarray,
+        integration_weights: Optional[pp.number | np.ndarray] = None,
+        p: pp.number = 2,
+    ) -> float:
+        r"""The discrete :math:`L_p`-norm of a vector or function evaluated on a
+        discretized grid.
+
+        The respective norm of a function in the space :math:`L_p` can be obtained by
+        approximating the integration with
+
+        .. math::
+
+            \lVert f \rVert_{L_p(|Omega)}
+            = \left( \int_{\Omega} \lvert f(x)\rvert^p dx \right)^(\frac{1}{p})
+            \approx \left(\sum w_i \lvert f_i \rvert^p \right)^(\frac{1}{p}),
+
+        with :math:`w_i` being the respective ``integration_weights``, and
+        :math:`f_i` the discretely evaluated function given by ``vec``.
+
+        For the :math:`L_{\infty}` norm it holds
+
+        .. math::
+
+            \lVert f \rVert_{L_{\infty}(|Omega)}
+            \approx max\left(w_i \lvert f_i \rvert \right).
+
+        Note:
+            If weights are given, a custom implementation is used which checks for
+            strict positivity of ``p``.
+
+            If no weights are given, or they are (all) 1, this function is a shallow
+            wrapper for the vector and matrix norms in :obj:`numpy.linalg.norm`.
+            Note however, that their ``p`` can take more options (including negative
+            values).
+
+        Parameters:
+            vec: The discrete function values for which the norm is to be computed.
+            integration_weights: ``default=None``
+
+                A scalar or vectorial weight for each component in
+                ``vec``. Defaults to None, which is treated as weight 1 leading to the
+                Euclidean-like :math:`L_p`-norm.
+            p: ``default=2``
+
+                Order of the norm. Allows ``p==numpy.inf``.
+
+        Raises:
+            ValueError: If ``p`` is not strictly positive when ``integration_weights``
+                are given.
+
+        Returns:
+            The norm value.
+
+        """
+
+        # No weights, or weight equal 1 (for some reason), is analogous to the discrete
+        # norm, which enables us to use numpy.
+        if integration_weights is None or np.all(integration_weights == 1):
+            # ignoring return value because numpy would allow matrices.
+            return np.linalg.norm(vec, ord=p)  # type:ignore[return-value]
+        # Weights (either integration or other) lead to the custom implementation.
+        else:
+            x = np.abs(vec)
+            if p == np.inf:
+                return np.max(integration_weights * x)
+            else:
+                if not (isinstance(p, (int, float)) and p > 0):
+                    raise ValueError(
+                        "Order p must be a positive float or numpy.inf,"
+                        + f" not {p, type(p)}."
+                    )
+                # NOTE The weights are the reason we cannot use numpy here. It would
+                # lead to the sum of (weights * x) ** p.
+                norm_inner = np.sum(integration_weights * x**p)
+                # Treating special cases 1,2,3, for which there are more efficient and
+                # precise implementations than Python's power.
+                if p == 1:
+                    norm = norm_inner
+                elif p == 2:
+                    norm = np.sqrt(norm_inner)
+                elif p == 3:
+                    norm = np.cbrt(norm_inner)
+                else:
+                    norm = norm_inner ** (1 / p)
+
+                return norm

--- a/src/porepy/examples/mandel_biot.py
+++ b/src/porepy/examples/mandel_biot.py
@@ -169,7 +169,7 @@ class MandelDataSaving(VerificationDataSaving):
         exact_pressure = self.exact_sol.pressure(sd, t)
         pressure_ad = self.pressure([sd])
         approx_pressure = pressure_ad.value(self.equation_system)
-        error_pressure = ConvergenceAnalysis.l2_error(
+        error_pressure = ConvergenceAnalysis.lp_error(
             grid=sd,
             true_array=exact_pressure,
             approx_array=cast(np.ndarray, approx_pressure),
@@ -181,7 +181,7 @@ class MandelDataSaving(VerificationDataSaving):
         exact_displacement = self.exact_sol.displacement(sd, t)
         displacement_ad = self.displacement([sd])
         approx_displacement = displacement_ad.value(self.equation_system)
-        error_displacement = ConvergenceAnalysis.l2_error(
+        error_displacement = ConvergenceAnalysis.lp_error(
             grid=sd,
             true_array=exact_displacement,
             approx_array=cast(np.ndarray, approx_displacement),
@@ -194,7 +194,7 @@ class MandelDataSaving(VerificationDataSaving):
         flux_ad = self.darcy_flux([sd])
         mobility = 1 / self.fluid.reference_component.viscosity
         approx_flux = mobility * flux_ad.value(self.equation_system)
-        error_flux = ConvergenceAnalysis.l2_error(
+        error_flux = ConvergenceAnalysis.lp_error(
             grid=sd,
             true_array=exact_flux,
             approx_array=cast(np.ndarray, approx_flux),
@@ -206,7 +206,7 @@ class MandelDataSaving(VerificationDataSaving):
         exact_force = self.exact_sol.poroelastic_force(sd, t)
         force_ad = self.stress([sd])
         approx_force = force_ad.value(self.equation_system)
-        error_force = ConvergenceAnalysis.l2_error(
+        error_force = ConvergenceAnalysis.lp_error(
             grid=sd,
             true_array=exact_force,
             approx_array=cast(np.ndarray, approx_force),

--- a/src/porepy/examples/terzaghi_biot.py
+++ b/src/porepy/examples/terzaghi_biot.py
@@ -156,7 +156,7 @@ class TerzaghiDataSaving(VerificationDataSaving):
         exact_pressure = self.exact_sol.pressure(sd.cell_centers[1], t)
         pressure_ad = self.pressure([sd])
         approx_pressure = pressure_ad.value(self.equation_system)
-        error_pressure = ConvergenceAnalysis.l2_error(
+        error_pressure = ConvergenceAnalysis.lp_error(
             grid=sd,
             true_array=exact_pressure,
             approx_array=cast(np.ndarray, approx_pressure),

--- a/tests/functional/setups/manu_flow_comp_2d_frac.py
+++ b/tests/functional/setups/manu_flow_comp_2d_frac.py
@@ -120,7 +120,7 @@ class ManuCompDataSaving(VerificationDataSaving):
         exact_matrix_pressure = exact_sol.matrix_pressure(sd_matrix, t)
         matrix_pressure_ad = self.pressure([sd_matrix])
         approx_matrix_pressure = matrix_pressure_ad.value(self.equation_system)
-        error_matrix_pressure = ConvergenceAnalysis.l2_error(
+        error_matrix_pressure = ConvergenceAnalysis.lp_error(
             grid=sd_matrix,
             true_array=exact_matrix_pressure,
             approx_array=approx_matrix_pressure,
@@ -132,7 +132,7 @@ class ManuCompDataSaving(VerificationDataSaving):
         exact_matrix_flux = exact_sol.matrix_flux(sd_matrix, t)
         matrix_flux_ad = self.darcy_flux([sd_matrix])
         approx_matrix_flux = matrix_flux_ad.value(self.equation_system)
-        error_matrix_flux = ConvergenceAnalysis.l2_error(
+        error_matrix_flux = ConvergenceAnalysis.lp_error(
             grid=sd_matrix,
             true_array=exact_matrix_flux,
             approx_array=approx_matrix_flux,
@@ -144,7 +144,7 @@ class ManuCompDataSaving(VerificationDataSaving):
         exact_frac_pressure = exact_sol.fracture_pressure(sd_frac, t)
         frac_pressure_ad = self.pressure([sd_frac])
         approx_frac_pressure = frac_pressure_ad.value(self.equation_system)
-        error_frac_pressure = ConvergenceAnalysis.l2_error(
+        error_frac_pressure = ConvergenceAnalysis.lp_error(
             grid=sd_frac,
             true_array=exact_frac_pressure,
             approx_array=approx_frac_pressure,
@@ -156,7 +156,7 @@ class ManuCompDataSaving(VerificationDataSaving):
         exact_frac_flux = exact_sol.fracture_flux(sd_frac, t)
         frac_flux_ad = self.darcy_flux([sd_frac])
         approx_frac_flux = frac_flux_ad.value(self.equation_system)
-        error_frac_flux = ConvergenceAnalysis.l2_error(
+        error_frac_flux = ConvergenceAnalysis.lp_error(
             grid=sd_frac,
             true_array=exact_frac_flux,
             approx_array=approx_frac_flux,
@@ -168,7 +168,7 @@ class ManuCompDataSaving(VerificationDataSaving):
         exact_intf_flux = exact_sol.interface_flux(intf, t)
         int_flux_ad = self.interface_darcy_flux([intf])
         approx_intf_flux = int_flux_ad.value(self.equation_system)
-        error_intf_flux = ConvergenceAnalysis.l2_error(
+        error_intf_flux = ConvergenceAnalysis.lp_error(
             grid=intf,
             true_array=exact_intf_flux,
             approx_array=approx_intf_flux,

--- a/tests/functional/setups/manu_flow_incomp_frac_2d.py
+++ b/tests/functional/setups/manu_flow_incomp_frac_2d.py
@@ -140,7 +140,7 @@ class ManuIncompDataSaving(VerificationDataSaving):
         exact_matrix_pressure = exact_sol.matrix_pressure(sd_matrix)
         matrix_pressure_ad = self.pressure([sd_matrix])
         approx_matrix_pressure = matrix_pressure_ad.value(self.equation_system)
-        error_matrix_pressure = ConvergenceAnalysis.l2_error(
+        error_matrix_pressure = ConvergenceAnalysis.lp_error(
             grid=sd_matrix,
             true_array=exact_matrix_pressure,
             approx_array=approx_matrix_pressure,
@@ -152,7 +152,7 @@ class ManuIncompDataSaving(VerificationDataSaving):
         exact_matrix_flux = exact_sol.matrix_flux(sd_matrix)
         matrix_flux_ad = self.darcy_flux([sd_matrix])
         approx_matrix_flux = matrix_flux_ad.value(self.equation_system)
-        error_matrix_flux = ConvergenceAnalysis.l2_error(
+        error_matrix_flux = ConvergenceAnalysis.lp_error(
             grid=sd_matrix,
             true_array=exact_matrix_flux,
             approx_array=approx_matrix_flux,
@@ -164,7 +164,7 @@ class ManuIncompDataSaving(VerificationDataSaving):
         exact_frac_pressure = exact_sol.fracture_pressure(sd_frac)
         frac_pressure_ad = self.pressure([sd_frac])
         approx_frac_pressure = frac_pressure_ad.value(self.equation_system)
-        error_frac_pressure = ConvergenceAnalysis.l2_error(
+        error_frac_pressure = ConvergenceAnalysis.lp_error(
             grid=sd_frac,
             true_array=exact_frac_pressure,
             approx_array=approx_frac_pressure,
@@ -176,7 +176,7 @@ class ManuIncompDataSaving(VerificationDataSaving):
         exact_frac_flux = exact_sol.fracture_flux(sd_frac)
         frac_flux_ad = self.darcy_flux([sd_frac])
         approx_frac_flux = frac_flux_ad.value(self.equation_system)
-        error_frac_flux = ConvergenceAnalysis.l2_error(
+        error_frac_flux = ConvergenceAnalysis.lp_error(
             grid=sd_frac,
             true_array=exact_frac_flux,
             approx_array=approx_frac_flux,
@@ -188,7 +188,7 @@ class ManuIncompDataSaving(VerificationDataSaving):
         exact_intf_flux = exact_sol.interface_flux(intf)
         int_flux_ad = self.interface_darcy_flux([intf])
         approx_intf_flux = int_flux_ad.value(self.equation_system)
-        error_intf_flux = ConvergenceAnalysis.l2_error(
+        error_intf_flux = ConvergenceAnalysis.lp_error(
             grid=intf,
             true_array=exact_intf_flux,
             approx_array=approx_intf_flux,

--- a/tests/functional/setups/manu_poromech_nofrac_2d.py
+++ b/tests/functional/setups/manu_poromech_nofrac_2d.py
@@ -160,7 +160,7 @@ class ManuPoroMechDataSaving(VerificationDataSaving):
         exact_pressure = self.exact_sol.pressure(sd=sd, time=t)
         pressure_ad = self.pressure([sd])
         approx_pressure = pressure_ad.value(self.equation_system)
-        error_pressure = ConvergenceAnalysis.l2_error(
+        error_pressure = ConvergenceAnalysis.lp_error(
             grid=sd,
             true_array=exact_pressure,
             approx_array=approx_pressure,
@@ -172,7 +172,7 @@ class ManuPoroMechDataSaving(VerificationDataSaving):
         exact_displacement = self.exact_sol.displacement(sd=sd, time=t)
         displacement_ad = self.displacement([sd])
         approx_displacement = displacement_ad.value(self.equation_system)
-        error_displacement = ConvergenceAnalysis.l2_error(
+        error_displacement = ConvergenceAnalysis.lp_error(
             grid=sd,
             true_array=exact_displacement,
             approx_array=approx_displacement,
@@ -184,7 +184,7 @@ class ManuPoroMechDataSaving(VerificationDataSaving):
         exact_flux = self.exact_sol.darcy_flux(sd=sd, time=t)
         flux_ad = self.darcy_flux([sd])
         approx_flux = flux_ad.value(self.equation_system)
-        error_flux = ConvergenceAnalysis.l2_error(
+        error_flux = ConvergenceAnalysis.lp_error(
             grid=sd,
             true_array=exact_flux,
             approx_array=approx_flux,
@@ -196,7 +196,7 @@ class ManuPoroMechDataSaving(VerificationDataSaving):
         exact_force = self.exact_sol.poroelastic_force(sd=sd, time=t)
         force_ad = self.stress([sd])
         approx_force = force_ad.value(self.equation_system)
-        error_force = ConvergenceAnalysis.l2_error(
+        error_force = ConvergenceAnalysis.lp_error(
             grid=sd,
             true_array=exact_force,
             approx_array=approx_force,

--- a/tests/functional/setups/manu_thermoporomech_nofrac_2d.py
+++ b/tests/functional/setups/manu_thermoporomech_nofrac_2d.py
@@ -171,7 +171,7 @@ class ManuThermoPoroMechDataSaving(VerificationDataSaving):
         exact_pressure = self.exact_sol.pressure(sd=sd, time=t)
         pressure_ad = self.pressure([sd])
         approx_pressure = pressure_ad.value(self.equation_system)
-        error_pressure = ConvergenceAnalysis.l2_error(
+        error_pressure = ConvergenceAnalysis.lp_error(
             grid=sd,
             true_array=exact_pressure,
             approx_array=approx_pressure,
@@ -183,7 +183,7 @@ class ManuThermoPoroMechDataSaving(VerificationDataSaving):
         exact_displacement = self.exact_sol.displacement(sd=sd, time=t)
         displacement_ad = self.displacement([sd])
         approx_displacement = displacement_ad.value(self.equation_system)
-        error_displacement = ConvergenceAnalysis.l2_error(
+        error_displacement = ConvergenceAnalysis.lp_error(
             grid=sd,
             true_array=exact_displacement,
             approx_array=approx_displacement,
@@ -195,7 +195,7 @@ class ManuThermoPoroMechDataSaving(VerificationDataSaving):
         exact_temperature = self.exact_sol.temperature(sd=sd, time=t)
         temperature_ad = self.temperature([sd])
         approx_temperature = temperature_ad.value(self.equation_system)
-        error_temperature = ConvergenceAnalysis.l2_error(
+        error_temperature = ConvergenceAnalysis.lp_error(
             grid=sd,
             true_array=exact_temperature,
             approx_array=approx_temperature,
@@ -207,7 +207,7 @@ class ManuThermoPoroMechDataSaving(VerificationDataSaving):
         exact_darcy_flux = self.exact_sol.darcy_flux(sd=sd, time=t)
         flux_ad = self.darcy_flux([sd])
         approx_darcy_flux = flux_ad.value(self.equation_system)
-        error_darcy_flux = ConvergenceAnalysis.l2_error(
+        error_darcy_flux = ConvergenceAnalysis.lp_error(
             grid=sd,
             true_array=exact_darcy_flux,
             approx_array=approx_darcy_flux,
@@ -219,7 +219,7 @@ class ManuThermoPoroMechDataSaving(VerificationDataSaving):
         exact_energy_flux = self.exact_sol.energy_flux(sd=sd, time=t)
         flux_ad = self.energy_flux([sd])
         approx_energy_flux = flux_ad.value(self.equation_system)
-        error_energy_flux = ConvergenceAnalysis.l2_error(
+        error_energy_flux = ConvergenceAnalysis.lp_error(
             grid=sd,
             true_array=exact_energy_flux,
             approx_array=approx_energy_flux,
@@ -231,7 +231,7 @@ class ManuThermoPoroMechDataSaving(VerificationDataSaving):
         exact_force = self.exact_sol.thermoporoelastic_force(sd=sd, time=t)
         force_ad = self.stress([sd])
         approx_force = force_ad.value(self.equation_system)
-        error_force = ConvergenceAnalysis.l2_error(
+        error_force = ConvergenceAnalysis.lp_error(
             grid=sd,
             true_array=exact_force,
             approx_array=approx_force,


### PR DESCRIPTION
## Proposed changes

I think the title explains it all.
Relevant changes are in `porepy/applications/convergence_analysis` and `tests/applications/test_convergence_analysis`.
Other changes are due to change in name `l2_error -> lp_error`.

## Types of changes

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [X] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

- [X] The documentation is up-to-date.
- [X] Static typing is included in the update.
- [X] This PR does not duplicate existing functionality.
- [X] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
