### PR TITLE
Require ruff and isort on the test suite

### DIFF
--- a/.github/workflows/run-static-checks.yml
+++ b/.github/workflows/run-static-checks.yml
@@ -102,17 +102,17 @@ jobs:
     # Run the various checks
     - name: Ruff linting
       if: ${{ always() }}
-      run: ruff check src
+      run: ruff check src tests
 
     - name: Ruff formatting
       if: ${{always()}}
-      run: ruff format --check src
+      run: ruff format --check src tests
 
       # EK note to self: Ruff may introduce sorting of imports in the future, if so, we
       # should use that instead of isort.
     - name: isort 
       if: ${{ always() }}
-      run: isort src 
+      run: isort src tests
 
     - name: mypy
       if: ${{ always() }}

--- a/tests/applications/md_grids/test_mdg_library.py
+++ b/tests/applications/md_grids/test_mdg_library.py
@@ -3,8 +3,8 @@ Some of these tests are sensitive to meshing or node ordering. If this turns out
 cause problems, we deactivate the corresponding asserts.
 """
 
-import pytest
 import numpy as np
+import pytest
 
 import porepy as pp
 

--- a/tests/applications/test_convergence_analysis.py
+++ b/tests/applications/test_convergence_analysis.py
@@ -21,8 +21,8 @@ import pytest
 import porepy as pp
 from porepy.applications.convergence_analysis import ConvergenceAnalysis
 from porepy.applications.md_grids.mdg_library import (
-    square_with_orthogonal_fractures,
     cube_with_orthogonal_fractures,
+    square_with_orthogonal_fractures,
 )
 from porepy.models.fluid_mass_balance import SinglePhaseFlow
 from porepy.utils.txt_io import read_data_from_txt

--- a/tests/compositional/test_materials.py
+++ b/tests/compositional/test_materials.py
@@ -11,13 +11,12 @@ Constitutive library tests.
 
 from __future__ import annotations
 
+from dataclasses import FrozenInstanceError
+
 import numpy as np
 import pytest
 
 import porepy as pp
-
-from dataclasses import FrozenInstanceError
-
 from porepy.examples.flow_benchmark_2d_case_1 import FractureSolidConstants
 
 

--- a/tests/functional/setups/manu_flow_comp_2d_frac.py
+++ b/tests/functional/setups/manu_flow_comp_2d_frac.py
@@ -567,9 +567,7 @@ class ManuCompExactSolution2d:
 
         return lmbda_cc
 
-    def matrix_boundary_pressure(
-        self, bg: pp.BoundaryGrid, time: number
-    ) -> np.ndarray:
+    def matrix_boundary_pressure(self, bg: pp.BoundaryGrid, time: number) -> np.ndarray:
         """Exact pressure at the boundary faces.
 
         Parameters:

--- a/tests/functional/setups/manu_poromech_nofrac_2d.py
+++ b/tests/functional/setups/manu_poromech_nofrac_2d.py
@@ -56,7 +56,6 @@ import numpy as np
 import sympy as sym
 
 import porepy as pp
-
 from porepy.applications.convergence_analysis import ConvergenceAnalysis
 from porepy.applications.md_grids.domains import nd_cube_domain
 from porepy.utils.examples_utils import VerificationUtils

--- a/tests/functional/test_benchmark_2d_case_3.py
+++ b/tests/functional/test_benchmark_2d_case_3.py
@@ -13,19 +13,18 @@ Reference:
 
 """
 
+from typing import Literal
+
 import numpy as np
 import pytest
 
 import porepy as pp
-
-
+from porepy.applications.test_utils.benchmarks import EffectivePermeability
 from porepy.examples.flow_benchmark_2d_case_3 import (
     FlowBenchmark2dCase3aModel,
     FlowBenchmark2dCase3bModel,
     solid_constants,
 )
-from porepy.applications.test_utils.benchmarks import EffectivePermeability
-from typing import Literal
 
 
 class Model3aWithEffectivePermeability(

--- a/tests/functional/test_benchmark_3d_case_3.py
+++ b/tests/functional/test_benchmark_3d_case_3.py
@@ -13,17 +13,17 @@ Reference:
 
 """
 
+from typing import Literal
+
 import numpy as np
 import pytest
 
 import porepy as pp
-
+from porepy.applications.test_utils.benchmarks import EffectivePermeability
 from porepy.examples.flow_benchmark_3d_case_3 import (
     FlowBenchmark3dCase3Model,
     solid_constants,
 )
