### PR TITLE
SPEED: Avoid double costly evaluation of permeability in constitutive law

### DIFF
--- a/src/porepy/models/constitutive_laws.py
+++ b/src/porepy/models/constitutive_laws.py
@@ -518,16 +518,16 @@ class SecondOrderTensorUtils(pp.PorePyModel):
             # fall back on reference value.
             permeability = fallback_value * np.ones(sd.num_cells) * volume
             return pp.SecondOrderTensor(permeability)
-        evaluated_value = self.equation_system.evaluate(operator)
-        if not isinstance(evaluated_value, np.ndarray):
+
+        if not isinstance(permeability, np.ndarray):
             # Raise error rather than cast for verbosity of function which is not
             # directly exposed to the user, but depends on a frequently user-defined
             # quantity (the tensor being converted).
             raise ValueError(
-                f"Operator {operator.name} has type {type(evaluated_value)}, "
+                f"Operator {operator.name} has type {type(permeability)}, "
                 f"expected numpy array for conversion to SecondOrderTensor."
             )
-        val = evaluated_value.reshape(9, -1, order="F")
+        val = permeability.reshape(9, -1, order="F")
         # SecondOrderTensor's constructor expects up to six entries: kxx, kyy, kzz,
         # kxy, kxz, kyz. These correspond to entries 0, 4, 8, 1, 2, 5 in the 9 x
         # num_cells array.


### PR DESCRIPTION
In the conversion of permeability from a tensor to an Ad operator, the permeability was calculated twice, with the first take effectively tossed away. This PR ensures permeability is only calculated once.

The speedup gained from this is surprisingly large, or negatively, the cost of the conversion to an operator is surprisingly high (though perhaps not surprisingly so). I hope to fix most of this in connection with #1182, but that project requires some more effort to complete.

## Proposed changes

Contributions to PorePy are highly appreciated. Clearly explain why this pull request (PR) is needed and why it should be accepted. If this PR solves an issue, explain how it is done. Please, also summarise the changes to the code.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [x] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
