### PR TITLE
Caching of the construction of constitutive laws in the model framework

### DIFF
--- a/src/porepy/examples/mandel_biot.py
+++ b/src/porepy/examples/mandel_biot.py
@@ -118,12 +118,6 @@ class MandelSaveData:
 class MandelDataSaving(pp.PorePyModel):
     """Mixin class to save relevant data."""
 
-    darcy_flux: Callable[[list[pp.Grid]], pp.ad.Operator]
-    """Method that returns the Darcy fluxes in the form of an Ad operator. Usually
-    provided by the mixin class :class:`~porepy.models.fluid_mass_balance.DarcysLaw`.
-
-    """
-
     displacement: Callable[[pp.SubdomainsOrBoundaries], pp.ad.MixedDimensionalVariable]
     """Displacement variable. Normally defined in a mixin instance of
     :class:`~porepy.models.momentum_balance.VariablesMomentumBalance`.

--- a/src/porepy/examples/tracer_flow.py
+++ b/src/porepy/examples/tracer_flow.py
@@ -107,7 +107,6 @@ class TracerBC(BoundaryConditionsMassDirNorthSouth, BoundaryConditionsMulticompo
 
 class TracerFlowModel(  # type: ignore[misc]
     SquareDomainOrthogonalFractures,
-    # pp.constitutive_laws.DisplacementJump,
     TracerFluid,
     CompositionalVariables,
     ComponentMassBalanceEquations,

--- a/src/porepy/examples/tracer_flow.py
+++ b/src/porepy/examples/tracer_flow.py
@@ -107,6 +107,7 @@ class TracerBC(BoundaryConditionsMassDirNorthSouth, BoundaryConditionsMulticompo
 
 class TracerFlowModel(  # type: ignore[misc]
     SquareDomainOrthogonalFractures,
+    # pp.constitutive_laws.DisplacementJump,
     TracerFluid,
     CompositionalVariables,
     ComponentMassBalanceEquations,
@@ -162,7 +163,17 @@ if __name__ == "__main__":
         "grid_type": "simplex",
     }
 
-    model = TracerFlowModel(params)
+    # EK: Ignore a mypy error here: Mypy complains that the model does not implement
+    # abstract methods displacement_jump, plastic_displacement_jump, and
+    # elastic_displacement_jump. The likely cause is that mypy believes the methods are
+    # decleared (as abstract?) but not implemented, but searching the codebase does not
+    # give any indication how mypy came to this false conclusion. I have also tried to
+    # search through the class hirearchy to look for clues, to no avail.
+    #
+    # The issue arose in connection with the decoration of the relevant methods with
+    # @pp.ad.cached_method, however, removing this decorator does not resolve the issue.
+
+    model = TracerFlowModel(params)  # type: ignore[abstract]
     pp.run_time_dependent_model(model, params)
     pp.plot_grid(
         model.mdg,

--- a/src/porepy/models/compositional_flow.py
+++ b/src/porepy/models/compositional_flow.py
@@ -244,8 +244,6 @@ class MassicPressureEquations(pp.fluid_mass_balance.FluidMassBalanceEquations):
 
     """
 
-    darcy_flux: Callable[[pp.SubdomainsOrBoundaries], pp.ad.Operator]
-    """See :class:`~porepy.models.constitutive_laws.DarcysLaw`."""
     interface_darcy_flux: Callable[
         [list[pp.MortarGrid]], pp.ad.MixedDimensionalVariable
     ]
@@ -439,9 +437,6 @@ class ComponentMassBalanceEquations(pp.BalanceEquation):
 
     porosity: Callable[[list[pp.Grid]], pp.ad.Operator]
     """See :class:`ConstitutiveLawsSolidSkeletonCF`."""
