### PR TITLE
MAINT: Added keyword to numpy reshape calls

### DIFF
--- a/src/porepy/params/bc.py
+++ b/src/porepy/params/bc.py
@@ -314,9 +314,9 @@ class BoundaryConditionVectorial(AbstractBoundaryCondition):
 
         #  Default robin weights
         r_w = np.tile(np.eye(sd.dim), (1, sd.num_faces))
-        self.robin_weight = np.reshape(r_w, (sd.dim, sd.dim, sd.num_faces), "F")
+        self.robin_weight = np.reshape(r_w, (sd.dim, sd.dim, sd.num_faces), order="F")
         basis = np.tile(np.eye(sd.dim), (1, sd.num_faces))
-        self.basis = np.reshape(basis, (sd.dim, sd.dim, sd.num_faces), "F")
+        self.basis = np.reshape(basis, (sd.dim, sd.dim, sd.num_faces), order="F")
 
     def __repr__(self) -> str:
         s = (

--- a/src/porepy/viz/exporter.py
+++ b/src/porepy/viz/exporter.py
@@ -968,7 +968,7 @@ class Exporter:
             if not value.size == num_dofs and not (
                 len(value.shape) > 1 and value.shape[1] == num_dofs
             ):
-                value = np.reshape(value, (-1, num_dofs), "F")
+                value = np.reshape(value, (-1, num_dofs), order="F")
 
             return value
 


### PR DESCRIPTION
When juggling with different numpy versions, I ran into some issues where calls of the type `array.reshape((n_row, n_dim), "F")` were not permitted. This PR changes these few cases to  `array.reshape((n_row, n_dim), order="F")`.

I did a search through the code base, and found no other cases where we used `reshape` with an order argument but without specifying the `order` keyword.

## Proposed changes

Contributions to PorePy are highly appreciated. Clearly explain why this pull request (PR) is needed and why it should be accepted. If this PR solves an issue, explain how it is done. Please, also summarise the changes to the code.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [x] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