-from porepy.applications.test_utils.benchmarks import EffectivePermeability
-from typing import Literal
 
 
 class ModelWithEffectivePermeability(

--- a/tests/functional/test_mandel.py
+++ b/tests/functional/test_mandel.py
@@ -21,10 +21,9 @@ import numpy as np
 import pytest
 
 import porepy as pp
-
 from porepy.examples.mandel_biot import (
-    MandelSaveData,
     MandelModel,
+    MandelSaveData,
     mandel_fluid_constants,
     mandel_solid_constants,
 )

--- a/tests/functional/test_manu_flow_comp_frac.py
+++ b/tests/functional/test_manu_flow_comp_frac.py
@@ -47,8 +47,8 @@ from porepy.applications.convergence_analysis import ConvergenceAnalysis
 from tests.functional.setups.manu_flow_comp_2d_frac import (
     ManuCompFlowModel2d,
     manu_comp_fluid,
-    manu_comp_solid,
     manu_comp_ref_vals,
+    manu_comp_solid,
 )
 from tests.functional.setups.manu_flow_comp_3d_frac import ManuCompFlowModel3d
 

--- a/tests/functional/test_terzaghi.py
+++ b/tests/functional/test_terzaghi.py
@@ -22,13 +22,12 @@ We consider three functional tests:
 import numpy as np
 
 import porepy as pp
-
 from porepy.examples.terzaghi_biot import (
     PseudoOneDimensionalColumn,
     TerzaghiDataSaving,
-    TerzaghiPoromechanicsBoundaryConditions,
     TerzaghiInitialConditions,
     TerzaghiModel,
+    TerzaghiPoromechanicsBoundaryConditions,
     TerzaghiSolutionStrategy,
     TerzaghiUtils,
     terzaghi_fluid_constants,

--- a/tests/geometry/test_half_space.py
+++ b/tests/geometry/test_half_space.py
@@ -3,8 +3,8 @@
 import numpy as np
 import pytest
 
-from porepy.geometry import half_space
 from porepy.applications.test_utils.arrays import compare_arrays
+from porepy.geometry import half_space
 
 
 def test_one_half_space():

--- a/tests/grids/test_coarsening.py
+++ b/tests/grids/test_coarsening.py
@@ -1,8 +1,8 @@
 import inspect
 import sys
-import pytest
 
 import numpy as np
+import pytest
 
 import porepy as pp
 from porepy.grids import coarsening as co

--- a/tests/grids/test_grid.py
+++ b/tests/grids/test_grid.py
@@ -14,8 +14,8 @@ import scipy.sparse as sps
 import porepy as pp
 from porepy.applications.test_utils import reference_dense_arrays
 from porepy.grids import simplex, structured
-from porepy.utils import setmembership
 from porepy.numerics.linalg.matrix_operations import sparse_array_to_row_col_data
+from porepy.utils import setmembership
 
 
 @pytest.mark.parametrize(

--- a/tests/grids/test_refinement.py
+++ b/tests/grids/test_refinement.py
@@ -12,14 +12,14 @@ from __future__ import division
 
 import numpy as np
 import pytest
+import scipy.sparse as sps
 
 import porepy as pp
+from porepy.applications.test_utils.arrays import compare_arrays
 from porepy.fracs import meshing
 from porepy.grids import refinement
 from porepy.grids.simplex import TriangleGrid
 from porepy.grids.structured import TensorGrid
-from porepy.applications.test_utils.arrays import compare_arrays
-import scipy.sparse as sps
 
 
 class TestGridPerturbation:

--- a/tests/models/test_constitutive_laws.py
+++ b/tests/models/test_constitutive_laws.py
@@ -17,23 +17,22 @@ constitutive laws, the first test might be removed.
 
 from __future__ import annotations
 
-from typing import Any, Literal, Type, Optional
+from typing import Any, Literal, Optional, Type
 
 import numpy as np
-import scipy.sparse as sps
 import pytest
+import scipy.sparse as sps
 
 import porepy as pp
 import porepy.models.constitutive_laws as c_l
+from porepy.applications.discretizations.flux_discretization import FluxDiscretization
+from porepy.applications.md_grids.model_geometries import (
+    SquareDomainOrthogonalFractures,
+)
 from porepy.applications.test_utils import models
 from porepy.applications.test_utils.reference_dense_arrays import (
     test_constitutive_laws as reference_dense_arrays,
 )
-from porepy.applications.md_grids.model_geometries import (
-    SquareDomainOrthogonalFractures,
-)
-from porepy.applications.discretizations.flux_discretization import FluxDiscretization
-
 
 solid_values = pp.solid_values.granite
 solid_values.update(

--- a/tests/models/test_contact_mechanics.py
+++ b/tests/models/test_contact_mechanics.py
@@ -10,10 +10,7 @@ from porepy.applications.md_grids.model_geometries import (
     CubeDomainOrthogonalFractures,
     SquareDomainOrthogonalFractures,
 )
-from porepy.applications.test_utils.models import (
-    ContactMechanicsTester,
-    _add_mixin,
-)
+from porepy.applications.test_utils.models import ContactMechanicsTester, _add_mixin
 
 grid_classes = {2: SquareDomainOrthogonalFractures, 3: CubeDomainOrthogonalFractures}
 

--- a/tests/models/test_fluid_mass_balance.py
+++ b/tests/models/test_fluid_mass_balance.py
@@ -24,19 +24,19 @@ import scipy.sparse as sps
 
 import porepy as pp
 from porepy.applications.discretizations.flux_discretization import FluxDiscretization
-from porepy.applications.md_grids.model_geometries import (
-    CubeDomainOrthogonalFractures,
-    SquareDomainOrthogonalFractures,
-    NonMatchingSquareDomainOrthogonalFractures,
-)
-from porepy.applications.test_utils import models, well_models
-from porepy.models.fluid_mass_balance import SinglePhaseFlow
-from porepy.applications.material_values.solid_values import (
-    extended_granite_values_for_testing as granite_values,
-)
 from porepy.applications.material_values.fluid_values import (
     extended_water_values_for_testing as water_values,
 )
+from porepy.applications.material_values.solid_values import (
+    extended_granite_values_for_testing as granite_values,
+)
+from porepy.applications.md_grids.model_geometries import (
+    CubeDomainOrthogonalFractures,
+    NonMatchingSquareDomainOrthogonalFractures,
+    SquareDomainOrthogonalFractures,
+)
+from porepy.applications.test_utils import models, well_models
+from porepy.models.fluid_mass_balance import SinglePhaseFlow
 
 
 @pytest.fixture(scope="function")

--- a/tests/models/test_geometry.py
+++ b/tests/models/test_geometry.py
@@ -26,7 +26,6 @@ import porepy as pp
 import porepy.applications.md_grids.model_geometries
 from porepy.applications.test_utils import models
 
-
 # List of geometry classes to test.
 # Turn mixins of specific grids into proper model geometries.
 geometry_list: list[type[pp.ModelGeometry]] = [

--- a/tests/models/test_momentum_balance.py
+++ b/tests/models/test_momentum_balance.py
@@ -8,14 +8,14 @@ import numpy as np
 import pytest
 
 import porepy as pp
+from porepy.applications.md_grids.model_geometries import (
+    CubeDomainOrthogonalFractures,
+    SquareDomainOrthogonalFractures,
+)
 from porepy.applications.test_utils.models import (
     MomentumBalance,
     compare_scaled_model_quantities,
     compare_scaled_primary_variables,
-)
-from porepy.applications.md_grids.model_geometries import (
-    SquareDomainOrthogonalFractures,
-    CubeDomainOrthogonalFractures,
 )
 
 

--- a/tests/numerics/ad/test_forward_mode.py
+++ b/tests/numerics/ad/test_forward_mode.py
@@ -8,9 +8,8 @@ add, sub, etc., which are also covered in other tests.
 
 from __future__ import annotations
 
-import pytest
-
 import numpy as np
+import pytest
 import scipy.sparse as sps
 
 from porepy.numerics.ad import functions as af

--- a/tests/numerics/ad/test_forward_mode.py
+++ b/tests/numerics/ad/test_forward_mode.py
@@ -291,7 +291,6 @@ def test_logical_operation(N: int, logical_op: str, other: int | np.ndarray | Ad
     # Ignore ad not being accessed, it is used in the exec statement.
     ad = AdArray(val, jac)  # noqa: F841
 
-
     global result_numpy, result_ad
     result_numpy = np.empty(N)
     result_ad = np.empty(N)

--- a/tests/numerics/ad/test_grid_operators.py
+++ b/tests/numerics/ad/test_grid_operators.py
@@ -16,6 +16,7 @@ Checks performed include the following:
 import numpy as np
 import pytest
 import scipy.sparse as sps
+
 import porepy as pp
 
 

--- a/tests/numerics/ad/test_operator_functions.py
+++ b/tests/numerics/ad/test_operator_functions.py
@@ -6,9 +6,9 @@ Testing involves their creation, arithmetic overloads and parsing.
 
 from __future__ import annotations
 
+import numpy as np
 import pytest
 
-import numpy as np
 import porepy as pp
 
 

--- a/tests/numerics/fracture_deformation/test_fracture_propagation.py
+++ b/tests/numerics/fracture_deformation/test_fracture_propagation.py
@@ -37,10 +37,10 @@ import numpy as np
 import pytest
 
 import porepy as pp
+from porepy.applications.test_utils.arrays import compare_arrays
 from porepy.fracs.fracture_network_2d import FractureNetwork2d
 from porepy.fracs.fracture_network_3d import FractureNetwork3d
 from porepy.numerics.linalg.matrix_operations import sparse_array_to_row_col_data
-from porepy.applications.test_utils.arrays import compare_arrays
 
 FractureNetwork = Union[FractureNetwork2d, FractureNetwork3d]
 

--- a/tests/numerics/fv/test_tpfa.py
+++ b/tests/numerics/fv/test_tpfa.py
@@ -6,21 +6,16 @@ The tests fall into two categories:
 
 """
 
-import pytest
-
-import scipy.sparse as sps
 import numpy as np
+import pytest
+import scipy.sparse as sps
+
 import porepy as pp
-
-from porepy.applications.test_utils import common_xpfa_tests as xpfa_tests
 from porepy.applications.discretizations.flux_discretization import FluxDiscretization
-
-from porepy.applications.md_grids.model_geometries import (
-    CubeDomainOrthogonalFractures,
-)
 from porepy.applications.md_grids import model_geometries
+from porepy.applications.md_grids.model_geometries import CubeDomainOrthogonalFractures
+from porepy.applications.test_utils import common_xpfa_tests as xpfa_tests
 from porepy.applications.test_utils import well_models
-
 
 """Local utility functions."""
 

--- a/tests/numerics/fv/test_tpsa.py
+++ b/tests/numerics/fv/test_tpsa.py
@@ -7,12 +7,14 @@
 
 """
 
-from typing import Optional, Literal
-import pytest
-import porepy as pp
-import numpy as np
-import scipy.sparse as sps
 from copy import deepcopy
+from typing import Literal, Optional
+
+import numpy as np
+import pytest
+import scipy.sparse as sps
+
+import porepy as pp
 
 KEYWORD = "mechanics"
 """Module level keyword which identifies the placement of parameters and discretization

--- a/tests/numerics/nonlinear/test_line_search.py
+++ b/tests/numerics/nonlinear/test_line_search.py
@@ -1,10 +1,10 @@
-import porepy as pp
 import numpy as np
 
-from porepy.numerics.nonlinear import line_search as ls
+import porepy as pp
 from porepy.applications.md_grids.model_geometries import (
     SquareDomainOrthogonalFractures,
 )
+from porepy.numerics.nonlinear import line_search as ls
 
 
 class ConstraintLineSearchNonlinearSolver(

--- a/tests/numerics/nonlinear/test_nonlinear_solvers.py
+++ b/tests/numerics/nonlinear/test_nonlinear_solvers.py
@@ -1,7 +1,8 @@
-import porepy as pp
-import numpy as np
 from typing import Any
 
+import numpy as np
+
+import porepy as pp
 from porepy.models.fluid_mass_balance import SinglePhaseFlow
 
 

--- a/tests/utils/test_sort_points.py
+++ b/tests/utils/test_sort_points.py
@@ -3,8 +3,8 @@
 import numpy as np
 import pytest
 
-from porepy.utils import sort_points
 from porepy.applications.test_utils.arrays import compare_arrays
+from porepy.utils import sort_points
 
 
 @pytest.mark.parametrize(

--- a/tests/viz/test_data_saving_model_mixin.py
+++ b/tests/viz/test_data_saving_model_mixin.py
@@ -6,14 +6,13 @@ The following is covered:
 """
 
 import numpy as np
+import pytest
 
 import porepy as pp
-from porepy.models.momentum_balance import MomentumBalance
 from porepy.applications.md_grids.model_geometries import (
     SquareDomainOrthogonalFractures,
 )
-
-import pytest
+from porepy.models.momentum_balance import MomentumBalance
 
 
 class DataSavingModelMixinModel(SquareDomainOrthogonalFractures, MomentumBalance):

--- a/tests/viz/test_exporter.py
+++ b/tests/viz/test_exporter.py
@@ -17,12 +17,13 @@ import os
 import shutil
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Generator, Any
+from typing import Any, Generator
 
 import numpy as np
 import pytest
 
 import porepy as pp
+from porepy.applications.test_utils.models import Thermoporomechanics
 from porepy.applications.test_utils.vtk import (
     PathLike,
     compare_pvd_files,
@@ -30,7 +31,6 @@ from porepy.applications.test_utils.vtk import (
 )
 from porepy.fracs.utils import pts_edges_to_linefractures
 from tests.models.test_poromechanics import NonzeroFractureGapPoromechanics
-from porepy.applications.test_utils.models import Thermoporomechanics
 
 # Globally store location of reference files
 FOLDER_REFERENCE = (


### PR DESCRIPTION
## Proposed changes
This PR requires that files in the tests folder are formatted with ruff and isort for the static GH action check to pass.

We do not do require mypy on the tests as this is highly unlikely to give a positive cost-benefit ratio, at least for now.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [x] Other: GH actions

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
