### PR TITLE
Added deprecation warnings

### DIFF
--- a/src/porepy/numerics/ad/_ad_utils.py
+++ b/src/porepy/numerics/ad/_ad_utils.py
@@ -27,6 +27,7 @@ Classes:
 
 from __future__ import annotations
 
+import warnings
 from abc import ABCMeta
 from typing import Any, Optional
 
@@ -43,6 +44,8 @@ from .forward_mode import AdArray
 def concatenate_ad_arrays(ad_arrays: list[AdArray], axis=0):
     """Concatenates a sequence of AD arrays into a single AD Array along a specified
     axis."""
+    msg = "This functionality is deprecated and will be removed in a future version"
+    warnings.warn(msg, DeprecationWarning)
     vals = [var.val for var in ad_arrays]
     jacs = np.array([var.jac for var in ad_arrays])
 

--- a/src/porepy/numerics/fv/tpfa.py
+++ b/src/porepy/numerics/fv/tpfa.py
@@ -5,6 +5,7 @@ approximation scheme. The implementation resides in the class Tpfa.
 
 from __future__ import annotations
 
+import warnings
 from typing import Any, Callable, Literal, Sequence
 
 import numpy as np
@@ -114,6 +115,11 @@ class Tpfa(pp.FVElliptic):
         # The periodic boundary is defined by a mapping from left faces to right
         # faces:
         if hasattr(sd, "periodic_face_map"):
+            msg = (
+                "This functionality is deprecated and will be removed "
+                "in a future version"
+            )
+            warnings.warn(msg, DeprecationWarning)
             fi_left = sd.periodic_face_map[0]
             fi_right = sd.periodic_face_map[1]
         else:

--- a/src/porepy/params/bc.py
+++ b/src/porepy/params/bc.py
@@ -441,6 +441,8 @@ def face_on_side(
     Raises:
         ValueError if not supported keyword is used to identify a boundary part.
     """
+    msg = "This functionality is deprecated and will be removed in a future version"
+    warnings.warn(msg, DeprecationWarning)
     if isinstance(side, str):
         side = [side]
 


### PR DESCRIPTION
## Proposed changes
* `face_on_side` function in the bc module.
* Option for periodic boundary conditions in tpfa
* Outdated utility function in the forward ad module.

Resolves #1411.


## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
