### PR TITLE
Deprecate unused code in the grid library

### DIFF
--- a/src/porepy/grids/coarsening.py
+++ b/src/porepy/grids/coarsening.py
@@ -137,8 +137,6 @@ def reorder_partition(
         The subdivision stored in a contiguous way.
 
     """
-    msg = "This functionality is deprecated and will be removed in a future version"
-    warnings.warn(msg, DeprecationWarning)
 
     if isinstance(subdiv, dict):
         for _, (_, partition) in subdiv.items():

--- a/src/porepy/grids/coarsening.py
+++ b/src/porepy/grids/coarsening.py
@@ -137,6 +137,9 @@ def reorder_partition(
         The subdivision stored in a contiguous way.
 
     """
+    msg = "This functionality is deprecated and will be removed in a future version"
+    warnings.warn(msg, DeprecationWarning)
+
     if isinstance(subdiv, dict):
         for _, (_, partition) in subdiv.items():
             old_ids = np.unique(partition)

--- a/src/porepy/grids/grid.py
+++ b/src/porepy/grids/grid.py
@@ -16,9 +16,9 @@ from __future__ import annotations
 
 import copy
 import itertools
-from warnings import warn
 from itertools import count
 from typing import Any, Optional, Union
+from warnings import warn
 
 import numpy as np
 from scipy import sparse as sps

--- a/src/porepy/grids/grid.py
+++ b/src/porepy/grids/grid.py
@@ -452,7 +452,7 @@ class Grid:
         if not is_oriented:
             # The assumptions underlying the computation for general cells is broken.
             # Fall back to a legacy implementation which is only valid for convex cells.
-            warnings.warn(
+            warn(
                 "Orientations in face_nodes and cell_faces are inconsistent. "
                 "Fall back on an implementation that assumes all cells are convex."
             )

--- a/src/porepy/grids/grid.py
+++ b/src/porepy/grids/grid.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import copy
 import itertools
-import warnings
+from warnings import warn
 from itertools import count
 from typing import Any, Optional, Union
 
@@ -755,6 +755,9 @@ class Grid:
             internal nodes.
 
         """
+        msg = "This functionality is deprecated and will be removed in a future version"
+        warn(msg, DeprecationWarning)
+
         internal_nodes = np.setdiff1d(
             np.arange(self.num_nodes), self.get_boundary_nodes(), assume_unique=True
         )
@@ -767,6 +770,7 @@ class Grid:
             all faces tagged as either fractures, domain boundary or tip.
 
         """
+        tags
         return self._indices(tags.all_face_tags(self.tags))
 
     def get_all_boundary_nodes(self) -> np.ndarray:
@@ -795,6 +799,9 @@ class Grid:
             faces.
 
         """
+        msg = "This functionality is deprecated and will be removed in a future version"
+        warn(msg, DeprecationWarning)
+
         return np.setdiff1d(
             np.arange(self.num_faces), self.get_all_boundary_faces(), assume_unique=True
         )
@@ -806,6 +813,9 @@ class Grid:
             boundary nodes.
 
         """
+        msg = "This functionality is deprecated and will be removed in a future version"
+        warn(msg, DeprecationWarning)
+
         return self._indices(self.tags["domain_boundary_nodes"])
 
     def update_boundary_face_tag(self) -> None:

--- a/src/porepy/grids/grid.py
+++ b/src/porepy/grids/grid.py
@@ -770,7 +770,6 @@ class Grid:
             all faces tagged as either fractures, domain boundary or tip.
 
         """
-        tags
         return self._indices(tags.all_face_tags(self.tags))
 
     def get_all_boundary_nodes(self) -> np.ndarray:

--- a/src/porepy/grids/md_grid.py
+++ b/src/porepy/grids/md_grid.py
@@ -527,8 +527,6 @@ class MixedDimensionalGrid:
            sd: The subdomain to be removed.
 
         """
-        msg = "This functionality is deprecated and will be removed in a future version"
-        warn(msg, DeprecationWarning)
 
         # Delete from the subdomain list.
         del self._subdomain_data[sd]
@@ -893,8 +891,6 @@ class MixedDimensionalGrid:
             The total number of mortar cells of the grid bucket.
 
         """
-        msg = "This functionality is deprecated and will be removed in a future version"
-        warn(msg, DeprecationWarning)
 
         if cond is None:
             cond = lambda g: True

--- a/src/porepy/grids/md_grid.py
+++ b/src/porepy/grids/md_grid.py
@@ -9,7 +9,6 @@ from typing import Any, Callable, Iterable, Literal, Optional, Union, overload
 
 import numpy as np
 from scipy import sparse as sps
-from warnings import warn
 
 import porepy as pp
 from porepy.grids import mortar_grid

--- a/src/porepy/grids/md_grid.py
+++ b/src/porepy/grids/md_grid.py
@@ -9,6 +9,7 @@ from typing import Any, Callable, Iterable, Literal, Optional, Union, overload
 
 import numpy as np
 from scipy import sparse as sps
+from warnings import warn
 
 import porepy as pp
 from porepy.grids import mortar_grid
@@ -526,6 +527,9 @@ class MixedDimensionalGrid:
            sd: The subdomain to be removed.
 
         """
+        msg = "This functionality is deprecated and will be removed in a future version"
+        warn(msg, DeprecationWarning)
+
         # Delete from the subdomain list.
         del self._subdomain_data[sd]
 
@@ -889,6 +893,9 @@ class MixedDimensionalGrid:
             The total number of mortar cells of the grid bucket.
 
         """
+        msg = "This functionality is deprecated and will be removed in a future version"
+        warn(msg, DeprecationWarning)
+
         if cond is None:
             cond = lambda g: True
         return np.sum(  # type: ignore

--- a/src/porepy/grids/mdg_generation.py
+++ b/src/porepy/grids/mdg_generation.py
@@ -6,7 +6,7 @@ different lower-level mdg generation.
 from __future__ import annotations
 
 import inspect
-import warnings
+from warnings import warn
 from typing import Callable, Literal, Optional, Union, get_args
 
 import numpy as np
@@ -415,7 +415,7 @@ def _validate_args(
             # user on purpose use the domain to get rid of some fractures.
             # Giving a warning seems like a fair compromise between raising an
             # error and doing nothing.
-            warnings.warn(f"Found {sz} fractures outside the domain boundary")
+            warn(f"Found {sz} fractures outside the domain boundary")
 
     if grid_type == "simplex":
         _validate_simplex_meshing_args_values(meshing_args)
@@ -541,7 +541,7 @@ def _preprocess_cartesian_args(
     if cell_size_x is not None:
         n_x = round((xmax - xmin) / cell_size_x)
         if np.abs((xmax - xmin)) - cell_size_x < 0.0:
-            warnings.warn(
+            warn(
                 "In the x-direction, cell_size_x is greater than the domain. The domain"
                 " size is used instead."
             )
@@ -552,7 +552,7 @@ def _preprocess_cartesian_args(
     if cell_size_y is not None:
         n_y = round((ymax - ymin) / cell_size_y)
         if np.abs((ymax - ymin)) - cell_size_y < 0.0:
-            warnings.warn(
+            warn(
                 "In the y-direction, cell_size_y is greater than the domain. The domain"
                 " size is used instead."
             )
@@ -566,7 +566,7 @@ def _preprocess_cartesian_args(
 
         n_z = round((zmax - zmin) / cell_size_z)
         if np.abs((zmax - zmin)) - cell_size_z < 0.0:
-            warnings.warn(
+            warn(
                 "In the z-direction, cell_size_z is greater than the domain. The domain"
                 " size is used instead."
             )
@@ -619,7 +619,7 @@ def _preprocess_tensor_grid_args(
     if cell_size is not None:
         n_x = round((xmax - xmin) / cell_size) + 1
         if np.abs((xmax - xmin)) - cell_size < 0.0:
-            warnings.warn(
+            warn(
                 "In the x-direction, cell_size is greater than the domain. The domain "
                 "size is used instead."
             )
@@ -627,7 +627,7 @@ def _preprocess_tensor_grid_args(
 
         n_y = round((ymax - ymin) / cell_size) + 1
         if np.abs((ymax - ymin)) - cell_size < 0.0:
-            warnings.warn(
+            warn(
                 "In the y-direction, cell_size is greater than the domain. The domain "
                 "size is used instead."
             )
@@ -642,7 +642,7 @@ def _preprocess_tensor_grid_args(
 
             n_z = round((zmax - zmin) / cell_size) + 1
             if np.abs((zmax - zmin)) - cell_size < 0.0:
-                warnings.warn(
+                warn(
                     "In the z-direction, cell_size is greater than the domain. The "
                     "domain size is used instead."
                 )

--- a/src/porepy/grids/mdg_generation.py
+++ b/src/porepy/grids/mdg_generation.py
@@ -6,8 +6,8 @@ different lower-level mdg generation.
 from __future__ import annotations
 
 import inspect
-from warnings import warn
 from typing import Callable, Literal, Optional, Union, get_args
+from warnings import warn
 
 import numpy as np
 

--- a/src/porepy/grids/partition.py
+++ b/src/porepy/grids/partition.py
@@ -18,7 +18,7 @@ available methods.
 
 from __future__ import annotations
 
-import warnings
+from warnings import warn
 from typing import Optional
 
 import numpy as np
@@ -43,7 +43,7 @@ def partition_metis(g: pp.Grid, num_part: int) -> np.ndarray:
     try:
         import pymetis
     except ImportError:
-        warnings.warn("Could not import pymetis. Partitioning by metis will not work.")
+        warn("Could not import pymetis. Partitioning by metis will not work.")
         raise ImportError("Cannot partition by pymetis")
 
     # Connection map between cells
@@ -822,6 +822,8 @@ def partition_grid(
             Each element contains the global indices of the local nodes.
 
     """
+    msg = "This functionality is deprecated and will be removed in a future version"
+    warn(msg, DeprecationWarning)
 
     sub_grid: list[pp.Grid] = []
     face_map_list: list[np.ndarray] = []

--- a/src/porepy/grids/partition.py
+++ b/src/porepy/grids/partition.py
@@ -18,8 +18,8 @@ available methods.
 
 from __future__ import annotations
 
-from warnings import warn
 from typing import Optional
+from warnings import warn
 
 import numpy as np
 import scipy.sparse as sps

--- a/src/porepy/grids/refinement.py
+++ b/src/porepy/grids/refinement.py
@@ -11,6 +11,7 @@ import abc
 import logging
 from pathlib import Path
 from typing import Literal, Optional
+from warnings import warn
 
 import gmsh
 import numpy as np
@@ -51,6 +52,9 @@ def distort_grid_1d(
          The grid, but with distorted nodes.
 
     """
+    msg = "This functionality is deprecated and will be removed in a future version"
+    warn(msg, DeprecationWarning)
+
     if fixed_nodes is None:
         fixed_nodes = np.array([0, g.num_nodes - 1], dtype=int)
     else:
@@ -250,6 +254,9 @@ def refine_triangle_grid(g: pp.TriangleGrid) -> tuple[pp.TriangleGrid, np.ndarra
             Mapping from new to old cells.
 
     """
+    msg = "This functionality is deprecated and will be removed in a future version"
+    warn(msg, DeprecationWarning)
+
     # g needs to have face centers
     if not hasattr(g, "face_centers"):
         g.compute_geometry()
@@ -325,6 +332,8 @@ def remesh_1d(g_old: pp.Grid, num_nodes: int, tol: float = 1e-6) -> pp.Grid:
         The new grid that covers the same domain as g_old.
 
     """
+    msg = "This functionality is deprecated and will be removed in a future version"
+    warn(msg, DeprecationWarning)
 
     # Create equi-spaced nodes covering the same domain as the old grid
     theta = np.linspace(0, 1, num_nodes)
@@ -396,6 +405,8 @@ def mdg_refinement(
             Refinement mode. ``'nested'`` corresponds to refinement by splitting.
 
     """
+    msg = "This functionality is deprecated and will be removed in a future version"
+    warn(msg, DeprecationWarning)
 
     # Check that both md-grids have the same dimension.
     assert mdg_ref.dim_max() == mdg.dim_max()
@@ -458,6 +469,9 @@ def structured_refinement(
         Column major sparse matrix mapping from coarse to fine cells.
 
     """
+    msg = "This functionality is deprecated and will be removed in a future version"
+    warn(msg, DeprecationWarning)
+
     # This method creates a mapping from fine to coarse cells by creating a matrix 'M'
     # where the rows represent the fine cells while the columns represent the coarse
     # cells. In practice this means that for an array 'p', of known values on a coarse
@@ -600,6 +614,9 @@ class GridSequenceIterator:
 
     """
 
+    msg = "GridSequenceIterator is deprecated and will be removed in a future version"
+    warn(msg, DeprecationWarning)
+
     def __init__(self, factory: GridSequenceFactory) -> None:
         self._factory = factory
         """The factory instance passed at instantiation."""
@@ -672,6 +689,9 @@ class GridSequenceFactory(abc.ABC):
             if not available.
 
     """
+
+    msg = "GridSequenceFactory is deprecated and will be removed in a future version"
+    warn(msg, DeprecationWarning)
 
     def __init__(self, network: pp.fracture_network, params: dict) -> None:
         self._network = network.copy()

--- a/src/porepy/grids/refinement.py
+++ b/src/porepy/grids/refinement.py
@@ -52,8 +52,6 @@ def distort_grid_1d(
          The grid, but with distorted nodes.
 
     """
-    msg = "This functionality is deprecated and will be removed in a future version"
-    warn(msg, DeprecationWarning)
 
     if fixed_nodes is None:
         fixed_nodes = np.array([0, g.num_nodes - 1], dtype=int)
@@ -254,8 +252,6 @@ def refine_triangle_grid(g: pp.TriangleGrid) -> tuple[pp.TriangleGrid, np.ndarra
             Mapping from new to old cells.
 
     """
-    msg = "This functionality is deprecated and will be removed in a future version"
-    warn(msg, DeprecationWarning)
 
     # g needs to have face centers
     if not hasattr(g, "face_centers"):
@@ -332,8 +328,6 @@ def remesh_1d(g_old: pp.Grid, num_nodes: int, tol: float = 1e-6) -> pp.Grid:
         The new grid that covers the same domain as g_old.
 
     """
-    msg = "This functionality is deprecated and will be removed in a future version"
-    warn(msg, DeprecationWarning)
 
     # Create equi-spaced nodes covering the same domain as the old grid
     theta = np.linspace(0, 1, num_nodes)
@@ -405,8 +399,6 @@ def mdg_refinement(
             Refinement mode. ``'nested'`` corresponds to refinement by splitting.
 
     """
-    msg = "This functionality is deprecated and will be removed in a future version"
-    warn(msg, DeprecationWarning)
 
     # Check that both md-grids have the same dimension.
     assert mdg_ref.dim_max() == mdg.dim_max()
@@ -469,8 +461,6 @@ def structured_refinement(
         Column major sparse matrix mapping from coarse to fine cells.
 
     """
-    msg = "This functionality is deprecated and will be removed in a future version"
-    warn(msg, DeprecationWarning)
 
     # This method creates a mapping from fine to coarse cells by creating a matrix 'M'
     # where the rows represent the fine cells while the columns represent the coarse
@@ -614,9 +604,6 @@ class GridSequenceIterator:
 
     """
 
-    msg = "GridSequenceIterator is deprecated and will be removed in a future version"
-    warn(msg, DeprecationWarning)
-
     def __init__(self, factory: GridSequenceFactory) -> None:
         self._factory = factory
         """The factory instance passed at instantiation."""
@@ -689,9 +676,6 @@ class GridSequenceFactory(abc.ABC):
             if not available.
 
     """
-
-    msg = "GridSequenceFactory is deprecated and will be removed in a future version"
-    warn(msg, DeprecationWarning)
 
     def __init__(self, network: pp.fracture_network, params: dict) -> None:
         self._network = network.copy()

--- a/src/porepy/grids/simplex.py
+++ b/src/porepy/grids/simplex.py
@@ -9,6 +9,7 @@ functions found in the `Matlab Reservoir Simulation Toolbox (MRST)
 """
 
 from typing import Optional
+from warnings import warn
 
 import numpy as np
 import scipy.sparse as sps
@@ -123,6 +124,8 @@ class TriangleGrid(Grid):
             An array with ``shape=(num_cells, 3)``, representing the cell-to-node map.
 
         """
+        msg = "This functionality is deprecated and will be removed in a future version"
+        warn(msg, DeprecationWarning)
 
         # Absolute value needed since cellFaces can be negative
         cn = self.face_nodes * np.abs(self.cell_faces) * sps.eye(self.num_cells)


### PR DESCRIPTION
After discussion with @keileg, the following unused functions have been marked as deprecated.

1. ../src/porepy/grids/grid.py
- get_internal_nodes()
- get_boundary_nodes() (only referenced by get_internal_nodes())
- get_internal_faces()

2. ../src/porepy/grids/partition.py
- partition_grid()

3. ../src/porepy/grids/simplex.py
- TriangleGrid.cell_node_matrix()