### PR TITLE
Add normals to boundary grids.

### DIFF
--- a/src/porepy/grids/boundary_grid.py
+++ b/src/porepy/grids/boundary_grid.py
@@ -93,12 +93,13 @@ class BoundaryGrid:
 
         Compute the cell centers and volumes of the boundary grid. By default, the
         boundary grid cell information is constructed from the domain boundary faces of
-        theparent grid.
+        the parent grid.
 
         """
         parent_boundary = self._parent.tags["domain_boundary_faces"]
         self.cell_centers = self._parent.face_centers[:, parent_boundary]
         self.cell_volumes = self._parent.face_areas[parent_boundary]
+        self.cell_normals = self._parent.face_normals[:, parent_boundary]
 
     def set_projections(self) -> None:
         """Set projections from the parent grid and set the corresponding attributes.

--- a/src/porepy/grids/boundary_grid.py
+++ b/src/porepy/grids/boundary_grid.py
@@ -88,6 +88,14 @@ class BoundaryGrid:
 
         """
 
+        self.cell_normals: np.ndarray
+        """Normals of cells of the boundary grid. Remember that boundary grid cells are
+        faces of the parent grid. Thus, it stores normals of boundary faces.
+
+        Initialized in :meth:`~compute_geometry`.
+
+        """
+
     def compute_geometry(self) -> None:
         """Compute the geometry of the boundary grid.
 


### PR DESCRIPTION
## Proposed changes

For boundary grids it is natural to request their normals (to e.g. apply stress tensors to a face by multiplication of the tensor with a normal). This PR adds cell normals to boundary grids by copying from their parent domain grid.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [X] The documentation is up-to-date.
- [X] Static typing is included in the update.
- [X] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
