### PR TITLE
Extend-damage-testing

### DIFF
--- a/src/porepy/examples/fracture_damage.py
+++ b/src/porepy/examples/fracture_damage.py
@@ -442,7 +442,15 @@ class IsotropicFractureDamage(  # type: ignore[misc]
     ContactMechanicsTester,
     FractureDamageContactMechanics,
 ):
-    pass
+    """Isotropic fracture damage model.
+
+    The equations are fracture damage and contact mechanics. Variables are contact
+    traction and damage history. The model is isotropic, i.e., the damage history is
+    independent of the loading direction.
+
+    Also contains specifics defining a test case.
+
+    """
 
 
 class AnisotropicFractureDamage(  # type: ignore[misc]
@@ -451,7 +459,14 @@ class AnisotropicFractureDamage(  # type: ignore[misc]
     ContactMechanicsTester,
     FractureDamageContactMechanics,
 ):
-    pass
+    """Anisotropic fracture damage model.
+
+    The equations are fracture damage and contact mechanics. Variables are contact
+    traction and damage history. The model is anisotropic, i.e., the damage history is
+    dependent on the loading direction.
+
+    Also contains specifics defining a test case.
+    """
 
 
 class FractureDamageMomentumBalance(  # type: ignore[misc]
@@ -461,4 +476,13 @@ class FractureDamageMomentumBalance(  # type: ignore[misc]
     TimeDependentDamageBCs,
     pp.MomentumBalance,
 ):
-    pass
+    """Fracture damage momentum balance model.
+
+    This model combines fracture damage mechanics with momentum balance and force
+    balance across interfaces. Variables are matrix and interface displacements, contact
+    traction, and damage history. The model is isotropic, i.e., the damage history is
+    independent of the loading direction.
+
+    Also contains specifics defining a test case in terms of the boundary conditions.
+
+    """

--- a/src/porepy/examples/fracture_damage.py
+++ b/src/porepy/examples/fracture_damage.py
@@ -44,11 +44,17 @@ class TimeDependentDamageBCs(BoundaryConditionsMechanicsDirNorthSouth):
         return values.ravel("F")
 
 
-class FractureDamageContactMechanics(  # type: ignore[misc]
+class DamageBase(
     pp.constitutive_laws.FrictionDamage,
     pp.constitutive_laws.DilationDamage,
     damage.DamageHistoryVariable,
     damage.DamageHistoryEquation,
+):
+    pass
+
+
+class FractureDamageContactMechanics(  # type: ignore[misc]
+    DamageBase,
     pp.contact_mechanics.ContactMechanics,
 ):
     """Fracture damage model.
@@ -407,7 +413,7 @@ solid_params = {
     "dilation_damage_decay": 0.5,
     "friction_coefficient": 0.1,  # Low friction to get slip \approx bc displacement
     "dilation_angle": 0.1,
-    # "shear_modulus": 1e6,  # Suppress shear displacement
+    "shear_modulus": 1e6,  # Suppress shear displacement in the matrix.
     "fracture_normal_stiffness": 1.0e-3,  # Low normal stiffness to promote slip
     "fracture_tangential_stiffness": 1.0e3,  # High tangential stiffness to suppress
     # elastic deformation
@@ -433,7 +439,6 @@ model_params = {
 class IsotropicFractureDamage(  # type: ignore[misc]
     damage.IsotropicHistoryEquation,
     DamageDataSaving,
-    # TimeDependentDamageBCs,
     ContactMechanicsTester,
     FractureDamageContactMechanics,
 ):
@@ -445,5 +450,15 @@ class AnisotropicFractureDamage(  # type: ignore[misc]
     DamageDataSaving,
     ContactMechanicsTester,
     FractureDamageContactMechanics,
+):
+    pass
+
+
+class FractureDamageMomentumBalance(  # type: ignore[misc]
+    damage.IsotropicHistoryEquation,
+    DamageDataSaving,
+    DamageBase,
+    TimeDependentDamageBCs,
+    pp.MomentumBalance,
 ):
     pass

--- a/src/porepy/examples/fracture_damage.py
+++ b/src/porepy/examples/fracture_damage.py
@@ -58,11 +58,11 @@ class FractureDamageContactMechanics(  # type: ignore[misc]
     used with the same model, specifically during testing. TODO: Consider to choose one
     as default.
 
-    Two methods are overridden in this class: - variables_stored_all_time_steps: The
-    interface displacement is not included in the
-      model, and thus the method is overridden to exclude it.
-    - update_time_dependent_interface_displacement: The interface displacement parameter
-      needs to be stored at all time steps.
+    Two methods are overridden in this class:
+        - variables_stored_all_time_steps: The interface displacement is not included in
+        the model, and thus the method is overridden to exclude it.
+        - update_interface_displacement_parameter: The interface displacement parameter
+        needs to be stored at all time steps.
 
     The combination of the two overrides amounts to replacing the variable stored at
     each time step with the parameter value being stored.
@@ -85,7 +85,7 @@ class FractureDamageContactMechanics(  # type: ignore[misc]
             ]
         )
 
-    def update_time_dependent_interface_displacement(self) -> None:
+    def update_interface_displacement_parameter(self) -> None:
         """Update the interface displacement parameter."""
 
         name = self.interface_displacement_parameter_key

--- a/tests/models/test_fracture_damage.py
+++ b/tests/models/test_fracture_damage.py
@@ -82,10 +82,6 @@ def test_damage(
     )
 
     m = model_class(params_local)
-    # Some simulations do not converge in the default number of iterations. Only
-    # slightly increase the number of iterations, thus capturing any future
-    # deterioration in the convergence and avoiding excessive run times.
-
     pp.run_time_dependent_model(m)
     # Initialize test names for assertions
     test_names = [
@@ -115,11 +111,11 @@ def test_damage(
 def test_momentum_balance_with_damage(dim: int):
     """Test that damage also works with momentum balance.
 
-    For a leaner test, we only parametrize on dimension. We cover both regimes and use
-    four time steps, which should be enough to capture most aspects of the damage
-    evolution. The full parametrization above should ensures proper testing of the
-    actual damage models, while this test is more about verifying that the damage model
-    works with momentum balance.
+    For a leaner test, we only parametrize on dimension. We cover both dilation and
+    friction damage and use four time steps, which should be enough to capture most
+    aspects of the damage evolution. The full parametrization above should ensures
+    proper testing of the actual damage models, while this test is more about verifying
+    that the damage model works with momentum balance.
 
     """
     regime = "both"

--- a/tests/models/test_fracture_damage.py
+++ b/tests/models/test_fracture_damage.py
@@ -86,12 +86,7 @@ def test_damage(
     # slightly increase the number of iterations, thus capturing any future
     # deterioration in the convergence and avoiding excessive run times.
 
-    pp.run_time_dependent_model(
-        m,
-        {
-            "max_iterations": 45,
-        },
-    )
+    pp.run_time_dependent_model(m)
     # Initialize test names for assertions
     test_names = [
         "friction_damage",
@@ -113,4 +108,71 @@ def test_damage(
             # print(f"Time step {t + 1}, {name} exact: {val}")
 
             # Assert that the error is small.
-            assert e < 1e-6
+            np.testing.assert_allclose(e, 0, atol=1e-8)
+
+
+@pytest.mark.parametrize("dim", [2, 3])
+def test_momentum_balance_with_damage(dim: int):
+    """Test that damage also works with momentum balance.
+
+    For a leaner test, we only parametrize on dimension. We cover both regimes and use
+    four time steps, which should be enough to capture most aspects of the damage
+    evolution. The full parametrization above should ensures proper testing of the
+    actual damage models, while this test is more about verifying that the damage model
+    works with momentum balance.
+
+    """
+    regime = "both"
+    time_steps = 4
+    # Copy the model parameters to avoid modifying the original dictionary.
+    # Deepcopy is needed to avoid modifying mutable objects in the dictionary,
+    # presumably the time manager.
+    params_local = copy.deepcopy(damage.model_params)
+    # Use the isotropic damage model.
+    model_class = damage.FractureDamageMomentumBalance
+    # Change the exact solution to the isotropic version.
+    params_local["exact_solution"] = damage.ExactSolutionIsotropic
+    # Add geometry mixin.
+    model_class = add_mixin(geometry_mixins[str(dim)], model_class)
+
+    # Combine the solid parameters giving priority to the additional parameters.
+    # solid_params is not modified and can be reused in other tests.
+    solid_params_local = {**damage.solid_params, **additional_solid_params[regime]}
+
+    params_local.update(
+        {
+            "material_constants": {
+                "solid": FractureDamageSolidConstants(**solid_params_local)
+            },
+            "time_manager": pp.TimeManager(np.arange(0, time_steps), 1, True),
+            "north_displacements": params_local["north_displacements"][:dim],
+        }
+    )
+
+    m = model_class(params_local)
+    # Some simulations do not converge in the default number of iterations. Only
+    # slightly increase the number of iterations, thus capturing any future
+    # deterioration in the convergence and avoiding excessive run times.
+
+    pp.run_time_dependent_model(m, {"max_iterations": 25})
+    test_names = [
+        "friction_damage",
+        "dilation_damage",
+        "damage_history",
+    ]
+    # Initial time step is not included in VerificationDataSaving
+    for t in np.arange(time_steps - 1):
+        # Retrieve stored results for time step t + 1
+        results = m.results[t]
+        for name in test_names:
+            # Retrieve the normalized error for the current time step and the current
+            # variable.
+            e = getattr(results, name + "_error")
+            # Uncomment to print the error. Useful for debugging. Might require running
+            # the test with pytest -s.
+            # val = getattr(results, "exact_" + name)
+            # print(f"Time step {t + 1}, {name}: {e}")
+            # print(f"Time step {t + 1}, {name} exact: {val}")
+
+            # Assert that the error is small.
+            np.testing.assert_allclose(e, 0, atol=1e-8)


### PR DESCRIPTION
## Proposed changes

This adds an integration test for momentum balance + fracture damage. It also fixes a bug which caused failure of one of the slow tests.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [x] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
