### PR TITLE
Unify names most of src

### DIFF
--- a/src/porepy/fracs/meshing.py
+++ b/src/porepy/fracs/meshing.py
@@ -437,18 +437,18 @@ def _assemble_mdg(
         # faces of the higher-dimensional grid. If this face-cell intersection is
         # non-empty, there is a coupling will be made between the higher and
         # lower-dimensional grid, and the face-to-cell relation will be saved.
-        for hsd in subdomains[dim]:
+        for subdomains_of_dim in subdomains[dim]:
             # We have to specify the number of nodes per face to generate a matrix of
             # the nodes of each face.
-            n_per_face = _nodes_per_face(hsd)
+            n_per_face = _nodes_per_face(subdomains_of_dim)
 
             # Get the face-node relation for the higher-dimensional grid, stored with
             # one column per face
-            fn_loc = hsd.face_nodes.indices.reshape(
-                (n_per_face, hsd.num_faces), order="F"
+            fn_loc = subdomains_of_dim.face_nodes.indices.reshape(
+                (n_per_face, subdomains_of_dim.num_faces), order="F"
             )
             # Convert to global numbering
-            fn = hsd.global_point_ind[fn_loc]
+            fn = subdomains_of_dim.global_point_ind[fn_loc]
             fn = np.sort(fn, axis=0)
 
             # Get a cell-node relation for the lower-dimensional grids. It turns out
@@ -460,7 +460,7 @@ def _assemble_mdg(
 
             # The treatment of the lower-dimensional grids is a bit special for point
             # grids (else below)
-            if hsd.dim > 1:
+            if subdomains_of_dim.dim > 1:
                 # Data structure for cell-nodes
                 cn = []
                 # Number of cells per grid. Will be used to define offsets for
@@ -532,10 +532,10 @@ def _assemble_mdg(
                         np.ones(loc_mem.size, dtype=bool),
                         (np.arange(loc_mem.size), cell_2_face[ind]),
                     ),
-                    shape=(lsd.num_cells, hsd.num_faces),
+                    shape=(lsd.num_cells, subdomains_of_dim.num_faces),
                 )
                 # Add the pairing of subdomains and the cell-face map to the list
-                sd_pair_to_face_cell_map[(hsd, lsd)] = face_cell_map
+                sd_pair_to_face_cell_map[(subdomains_of_dim, lsd)] = face_cell_map
 
     return mdg, sd_pair_to_face_cell_map
 
@@ -560,7 +560,7 @@ def create_interfaces(
 
     # loop on all the subdomain pairs and create the mortar grids
     for sd_pair, face_cells in sd_pair_to_face_cell_map.items():
-        sd_h, sd_l = sd_pair
+        sd_primary, sd_secondary = sd_pair
 
         # face_cells.indices gives mappings into the lower dimensional cells. Count
         # the number of occurrences for each cell.
@@ -579,12 +579,12 @@ def create_interfaces(
         if np.all(num_sides > 1):
             # we are in a two sides situation
             side_g = {
-                mortar_sides.LEFT_SIDE: sd_l.copy(),
-                mortar_sides.RIGHT_SIDE: sd_l.copy(),
+                mortar_sides.LEFT_SIDE: sd_secondary.copy(),
+                mortar_sides.RIGHT_SIDE: sd_secondary.copy(),
             }
         else:
             # the tag name is just a place-holder we assume left side
-            side_g = {mortar_sides.LEFT_SIDE: sd_l.copy()}
-        mg = mortar_grid.MortarGrid(sd_l.dim, side_g, face_cells)
+            side_g = {mortar_sides.LEFT_SIDE: sd_secondary.copy()}
+        mg = mortar_grid.MortarGrid(sd_secondary.dim, side_g, face_cells)
 
         mdg.add_interface(mg, sd_pair, face_cells)

--- a/src/porepy/fracs/split_grid.py
+++ b/src/porepy/fracs/split_grid.py
@@ -48,10 +48,10 @@ def split_fractures(
     offset = kwargs.get("offset", 0)
 
     # For each vertex in the mdg we find the corresponding lower-dimensional grids.
-    for gh in mdg.subdomains():
+    for sd_primary in mdg.subdomains():
         # add new field to grid
-        gh.frac_pairs = np.zeros((2, 0), dtype=np.int32)
-        if gh.dim < 1:
+        sd_primary.frac_pairs = np.zeros((2, 0), dtype=np.int32)
+        if sd_primary.dim < 1:
             # Nothing to do. We can not split 0D grids.
             continue
 
@@ -60,10 +60,10 @@ def split_fractures(
 
         matrix_list = []
 
-        for pair, matrix in sd_pairs.items():
-            if gh in pair:
-                other = list(set(pair).difference({gh}))[0]
-                if other.dim >= gh.dim:
+        for sd_pair, matrix in sd_pairs.items():
+            if sd_primary in sd_pair:
+                other = list(set(sd_pair).difference({sd_primary}))[0]
+                if other.dim >= sd_primary.dim:
                     continue
 
                 matrix_list.append(matrix)
@@ -80,36 +80,36 @@ def split_fractures(
 
         # We split all the faces that are connected to a lower-dim grid. The new
         # faces will share the same nodes and properties (normals, etc.)
-        face_cells_modified = split_faces(gh, matrix_list)
+        face_cells_modified = split_faces(sd_primary, matrix_list)
 
-        for gl, matrix in zip(low_dim_neigh, face_cells_modified):
-            sd_pairs[(gh, gl)] = matrix
+        for sd_secondary, matrix in zip(low_dim_neigh, face_cells_modified):
+            sd_pairs[(sd_primary, sd_secondary)] = matrix
 
         # We now find which lower-dim nodes correspond to which higher- dim nodes. We
         # split these nodes according to the topology of the connected higher-dim
         # cells. At a X-intersection we split the node into four, while at the
         # fracture boundary it is not split.
 
-        gl_2_gh_nodes = []
-        for g in low_dim_neigh:
+        secondary_2_primary_nodes = []
+        for sd in low_dim_neigh:
             # Enforce 64 bit to comply with ismember_rows. Was np.int32
-            source = np.atleast_2d(g.global_point_ind).astype(np.int64)
-            target = np.atleast_2d(gh.global_point_ind).astype(np.int64)
+            source = np.atleast_2d(sd.global_point_ind).astype(np.int64)
+            target = np.atleast_2d(sd_primary.global_point_ind).astype(np.int64)
             _, mapping = setmembership.ismember_rows(source, target)
-            gl_2_gh_nodes.append(mapping)
+            secondary_2_primary_nodes.append(mapping)
 
-        split_nodes(gh, low_dim_neigh, gl_2_gh_nodes, offset)
+        split_nodes(sd_primary, low_dim_neigh, secondary_2_primary_nodes, offset)
 
     # Remove zeros from cell_faces
 
-    [g.cell_faces.eliminate_zeros() for g in mdg.subdomains()]
-    for g in mdg.subdomains():
-        g.update_boundary_node_tag()
+    [sd.cell_faces.eliminate_zeros() for sd in mdg.subdomains()]
+    for sd in mdg.subdomains():
+        sd.update_boundary_node_tag()
 
     return mdg, sd_pairs
 
 
-def split_faces(gh: pp.Grid, face_cells: list[sps.spmatrix]) -> list[sps.spmatrix]:
+def split_faces(sd: pp.Grid, face_cells: list[sps.spmatrix]) -> list[sps.spmatrix]:
     """Splits faces of the grid along each fracture.
 
     This function will add an extra face to each fracture face. Note that the
@@ -122,24 +122,24 @@ def split_faces(gh: pp.Grid, face_cells: list[sps.spmatrix]) -> list[sps.spmatri
     lower-dim cell.
 
     Parameters:
-        gh: The grid (considered as the higher-dimensional grid) within which the
+        sd: The grid (considered as the higher-dimensional grid) within which the
             splitting is performed
         face_cells: A list of connection matrix mapping from the cells of the resulting
-            lower-dimensional grid to the faces of the higher-dimensional grid ``gh``.
+            lower-dimensional grid to the faces of the higher-dimensional grid ``sd``.
 
-            Each connection matrix introduces a new fracture into ``gh``.
+            Each connection matrix introduces a new fracture into ``sd``.
 
     Returns:
         An updated list of connection matrix between the faces of the higher-dimensional
         grid and the cells of the resulting lower-dimensional grid.
 
     """
-    gh.frac_pairs = np.zeros((2, 0), dtype=int)
+    sd.frac_pairs = np.zeros((2, 0), dtype=int)
     for i in range(len(face_cells)):
         # We first duplicate faces along tagged faces. The duplicate faces will share
         # the same nodes as the original faces, however, the new faces are not yet
         # added to the cell_faces map (to save computation).
-        face_id = duplicate_faces(gh, face_cells[i])
+        face_id = duplicate_faces(sd, face_cells[i])
         face_cells = _update_face_cells(face_cells, face_id, i)
         if face_id.size == 0:
             continue
@@ -147,24 +147,24 @@ def split_faces(gh: pp.Grid, face_cells: list[sps.spmatrix]) -> list[sps.spmatri
         # We now set the cell_faces map based on which side of the fractures the
         # cells lie. We assume that all fractures are flat surfaces and pick the
         # normal of the first face as a normal for the whole fracture.
-        n = np.reshape(gh.face_normals[:, face_id[0]], (3, 1))
+        n = np.reshape(sd.face_normals[:, face_id[0]], (3, 1))
         n = n / np.linalg.norm(n)
-        x0 = np.reshape(gh.face_centers[:, face_id[0]], (3, 1))
-        flag = update_cell_connectivity(gh, face_id, n, x0)
+        x0 = np.reshape(sd.face_centers[:, face_id[0]], (3, 1))
+        flag = update_cell_connectivity(sd, face_id, n, x0)
 
         if flag == 0:
             # if flag== 0 we added left and right faces (if it is -1, no faces was
             # added, so we don't have left and right face pairs). We now add the new
             # faces to the frac_pair array.
             left = face_id
-            right = np.arange(gh.num_faces - face_id.size, gh.num_faces)
-            gh.frac_pairs = np.hstack((gh.frac_pairs, np.vstack((left, right))))
+            right = np.arange(sd.num_faces - face_id.size, sd.num_faces)
+            sd.frac_pairs = np.hstack((sd.frac_pairs, np.vstack((left, right))))
 
     return face_cells
 
 
 def split_specific_faces(
-    sd_primary: pp.Grid,
+    sd: pp.Grid,
     face_cell_list: list[sps.spmatrix],
     faces: np.ndarray,
     cells: np.ndarray,
@@ -186,16 +186,16 @@ def split_specific_faces(
 
         .. code:: python3
 
-            # If ``gl_ind`` identifies a lower-dimensional grid ``gl`` in
+            # If ``sd_low`` identifies a lower-dimensional grid ``sd_low`` in
             # ``face_cell_list``, then the respective face-cell mapping is given by:
-            intf = mdg.subdomain_pair_to_interface((gh, gl))
-            face_cell_list[gl_ind] = mdg.interface_data(intf, 'face_cells')
+            intf = mdg.subdomain_pair_to_interface((sd, sd_low))
+            face_cell_list[sd_low] = mdg.interface_data(intf, 'face_cells')
 
     Parameters:
-        sd_primary: The primary, higher-dimensional grid.
-        face_cell_list: A list of face-cell maps, mapping faces in ``sd_primary``
+        sd: The primary, higher-dimensional grid.
+        face_cell_list: A list of face-cell maps, mapping faces in ``sd``
             to cells of intended lower-dimensional grids.
-        faces: Array of indices of faces in ``sd_primary`` affected.
+        faces: Array of indices of faces in ``sd`` affected.
         cells: Array of indices of lower-dimensional cells.
         secondary_ind: Index of which face-cell map in ``face_cell_list`` should be
             treated.
@@ -216,7 +216,7 @@ def split_specific_faces(
         # We first we duplicate faces along tagged faces. The duplicate faces will
         # share the same nodes as the original faces, however, the new faces are not
         # yet added to the cell_faces map (to save computation).
-        face_id = _duplicate_specific_faces(sd_primary, faces)
+        face_id = _duplicate_specific_faces(sd, faces)
 
         # Update the mapping between higher-dimensional faces and lower-dimensional
         # cells.
@@ -232,12 +232,10 @@ def split_specific_faces(
             # In this case, a loop over the elements in face_id should do the job.
             flag_array: list[int] = []
             for fi in face_id:
-                n = np.reshape(sd_primary.face_normals[:, fi], (3, 1))
+                n = np.reshape(sd.face_normals[:, fi], (3, 1))
                 n = n / np.linalg.norm(n)
-                x0 = np.reshape(sd_primary.face_centers[:, fi], (3, 1))
-                this_flag: int = update_cell_connectivity(
-                    sd_primary, np.array([fi]), n, x0
-                )
+                x0 = np.reshape(sd.face_centers[:, fi], (3, 1))
+                this_flag: int = update_cell_connectivity(sd, np.array([fi]), n, x0)
                 flag_array.append(this_flag)
 
             if np.allclose(np.asarray(flag_array), 0):
@@ -250,20 +248,18 @@ def split_specific_faces(
         else:
             # The fracture is considered flat, we can use the same normal vector for
             # all faces. This should make the computations faster
-            n = np.reshape(sd_primary.face_normals[:, face_id[0]], (3, 1))
+            n = np.reshape(sd.face_normals[:, face_id[0]], (3, 1))
             n = n / np.linalg.norm(n)
-            x0 = np.reshape(sd_primary.face_centers[:, face_id[0]], (3, 1))
-            flag = update_cell_connectivity(sd_primary, face_id, n, x0)
+            x0 = np.reshape(sd.face_centers[:, face_id[0]], (3, 1))
+            flag = update_cell_connectivity(sd, face_id, n, x0)
 
         if flag == 0:
             # if flag== 0 we added left and right faces (if it is -1 no faces was
             # added, so we don't have left and right face pairs). we now add the new
             # faces to the frac_pair array.
             left = face_id
-            right = np.arange(sd_primary.num_faces - face_id.size, sd_primary.num_faces)
-            sd_primary.frac_pairs = np.hstack(
-                (sd_primary.frac_pairs, np.vstack((left, right)))
-            )
+            right = np.arange(sd.num_faces - face_id.size, sd.num_faces)
+            sd.frac_pairs = np.hstack((sd.frac_pairs, np.vstack((left, right))))
         return face_cell_list
 
 
@@ -309,11 +305,11 @@ def split_nodes(
     sd_primary.num_nodes = sd_primary.num_nodes + node_count  # - nodes.size
 
 
-def duplicate_faces(sd_primary: pp.Grid, face_cells: np.ndarray) -> np.ndarray:
+def duplicate_faces(sd: pp.Grid, face_cells: np.ndarray) -> np.ndarray:
     """Duplicates all faces that are connected to a lower-dimensional cell.
 
     Parameters:
-        sd_primary: Higher-dimensional grid.
+        sd: (Higher-dimensional) grid.
         face_cells: Connection matrix mapping from the cells of a lower-dim
             grid to the faces of the higher-dimensional grid.
 
@@ -327,14 +323,14 @@ def duplicate_faces(sd_primary: pp.Grid, face_cells: np.ndarray) -> np.ndarray:
     # later anyway.
     frac_id = face_cells.nonzero()[1]
     frac_id = np.unique(frac_id)
-    return _duplicate_specific_faces(sd_primary, frac_id)
+    return _duplicate_specific_faces(sd, frac_id)
 
 
-def _duplicate_specific_faces(sd_primary: pp.Grid, frac_id: np.ndarray) -> np.ndarray:
+def _duplicate_specific_faces(sd: pp.Grid, frac_id: np.ndarray) -> np.ndarray:
     """Duplicate specified faces in a grid.
 
     Parameters:
-        sd_primary: The grid containing the faces.
+        sd: The grid containing the faces.
         frac_id: Indices of fractures, corresponding to the faces which should be
             duplicated.
 
@@ -346,16 +342,16 @@ def _duplicate_specific_faces(sd_primary: pp.Grid, frac_id: np.ndarray) -> np.nd
 
     # Find which of the faces to split are tagged with a standard face tag, that is,
     # as fracture, tip or domain_boundary
-    rem = tags.all_face_tags(sd_primary.tags)[frac_id]
+    rem = tags.all_face_tags(sd.tags)[frac_id]
 
     # Set the faces to be split to fracture faces.
 
     # Q: Why only if the face already had a tag (e.g., why [rem])?. Possible answer:
     # We wil not split them (see redefinition of frac_id below), but want them to be
     # tagged as fracture_faces .
-    sd_primary.tags["fracture_faces"][frac_id[rem]] = True
+    sd.tags["fracture_faces"][frac_id[rem]] = True
     # Faces to be split should not be tip
-    sd_primary.tags["tip_faces"][frac_id] = False
+    sd.tags["tip_faces"][frac_id] = False
 
     # Only consider previously untagged faces for splitting
     frac_id = frac_id[~rem]
@@ -364,56 +360,48 @@ def _duplicate_specific_faces(sd_primary: pp.Grid, frac_id: np.ndarray) -> np.nd
 
     # Expand the face-node relation to include duplicated nodes Do this by directly
     # manipulating the CSC-format of the matrix Nodes of the target faces
-    node_start = sd_primary.face_nodes.indptr[frac_id]
-    node_end = sd_primary.face_nodes.indptr[frac_id + 1]
-    nodes = sd_primary.face_nodes.indices[mcolon(node_start, node_end)]
+    node_start = sd.face_nodes.indptr[frac_id]
+    node_end = sd.face_nodes.indptr[frac_id + 1]
+    nodes = sd.face_nodes.indices[mcolon(node_start, node_end)]
 
     # Start point for the new columns. They will be appended to the matrix, thus the
     # offset of the previous size of gh.face_nodes
-    added_node_pos = np.cumsum(node_end - node_start) + sd_primary.face_nodes.indptr[-1]
+    added_node_pos = np.cumsum(node_end - node_start) + sd.face_nodes.indptr[-1]
     # Sanity checks
     assert added_node_pos.size == frac_id.size
-    assert added_node_pos[-1] - sd_primary.face_nodes.indptr[-1] == nodes.size
+    assert added_node_pos[-1] - sd.face_nodes.indptr[-1] == nodes.size
     # Expand row-data by adding node indices
-    sd_primary.face_nodes.indices = np.hstack((sd_primary.face_nodes.indices, nodes))
+    sd.face_nodes.indices = np.hstack((sd.face_nodes.indices, nodes))
     # Expand column pointers
-    sd_primary.face_nodes.indptr = np.hstack(
-        (sd_primary.face_nodes.indptr, added_node_pos)
-    )
+    sd.face_nodes.indptr = np.hstack((sd.face_nodes.indptr, added_node_pos))
     # Expand data array
-    sd_primary.face_nodes.data = np.hstack(
-        (sd_primary.face_nodes.data, np.ones(nodes.size, dtype=bool))
+    sd.face_nodes.data = np.hstack(
+        (sd.face_nodes.data, np.ones(nodes.size, dtype=bool))
     )
     # Update matrix shape
-    sd_primary.face_nodes._shape = (
-        sd_primary.num_nodes,
-        sd_primary.face_nodes.shape[1] + frac_id.size,
+    sd.face_nodes._shape = (
+        sd.num_nodes,
+        sd.face_nodes.shape[1] + frac_id.size,
     )
-    assert sd_primary.face_nodes.indices.size == sd_primary.face_nodes.indptr[-1]
+    assert sd.face_nodes.indices.size == sd.face_nodes.indptr[-1]
 
     # We also copy the attributes of the original faces.
-    sd_primary.num_faces += frac_id.size
-    sd_primary.face_normals = np.hstack(
-        (sd_primary.face_normals, sd_primary.face_normals[:, frac_id])
-    )
-    sd_primary.face_areas = np.append(
-        sd_primary.face_areas, sd_primary.face_areas[frac_id]
-    )
-    sd_primary.face_centers = np.hstack(
-        (sd_primary.face_centers, sd_primary.face_centers[:, frac_id])
-    )
+    sd.num_faces += frac_id.size
+    sd.face_normals = np.hstack((sd.face_normals, sd.face_normals[:, frac_id]))
+    sd.face_areas = np.append(sd.face_areas, sd.face_areas[frac_id])
+    sd.face_centers = np.hstack((sd.face_centers, sd.face_centers[:, frac_id]))
 
     # Not sure if this still does the correct thing. Might have to send in a logical
     # array instead of frac_id.
-    sd_primary.tags["fracture_faces"][frac_id] = True
-    sd_primary.tags["tip_faces"][frac_id] = False
-    update_fields = sd_primary.tags.keys()
+    sd.tags["fracture_faces"][frac_id] = True
+    sd.tags["tip_faces"][frac_id] = False
+    update_fields = sd.tags.keys()
     update_values: list[list[np.ndarray]] = [[]] * len(update_fields)
     for i, key in enumerate(update_fields):
         # faces related tags are doubled and the value is inherit from the original
         if key.endswith("_faces"):
-            update_values[i] = sd_primary.tags[key][frac_id]
-    tags.append_tags(sd_primary.tags, update_fields, update_values)
+            update_values[i] = sd.tags[key][frac_id]
+    tags.append_tags(sd.tags, update_fields, update_values)
 
     return frac_id
 
@@ -506,7 +494,7 @@ def _update_face_cells(
 
 
 def update_cell_connectivity(
-    g: pp.Grid, face_id: np.ndarray, normal: np.ndarray, x0: np.ndarray
+    sd: pp.Grid, face_id: np.ndarray, normal: np.ndarray, x0: np.ndarray
 ) -> int:
     """After the faces in a grid are duplicated, the cell connectivity list must be
     updated.
@@ -518,7 +506,7 @@ def update_cell_connectivity(
     ``face_id``. The cell on the right side is attached to the face ``frac_id``.
 
     Parameters:
-        g: The grid for which the cell_face mapping is updated.
+        sd: The grid for which the cell_face mapping is updated.
         frac_id: Indices of the faces that have been duplicated.
         normal: Normal of faces that have been duplicated.
             Note that we assume that all faces have the same normal.
@@ -536,22 +524,22 @@ def update_cell_connectivity(
     """
 
     # We find the cells attached to the tagged faces.
-    g.cell_faces = g.cell_faces.tocsr()
-    cell_frac = g.cell_faces[face_id, :]
+    sd.cell_faces = sd.cell_faces.tocsr()
+    cell_frac = sd.cell_faces[face_id, :]
     cell_face_id = np.argwhere(cell_frac)
 
     # We divide the cells into the cells on the right side of the fracture and cells
     # on the left side of the fracture.
     left_cell = pp.half_space.point_inside_half_space_intersection(
-        normal, x0, g.cell_centers[:, cell_face_id[:, 1]]
+        normal, x0, sd.cell_centers[:, cell_face_id[:, 1]]
     )
 
     if np.all(left_cell) or not np.any(left_cell):
         # Fracture is on boundary of domain. There is nothing to do. Remove the extra
         # faces. We have not yet updated cell_faces, so we should not delete anything
         # from this matrix.
-        rem = np.arange(g.cell_faces.shape[0], g.num_faces)
-        remove_faces(g, rem, rem_cell_faces=False)
+        rem = np.arange(sd.cell_faces.shape[0], sd.num_faces)
+        remove_faces(sd, rem, rem_cell_faces=False)
         return -1
 
     # Assume that fracture is either on boundary (above case) or completely inside
@@ -566,10 +554,10 @@ def update_cell_connectivity(
     # mapping during the duplication of faces.
     col = cell_face_id[left_cell, 1]
     row = cell_face_id[left_cell, 0]
-    data = np.ravel(g.cell_faces[np.ravel(face_id[row]), col])
+    data = np.ravel(sd.cell_faces[np.ravel(face_id[row]), col])
     assert data.size == face_id.size
     cell_frac_left = sps.csr_matrix(
-        (data, (row, col)), (face_id.size, g.cell_faces.shape[1])
+        (data, (row, col)), (face_id.size, sd.cell_faces.shape[1])
     )
 
     # We now update the cell_faces map of the faces on the right side of the
@@ -577,57 +565,57 @@ def update_cell_connectivity(
     # remove their connection to the cells on the left side of the fracture.
     col = cell_face_id[~left_cell, 1]
     row = cell_face_id[~left_cell, 0]
-    data = np.ravel(g.cell_faces[np.ravel(face_id[row]), col])
+    data = np.ravel(sd.cell_faces[np.ravel(face_id[row]), col])
     cell_frac_right = sps.csr_matrix(
-        (data, (row, col)), (face_id.size, g.cell_faces.shape[1])
+        (data, (row, col)), (face_id.size, sd.cell_faces.shape[1])
     )
 
-    assert g.cell_faces.getformat() == "csr"
+    assert sd.cell_faces.getformat() == "csr"
 
     pp.matrix_operations.merge_matrices(
-        g.cell_faces, cell_frac_right, face_id, matrix_format="csr"
+        sd.cell_faces, cell_frac_right, face_id, matrix_format="csr"
     )
 
     # And then we add the new left-faces to the cell_face map. We do not change the
     # sign of the matrix since we did not flip the normals. This means that the
     # normals of right and left cells point in the same direction, but their
     # cell_faces values have oposite signs.
-    pp.matrix_operations.stack_mat(g.cell_faces, cell_frac_left)
-    g.cell_faces = g.cell_faces.tocsc()
+    pp.matrix_operations.stack_mat(sd.cell_faces, cell_frac_left)
+    sd.cell_faces = sd.cell_faces.tocsc()
 
     return 0
 
 
-def remove_faces(g: pp.Grid, face_id: np.ndarray, rem_cell_faces: bool = True) -> None:
+def remove_faces(sd: pp.Grid, face_id: np.ndarray, rem_cell_faces: bool = True) -> None:
     """Remove faces from grid.
 
     Parameters:
-        g: A grid.
+        sd: A grid.
         face_id: ``dtype=int``
 
             Indices of faces to be remove.
         rem_cell_faces: ``default=True``
 
-            If set to False, the ``cell_faces`` matrix of ``g`` is not changed.
+            If set to False, the ``cell_faces`` matrix of ``sd`` is not changed.
 
     """
     # update face info
-    keep = np.array([True] * g.num_faces)
+    keep = np.array([True] * sd.num_faces)
     keep[face_id] = False
-    g.face_nodes = g.face_nodes[:, keep]
-    g.num_faces -= face_id.size
-    g.face_normals = g.face_normals[:, keep]
-    g.face_areas = g.face_areas[keep]
-    g.face_centers = g.face_centers[:, keep]
+    sd.face_nodes = sd.face_nodes[:, keep]
+    sd.num_faces -= face_id.size
+    sd.face_normals = sd.face_normals[:, keep]
+    sd.face_areas = sd.face_areas[keep]
+    sd.face_centers = sd.face_centers[:, keep]
     # Not sure if still works
     for key in tags.standard_face_tags():
-        g.tags[key] = g.tags[key][keep]
+        sd.tags[key] = sd.tags[key][keep]
 
     if rem_cell_faces:
-        g.cell_faces = g.cell_faces[keep, :]
+        sd.cell_faces = sd.cell_faces[keep, :]
 
 
-def duplicate_nodes(g: pp.Grid, nodes: np.ndarray, offset: float) -> int:
+def duplicate_nodes(sd: pp.Grid, nodes: np.ndarray, offset: float) -> int:
     """Duplicate nodes on a fracture.
 
     The number of duplication will depend on the cell topology around the node.
@@ -640,7 +628,7 @@ def duplicate_nodes(g: pp.Grid, nodes: np.ndarray, offset: float) -> int:
     Equivalently for other types of intersections.
 
     Parameters:
-        g: The grid for which the nodes are duplicated.
+        sd: The grid for which the nodes are duplicated.
         nodes: The nodes to be duplicated.
         offset: A number defining how far from the original node the duplications should
             be placed.
@@ -654,7 +642,7 @@ def duplicate_nodes(g: pp.Grid, nodes: np.ndarray, offset: float) -> int:
     # In the case of a non-zero offset (presumably intended for visualization),
     # use a (somewhat slow) legacy implementation which can handle this.
     if offset != 0:
-        return _duplicate_nodes_with_offset(g, nodes, offset)
+        return _duplicate_nodes_with_offset(sd, nodes, offset)
 
     # Nodes must be duplicated in the array of node coordinates. Moreover,
     # the face-node relation must be updated so that when a node is split in two or
@@ -673,9 +661,9 @@ def duplicate_nodes(g: pp.Grid, nodes: np.ndarray, offset: float) -> int:
     # 4. Duplicate split nodes in the coordinate array.
 
     # Bookkeeping etc.
-    cell_node = g.cell_nodes().tocsr()
-    face_node = g.face_nodes.tocsc()
-    cell_face = g.cell_faces
+    cell_node = sd.cell_nodes().tocsr()
+    face_node = sd.face_nodes.tocsc()
+    cell_face = sd.cell_faces
 
     num_nodes_to_duplicate = nodes.size
 
@@ -696,7 +684,7 @@ def duplicate_nodes(g: pp.Grid, nodes: np.ndarray, offset: float) -> int:
     rows_cell_map = np.hstack(cell_clusters)
     cell_map = sps.coo_matrix(
         (np.ones(tot_sz), (rows_cell_map, np.arange(tot_sz))),
-        shape=(g.num_cells, tot_sz),
+        shape=(sd.num_cells, tot_sz),
     ).tocsc()
 
     # Connection map between cells, limited to the cells included in the clusters.
@@ -834,7 +822,7 @@ def duplicate_nodes(g: pp.Grid, nodes: np.ndarray, offset: float) -> int:
         loc_cells = rows_cell_map[comp]
         # Faces of these cells
         loc_faces = np.unique(
-            pp.matrix_operations.slice_indices(g.cell_faces, loc_cells)  # type: ignore
+            pp.matrix_operations.slice_indices(sd.cell_faces, loc_cells)  # type: ignore
         )
         # Nodes of the faces, and indices in the sparse storage format where the
         # nodes are located.
@@ -852,7 +840,7 @@ def duplicate_nodes(g: pp.Grid, nodes: np.ndarray, offset: float) -> int:
 
     # Count the number of repetitions in the nodes: The unsplit nodes have 1,
     # the split depends on the number of identified subclusters
-    repetitions = np.ones(g.num_nodes, dtype=np.int32)
+    repetitions = np.ones(sd.num_nodes, dtype=np.int32)
     repetitions[nodes] = np.bincount(node_of_component)
     # The number of added nodes
     added = repetitions - 1
@@ -871,7 +859,7 @@ def duplicate_nodes(g: pp.Grid, nodes: np.ndarray, offset: float) -> int:
     face_node.indptr = face_node.indptr.astype(np.int32)
 
     # Adjust the shape of face-nodes to account for the added nodes
-    face_node._shape = (g.num_nodes + num_added, g.num_faces)
+    face_node._shape = (sd.num_nodes + num_added, sd.num_faces)
 
     # From the number of repetitions of the node (1 for untouched nodes), get mapping
     # from new to old indices. To see how this works, read the documentation of
@@ -879,21 +867,21 @@ def duplicate_nodes(g: pp.Grid, nodes: np.ndarray, offset: float) -> int:
     new_2_old_nodes = pp.matrix_operations.rldecode(
         np.arange(repetitions.size), repetitions
     )
-    g.nodes = g.nodes[:, new_2_old_nodes]
+    sd.nodes = sd.nodes[:, new_2_old_nodes]
     # The global point ind is shared by all split nodes
-    g.global_point_ind = g.global_point_ind[new_2_old_nodes]
+    sd.global_point_ind = sd.global_point_ind[new_2_old_nodes]
 
     # Also map the tags for nodes that are on fracture tips if this is relevant (that
     # is, if the grid is of the highest dimension)
     keys = ["node_is_fracture_tip", "node_is_tip_of_some_fracture"]
     for key in keys:
-        if hasattr(g, "tags") and key in g.tags:
-            g.tags[key] = g.tags[key][new_2_old_nodes].astype(bool)
+        if hasattr(sd, "tags") and key in sd.tags:
+            sd.tags[key] = sd.tags[key][new_2_old_nodes].astype(bool)
 
     return num_added
 
 
-def _duplicate_nodes_with_offset(g: pp.Grid, nodes: np.ndarray, offset: float) -> int:
+def _duplicate_nodes_with_offset(sd: pp.Grid, nodes: np.ndarray, offset: float) -> int:
     """Duplicate nodes on a fracture, and perturb the duplicated nodes.
 
     This option is useful for visualization purposes.
@@ -905,7 +893,7 @@ def _duplicate_nodes_with_offset(g: pp.Grid, nodes: np.ndarray, offset: float) -
         perturbation is requested.
 
     Parameters:
-        g: The grid for which the nodes are duplicated.
+        sd: The grid for which the nodes are duplicated.
         nodes: The nodes to be duplicated.
         offset: A number defining how far from the original node the duplications should
             be placed.
@@ -921,13 +909,13 @@ def _duplicate_nodes_with_offset(g: pp.Grid, nodes: np.ndarray, offset: float) -
     # order when we convert back. We therefore find the inverse sorting of the nodes
     # of each face. After we have performed the row operations we will map the nodes
     # back to their original position.
-    _, iv = _sort_sub_list(g.face_nodes.indices, g.face_nodes.indptr)
+    _, iv = _sort_sub_list(sd.face_nodes.indices, sd.face_nodes.indptr)
 
-    g.face_nodes = g.face_nodes.tocsr()
+    sd.face_nodes = sd.face_nodes.tocsr()
     # Iterate over each internal node and split it according to the graph. For each
     # cell attached to the node, we check wich color the cell has. All cells with the
     # same color is then attached to a new copy of the node.
-    cell_nodes = g.cell_nodes().tocsr()
+    cell_nodes = sd.cell_nodes().tocsr()
 
     for node in nodes:
         # t_node takes into account the added nodes.
@@ -948,24 +936,26 @@ def _duplicate_nodes_with_offset(g: pp.Grid, nodes: np.ndarray, offset: float) -
         # fracture will have the same color, but a different color than the cells on
         # the other side of the fracture. Equivalently, the cells at a X-intersection
         # will be given four different colors
-        colors = _find_cell_color(g, cells)
+        colors = _find_cell_color(sd, cells)
         # Find which cells share the same color
         colors, ix = np.unique(colors, return_inverse=True)
 
         # copy coordinate of old node
-        new_nodes = np.repeat(g.nodes[:, t_node, None], colors.size, axis=1)
+        new_nodes = np.repeat(sd.nodes[:, t_node, None], colors.size, axis=1)
         faces = np.array([], dtype=int)
-        face_pos = np.array([g.face_nodes.indptr[t_node]])
-        assert g.cell_faces.getformat() == "csc"
-        assert g.face_nodes.getformat() == "csr"
+        face_pos = np.array([sd.face_nodes.indptr[t_node]])
+        assert sd.cell_faces.getformat() == "csc"
+        assert sd.face_nodes.getformat() == "csr"
 
-        faces_of_node_t = pp.matrix_operations.slice_indices(g.face_nodes, t_node)
+        faces_of_node_t = pp.matrix_operations.slice_indices(sd.face_nodes, t_node)
         assert isinstance(faces_of_node_t, np.ndarray)  # Appease mypy
 
         for j in range(colors.size):
             # For each color we wish to add one node. First we find all faces that
             # are connected to the fracture node, and have the correct cell color
-            all_faces = pp.matrix_operations.slice_indices(g.cell_faces, cells[ix == j])
+            all_faces = pp.matrix_operations.slice_indices(
+                sd.cell_faces, cells[ix == j]
+            )
             assert isinstance(all_faces, np.ndarray)  # Appease mypy
             colored_faces = np.unique(all_faces)
 
@@ -979,33 +969,38 @@ def _duplicate_nodes_with_offset(g: pp.Grid, nodes: np.ndarray, offset: float) -
             # If an offset is given, we will change the position of the nodes. We
             # move the nodes a length of offset away from the fracture(s).
             if offset > 0 and colors.size > 1:
-                new_nodes[:, j] -= _avg_normal(g, faces_of_node_t[is_colored]) * offset
+                new_nodes[:, j] -= _avg_normal(sd, faces_of_node_t[is_colored]) * offset
 
                 # The total number of faces should not have changed, only their
         # connection to nodes. We can therefore just update the indices and
         # indptr map.
-        g.face_nodes.indices[face_pos[0] : face_pos[-1]] = faces
+        sd.face_nodes.indices[face_pos[0] : face_pos[-1]] = faces
         node_count += colors.size - 1
-        g.face_nodes.indptr = np.insert(g.face_nodes.indptr, t_node + 1, face_pos[1:-1])
-        g.face_nodes._shape = (
-            g.face_nodes.shape[0] + colors.size - 1,
-            g.face_nodes._shape[1],
+        sd.face_nodes.indptr = np.insert(
+            sd.face_nodes.indptr, t_node + 1, face_pos[1:-1]
+        )
+        sd.face_nodes._shape = (
+            sd.face_nodes.shape[0] + colors.size - 1,
+            sd.face_nodes._shape[1],
         )
         # We delete the old node because of the offset. If we do not have an offset
         # we could keep it and add one less node.
 
-        g.nodes = np.delete(g.nodes, t_node, axis=1)
-        g.nodes = np.insert(g.nodes, [t_node] * new_nodes.shape[1], new_nodes, axis=1)
+        sd.nodes = np.delete(sd.nodes, t_node, axis=1)
+        sd.nodes = np.insert(sd.nodes, [t_node] * new_nodes.shape[1], new_nodes, axis=1)
 
-        new_point_ind = np.array([g.global_point_ind[t_node]] * new_nodes.shape[1])
-        g.global_point_ind = np.delete(g.global_point_ind, t_node)
-        g.global_point_ind = np.insert(
-            g.global_point_ind, [t_node] * new_point_ind.shape[0], new_point_ind, axis=0
+        new_point_ind = np.array([sd.global_point_ind[t_node]] * new_nodes.shape[1])
+        sd.global_point_ind = np.delete(sd.global_point_ind, t_node)
+        sd.global_point_ind = np.insert(
+            sd.global_point_ind,
+            [t_node] * new_point_ind.shape[0],
+            new_point_ind,
+            axis=0,
         )
 
     # Transform back to csc format and fix node ordering.
-    g.face_nodes = g.face_nodes.tocsc()
-    g.face_nodes.indices = g.face_nodes.indices[iv]  # For fast row operation
+    sd.face_nodes = sd.face_nodes.tocsc()
+    sd.face_nodes.indices = sd.face_nodes.indices[iv]  # For fast row operation
 
     return node_count
 
@@ -1048,7 +1043,7 @@ def _sort_sub_list(
     return indices, iv
 
 
-def _find_cell_color(g: pp.Grid, cells: np.ndarray) -> np.ndarray:
+def _find_cell_color(sd: pp.Grid, cells: np.ndarray) -> np.ndarray:
     r"""Color the cells depending on the cell connections.
 
     Each group of cells that are connected (either directly by a shared face or
@@ -1079,9 +1074,9 @@ def _find_cell_color(g: pp.Grid, cells: np.ndarray) -> np.ndarray:
     """
     c = np.sort(cells)
     # Local cell-face and face-node maps.
-    assert g.cell_faces.getformat() == "csc"
-    cell_faces = pp.matrix_operations.slice_mat(g.cell_faces, c)
-    child_cell_ind = -np.ones(g.num_cells, dtype=int)
+    assert sd.cell_faces.getformat() == "csc"
+    cell_faces = pp.matrix_operations.slice_mat(sd.cell_faces, c)
+    child_cell_ind = -np.ones(sd.num_cells, dtype=int)
     child_cell_ind[c] = np.arange(cell_faces.shape[1])
 
     # Create a copy of the cell-face relation, so that we can modify it at will.
@@ -1101,7 +1096,7 @@ def _find_cell_color(g: pp.Grid, cells: np.ndarray) -> np.ndarray:
     return graph.color[child_cell_ind[cells]]
 
 
-def _avg_normal(g: pp.Grid, faces: np.ndarray) -> np.ndarray:
+def _avg_normal(sd: pp.Grid, faces: np.ndarray) -> np.ndarray:
     """Calculates the average face normal of a set of faces.
 
     The average normal is only constructed from the boundary faces, i.e. faces that
@@ -1109,7 +1104,7 @@ def _avg_normal(g: pp.Grid, faces: np.ndarray) -> np.ndarray:
     The faces normals are flipped such that they point out of the cells.
 
     Parameters:
-        g: A grid constituted of the faces.
+        sd: A grid constituted of the faces.
         faces: ``dtype=int``
 
             An array of indices of faces for which the normals should be averaged.
@@ -1118,28 +1113,28 @@ def _avg_normal(g: pp.Grid, faces: np.ndarray) -> np.ndarray:
         The averaged face normal as an array.
 
     """
-    frac_face = np.ravel(np.sum(np.abs(g.cell_faces[faces, :]), axis=1) == 1)
-    f, _, sign = sparse_array_to_row_col_data(g.cell_faces[faces[frac_face], :])
-    n = g.face_normals[:, faces[frac_face]]
+    frac_face = np.ravel(np.sum(np.abs(sd.cell_faces[faces, :]), axis=1) == 1)
+    f, _, sign = sparse_array_to_row_col_data(sd.cell_faces[faces[frac_face], :])
+    n = sd.face_normals[:, faces[frac_face]]
     n = n[:, f] * sign
     n = np.mean(n, axis=1)
     n = n / np.linalg.norm(n)
     return n
 
 
-def remove_nodes(g: pp.Grid, rem: np.ndarray) -> pp.Grid:
+def remove_nodes(sd: pp.Grid, rem: np.ndarray) -> pp.Grid:
     """Removes nodes from a grid.
 
     Parameters:
-        g: A grid inside which nodes should be removed
+        sd: A grid inside which nodes should be removed
         rem: An array of indices of nodes to be removed.
 
     Returns:
         The grid with modified nodes and face-node mapping.
 
     """
-    all_rows = np.arange(g.face_nodes.shape[0])
+    all_rows = np.arange(sd.face_nodes.shape[0])
     rows_to_keep = np.where(np.logical_not(np.isin(all_rows, rem)))[0]
-    g.face_nodes = g.face_nodes[rows_to_keep, :]
-    g.nodes = g.nodes[:, rows_to_keep]
-    return g
+    sd.face_nodes = sd.face_nodes[rows_to_keep, :]
+    sd.nodes = sd.nodes[:, rows_to_keep]
+    return sd

--- a/src/porepy/fracs/split_grid.py
+++ b/src/porepy/fracs/split_grid.py
@@ -90,15 +90,15 @@ def split_fractures(
         # cells. At a X-intersection we split the node into four, while at the
         # fracture boundary it is not split.
 
-        secondary_2_primary_nodes = []
+        secondary_to_primary_nodes = []
         for sd in low_dim_neigh:
             # Enforce 64 bit to comply with ismember_rows. Was np.int32
             source = np.atleast_2d(sd.global_point_ind).astype(np.int64)
             target = np.atleast_2d(sd_primary.global_point_ind).astype(np.int64)
             _, mapping = setmembership.ismember_rows(source, target)
-            secondary_2_primary_nodes.append(mapping)
+            secondary_to_primary_nodes.append(mapping)
 
-        split_nodes(sd_primary, low_dim_neigh, secondary_2_primary_nodes, offset)
+        split_nodes(sd_primary, low_dim_neigh, secondary_to_primary_nodes, offset)
 
     # Remove zeros from cell_faces
 

--- a/src/porepy/fracs/tools.py
+++ b/src/porepy/fracs/tools.py
@@ -335,13 +335,13 @@ def determine_mesh_size(
 
 
 def obtain_interdim_mappings(
-    lg: pp.Grid, fn: sps.spmatrix, n_per_face: int
+    g: pp.Grid, fn: sps.spmatrix, n_per_face: int
 ) -> tuple[np.ndarray, np.ndarray]:
     """Finds mappings between faces in higher dimension and cells in the lower
     dimension.
 
     Parameters:
-        lg: Lower dimensional grid.
+        g: Lower dimensional grid.
         fn: Face-node map of the higher-dimensional grid
             (see :data:`~porepy.grids.grid.Grid.face_nodes`).
         n_per_face: Number of nodes per face in the higher-dimensional grid.
@@ -357,12 +357,12 @@ def obtain_interdim_mappings(
             Indices of the corresponding cells in the lower-dimensional grid.
 
     """
-    if lg.dim > 0:
-        cn_loc = lg.cell_nodes().indices.reshape((n_per_face, lg.num_cells), order="F")
-        cn = lg.global_point_ind[cn_loc]
+    if g.dim > 0:
+        cn_loc = g.cell_nodes().indices.reshape((n_per_face, g.num_cells), order="F")
+        cn = g.global_point_ind[cn_loc]
         cn = np.sort(cn, axis=0)
     else:
-        cn = np.array([lg.global_point_ind])
+        cn = np.array([g.global_point_ind])
         # We also know that the higher-dimensional grid has faces of a single node.
         # This sometimes fails, so enforce it.
         if cn.ndim == 1:

--- a/src/porepy/grids/coarsening.py
+++ b/src/porepy/grids/coarsening.py
@@ -19,7 +19,7 @@ from porepy.utils import accumarray, grid_utils, mcolon, setmembership, tags
 
 
 def coarsen(
-    g: Union[pp.Grid, pp.MixedDimensionalGrid], method: str, **method_kwargs
+    grid: Union[pp.Grid, pp.MixedDimensionalGrid], method: str, **method_kwargs
 ) -> None:
     """Create a coarse grid from a given grid.
 
@@ -31,7 +31,7 @@ def coarsen(
         - Do not call :meth:`~porepy.grids.grid.Grid.compute_geometry` afterwards.
 
     Parameters:
-        g: The grid or mixed-dimensional grid to be coarsened.
+        grid: The grid or mixed-dimensional grid to be coarsened.
         method: A string defining the coarsening method.
 
             The available options are:
@@ -57,23 +57,23 @@ def coarsen(
     warnings.warn(msg, DeprecationWarning)
 
     if method.lower() == "by_volume":
-        partition = create_aggregations(g, **method_kwargs)
+        partition = create_aggregations(grid, **method_kwargs)
 
     elif method.lower() == "by_tpfa":
         seeds = np.empty(0, dtype=int)
         if method_kwargs.get("if_seeds", False):
-            seeds = generate_seeds(g)
-        matrix = _tpfa_matrix(g)
-        partition = create_partition(matrix, g, seeds=seeds, **method_kwargs)  # type: ignore
+            seeds = generate_seeds(grid)
+        matrix = _tpfa_matrix(grid)
+        partition = create_partition(matrix, grid, seeds=seeds, **method_kwargs)  # type: ignore
 
     else:
         raise ValueError(f"Undefined method `{method}` for coarsening algorithm.")
 
-    generate_coarse_grid(g, partition)  # type: ignore
+    generate_coarse_grid(grid, partition)  # type: ignore
 
 
 def generate_coarse_grid(
-    g: Union[pp.Grid, pp.MixedDimensionalGrid],
+    grid: Union[pp.Grid, pp.MixedDimensionalGrid],
     subdiv: Union[np.ndarray, dict[pp.Grid, tuple[Any, np.ndarray]]],
 ) -> None:
     """Generates a coarse grid by clustering the cells according to the flags
@@ -83,7 +83,7 @@ def generate_coarse_grid(
     integers (possibly not continuous) which represent the cell IDs in the final,
     coarser mesh. I.e. it is a cell map from finer to coarser.
 
-    If ``g`` is a mixed-dimensional grid, the coarsening is applied to the higher
+    If ``grid`` is a mixed-dimensional grid, the coarsening is applied to the higher
     dimensional grid.
 
     Warning:
@@ -96,32 +96,32 @@ def generate_coarse_grid(
 
     Example:
 
-        >>> g = ...  # some grid with 12 cells
+        >>> grid = ...  # some grid with 12 cells
         >>> subdiv = np.array([0,0,1,1,2,2,3,3,4,4,5,5])  # coarser grid with 6 cells
-        >>> generate_coarse_grid(g, subdiv)
+        >>> generate_coarse_grid(grid, subdiv)
 
     Parameters:
-        g: A grid or mixed-dimensional grid.
-        subdiv: If ``g`` is a single grid, a single array-like object as in above
+        grid: A grid or mixed-dimensional grid.
+        subdiv: If ``grid`` is a single grid, a single array-like object as in above
             example suffices.
 
-            If ``g`` is a mixed-dimensional grid, a dictionary containing per grid (key)
-            a 2-tuple, where the second entry is the partition map as seen above.
+            If ``grid`` is a mixed-dimensional grid, a dictionary containing per grid
+            (key) a 2-tuple, where the second entry is the partition map as seen above.
             This special structure is passed by :func:`coarsen`.
 
     """
     msg = "This functionality is deprecated and will be removed in a future version"
     warnings.warn(msg, DeprecationWarning)
 
-    if isinstance(g, grid.Grid):
+    if isinstance(grid, pp.Grid):
         if isinstance(subdiv, dict):
-            # If the subdiv is a dictionary with g as a key (this can happen if we are
+            # If the subdiv is a dictionary with grid as a key (this can happen if we are
             # forwarded here from coarsen), the input must be simplified.
-            subdiv = subdiv[g][1]
-        _generate_coarse_grid_single(g, subdiv, False)
+            subdiv = subdiv[grid][1]
+        _generate_coarse_grid_single(grid, subdiv, False)
 
-    if isinstance(g, pp.MixedDimensionalGrid):
-        _generate_coarse_grid_mdg(g, subdiv)
+    if isinstance(grid, pp.MixedDimensionalGrid):
+        _generate_coarse_grid_mdg(grid, subdiv)
 
 
 def reorder_partition(

--- a/src/porepy/grids/grid.py
+++ b/src/porepy/grids/grid.py
@@ -206,7 +206,7 @@ class Grid:
 
         # Add tag for the boundary faces
         self.tags: dict[str, Any]
-        """Tags allow to mark subdomains of interest.
+        """Tags allow to mark grid entities of interest.
 
         The default tags are used to mark faces or nodes as fracture, tips and domain
         boundaries.

--- a/src/porepy/grids/md_grid.py
+++ b/src/porepy/grids/md_grid.py
@@ -698,7 +698,7 @@ class MixedDimensionalGrid:
     def replace_subdomains_and_interfaces(
         self,
         sd_map: Optional[dict[pp.Grid, pp.Grid]] = None,
-        intf_map: Optional[
+        interface_map: Optional[
             dict[
                 pp.MortarGrid,
                 Union[pp.MortarGrid, dict[mortar_grid.MortarSides, pp.Grid]],
@@ -713,7 +713,7 @@ class MixedDimensionalGrid:
 
                 Mapping between the old and new grids. Keys are the old
                 grids, and values are the new grids.
-            intf_map: ``default=None``
+            interface_map: ``default=None``
 
                 Mapping between the old mortar grid and new (side grids of the) mortar
                 grid. Keys are the old mortar grids, and values are dictionaries with
@@ -738,8 +738,8 @@ class MixedDimensionalGrid:
         # projections will be updated twice.
 
         # refine the mortar grids when specified
-        if intf_map is not None:
-            for intf_old, intf_new in intf_map.items():
+        if interface_map is not None:
+            for intf_old, intf_new in interface_map.items():
                 # Update the mortar grid. The update_mortar function in class MortarGrid
                 # performs the update in place, thus the mortar grid will not be
                 # modified in the mixed-dimensional grid itself (thus no changes to

--- a/src/porepy/numerics/ad/_ad_utils.py
+++ b/src/porepy/numerics/ad/_ad_utils.py
@@ -275,19 +275,19 @@ def discretize_from_list(
         # discr is a discretization (on node or interface in the MixedDimensionalGrid sense)
 
         # Loop over all subdomains (or MixedDimensionalGrid edges), do discretization.
-        for g in discretizations[discr]:
-            if isinstance(g, pp.MortarGrid):
-                data = mdg.interface_data(g)  # type:ignore
-                g_primary, g_secondary = mdg.interface_to_subdomain_pair(g)
+        for grid in discretizations[discr]:
+            if isinstance(grid, pp.MortarGrid):
+                data = mdg.interface_data(grid)  # type:ignore
+                g_primary, g_secondary = mdg.interface_to_subdomain_pair(grid)
                 d_primary = mdg.subdomain_data(g_primary)
                 d_secondary = mdg.subdomain_data(g_secondary)
                 discr.discretize(
-                    g_primary, g_secondary, g, d_primary, d_secondary, data
+                    g_primary, g_secondary, grid, d_primary, d_secondary, data
                 )
             else:
-                data = mdg.subdomain_data(g)
+                data = mdg.subdomain_data(grid)
                 try:
-                    discr.discretize(g, data)
+                    discr.discretize(grid, data)
                 except NotImplementedError:
                     # This will likely be GradP and other Biot discretizations
                     pass
@@ -602,12 +602,12 @@ class MergedOperator(operators.Operator):
 
         # Loop over all grid-discretization combinations, get hold of the discretization
         # matrix for this grid quantity.
-        for g in self.domains:
+        for grid in self.domains:
             # Get data dictionary for either grid or interface
-            if isinstance(g, pp.MortarGrid):
-                data = mdg.interface_data(g)
-            elif isinstance(g, pp.Grid):
-                data = mdg.subdomain_data(g)
+            if isinstance(grid, pp.MortarGrid):
+                data = mdg.interface_data(grid)
+            elif isinstance(grid, pp.Grid):
+                data = mdg.subdomain_data(grid)
             else:
                 s = "Did not expect a discretization defined on a BoundaryGrid."
                 raise ValueError(s)

--- a/src/porepy/numerics/ad/equation_system.py
+++ b/src/porepy/numerics/ad/equation_system.py
@@ -245,7 +245,8 @@ class EquationSystem:
         equations = list(self._parse_equations(equation_names).keys())
         variables = self._parse_variable_type(variable_names)
 
-        # Check that the requested equations and variables are known to the system.
+        # Check that the requested equations and variables are known to the equation
+        # system.
         known_equations = set(self._equations.keys())
         unknown_equations = set(equations).difference(known_equations)
         if len(unknown_equations) > 0:
@@ -254,7 +255,7 @@ class EquationSystem:
         if len(unknown_variables) > 0:
             raise ValueError(f"Unknown variable(s) {unknown_variables}.")
 
-        # Create the new subsystem.
+        # Create the new equation system.
         new_equation_system = EquationSystem(self.mdg)
 
         # IMPLEMENTATION NOTE: This method imitates the variable creation and equation
@@ -264,15 +265,15 @@ class EquationSystem:
         # Loop over known variables to preserve DOF order.
         for variable in self.variables:
             if variable in variables:
-                # Update variables in subsystem.
+                # Update variables.
                 new_equation_system._variables[variable.id] = variable
 
-                # Update variable numbers in subsystem.
+                # Update variable numbers.
                 new_equation_system._variable_dof_type[variable.id] = (
                     self._variable_dof_type[variable.id]
                 )
 
-                # Create dofs in subsystem.
+                # Create DOFs.
                 new_equation_system._append_dofs(variable)
 
         new_equation_system._cluster_dofs_gridwise()
@@ -294,7 +295,7 @@ class EquationSystem:
     @property
     def equations(self) -> dict[str, Operator]:
         """Dictionary containing names of operators (keys) and operators (values), which
-        have been set as equations in this system.
+        have been set as equations in this EquationSystem.
 
         """
         return self._equations
@@ -318,13 +319,13 @@ class EquationSystem:
     ### Variable management ------------------------------------------------------------
 
     def md_variable(
-        self, name: str, grids: Optional[DomainList] = None
+        self, name: str, domains: Optional[DomainList] = None
     ) -> MixedDimensionalVariable:
         """Create a mixed-dimensional variable for a given name-domain list combination.
 
         Parameters:
             name (str): Name of the mixed-dimensional variable.
-            grids (optional): List of grids where the variable is defined. If None
+            domains (optional): List of grids where the variable is defined. If None
                 (default), all grids where the variable is defined are used.
 
         Returns:
@@ -332,10 +333,10 @@ class EquationSystem:
 
         Raises:
             ValueError: If variables name exist on both grids and interfaces and domain
-                type is not specified (grids is None).
+                type is not specified (domains is None).
 
         """
-        if grids is None:
+        if domains is None:
             variables = [var for var in self.variables if var.name == name]
             # We don't allow combinations of variables with different domain types
             # in a md variable.
@@ -358,7 +359,7 @@ class EquationSystem:
             variables = [
                 var
                 for var in self.variables
-                if var.name == name and var.domain in grids
+                if var.name == name and var.domain in domains
             ]
         return MixedDimensionalVariable(variables)
 
@@ -381,7 +382,8 @@ class EquationSystem:
 
             .. code:: Python
 
-                p = ad_system.create_variables('pressure', subdomains=mdg.subdomains())
+                p = equation_system.create_variables('pressure',
+                                                     subdomains=mdg.subdomains())
 
         Parameters:
             name: Name of the variable.
@@ -537,12 +539,12 @@ class EquationSystem:
         """Filter variables based on grid, tag name and tag value.
 
         Particular usage: calling without arguments will return all variables in the
-        system.
+        EquationSystem.
 
         Parameters:
-            variables: List of variables to filter. If None, all variables in the system
-                are included. Variables can be given as a list of variables, mixed-
-                dimensional variables, or variable names (strings).
+            variables: List of variables to filter. If None, all variables in the
+                EquationSystem are included. Variables can be given as a list of
+                variables, mixed- dimensional variables, or variable names (strings).
             grids: List of grids to filter on. If None, all grids are included.
             tag_name: Name of the tag to filter on. If None, no filtering on tags.
             tag_value: Value of the tag to filter on. If None, no filtering on tag
@@ -733,7 +735,7 @@ class EquationSystem:
             variables: ``default=None``
 
                 VariableType input for which the values should be shifted in time.
-                If None, all variables created by this system will be shifted.
+                If None, all variables created by this EquationSystem will be shifted.
             max_index: ``default=None``
 
                 A positive integer, capping the range of the shift operation to
@@ -1528,11 +1530,11 @@ class EquationSystem:
         included will simply be sliced out.
 
         Note:
-            The ordering of columns in the returned system are defined by the global DOF
-            order. The row blocks are in the same order as equations were added to this
-            system. If an equation is defined on multiple grids, the respective
-            row-block is internally ordered as given by the mixed-dimensional grid (for
-            sd in subdomains, for intf in interfaces).
+            The ordering of columns in the returned EquationSystem are defined by the
+            global DOF order. The row blocks are in the same order as equations were
+            added to this EquationSystem. If an equation is defined on multiple grids,
+            the respective row-block is internally ordered as given by the
+            mixed-dimensional grid (for sd in subdomains, for intf in interfaces).
 
             The columns of the subsystem are assumed to be properly defined by
             ``variables``, otherwise a matrix of shape ``(M,)`` is returned. This

--- a/src/porepy/numerics/ad/grid_operators.py
+++ b/src/porepy/numerics/ad/grid_operators.py
@@ -74,8 +74,8 @@ class SubdomainProjections:
 
         # Store total number of faces and cells in the list of subdomains. This will be
         # needed to handle projections to and from empty lists (see usage below).
-        self._tot_num_cells: int = sum([g.num_cells for g in subdomains])
-        self._tot_num_faces: int = sum([g.num_faces for g in subdomains])
+        self._tot_num_cells: int = sum([sd.num_cells for sd in subdomains])
+        self._tot_num_faces: int = sum([sd.num_faces for sd in subdomains])
 
         # Initialize storage for the projection matrices. These will be constructed
         # lazily, when the projection is requested, and then stored for later use.
@@ -107,7 +107,9 @@ class SubdomainProjections:
             # A key error will be raised if a grid in g is not known to
             # self._cell_projection. Use csr format, since the number of rows can be
             # much smaller than the number of columns.
-            mat = sps.bmat([[self._cell_projections[g].T] for g in subdomains]).tocsr()
+            mat = sps.bmat(
+                [[self._cell_projections[sd].T] for sd in subdomains]
+            ).tocsr()
         else:
             # If the grid list is empty, we project from the full set of cells to
             # nothing.
@@ -140,7 +142,7 @@ class SubdomainProjections:
             # A key error will be raised if a grid in g is not known to
             # self._cell_projection.  Use csc format, since the number of columns can be
             # much smaller than the number of rows.
-            mat = sps.bmat([[self._cell_projections[g] for g in subdomains]]).tocsc()
+            mat = sps.bmat([[self._cell_projections[sd] for sd in subdomains]]).tocsc()
         else:
             # If the grid list is empty, we project from nothing to the full set of
             # cells.
@@ -173,7 +175,9 @@ class SubdomainProjections:
             # A key error will be raised if a grid in subdomains is not known to
             # self._face_projection. Use csr format, since the number of rows can be
             # much smaller than the number of columns.
-            mat = sps.bmat([[self._face_projections[g].T] for g in subdomains]).tocsr()
+            mat = sps.bmat(
+                [[self._face_projections[sd].T] for sd in subdomains]
+            ).tocsr()
         else:
             # If the grid list is empty, we project from the full set of faces to
             # nothing.
@@ -205,7 +209,7 @@ class SubdomainProjections:
             # A key error will be raised if a grid in subdomains is not known to
             # self._face_projection. Use csc format, since the number of columns can be
             # far smaller than the number of rows.
-            mat = sps.bmat([[self._face_projections[g] for g in subdomains]]).tocsc()
+            mat = sps.bmat([[self._face_projections[sd] for sd in subdomains]]).tocsc()
         else:
             # If the grid list is empty, we project from nothing to the full set of
             # faces.
@@ -920,9 +924,9 @@ class Divergence(Operator):
 
         num_faces = 0
         num_cells = 0
-        for g in self.subdomains:
-            num_faces += g.num_faces * self.dim
-            num_cells += g.num_cells * self.dim
+        for sd in self.subdomains:
+            num_faces += sd.num_faces * self.dim
+            num_cells += sd.num_cells * self.dim
         s += f"The total size of the matrix is ({num_cells}, {num_faces}).\n"
 
         return s
@@ -973,7 +977,7 @@ def _cell_projections(
     if len(subdomains) == 0:
         return cell_projection
 
-    tot_num_cells = np.sum([g.num_cells for g in subdomains]) * dim
+    tot_num_cells = np.sum([sd.num_cells for sd in subdomains]) * dim
     cell_offset = 0
 
     for sd in subdomains:
@@ -1013,7 +1017,7 @@ def _face_projections(
     if len(subdomains) == 0:
         return face_projection
 
-    tot_num_faces = np.sum([g.num_faces for g in subdomains]) * dim
+    tot_num_faces = np.sum([sd.num_faces for sd in subdomains]) * dim
     face_offset = 0
 
     for sd in subdomains:

--- a/src/porepy/numerics/ad/surrogate_operator.py
+++ b/src/porepy/numerics/ad/surrogate_operator.py
@@ -492,11 +492,11 @@ class SurrogateFactory:
         if len(domains) == 0:
             return pp.wrap_as_dense_ad_array(np.zeros((0,)), name=self.name)
         # On the boundary, this is a Time-Dependent dense array
-        elif all(isinstance(g, pp.BoundaryGrid) for g in domains):
+        elif all(isinstance(grid, pp.BoundaryGrid) for grid in domains):
             return pp.ad.TimeDependentDenseArray(self.name, domains)
         # On subdomains or interfaces, create the surrogate operators
-        elif all(isinstance(g, pp.Grid) for g in domains) or all(
-            isinstance(g, pp.MortarGrid) for g in domains
+        elif all(isinstance(grid, pp.Grid) for grid in domains) or all(
+            isinstance(grid, pp.MortarGrid) for grid in domains
         ):
             # for mypy
             domains_ = cast(Sequence[pp.Grid] | Sequence[pp.MortarGrid], domains)
@@ -820,7 +820,7 @@ class SurrogateFactory:
     # Methods to progress values in time and iterate sense
 
     def update_boundary_values(
-        self, values: np.ndarray, boundary_grid: pp.BoundaryGrid, depth: int = 1
+        self, values: np.ndarray, bg: pp.BoundaryGrid, depth: int = 1
     ) -> None:
         """Function to update the value of the surrogate operator on the boundary.
 
@@ -839,8 +839,8 @@ class SurrogateFactory:
 
                 A new value to be set for the boundary. ``N`` is computed from the
                 information passed in ``dof_info`` at instantiation and the number of
-                cells in ``boundary_grid``.
-            boundary_grid: A boundary grid in the mixed-dimensional domain.
+                cells in ``bg``.
+            bg: A boundary grid in the mixed-dimensional domain.
             depth: ``default=1``
 
                 Maximal number of time steps stored. The default value 1 leads to
@@ -854,11 +854,11 @@ class SurrogateFactory:
 
         _check_expected_values(
             values,
-            (self.num_dofs_on_grid(boundary_grid),),
-            boundary_grid,
+            (self.num_dofs_on_grid(bg),),
+            bg,
             iterate_index=0,
         )
-        data = self._data_of(boundary_grid)
+        data = self._data_of(bg)
 
         # If boundary values stored in time, shift them and store the current time step
         # (iterate idx 0) as the most recent previous time step

--- a/src/porepy/numerics/fracture_deformation/conforming_propagation.py
+++ b/src/porepy/numerics/fracture_deformation/conforming_propagation.py
@@ -404,7 +404,7 @@ class ConformingFracturePropagation(FracturePropagation):
 
         Parameters
         ----------
-        g : pp.Grid
+        sd : pp.Grid
             Fracture grid.
         d : dict
             The grid's data dictionary.

--- a/src/porepy/numerics/fv/mpsa.py
+++ b/src/porepy/numerics/fv/mpsa.py
@@ -485,7 +485,7 @@ class Mpsa(Discretization):
         approximation.
 
         Parameters:
-            g: Grid to be discretized.
+            sd: Grid to be discretized.
             data: dictionary to store the data. For details on necessary keywords,
                 see ``:meth:discretize``.
 
@@ -585,7 +585,7 @@ class Mpsa(Discretization):
         and internal faces are mixed together, decided by their face ordering.
 
         Parameters:
-            g: Grid to be discretized.
+            sd: Grid to be discretized.
             constit: Constitutive law for the rock.
             bound: Boundary conditions for the displacement.
             eta: Parameter controlling continuity of displacement. If None, a default

--- a/tests/numerics/ad/test_equation_system.py
+++ b/tests/numerics/ad/test_equation_system.py
@@ -158,7 +158,7 @@ def test_variable_creation():
     # Next, fetch a version of var_1, restricted to a single subdomain. This should
     # in practice be equivalent to var_2.
     single_subdomain_variable_fetched = equation_system.md_variable(
-        "var_1", grids=single_subdomain
+        "var_1", domains=single_subdomain
     )
     assert len(single_subdomain_variable_fetched.sub_vars) == 1
     assert (
@@ -187,7 +187,9 @@ def test_variable_creation():
     )
     ndof_interface = mdg.num_interface_cells() * num_dof_per_cell
 
-    assert (equation_system.dofs_of(subdomain_variable.sub_vars).size) == ndof_subdomains
+    assert (
+        equation_system.dofs_of(subdomain_variable.sub_vars).size
+    ) == ndof_subdomains
     assert (
         equation_system.dofs_of(single_subdomain_variable.sub_vars).size
         == ndof_single_subdomain
@@ -195,7 +197,8 @@ def test_variable_creation():
     assert equation_system.dofs_of(interface_variable.sub_vars).size == ndof_interface
 
     assert (
-        equation_system.num_dofs() == ndof_subdomains + ndof_single_subdomain + ndof_interface
+        equation_system.num_dofs()
+        == ndof_subdomains + ndof_single_subdomain + ndof_interface
     )
 
 
@@ -295,7 +298,9 @@ def test_variable_tags():
     var_1 = equation_system.create_variables(
         "var_1", dof_info, subdomains=subdomains, tags={"tag_1": 1}
     )
-    var_2 = equation_system.create_variables("var_2", dof_info, subdomains=single_subdomain)
+    var_2 = equation_system.create_variables(
+        "var_2", dof_info, subdomains=single_subdomain
+    )
 
     assert var_1.tags == {"tag_1": 1}
     # By default, variables should not have tags
@@ -305,7 +310,11 @@ def test_variable_tags():
     # var_1 itself.
     equation_system.update_variable_tags({"tag_2": 2}, [var_1])
     assert all(
-        [var.tags["tag_2"] == 2 for var in equation_system.variables if var.name == "var_1"]
+        [
+            var.tags["tag_2"] == 2
+            for var in equation_system.variables
+            if var.name == "var_1"
+        ]
     )
 
     assert "tag_2" not in var_1.tags
@@ -653,8 +662,13 @@ def _variable_from_model(
 @pytest.mark.parametrize("full_grid", [True, False])
 @pytest.mark.parametrize("iterate", [True, False])
 def test_set_get_methods(
-    model: EquationSystemMockModel, as_str, on_interface, on_subdomain, single_grid,
-    full_grid, iterate
+    model: EquationSystemMockModel,
+    as_str,
+    on_interface,
+    on_subdomain,
+    single_grid,
+    full_grid,
+    iterate,
 ):
     """Test the set and get methods of the EquationSystem class.
 
@@ -717,18 +731,24 @@ def test_set_get_methods(
         # the global ordering.
         assert np.allclose(model.initial_values[np.sort(inds)], retrieved_vals)
     # The time step solution should not have been updated
-    retrieved_vals_state = equation_system.get_variable_values(variables, time_step_index=0)
+    retrieved_vals_state = equation_system.get_variable_values(
+        variables, time_step_index=0
+    )
     assert np.allclose(model.initial_values[np.sort(inds)], retrieved_vals_state)
 
     # Set values again, this time also to the time step solutions.
     if iterate:
-        equation_system.set_variable_values(vals, variables, iterate_index=0, time_step_index=0)
+        equation_system.set_variable_values(
+            vals, variables, iterate_index=0, time_step_index=0
+        )
     else:
         equation_system.set_variable_values(vals, variables, time_step_index=0)
     # Retrieve only values from time step solutions; iterate should be the same as
     # before (and the additive mode is checked below).
 
-    retrieved_vals_state = equation_system.get_variable_values(variables, time_step_index=0)
+    retrieved_vals_state = equation_system.get_variable_values(
+        variables, time_step_index=0
+    )
 
     assert np.allclose(vals, retrieved_vals_state)
 
@@ -737,9 +757,13 @@ def test_set_get_methods(
     new_vals = np.random.rand(inds.size)
     if iterate:
         equation_system.set_variable_values(new_vals, variables, iterate_index=0)
-        retrieved_vals2 = equation_system.get_variable_values(variables, iterate_index=0)
+        retrieved_vals2 = equation_system.get_variable_values(
+            variables, iterate_index=0
+        )
     if not iterate:
-        retrieved_vals2 = equation_system.get_variable_values(variables, time_step_index=0)
+        retrieved_vals2 = equation_system.get_variable_values(
+            variables, time_step_index=0
+        )
     # Iterate has either been updated, or it still has the initial value
     if iterate:
         assert np.allclose(new_vals, retrieved_vals2)
@@ -754,16 +778,24 @@ def test_set_get_methods(
         )
     else:
         equation_system.set_variable_values(new_vals, variables, time_step_index=0)
-    retrieved_vals_state_2 = equation_system.get_variable_values(variables, time_step_index=0)
+    retrieved_vals_state_2 = equation_system.get_variable_values(
+        variables, time_step_index=0
+    )
     assert np.allclose(new_vals, retrieved_vals_state_2)
 
     # Set the values again, this time with additive=True. This should double the
     # retrieved values.
     if iterate:
-        equation_system.set_variable_values(new_vals, variables, iterate_index=0, additive=True)
-        retrieved_vals3 = equation_system.get_variable_values(variables, iterate_index=0)
+        equation_system.set_variable_values(
+            new_vals, variables, iterate_index=0, additive=True
+        )
+        retrieved_vals3 = equation_system.get_variable_values(
+            variables, iterate_index=0
+        )
     elif not iterate:
-        retrieved_vals3 = equation_system.get_variable_values(variables, time_step_index=0)
+        retrieved_vals3 = equation_system.get_variable_values(
+            variables, time_step_index=0
+        )
 
     if iterate:
         assert np.allclose(2 * new_vals, retrieved_vals3)
@@ -780,7 +812,9 @@ def test_set_get_methods(
         equation_system.set_variable_values(
             new_vals, variables, time_step_index=0, additive=True
         )
-    retrieved_vals_state_3 = equation_system.get_variable_values(variables, time_step_index=0)
+    retrieved_vals_state_3 = equation_system.get_variable_values(
+        variables, time_step_index=0
+    )
     assert np.allclose(2 * new_vals, retrieved_vals_state_3)
 
     # Test storage of multiple values of time step and iterate solutions from here and
@@ -806,7 +840,9 @@ def test_set_get_methods(
 
     # Test setting values at several indices and then gathering them
     for i, val in zip(solution_indices, vals_mat):
-        equation_system.set_variable_values(values=val, variables=variables, time_step_index=i)
+        equation_system.set_variable_values(
+            values=val, variables=variables, time_step_index=i
+        )
 
     _retrieve_and_check_time_step([vals0, vals1, vals2])
 
@@ -825,9 +861,13 @@ def test_set_get_methods(
     _retrieve_and_check_time_step([2 * vals0, vals0, vals1])
 
     # Finally test setting and getting values at a non-zero storage index
-    equation_system.set_variable_values(values=vals2, variables=variables, time_step_index=2)
+    equation_system.set_variable_values(
+        values=vals2, variables=variables, time_step_index=2
+    )
 
-    retrieved_set_ind_vals2 = equation_system.get_variable_values(variables, time_step_index=2)
+    retrieved_set_ind_vals2 = equation_system.get_variable_values(
+        variables, time_step_index=2
+    )
 
     assert np.allclose(retrieved_set_ind_vals2, vals2)
 
@@ -853,7 +893,9 @@ def test_projection_matrix(model: EquationSystemMockModel, var_names):
     # Jacobian matrix is altered only in columns that correspond to eliminated
     # variables.
 
-    variables = [var for var in model.equation_system.variables if var.name not in var_names]
+    variables = [
+        var for var in model.equation_system.variables if var.name not in var_names
+    ]
 
     proj = model.equation_system.projection_to(variables=variables)
 
@@ -865,7 +907,9 @@ def test_projection_matrix(model: EquationSystemMockModel, var_names):
     else:
         removed_dofs = []
 
-    remaining_dofs = np.setdiff1d(np.arange(model.equation_system.num_dofs()), removed_dofs)
+    remaining_dofs = np.setdiff1d(
+        np.arange(model.equation_system.num_dofs()), removed_dofs
+    )
 
     assert np.allclose(proj.indices, remaining_dofs)
 
@@ -981,7 +1025,9 @@ def test_parse_variable_like(model: EquationSystemMockModel):
     assert all([var in received_variables_5 for var in model.sd_variable.sub_vars])
 
     # Send in the md-variable as a string, it should not make a difference
-    received_variables_6 = equation_system._parse_variable_type([model.name_sd_variable])
+    received_variables_6 = equation_system._parse_variable_type(
+        [model.name_sd_variable]
+    )
     assert len(received_variables_6) == len(model.sd_variable.sub_vars)
     assert all([var in received_variables_6 for var in model.sd_variable.sub_vars])
 
@@ -1133,12 +1179,16 @@ def test_secondary_variable_assembly(model: EquationSystemMockModel, var_names):
     # Jacobian matrix is altered only in columns that correspond to eliminated
     # variables.
 
-    variables = [var for var in model.equation_system.variables if var.name not in var_names]
+    variables = [
+        var for var in model.equation_system.variables if var.name not in var_names
+    ]
     A, b = model.equation_system.assemble(variables=variables)
 
     # Get dof indices of the variables that have been eliminated
     if len(var_names) > 0:
-        dofs = np.sort(np.hstack([model.equation_system.dofs_of([var]) for var in var_names]))
+        dofs = np.sort(
+            np.hstack([model.equation_system.dofs_of([var]) for var in var_names])
+        )
     else:
         dofs = []
 
@@ -1204,7 +1254,9 @@ def test_assemble(model: EquationSystemMockModel, equation_variables):
     # Convert variable names into variables
     if var_names is None:
         var_names = []
-    variables = [var for var in model.equation_system.variables if var.name in var_names]
+    variables = [
+        var for var in model.equation_system.variables if var.name in var_names
+    ]
 
     A_sub, b_sub = equation_system.assemble(equations=eq_names, variables=var_names)
     b_sub_only_rhs = equation_system.assemble(
@@ -1310,7 +1362,9 @@ def test_extract_subsystem(model: EquationSystemMockModel, equation_variables):
     # Convert variable names into variables
     if var_names is None:
         var_names = []
-    variables = [var for var in model.equation_system.variables if var.name in var_names]
+    variables = [
+        var for var in model.equation_system.variables if var.name in var_names
+    ]
 
     new_manager = equation_system.SubSystem(eq_names, var_names)
 

--- a/tests/numerics/ad/test_operators.py
+++ b/tests/numerics/ad/test_operators.py
@@ -816,8 +816,8 @@ def test_variable_combinations(grids, variables):
                 # The variable must be projected to the full set of grid for addition
                 # to be meaningful. This requires a bit of work.
                 sv_size = np.array([sv.size for sv in mv.sub_vars])
-                mv_grids = [sv._g for sv in mv.sub_vars]
-                ind = mv_grids.index(var._g)
+                mv_grids = [sv._grid for sv in mv.sub_vars]
+                ind = mv_grids.index(var._grid)
                 offset = np.hstack((0, np.cumsum(sv_size)))[ind]
                 rows = offset + np.arange(nc)
                 P = pp.ad.SparseArray(


### PR DESCRIPTION
## Proposed changes
Name unification of the remainder of the source. All cases `(equation_system,` `subdomains` etc.) treated in one go.

I am not sure about the fracs subpackage, in particular the module `split_grid`: Both variable names and documentation (over)use a logic of high and low dimensions, denoted with names like `gh/gl`, `g_h(igh), g_l(ow)`, `sd_primary` etc. etc. I tried to unify the terminology, but I am not confident things have been improved, and there is a risk I added a new layer of confusion. What is really needed is a full refactoring, but that will take hours to days. Please consider if it is better to revert the changes in each of the files in this module (they are separate commits, so reversion is easy).


## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
