### PR TITLE
Add naming conventions to tutorial

### DIFF
--- a/tutorials/conventions.ipynb
+++ b/tutorials/conventions.ipynb
@@ -15,12 +15,22 @@
    "source": [
     "This tutorial lists some of the most important conventions and assumptions used in PorePy.\n",
     "\n",
-    "Specifically, we cover conventions for:\n",
+    "Specifically, we cover naming conventions, as well as conventions for:\n",
     "* Geometry\n",
     "* Boundaries\n",
     "* Equations\n",
     "* Apertures\n",
     "* Coupling between dimensions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Naming conventions\n",
+    "\n",
+    "Some common conventions and acronyms used in PorePy can be found here (section 1.2):\n",
+    "https://pmgbergen.github.io/porepy/html/docsrc/howto/howto-docstring.html"
    ]
   },
   {
@@ -124,7 +134,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -138,7 +148,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.11.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Proposed changes

Issue #1390. Updates conventions.ipynb with a brief section on naming conventions, which refers the reader to howto-docstring.html. Once PR #1425 is accepted, howto-docstring will be updated with the naming conventions table from the UserManual.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [x] Documentation (contribution related to adding, improving, or fixing documentation).
- [x] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [x] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