-
-    darcy_flux: Callable[[pp.SubdomainsOrBoundaries], pp.ad.Operator]
-    """See :class:`~porepy.models.constitutive_laws.DarcysLaw`."""
 
     advective_flux: Callable[
         [

--- a/src/porepy/models/constitutive_laws.py
+++ b/src/porepy/models/constitutive_laws.py
@@ -292,7 +292,7 @@ class DisplacementJumpAperture(DimensionReduction):
     # NOTE: This method contains a call to self.equation_system.evaluate, signifying
     # that caching may not be a good idea. However, the evaluated quantity is static, it
     # depends only on geometric properties of the grid, and the caching is therefore
-    # safe.
+    # safe as long as the grid does not change.
     @pp.ad.cached_method
     def aperture(self, subdomains: list[pp.Grid]) -> pp.ad.Operator:
         """Aperture [m].

--- a/src/porepy/models/constitutive_laws.py
+++ b/src/porepy/models/constitutive_laws.py
@@ -107,7 +107,6 @@ class DisplacementJump(pp.PorePyModel):
         u_n = self.elastic_normal_fracture_deformation(subdomains)
         return tangential_to_nd @ u_t + normal_to_nd @ u_n
 
-    @pp.ad.cached_method
     def plastic_displacement_jump(self, subdomains: list[pp.Grid]) -> pp.ad.Operator:
         """The plastic component of the displacement jump.
 
@@ -3392,6 +3391,12 @@ class ShearDilation(pp.PorePyModel):
 
     The main method of the class is :meth:`shear_dilation_gap`.
 
+    """
+
+    plastic_displacement_jump: Callable[[list[pp.Grid]], pp.ad.Operator]
+    """The plastic component of the displacement jump. Normally defined in a mixin
+    instance of
+    :class:`~porepy.models.constitutive_laws.DisplacementJump`.
     """
 
     def shear_dilation_gap(self, subdomains: list[pp.Grid]) -> pp.ad.Operator:

--- a/src/porepy/models/constitutive_laws.py
+++ b/src/porepy/models/constitutive_laws.py
@@ -275,12 +275,6 @@ class DimensionReduction(pp.PorePyModel):
 class DisplacementJumpAperture(DimensionReduction):
     """Fracture aperture from displacement jump."""
 
-    displacement_jump: Callable[[list[pp.Grid]], pp.ad.Operator]
-    """Operator giving the displacement jump on fracture grids. Normally defined in a
-    mixin instance of :class:`~porepy.models.constitutive_laws.DisplacementJump`.
-
-    """
-
     def residual_aperture(self, subdomains: list[pp.Grid]) -> Scalar:
         """Residual aperture [m].
 
@@ -2497,10 +2491,6 @@ class FouriersLawAd(AdTpfaFlux):
 class AdvectiveFlux(pp.PorePyModel):
     """Mixin class for discretizing advective fluxes."""
 
-    darcy_flux: Callable[[pp.SubdomainsOrBoundaries], pp.ad.Operator]
-    """Darcy flux variables on subdomains. Normally defined in a mixin instance of
-    :class:`~porepy.models.constitutive_laws.DarcysLaw`.
-    """
     interface_darcy_flux: Callable[
         [list[pp.MortarGrid]], pp.ad.MixedDimensionalVariable
     ]
@@ -3401,13 +3391,6 @@ class ShearDilation(pp.PorePyModel):
     """Class for calculating fracture dilation due to tangential shearing.
 
     The main method of the class is :meth:`shear_dilation_gap`.
-
-    """
-
-    plastic_displacement_jump: Callable[[list[pp.Grid]], pp.ad.Operator]
-    """The plastic component of the displacement jump. Normally defined in a mixin
-    instance of
-    :class:`~porepy.models.constitutive_laws.DisplacementJump`.
 
     """
 

--- a/src/porepy/models/constitutive_laws.py
+++ b/src/porepy/models/constitutive_laws.py
@@ -41,6 +41,7 @@ class DisplacementJump(pp.PorePyModel):
     elastic_tangential_fracture_deformation: Callable[[list[pp.Grid]], pp.ad.Operator]
     """Operator giving the tangential component of the elastic fracture deformation."""
 
+    @pp.ad.cached_method
     def displacement_jump(self, subdomains: list[pp.Grid]) -> pp.ad.Operator:
         """Displacement jump on fracture-matrix interfaces.
 
@@ -77,6 +78,7 @@ class DisplacementJump(pp.PorePyModel):
         rotated_jumps.set_name("Rotated_displacement_jump")
         return rotated_jumps
 
+    @pp.ad.cached_method
     def elastic_displacement_jump(self, subdomains: list[pp.Grid]) -> pp.ad.Operator:
         """The elastic component of the displacement jump [m].
 
@@ -105,6 +107,7 @@ class DisplacementJump(pp.PorePyModel):
         u_n = self.elastic_normal_fracture_deformation(subdomains)
         return tangential_to_nd @ u_t + normal_to_nd @ u_n
 
+    @pp.ad.cached_method
     def plastic_displacement_jump(self, subdomains: list[pp.Grid]) -> pp.ad.Operator:
         """The plastic component of the displacement jump.
 
@@ -150,6 +153,7 @@ class DimensionReduction(pp.PorePyModel):
                 aperture = self.solid.residual_aperture * aperture
         return aperture
 
+    @pp.ad.cached_method
     def aperture(self, subdomains: list[pp.Grid]) -> pp.ad.Operator:
         """Aperture [m].
 
@@ -191,6 +195,7 @@ class DimensionReduction(pp.PorePyModel):
 
         return apertures
 
+    @pp.ad.cached_method
     def specific_volume(
         self, grids: Union[list[pp.Grid], list[pp.MortarGrid]]
     ) -> pp.ad.Operator:
@@ -290,6 +295,11 @@ class DisplacementJumpAperture(DimensionReduction):
         """
         return Scalar(self.solid.residual_aperture, name="residual_aperture")
 
+    # NOTE: This method contains a call to self.equation_system.evaluate, signifying
+    # that caching may not be a good idea. However, the evaluated quantity is static, it
+    # depends only on geometric properties of the grid, and the caching is therefore
+    # safe.
+    @pp.ad.cached_method
     def aperture(self, subdomains: list[pp.Grid]) -> pp.ad.Operator:
         """Aperture [m].
 
@@ -917,6 +927,7 @@ class DarcysLaw(pp.PorePyModel):
         )
         return pressure_trace
 
+    @pp.ad.cached_method
     def darcy_flux(self, domains: pp.SubdomainsOrBoundaries) -> pp.ad.Operator:
         """Discretization of Darcy's law.
 

--- a/src/porepy/models/contact_mechanics.py
+++ b/src/porepy/models/contact_mechanics.py
@@ -22,16 +22,7 @@ class ContactMechanicsEquations(pp.BalanceEquation):
 
     nd: int
     """Ambient dimension of the problem."""
-    displacement_jump: Callable[[list[pp.Grid]], pp.ad.Operator]
-    """Operator giving the displacement jump on fracture grids. Normally defined in a
-    mixin instance of :class:`~porepy.models.geometry.ModelGeometry`.
 
-    """
-    plastic_displacement_jump: Callable[[list[pp.Grid]], pp.ad.Operator]
-    """Operator giving the plastic displacement jump on fracture grids. Normally defined
-    in a mixin instance of
-    :class:`~porepy.models.constitutive_laws.DisplacementJump`.
-    """
     contact_traction: Callable[[list[pp.Grid]], pp.ad.Operator]
     """Contact traction variable. Normally defined in a mixin instance of
     :class:`~porepy.models.contact_mechanics.ContactTractionVariable`.

--- a/src/porepy/models/contact_mechanics.py
+++ b/src/porepy/models/contact_mechanics.py
@@ -28,6 +28,11 @@ class ContactMechanicsEquations(pp.BalanceEquation):
     :class:`~porepy.models.contact_mechanics.ContactTractionVariable`.
 
     """
+    plastic_displacement_jump: Callable[[list[pp.Grid]], pp.ad.Operator]
+    """The plastic component of the displacement jump. Normally defined in a mixin
+    instance of
+    :class:`~porepy.models.constitutive_laws.DisplacementJump`.
+    """
     fracture_gap: Callable[[list[pp.Grid]], pp.ad.Operator]
     """Gap of a fracture. Normally provided by a mixin instance of
     :class:`~porepy.models.constitutive_laws.FractureGap`.

--- a/src/porepy/models/fluid_mass_balance.py
+++ b/src/porepy/models/fluid_mass_balance.py
@@ -425,7 +425,6 @@ class BoundaryConditionsSinglePhaseFlow(pp.BoundaryConditionMixin):
     pressure_variable: str
     """Name of the pressure variable."""
     pressure: Callable[[pp.SubdomainsOrBoundaries], pp.ad.Operator]
-    darcy_flux: Callable[[pp.SubdomainsOrBoundaries], pp.ad.Operator]
 
     def bc_type_darcy_flux(self, sd: pp.Grid) -> pp.BoundaryCondition:
         """Boundary conditions on all external boundaries.

--- a/src/porepy/models/geometry.py
+++ b/src/porepy/models/geometry.py
@@ -150,6 +150,7 @@ class ModelGeometry(pp.PorePyModel):
             meshing_kwargs = {}
         return meshing_kwargs
 
+    @pp.ad.cached_method
     def subdomains_to_interfaces(
         self, subdomains: list[pp.Grid], codims: list[int]
     ) -> list[pp.MortarGrid]:
@@ -174,6 +175,7 @@ class ModelGeometry(pp.PorePyModel):
                     interfaces.append(intf)
         return self.mdg.sort_interfaces(interfaces)
 
+    @pp.ad.cached_method
     def interfaces_to_subdomains(
         self, interfaces: list[pp.MortarGrid]
     ) -> list[pp.Grid]:
@@ -315,6 +317,7 @@ class ModelGeometry(pp.PorePyModel):
         # Stack the basis functions horizontally.
         return basis
 
+    @pp.ad.cached_method
     def e_i(
         self, grids: Sequence[pp.GridLike], *, i: int, dim: int
     ) -> pp.ad.Projection:
@@ -372,6 +375,7 @@ class ModelGeometry(pp.PorePyModel):
         return slicer
 
     # Local basis related methods
+    @pp.ad.cached_method
     def tangential_component(self, subdomains: list[pp.Grid]) -> pp.ad.Operator:
         """Compute the tangential component of a vector field.
 
@@ -404,6 +408,7 @@ class ModelGeometry(pp.PorePyModel):
         op.set_name("tangential_component")
         return op
 
+    @pp.ad.cached_method
     def normal_component(self, subdomains: list[pp.Grid]) -> pp.ad.Projection:
         """Compute the normal component of a vector field.
 
@@ -638,6 +643,7 @@ class ModelGeometry(pp.PorePyModel):
         sign_flipper.set_name("Flip_normal_vectors")
         return sign_flipper
 
+    @pp.ad.cached_method
     def outwards_internal_boundary_normals(
         self,
         interfaces: list[pp.MortarGrid],

--- a/src/porepy/models/protocol.py
+++ b/src/porepy/models/protocol.py
@@ -929,6 +929,89 @@ else:
 
             """
 
+    class CachedMethodProtocol(Protocol):
+        """This protocol provides the declarations of methods that have been decorated
+        with @pp.ad.cached_method, and that are not decleared in the other protocols.
+        """
+
+        # This is a workaround for a technical issue: While the decorated methods should
+        # keep their original signature, by use of functools.wraps, it was impossible to
+        # make mypy realize what is the signature of the decorated method. EK's
+        # suspicion is that this has to do with the combination of mixins and
+        # decorators, but this is just a hunch.
+
+        def displacement_jump(self, subdomains: list[pp.Grid]) -> pp.ad.Operator:
+            """Displacement jump on fracture-matrix interfaces.
+
+            Parameters:
+                subdomains: List of subdomains where the displacement jump is defined.
+                    Should be a fracture subdomain.
+
+            Returns:
+                Operator for the displacement jump.
+
+            Raises:
+                AssertionError: If the subdomains are not fractures, i.e. have dimension
+                    `nd - 1`.
+
+            """
+
+        def elastic_displacement_jump(
+            self, subdomains: list[pp.Grid]
+        ) -> pp.ad.Operator:
+            """The elastic component of the displacement jump [m].
+
+            The elastic displacement jump is composed of a tangential and normal component,
+            each implementing a relation between displacement jumps, contact tractions and
+            stiffness. The relation may or may not be linear.
+
+            Parameters:
+                subdomains: List of fracture subdomains.
+
+            Returns:
+                Operator representing the elastic displacement jump.
+
+            """
+            pass
+
+        def plastic_displacement_jump(
+            self, subdomains: list[pp.Grid]
+        ) -> pp.ad.Operator:
+            """The plastic component of the displacement jump.
+
+            The plastic displacement jump is the difference between the total displacement
+            jump and the elastic displacement jump.
+
+            Parameters:
+                subdomains: List of fracture subdomains.
+
+            Returns:
+                Operator representing the plastic displacement jump.
+
+            """
+            pass
+
+        def darcy_flux(self, domains: pp.SubdomainsOrBoundaries) -> pp.ad.Operator:
+            """Discretization of Darcy's law.
+
+            Note:
+                The fluid mobility is not included in the Darcy flux. This is because we
+                discretize it with an upstream scheme. This means that the fluid mobility
+                may have to be included when using the flux in a transport equation.
+                The units of the Darcy flux are [m^2 Pa / s].
+
+            Parameters:
+                domains: List of domains where the Darcy flux is defined.
+
+            Raises:
+                ValueError if the domains are a mixture of grids and boundary grids.
+
+            Returns:
+                Face-wise Darcy flux in cubic meters per second.
+
+            """
+            pass
+
     class PorePyModel(
         BoundaryConditionProtocol,
         InitialConditionProtocol,
@@ -938,6 +1021,7 @@ else:
         ModelGeometryProtocol,
         DataSavingProtocol,
         SolutionStrategyProtocol,
+        CachedMethodProtocol,
         Protocol,
     ):
         """This protocol declares the core, physics-agnostic functionality of

--- a/src/porepy/models/protocol.py
+++ b/src/porepy/models/protocol.py
@@ -963,9 +963,9 @@ else:
         ) -> pp.ad.Operator:
             """The elastic component of the displacement jump [m].
 
-            The elastic displacement jump is composed of a tangential and normal component,
-            each implementing a relation between displacement jumps, contact tractions and
-            stiffness. The relation may or may not be linear.
+            The elastic displacement jump is composed of a tangential and normal
+            component, each implementing a relation between displacement jumps, contact
+            tractions and stiffness. The relation may or may not be linear.
 
             Parameters:
                 subdomains: List of fracture subdomains.
@@ -981,9 +981,9 @@ else:
 
             Note:
                 The fluid mobility is not included in the Darcy flux. This is because we
-                discretize it with an upstream scheme. This means that the fluid mobility
-                may have to be included when using the flux in a transport equation.
-                The units of the Darcy flux are [m^2 / s].
+                discretize it with an upstream scheme. This means that the fluid
+                mobility may have to be included when using the flux in a transport
+                equation. The units of the Darcy flux are [m^2 / s].
 
             Parameters:
                 domains: List of domains where the Darcy flux is defined.

--- a/src/porepy/models/protocol.py
+++ b/src/porepy/models/protocol.py
@@ -945,7 +945,7 @@ else:
 
             Parameters:
                 subdomains: List of subdomains where the displacement jump is defined.
-                    Should be a fracture subdomain.
+                    Should be fracture subdomains.
 
             Returns:
                 Operator for the displacement jump.
@@ -998,7 +998,7 @@ else:
                 The fluid mobility is not included in the Darcy flux. This is because we
                 discretize it with an upstream scheme. This means that the fluid mobility
                 may have to be included when using the flux in a transport equation.
-                The units of the Darcy flux are [m^2 Pa / s].
+                The units of the Darcy flux are [m^2 / s].
 
             Parameters:
                 domains: List of domains where the Darcy flux is defined.

--- a/src/porepy/models/protocol.py
+++ b/src/porepy/models/protocol.py
@@ -974,23 +974,6 @@ else:
             """
             pass
 
-        def plastic_displacement_jump(
-            self, subdomains: list[pp.Grid]
-        ) -> pp.ad.Operator:
-            """The plastic component of the displacement jump.
-
-            The plastic displacement jump is the difference between the total displacement
-            jump and the elastic displacement jump.
-
-            Parameters:
-                subdomains: List of fracture subdomains.
-
-            Returns:
-                Operator representing the plastic displacement jump.
-
-            """
-            pass
-
         def darcy_flux(self, domains: pp.SubdomainsOrBoundaries) -> pp.ad.Operator:
             """Discretization of Darcy's law.
 

--- a/src/porepy/models/solution_strategy.py
+++ b/src/porepy/models/solution_strategy.py
@@ -747,9 +747,6 @@ class ContactIndicators(pp.PorePyModel):
     contact_mechanics_numerical_constant: Callable[[list[pp.Grid]], pp.ad.Operator]
     """Contact mechanics numerical constant."""
 
-    displacement_jump: Callable[[list[pp.Grid]], pp.ad.Operator]
-    """Displacement jump operator."""
-
     fracture_gap: Callable[[list[pp.Grid]], pp.ad.Operator]
     """Fracture gap operator."""
 

--- a/src/porepy/models/solution_strategy.py
+++ b/src/porepy/models/solution_strategy.py
@@ -120,7 +120,7 @@ class SolutionStrategy(pp.PorePyModel):
         self._operator_cache: dict[Any, pp.ad.Operator] = {}
         """Cache for storing the result of methods that return Ad operators. This is
         used to avoid re-construction of the same operator multiple times, but does not
-        affect evaluation of the operator. 
+        affect evaluation of the operator.
 
         An operator is added to the cache by adding the decorator @pp.ad.cache_operator
         to the method that returns the operator. It is considered good practice to use

--- a/src/porepy/models/solution_strategy.py
+++ b/src/porepy/models/solution_strategy.py
@@ -117,6 +117,17 @@ class SolutionStrategy(pp.PorePyModel):
         """A list of results collected by the data saving mixin in
         :meth:`~porepy.viz.data_saving_model_mixin.DataSavingMixin.collect_data`."""
 
+        self._operator_cache: dict[Any, pp.ad.Operator] = {}
+        """Cache for storing the result of methods that return Ad operators. This is
+        used to avoid re-construction of the same operator multiple times, but does not
+        affect evaluation of the operator. 
+
+        An operator is added to the cache by adding the decorator @pp.ad.cache_operator
+        to the method that returns the operator. It is considered good practice to use
+        the cache sparingly, and only for operators that have been shown to be expensive
+        to construct.
+        """
+
         self.set_solver_statistics()
 
     def prepare_simulation(self) -> None:

--- a/src/porepy/numerics/ad/operators.py
+++ b/src/porepy/numerics/ad/operators.py
@@ -6,7 +6,7 @@ import copy
 import inspect
 from collections import deque
 from enum import Enum
-from functools import reduce
+from functools import reduce, wraps
 from hashlib import sha256
 from itertools import count
 from typing import (
@@ -2273,7 +2273,8 @@ def cached_method(func: Callable) -> Callable:
 
     """
 
-    def wrapper(self, *args, **kwargs):
+    @wraps(func)
+    def wrapper(self, *args, **kwargs) -> Any:
         # We will build a key from the function name, the arguments, and the keyword
         # arguments. To that end, we need to convert all arguments to hashable types.
 

--- a/src/porepy/numerics/ad/operators.py
+++ b/src/porepy/numerics/ad/operators.py
@@ -2265,6 +2265,21 @@ def cached_method(func: Callable) -> Callable:
     Ad module. If an unhashable argument is passed, a warning will be given, and the
     function will be called every time.
 
+    Known limitations:
+        - A call with a (non-keyword) argument, and call with the same argument passed
+          as a keyword argument (respectively, func(1) and func(arg=1)) will be
+          conisedered different and lead to two actual function evaluations and two
+          different items in the cache. It may be possible to extend the caching
+          mechanism (really, the way the cache key is constructed) to fix this, but
+          considering the current use cases, this is not deemed necessary.
+
+    Note:
+        This caching mechanism should not be confused with hashing of individual Ad
+        Operators, see above classes. The difference is that the present caching is
+        invoked on a method that returns an Operator, without constructing the Operator
+        itself (this can be costly). In contrast, caching of Operators is done after
+        construction, and is primarily intended for Operator evaluation.
+
     Parameters:
         func: The function to be cached.
 
@@ -2317,10 +2332,12 @@ def cached_method(func: Callable) -> Callable:
             self._operator_cache[key] = func(self, *args, **kwargs)
         return self._operator_cache[key]
 
-    # For testing purposes, we need to be able to access the signature of the original
-    # function. Calling inspect.signature on the wrapper would return the signature of
-    # the wrapper (*args, **kwargs, see above), which is not very useful. Therefore, we
-    # copy the signature from the original function to the wrapper.
+    # For testing purposes (specifically testing of constitutive laws and other tests
+    # that dynamically adapt to method signatures), we need to be able to access the
+    # signature of the original function. Calling inspect.signature on the wrapper would
+    # return the signature of the wrapper (*args, **kwargs, see above), which is not
+    # very useful. Therefore, we copy the signature from the original function to the
+    # wrapper.
     wrapper.__signature__ = inspect.signature(func)  # type: ignore[attr-defined]
 
     return wrapper

--- a/src/porepy/numerics/ad/operators.py
+++ b/src/porepy/numerics/ad/operators.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+import inspect
 from collections import deque
 from enum import Enum
 from functools import reduce
@@ -2282,5 +2283,11 @@ def cached_method(func: Callable) -> Callable:
         if key not in self._operator_cache:
             self._operator_cache[key] = func(self, *args, **kwargs)
         return self._operator_cache[key]
+
+    # For testing purposes, we need to be able to access the signature of the original
+    # function. Calling inspect.signature on the wrapper would return the signature of
+    # the wrapper (*args, **kwargs, see above), which is not very useful. Therefore, we
+    # copy the signature from the original function to the wrapper.
+    wrapper.__signature__ = inspect.signature(func)  # type: ignore[attr-defined]
 
     return wrapper

--- a/src/porepy/numerics/ad/operators.py
+++ b/src/porepy/numerics/ad/operators.py
@@ -45,6 +45,7 @@ __all__ = [
     "ProjectionList",
     "sum_operator_list",
     "sum_projection_list",
+    "cached_method",
 ]
 
 
@@ -2250,3 +2251,36 @@ def sum_projection_list(
             result = ProjectionList(new_operators, name)
 
     return result
+
+
+def cached_method(func: Callable) -> Callable:
+    """Decorator for caching function results.
+
+    The decorator is used to cache the results of a function. The cache is stored in the
+    `_operator_cache` attribute of the class instance.
+
+    Parameters:
+        func: The function to be cached.
+
+    Returns:
+        The decorated function.
+
+    """
+
+    def wrapper(self, *args, **kwargs):
+        args_as_tuples = []
+        for arg in args:
+            if isinstance(arg, list):
+                args_as_tuples.append(tuple(arg))
+            else:
+                args_as_tuples.append(arg)
+
+        # Use qualname to get the full name of the function, including the class name if
+        # the function is a method. In this way, we should avoid collisions related to
+        # inheritance.
+        key = (func.__qualname__, tuple(args_as_tuples), frozenset(kwargs.items()))
+        if key not in self._operator_cache:
+            self._operator_cache[key] = func(self, *args, **kwargs)
+        return self._operator_cache[key]
+
+    return wrapper

--- a/src/porepy/numerics/ad/operators.py
+++ b/src/porepy/numerics/ad/operators.py
@@ -2261,7 +2261,7 @@ def cached_method(func: Callable) -> Callable:
     `_operator_cache` attribute of the class instance.
 
     It is assumed that any arguments (both positional and keyword) to the function to be
-    decorated is either hashable, or a list. This covers all known use cases within the
+    decorated are either hashable, or a list. This covers all known use cases within the
     Ad module. If an unhashable argument is passed, a warning will be given, and the
     function will be called every time.
 
@@ -2283,6 +2283,9 @@ def cached_method(func: Callable) -> Callable:
         # IMPLEMENTATION NOTE: It is possible to extend the below if-else to handle more
         # cases, but this should be done as needed. The same applies to the keyword
         # arguments just below.
+
+        # Create a list to be converted to a tuple below. Append the arguments as they
+        # are, unless they are lists, in which case they are converted to tuples.
         args_as_tuples = []
         for arg in args:
             if isinstance(arg, list):

--- a/src/porepy/numerics/ad/operators.py
+++ b/src/porepy/numerics/ad/operators.py
@@ -2260,6 +2260,11 @@ def cached_method(func: Callable) -> Callable:
     The decorator is used to cache the results of a function. The cache is stored in the
     `_operator_cache` attribute of the class instance.
 
+    It is assumed that any arguments (both positional and keyword) to the function to be
+    decorated is either hashable, or a list. This covers all known use cases within the
+    Ad module. If an unhashable argument is passed, a warning will be given, and the
+    function will be called every time.
+
     Parameters:
         func: The function to be cached.
 
@@ -2269,6 +2274,14 @@ def cached_method(func: Callable) -> Callable:
     """
 
     def wrapper(self, *args, **kwargs):
+        # We will build a key from the function name, the arguments, and the keyword
+        # arguments. To that end, we need to convert all arguments to hashable types.
+
+        # If any argument is given as a list, convert it to a tuple to make it hashable.
+        #
+        # IMPLEMENTATION NOTE: It is possible to extend the below if-else to handle more
+        # cases, but this should be done as needed. The same applies to the keyword
+        # arguments just below.
         args_as_tuples = []
         for arg in args:
             if isinstance(arg, list):
@@ -2276,10 +2289,26 @@ def cached_method(func: Callable) -> Callable:
             else:
                 args_as_tuples.append(arg)
 
+        # The keyword arguments can be made hashable by calling frozenset, but we first
+        # need to convert any list values to tuples.
+        kwargs_as_tuples = {
+            k: tuple(v) if isinstance(v, list) else v for k, v in kwargs.items()
+        }
+        kwargs_as_frozenset = frozenset(kwargs_as_tuples.items())
+
         # Use qualname to get the full name of the function, including the class name if
         # the function is a method. In this way, we should avoid collisions related to
         # inheritance.
-        key = (func.__qualname__, tuple(args_as_tuples), frozenset(kwargs.items()))
+        try:
+            key = (func.__qualname__, tuple(args_as_tuples), kwargs_as_frozenset)
+        except Exception as e:
+            s = "Error in caching function: {}\n".format(func.__qualname__)
+            s += "This is likely due to an unhashable argument in the function call.\n"
+            s += "Instead of caching, the function will be called every time.\n"
+            s += "The error message was: {}\n".format(str(e))
+            warn(s)
+            return func(self, *args, **kwargs)
+
         if key not in self._operator_cache:
             self._operator_cache[key] = func(self, *args, **kwargs)
         return self._operator_cache[key]

--- a/tests/functional/setups/manu_flow_comp_2d_frac.py
+++ b/tests/functional/setups/manu_flow_comp_2d_frac.py
@@ -78,12 +78,6 @@ class ManuCompSaveData(ManuIncompSaveData):
 class ManuCompDataSaving(pp.PorePyModel):
     """Mixin class to store relevant data."""
 
-    darcy_flux: Callable[[list[pp.Grid]], pp.ad.Operator]
-    """Method that returns the Darcy fluxes in the form of an Ad operator. Usually
-    provided by the mixin class :class:`porepy.models.constitutive_laws.DarcysLaw`.
-
-    """
-
     exact_sol: ManuCompExactSolution2d
     """Exact solution object."""
 
@@ -678,12 +672,6 @@ class ManuCompBalanceEquation(pp.fluid_mass_balance.FluidMassBalanceEquations):
 # -----> Solution strategy
 class ManuCompSolutionStrategy2d(pp.fluid_mass_balance.SolutionStrategySinglePhaseFlow):
     """Modified solution strategy for the verification model."""
-
-    darcy_flux: Callable[[list[pp.Grid]], pp.ad.Operator]
-    """Method that returns the Darcy fluxes in the form of an Ad operator. Usually
-    provided by the mixin class :class:`porepy.models.constitutive_laws.DarcysLaw`.
-
-    """
 
     exact_sol: ManuCompExactSolution2d
     """Exact solution object."""

--- a/tests/functional/setups/manu_flow_incomp_frac_2d.py
+++ b/tests/functional/setups/manu_flow_incomp_frac_2d.py
@@ -100,12 +100,6 @@ class ManuIncompSaveData:
 class ManuIncompDataSaving(pp.PorePyModel):
     """Mixin class to save relevant data."""
 
-    darcy_flux: Callable[[list[pp.Grid]], pp.ad.Operator]
-    """Method that returns the Darcy fluxes in the form of an Ad operator. Usually
-    provided by the mixin class :class:`porepy.models.constitutive_laws.DarcysLaw`.
-
-    """
-
     exact_sol: ManuIncompExactSolution2d
     """Exact solution object."""
 

--- a/tests/functional/setups/manu_poromech_nofrac_2d.py
+++ b/tests/functional/setups/manu_poromech_nofrac_2d.py
@@ -113,12 +113,6 @@ class ManuPoroMechSaveData:
 class ManuPoroMechDataSaving(pp.PorePyModel):
     """Mixin class to save relevant data."""
 
-    darcy_flux: Callable[[list[pp.Grid]], pp.ad.Operator]
-    """Method that returns the Darcy fluxes in the form of an Ad operator. Usually
-    provided by the mixin class :class:`porepy.models.constitutive_laws.DarcysLaw`.
-
-    """
-
     displacement: Callable[[pp.SubdomainsOrBoundaries], pp.ad.MixedDimensionalVariable]
     """Displacement variable. Normally defined in a mixin instance of
     :class:`~porepy.models.momentum_balance.VariablesMomentumBalance`.

--- a/tests/functional/setups/manu_sneddon_2d.py
+++ b/tests/functional/setups/manu_sneddon_2d.py
@@ -10,7 +10,6 @@ References:
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable
 
 import numpy as np
 
@@ -347,8 +346,6 @@ class ManuSneddonDataSaving(pp.PorePyModel):
     """Class for saving the error in the displacement field."""
 
     exact_sol: SneddonExactSolution2d
-
-    displacement_jump: Callable[[list[pp.Grid]], pp.ad.Operator]
 
     def collect_data(self) -> ManuSneddonSaveData:
         """Collecting the error in the displacement field."""

--- a/tests/functional/setups/manu_thermoporomech_nofrac_2d.py
+++ b/tests/functional/setups/manu_thermoporomech_nofrac_2d.py
@@ -143,11 +143,7 @@ class ManuThermoPoroMechDataSaving(pp.PorePyModel):
     :class:`porepy.models.energy_balance.EnergyBalanceEquations`.
 
     """
-    darcy_flux: Callable[[list[pp.Grid]], pp.ad.Operator]
-    """Method that returns the Darcy fluxes in the form of an Ad operator. Usually
-    provided by the mixin class :class:`porepy.models.constitutive_laws.DarcysLaw`.
 
-    """
     stress: Callable[[list[pp.Grid]], pp.ad.Operator]
     """Method that returns the (integrated) poroelastic stress in the form of an Ad
     operator. Usually provided by the mixin class

--- a/tests/models/test_geometry.py
+++ b/tests/models/test_geometry.py
@@ -77,6 +77,10 @@ class TestGeometry:
                 # Set the geometry configuration.
                 geometry_model.set_geometry()
 
+                # The operator_cache is usually set by the SolutionStrategy, but since
+                # this class is used standalone, we need to set it here.
+                geometry_model._operator_cache = {}
+
                 self.geometries[(geometry_class, num_fracs)] = geometry_model
 
     def test_set_geometry(

--- a/tests/numerics/ad/test_operators.py
+++ b/tests/numerics/ad/test_operators.py
@@ -1892,7 +1892,7 @@ def test_operator_method_caching():
     assert model.method_with_two_args(foo=1, bar=2) == 5
     # When the keywords are passed in the opposite order, they will be found in the
     # cache.
-    assert model.method_with_two_args(bar=2, foo=1) == 6
+    assert model.method_with_two_args(bar=2, foo=1) == 5
 
     # The model with a list argument should have its counter incremented each time it is
     # called with a different list argument. When later called with the same list

--- a/tests/numerics/ad/test_operators.py
+++ b/tests/numerics/ad/test_operators.py
@@ -1801,3 +1801,138 @@ def test_hashing_sparse_array(two_spmatrices):
     """
     m1, m2 = [pp.ad.SparseArray(mat) for mat in two_spmatrices]
     assert hash(m1) != hash(m2)
+
+
+class MockModelForCacheTesting:
+    """A mock model for testing the caching of methods.
+
+    The class has a number of methods with different signatures, all of which are
+    decorated with @pp.ad.cached_method. The methods increment a counter each time the
+    actual method body is executed (but *not* when the cache decorater reroutes the
+    call), and return the current value of the counter.
+    """
+
+    def __init__(self):
+        self._operator_cache = {}
+        self._no_args_counter = 0
+        self._one_arg_counter = 0
+        self._two_args_counter = 0
+        self._list_arg_counter = 0
+        self._kwarg_counter = 0
+        self._arg_and_kwarg_counter = 0
+
+    @pp.ad.cached_method
+    def method_with_no_arguments(self):
+        self._no_args_counter += 1
+        return self._no_args_counter
+
+    @pp.ad.cached_method
+    def method_with_one_arg(self, foo: int):
+        self._one_arg_counter += 1
+        return self._one_arg_counter
+
+    @pp.ad.cached_method
+    def method_with_two_args(self, foo: int, bar: int):
+        self._two_args_counter += 1
+        return self._two_args_counter
+
+    @pp.ad.cached_method
+    def method_with_list_arg(self, foo: list[int]):
+        self._list_arg_counter += 1
+        return self._list_arg_counter
+
+    @pp.ad.cached_method
+    def method_with_kwargs(self, *, foo: int = 1):
+        self._kwarg_counter += 1
+        return self._kwarg_counter
+
+    @pp.ad.cached_method
+    def method_with_arg_and_kwarg(self, foo: int, *, bar: int = 1):
+        self._arg_and_kwarg_counter += 1
+        return self._arg_and_kwarg_counter
+
+
+class InheritedMockModel(MockModelForCacheTesting):
+    def method_with_no_arguments(self):
+        # A method with no caching at all.
+        return 0
+
+    def method_with_one_arg(self, foo: int):
+        # A method that forwards the call to the parent class, which is cached.
+        return super().method_with_one_arg(foo)
+
+
+def test_operator_method_caching():
+    model = MockModelForCacheTesting()
+
+    # The model with no argument should be called once, then have its result cached.
+    for _ in range(2):
+        assert model.method_with_no_arguments() == 1
+
+    # The model with a single argument should have its counter incremented each time it
+    # is called with a different argument. When later called with the same argument, the
+    # return should be the same as at the original call.
+    for _ in range(2):
+        assert model.method_with_one_arg(1) == 1
+    assert model.method_with_one_arg(3) == 2
+    assert model.method_with_one_arg(1) == 1
+
+    # The model with two arguments should have its counter incremented each time it is
+    # called with at least one argument not seen before. When later called with the same
+    # arguments, the return should be the same as at the original call.
+    for _ in range(2):
+        assert model.method_with_two_args(1, 2) == 1
+    assert model.method_with_two_args(3, 4) == 2
+    assert model.method_with_two_args(1, 3) == 3
+    assert model.method_with_two_args(2, 2) == 4
+    assert model.method_with_two_args(1, 2) == 1
+    # With the current implementation, passing the same arguments, but as keyword
+    # arguments should trigger a new evaluation, but then the cache should be used.
+    assert model.method_with_two_args(foo=1, bar=2) == 5
+    assert model.method_with_two_args(foo=1, bar=2) == 5
+    # When the keywords are passed in the opposite order, they will be found in the
+    # cache.
+    assert model.method_with_two_args(bar=2, foo=1) == 6
+
+    # The model with a list argument should have its counter incremented each time it is
+    # called with a different list argument. When later called with the same list
+    # argument, the return should be the same as at the original call.
+    for _ in range(2):
+        assert model.method_with_list_arg([1, 2]) == 1
+    assert model.method_with_list_arg([3, 4]) == 2
+    assert model.method_with_list_arg([1, 2]) == 1
+
+    # The model with a keyword argument should have its counter incremented each time it
+    # is called with a different keyword argument. When later called with the same
+    # keyword argument, the return should be the same as at the original call.
+    for _ in range(2):
+        assert model.method_with_kwargs(foo=1) == 1
+    assert model.method_with_kwargs(foo=2) == 2
+    assert model.method_with_kwargs(foo=1) == 1
+
+    # Test method with a positional argument and a keyword argument.
+    for _ in range(2):
+        assert model.method_with_arg_and_kwarg(1, bar=2) == 1
+    assert model.method_with_arg_and_kwarg(3, bar=4) == 2
+    assert model.method_with_arg_and_kwarg(1, bar=2) == 1
+
+    # Also test that the cache works for inherited classes.
+    inherited_model = InheritedMockModel()
+
+    for _ in range(2):
+        # A method with no caching should behave the same time every time it is called.
+        assert inherited_model.method_with_no_arguments() == 0
+
+    # Test a method that forwards the call to the parent class, which is cached. The
+    # behavior should be identical to the test of the parent class.
+    for _ in range(2):
+        assert inherited_model.method_with_one_arg(1) == 1
+    assert inherited_model.method_with_one_arg(3) == 2
+    assert inherited_model.method_with_one_arg(1) == 1
+
+    # Test a method that is not overridden in the inherited class. The behavior should
+    # be identical to the test of the parent class.
+    for _ in range(2):
+        assert inherited_model.method_with_list_arg([1, 2]) == 1
+    assert inherited_model.method_with_list_arg([3, 4]) == 2
+    assert inherited_model.method_with_list_arg([1, 2]) == 1


### PR DESCRIPTION
## Proposed changes
As discussed in #1345, the cost of constructing operators for constitutive laws is high, in particular for laws that are called multiple times. This PR introduces a simple caching-mechanism that stores the constructed operator.

Caching is invoked by adding a decorator `@pp.ad.cached_method` on target methods. Though in principle caching can be applied widely, this PR introduces it only in a few selected methods. Profiling indicates that this PR, together with an upcoming PR that targets parameter updates within Newton iterations, removes most if not all the non-standard bottlenecks (those that are not assembly linear solve, rediscretization, exporting) within Newton.

---------------------

UPDATE: Preserving type information for the decorated methods turned out to be non-trivial (for reference: Using `functools.wraps()` should solve the issue, but in practice it does not - I can speculate that the combination of many classes, mixins and decorators is simply too much for mypy). Having explored all reasonable suggestions from the internet and copilot, I had to introduce the cached methods in the protocol. This is far from a perfect solution, but I am afraid it will have to do.


## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [x] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
