### PR TITLE
BUG: Tetrahedral generation from Gmsh, 2d array should be 1d

### DIFF
--- a/src/porepy/grids/simplex.py
+++ b/src/porepy/grids/simplex.py
@@ -266,9 +266,15 @@ class TetrahedralGrid(Grid):
         sort_ind = np.squeeze(np.argsort(face_nodes, axis=0))
         face_nodes_sorted = np.sort(face_nodes, axis=0)
 
+        # Now find the unique face-nodes, by comparing columns in the sorted array.
+        # Internal faces will be found twice, once  for ecah cell, while external faces
+        # only occur once. The second returned value gives the index of the cells which
+        # the face belongs to.
         face_nodes, cell_faces = np.unique(
             face_nodes_sorted, axis=1, return_inverse=True
         )
+        # Numpy may return cell-faces as a 2d array, so we need to flatten it.
+        cell_faces = cell_faces.ravel(order="F")
 
         num_faces = face_nodes.shape[1]
 


### PR DESCRIPTION
## Proposed changes
This fixes an issue that likely arose when a call to a PorePy function was changed to `numpy` unique in PR #1386. 

NOTE: The issue is picked up when I run `test_mdg_library` with `--run-skipped` locally (generation of the 3rd 3d benchmark geometry fails) on `numpy v2.0`, but *not* `v2.1.3`, as was done on the latest GH run of all tests. There is thus a workaround that avoids this update, but I don't see any harm in the minor changes suggested.


Contributions to PorePy are highly appreciated. Clearly explain why this pull request (PR) is needed and why it should be accepted. If this PR solves an issue, explain how it is done. Please, also summarise the changes to the code.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [x] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
