### PR TITLE
Optimize Darcy flux evaluation

### DIFF
--- a/src/porepy/models/energy_balance.py
+++ b/src/porepy/models/energy_balance.py
@@ -1186,7 +1186,7 @@ class SolutionStrategyEnergyBalance(pp.SolutionStrategy):
                 },
             )
 
-    def darcy_flux_keywords(self) -> list[str]:
+    def darcy_flux_storage_keywords(self) -> list[str]:
         """Return the keywords for which the Darcy flux values are stored.
 
         Returns:
@@ -1194,7 +1194,7 @@ class SolutionStrategyEnergyBalance(pp.SolutionStrategy):
             :attr:`enthalpy_keyword`.
 
         """
-        return super().darcy_flux_keywords() + [self.enthalpy_keyword]
+        return super().darcy_flux_storage_keywords() + [self.enthalpy_keyword]
 
     def set_nonlinear_discretizations(self) -> None:
         """Collect discretizations for nonlinear terms."""

--- a/src/porepy/models/energy_balance.py
+++ b/src/porepy/models/energy_balance.py
@@ -1187,10 +1187,10 @@ class SolutionStrategyEnergyBalance(pp.SolutionStrategy):
             )
 
     def darcy_flux_keywords(self) -> list[str]:
-        """Return the keywords for which the Darcy flux discretization is stored.
+        """Return the keywords for which the Darcy flux values are stored.
 
         Returns:
-            List of keywords for the Darcy flux discretization. This class adds
+            List of keywords for the Darcy flux values. This class adds
             :attr:`enthalpy_keyword`.
 
         """

--- a/src/porepy/models/energy_balance.py
+++ b/src/porepy/models/energy_balance.py
@@ -1187,7 +1187,7 @@ class SolutionStrategyEnergyBalance(pp.SolutionStrategy):
             )
 
     def darcy_flux_keywords(self) -> list[str]:
-        """Return the keywords for twhich the Darcy flux discretization is stored.
+        """Return the keywords for which the Darcy flux discretization is stored.
 
         Returns:
             List of keywords for the Darcy flux discretization. This class adds

--- a/src/porepy/models/fluid_mass_balance.py
+++ b/src/porepy/models/fluid_mass_balance.py
@@ -959,6 +959,12 @@ class SolutionStrategySinglePhaseFlow(pp.SolutionStrategy):
         keywords in self.darcy_flux_keywords().
 
         """
+
+        def update_dicts(vals: np.ndarray, data: dict) -> None:
+            """Update the data dictionary with the Darcy flux values."""
+            for key in self.darcy_flux_keywords():
+                data[pp.PARAMETERS][key].update({"darcy_flux": vals})
+
         # Evaluate the Darcy flux for all subdomains together, then distribute the
         # computed values. For domains with many subdomains, this is significantly
         # faster than evaluating the Darcy flux for each subdomain individually.
@@ -966,11 +972,6 @@ class SolutionStrategySinglePhaseFlow(pp.SolutionStrategy):
         darcy_flux = self.equation_system.evaluate(self.darcy_flux(subdomains))
         # Compute offsets for the start of each subdomain in the darcy_flux array.
         subdomain_offsets = np.cumsum([0] + [sd.num_faces for sd in subdomains])
-
-        def update_dicts(vals: np.ndarray, data: dict) -> None:
-            """Update the data dictionary with the Darcy flux values."""
-            for key in self.darcy_flux_keywords():
-                data[pp.PARAMETERS][key].update({"darcy_flux": vals})
 
         for id, sd in enumerate(subdomains):
             # Update the data dictionary with the Darcy flux for the current subdomain.

--- a/src/porepy/models/fluid_mass_balance.py
+++ b/src/porepy/models/fluid_mass_balance.py
@@ -956,13 +956,13 @@ class SolutionStrategySinglePhaseFlow(pp.SolutionStrategy):
         """Evaluate Darcy flux for each subdomain and interface and store in the data
         dictionary for use in upstream weighting. The Darcy flux is evaluated for all
         subdomains and interfaces and distributed to the parameter dictionaries for all
-        keywords in self.darcy_flux_keywords().
+        keywords in self.darcy_flux_storage_keywords().
 
         """
 
         def update_dicts(vals: np.ndarray, data: dict) -> None:
             """Update the data dictionary with the Darcy flux values."""
