### PR TITLE
Minor change: Improved time manager

### DIFF
--- a/src/porepy/numerics/time_step_control.py
+++ b/src/porepy/numerics/time_step_control.py
@@ -132,9 +132,10 @@ class TimeManager:
             `schedule` are compatible.
         dt_min_max: Minimum and maximum permissible time steps.
             If None, then the minimum time step is set to 0.1% of the final simulation
-            time and the maximum time step is set to 10% of the final simulation time.
-            If given, then the first and second elements of the tuple corresponds to the
-            minimum and maximum time steps, respectively.
+            time or the initial time step if it is smaller than that. The maximum time
+            step is set to 10% of the final simulation time. If given, then the first
+            and second elements of the tuple corresponds to the minimum and maximum time
+            steps, respectively.
 
             To avoid oscillations and ensure a stable time step adaptation in
             combination with the relaxation factors, we further require:
@@ -232,7 +233,7 @@ class TimeManager:
         self.rtol = rtol
         self.atol = atol
 
-        # If dt_min_max is not given, set dt_min=0.001*final_time and
+        # If dt_min_max is not given, set dt_min=min(0.001*final_time, dt_init) and
         # dt_max=0.1*final_time
         dt_min_max_passed = dt_min_max  # store for later use
         if dt_min_max is None:

--- a/src/porepy/numerics/time_step_control.py
+++ b/src/porepy/numerics/time_step_control.py
@@ -255,10 +255,7 @@ class TimeManager:
             )
 
             if dt_init < dt_min_max[0]:
-                if dt_min_max_passed is not None:
-                    raise ValueError(msg_dtmin)
-                else:
-                    raise ValueError(msg_dtmin + msg_unset)
+                raise ValueError(msg_dtmin)
 
             if dt_init > dt_min_max[1]:
                 if dt_min_max_passed is not None:

--- a/src/porepy/numerics/time_step_control.py
+++ b/src/porepy/numerics/time_step_control.py
@@ -236,7 +236,7 @@ class TimeManager:
         # dt_max=0.1*final_time
         dt_min_max_passed = dt_min_max  # store for later use
         if dt_min_max is None:
-            dt_min_max = (0.001 * schedule[-1], 0.1 * schedule[-1])
+            dt_min_max = (min(dt_init, 0.001 * schedule[-1]), 0.1 * schedule[-1])
 
         # More sanity checks below. Note that all the remaining sanity checks (but one)
         # are only needed when constant_dt = False. Thus, to save time when constant_dt

--- a/tests/numerics/test_time_step_control.py
+++ b/tests/numerics/test_time_step_control.py
@@ -160,15 +160,15 @@ class TestParameterInputs:
     def test_initial_time_step_larger_than_minimum_time_step(self):
         """An error should be raised if initial time step is less than minimum time step."""
         msg_dtmin = "Initial time step cannot be smaller than minimum time step. "
-        msg_unset = (
-            "This error was raised since `dt_min_max` was not set on "
-            "initialization. Thus, values of dt_min and dt_max were assigned "
-            "based on the final simulation time. If you still want to use this "
-            "initial time step, consider passing `dt_min_max` explicitly."
-        )
         with pytest.raises(ValueError) as excinfo:
-            pp.TimeManager(schedule=[0, 1], dt_init=0.0009)
-        assert (msg_dtmin + msg_unset) in str(excinfo.value)
+            pp.TimeManager(schedule=[0, 1], dt_min_max=[0.001, 0.1], dt_init=0.0009)
+        assert msg_dtmin in str(excinfo.value)
+
+    def test_initial_time_step_smaller_than_default_minimum_time_step(self):
+        """The default minimum time step should be adjusted if the user passed a smaller
+        value."""
+        time_manager = pp.TimeManager(schedule=[0, 1], dt_init=1e-6)
+        assert time_manager.dt_min_max[0] == 1e-6
 
     def test_initial_time_step_smaller_than_maximum_time_step(self):
         """An error should be raised if initial time step is larger than the maximum time
@@ -798,9 +798,9 @@ class DynamicTimeStepTestCaseModel(SinglePhaseFlow):
         if self.num_nonlinear_iters == 0:
             iterate_values = self.equation_system.get_variable_values(iterate_index=0)
             state_values = self.equation_system.get_variable_values(time_step_index=0)
-            assert np.all(iterate_values == state_values), (
-                "Likely, 'iterate' was not reset after the unsuccessful time step."
-            )
+            assert np.all(
+                iterate_values == state_values
+            ), "Likely, 'iterate' was not reset after the unsuccessful time step."
 
         self.num_nonlinear_iters += 1
 
@@ -823,9 +823,9 @@ class DynamicTimeStepTestCaseModel(SinglePhaseFlow):
         if self.time_step_converged[self.time_step_idx] is False:
             # Diverged
             return False, True
-        assert False, (
-            "Nonlinear solver did not stop iterating after the iteration limit."
-        )
+        assert (
+            False
+        ), "Nonlinear solver did not stop iterating after the iteration limit."
 
     # Minimizing computational expences.
 


### PR DESCRIPTION
## Proposed changes

This is a small change that improves (at least my) experience of using PorePy. When using dynamic time stepping, the lower limit of a time step is by default inferred to be `Δt_min = 0.001 * t_max`. This will raise a mistake if I set the initial time step to be smaller, which is usually desired. Therefore, I must always pass an additional argument to change this limit.

My suggestion is to change this rule for the lower limit to the following: `Δt_min = min(0.001 * t_max, Δt_init)`, because if the user passes a small time step, it is obviously considered within the limits. I don't think this change can harm anything, please let me know if I'm wrong!

Upd: I also updated the corresponding tests to the new behavior.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [x] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