-            for key in self.darcy_flux_keywords():
+            for key in self.darcy_flux_storage_keywords():
                 data[pp.PARAMETERS][key].update({"darcy_flux": vals})
 
         # Evaluate the Darcy flux for all subdomains together, then distribute the
@@ -1005,15 +1005,15 @@ class SolutionStrategySinglePhaseFlow(pp.SolutionStrategy):
 
         super().before_nonlinear_iteration()
 
-    def darcy_flux_keywords(self) -> list[str]:
-        """Return the keywords for which the Darcy flux discretization is stored.
+    def darcy_flux_storage_keywords(self) -> list[str]:
+        """Return the keywords for which the Darcy flux values are stored.
 
         Returns:
-            List of keywords for the Darcy flux discretization. This class adds
+            List of keywords for the Darcy flux values. This class adds
             :attr:`mobility_keyword`.
 
         """
-        return super().darcy_flux_keywords() + [self.mobility_keyword]
+        return super().darcy_flux_storage_keywords() + [self.mobility_keyword]
 
     def set_nonlinear_discretizations(self) -> None:
         """Collect discretizations for nonlinear terms."""

--- a/src/porepy/models/fluid_mass_balance.py
+++ b/src/porepy/models/fluid_mass_balance.py
@@ -1005,7 +1005,7 @@ class SolutionStrategySinglePhaseFlow(pp.SolutionStrategy):
         super().before_nonlinear_iteration()
 
     def darcy_flux_keywords(self) -> list[str]:
-        """Return the keywords for twhich the Darcy flux discretization is stored.
+        """Return the keywords for which the Darcy flux discretization is stored.
 
         Returns:
             List of keywords for the Darcy flux discretization. This class adds

--- a/src/porepy/models/solution_strategy.py
+++ b/src/porepy/models/solution_strategy.py
@@ -728,7 +728,7 @@ class SolutionStrategy(pp.PorePyModel):
         self.update_all_boundary_conditions()
 
     def darcy_flux_keywords(self) -> list[str]:
-        """Return the keywords for twhich the Darcy flux discretization is stored.
+        """Return the keywords for which the Darcy flux discretization is stored.
 
         Returns:
             List of keywords for the Darcy flux discretization.

--- a/src/porepy/models/solution_strategy.py
+++ b/src/porepy/models/solution_strategy.py
@@ -728,10 +728,10 @@ class SolutionStrategy(pp.PorePyModel):
         self.update_all_boundary_conditions()
 
     def darcy_flux_keywords(self) -> list[str]:
-        """Return the keywords for which the Darcy flux discretization is stored.
+        """Return the keywords for which the Darcy flux values are stored.
 
         Returns:
-            List of keywords for the Darcy flux discretization.
+            List of keywords for the Darcy flux values.
 
         """
         return []

--- a/src/porepy/models/solution_strategy.py
+++ b/src/porepy/models/solution_strategy.py
@@ -727,6 +727,15 @@ class SolutionStrategy(pp.PorePyModel):
         """
         self.update_all_boundary_conditions()
 
+    def darcy_flux_keywords(self) -> list[str]:
+        """Return the keywords for twhich the Darcy flux discretization is stored.
+
+        Returns:
+            List of keywords for the Darcy flux discretization.
+
+        """
+        return []
+
 
 class ContactIndicators(pp.PorePyModel):
     """Class for computing contact indicators used for tailored line search.

--- a/src/porepy/models/solution_strategy.py
+++ b/src/porepy/models/solution_strategy.py
@@ -727,7 +727,7 @@ class SolutionStrategy(pp.PorePyModel):
         """
         self.update_all_boundary_conditions()
 
-    def darcy_flux_keywords(self) -> list[str]:
+    def darcy_flux_storage_keywords(self) -> list[str]:
         """Return the keywords for which the Darcy flux values are stored.
 
         Returns:


### PR DESCRIPTION
## Proposed changes


Streamline the evaluation of Darcy flux by 
- Computing fluxes once during before_nonlinear_iteration, storing for all keywords.
-processing all wells, improving performance in the case of many wells.

Please have a look at the placement of affected methods and naming of the new one.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
