### PR TITLE
Updates related to mypy v 1.16

### DIFF
--- a/.github/workflows/run-static-checks.yml
+++ b/.github/workflows/run-static-checks.yml
@@ -96,7 +96,9 @@ jobs:
     # for the install (hence the installed packages are sure to be available also after
     # the build), while --no-deps will only install the specified packages (in this
     # case, the dependencies of PorePy). The third line similarly installs the
-    # development dependencies.
+    # development dependencies. Note that we do not use the --no-deps option for the
+    # development dependencies, since we need fully functioning versions of mypy, ruff,
+    # and isort to run the static checks.
     #
     # Thanks, copilot!
     - name: Install requirements
@@ -104,7 +106,7 @@ jobs:
         pip install -U pip
         pip install toml
         pip install --no-build-isolation --no-deps -r <(python -c "import toml; print('\n'.join(toml.load('pyproject.toml')['project']['dependencies']))")
-        pip install --no-build-isolation --no-deps -r <(python -c "import toml; print('\n'.join(toml.load('pyproject.toml')['project']['optional-dependencies']['development']))")
+        pip install --no-build-isolation -r <(python -c "import toml; print('\n'.join(toml.load('pyproject.toml')['project']['optional-dependencies']['development']))")
         pip freeze
 
     # Run the various checks

--- a/src/porepy/applications/test_utils/grids.py
+++ b/src/porepy/applications/test_utils/grids.py
@@ -14,6 +14,7 @@ Content:
 
 import numpy as np
 import scipy.sparse as sps
+
 import porepy as pp
 
 from . import arrays

--- a/src/porepy/applications/test_utils/vtk.py
+++ b/src/porepy/applications/test_utils/vtk.py
@@ -143,4 +143,8 @@ def compare_pvd_files(
         keys = ["part", "timestep", "file"]
     else:
         keys = ["part", "file"]
-    return _check_xml_tree_equality(tree_test, tree_ref, keys)
+
+    # Mypy v1.16 somehow surmises that the argument to _check_xml_tree_equality can
+    # be ElementTree[Element[str] | None], but it is unclear where the None comes from.
+    # Ignore this.
+    return _check_xml_tree_equality(tree_test, tree_ref, keys)  # type: ignore[arg-type]

--- a/src/porepy/models/compositional_flow.py
+++ b/src/porepy/models/compositional_flow.py
@@ -1992,7 +1992,7 @@ class SolutionStrategyCFF(
 # endregion
 
 
-class CompositionalFlowTemplate(  # type: ignore[misc]
+class CompositionalFlowTemplate(  # type: ignore[misc,override]
     ConstitutiveLawsCF,
     PrimaryEquationsCF,
     VariablesCF,
@@ -2043,7 +2043,7 @@ class CompositionalFlowTemplate(  # type: ignore[misc]
     """
 
 
-class CompositionalFractionalFlowTemplate(  # type: ignore[misc]
+class CompositionalFractionalFlowTemplate(  # type: ignore[misc,override]
     ConstitutiveLawsCF,
     PrimaryEquationsCF,
     VariablesCF,

--- a/src/porepy/numerics/fv/biot.py
+++ b/src/porepy/numerics/fv/biot.py
@@ -29,6 +29,7 @@ import numpy as np
 import scipy.sparse as sps
 
 import porepy as pp
+from warnings import warn
 
 # Module-wide logger
 logger = logging.getLogger(__name__)
@@ -324,8 +325,16 @@ class Biot(pp.Mpsa):
 
         # Whether to update an existing discretization, or construct a new one.
         # If True, either specified_cells, _faces or _nodes should also be given, or
-        # else a full new discretization will be computed
+        # else a full new discretization will be computed.
         update: bool = parameter_dictionary.get("update_discretization", False)
+        if update:
+            # EK comment: The functionality to update discretizations has not been
+            # thoroughly tested and should be used with extreme care.
+            msg = "Discretization update is not fully tested"
+            msg += " and should be used with care.\n"
+            msg += "If you do not want to run into trouble, it is recommended to"
+            msg += " set 'update_discretization' to False in the parameter dictionary."
+            warn(msg)
 
         # The discretization can be limited to a specified set of cells, faces or nodes
         # If none of these are specified, the entire grid will be discretized.

--- a/src/porepy/numerics/fv/biot.py
+++ b/src/porepy/numerics/fv/biot.py
@@ -24,12 +24,12 @@ from __future__ import annotations
 import logging
 from time import time
 from typing import Any, Literal
+from warnings import warn
 
 import numpy as np
 import scipy.sparse as sps
 
 import porepy as pp
-from warnings import warn
 
 # Module-wide logger
 logger = logging.getLogger(__name__)

--- a/src/porepy/numerics/fv/biot.py
+++ b/src/porepy/numerics/fv/biot.py
@@ -642,8 +642,8 @@ class Biot(pp.Mpsa):
         )
 
         # Either update the discretization scheme, or store the full one
-        matrices: dict[str, dict] = sd_data[pp.DISCRETIZATION_MATRICES]
-        matrices_m: dict[str, sps.spmatrix] = matrices[self.keyword]
+        matrices: dict[str, Any] = sd_data[pp.DISCRETIZATION_MATRICES]
+        matrices_m = matrices[self.keyword]
 
         if update:
             # The faces to be updated are given by active_faces
@@ -658,27 +658,28 @@ class Biot(pp.Mpsa):
                 update_face_ind
             ]
 
-            matrices_m[self.displacement_divergence_matrix_key][update_cell_ind] = (
-                displacement_divergence[update_cell_ind]
-            )
-            matrices_m[self.bound_displacement_divergence_matrix_key][
-                update_cell_ind
-            ] = bound_displacement_divergence[update_cell_ind]
-            matrices_m[self.scalar_gradient_matrix_key][update_face_ind] = (
-                scalar_gradient[update_face_ind]
-            )
-            matrices_m[self.consistency_matrix_key][update_cell_ind] = consistency[
-                update_cell_ind
-            ]
+            for key in coupling_keywords:
+                matrices_m[self.displacement_divergence_matrix_key][update_cell_ind] = (
+                    displacement_divergence[key][update_cell_ind]
+                )
+                matrices_m[self.bound_displacement_divergence_matrix_key][
+                    update_cell_ind
+                ] = bound_displacement_divergence[key][update_cell_ind]
+                matrices_m[self.scalar_gradient_matrix_key][update_face_ind] = (
+                    scalar_gradient[key][update_face_ind]
+                )
+                matrices_m[self.consistency_matrix_key][update_cell_ind] = consistency[
+                    key
+                ][update_cell_ind]
+                matrices_m[self.bound_pressure_matrix_key][update_face_ind] = (
+                    bound_displacement_pressure[key][update_face_ind]
+                )
 
             matrices_m[self.bound_displacement_cell_matrix_key][update_face_ind] = (
                 bound_displacement_cell[update_face_ind]
             )
             matrices_m[self.bound_displacement_face_matrix_key][update_face_ind] = (
                 bound_displacement_face[update_face_ind]
-            )
-            matrices_m[self.bound_pressure_matrix_key][update_face_ind] = (
-                bound_displacement_pressure[update_face_ind]
             )
         else:
             matrices_m[self.stress_matrix_key] = stress

--- a/src/porepy/numerics/fv/mpfa.py
+++ b/src/porepy/numerics/fv/mpfa.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 from typing import Literal, Optional
+from warnings import warn
 
 import numpy as np
 import scipy.sparse as sps
-from warnings import warn
 
 import porepy as pp
 

--- a/src/porepy/numerics/fv/mpfa.py
+++ b/src/porepy/numerics/fv/mpfa.py
@@ -6,6 +6,7 @@ from typing import Literal, Optional
 
 import numpy as np
 import scipy.sparse as sps
+from warnings import warn
 
 import porepy as pp
 
@@ -162,6 +163,14 @@ class Mpfa(pp.FVElliptic):
         # If True, either specified_cells, _faces or _nodes should also be given, or
         # else a full new discretization will be computed
         update: bool = parameter_dictionary.get("update_discretization", False)
+        if update:
+            # EK comment: The functionality to update discretizations has not been
+            # thoroughly tested and should be used with extreme care.
+            msg = "Discretization update is not fully tested"
+            msg += " and should be used with care.\n"
+            msg += "If you do not want to run into trouble, it is recommended to"
+            msg += " set 'update_discretization' to False in the parameter dictionary."
+            warn(msg)
 
         # NOTE: active_faces are all faces to have their stencils updated, while
         # active_cells may form a larger set (to accurately update all faces on a

--- a/src/porepy/numerics/fv/mpsa.py
+++ b/src/porepy/numerics/fv/mpsa.py
@@ -13,10 +13,10 @@ from __future__ import annotations
 import logging
 from time import time
 from typing import Any, Literal, Optional
+from warnings import warn
 
 import numpy as np
 import scipy.sparse as sps
-from warnings import warn
 
 import porepy as pp
 from porepy.numerics.discretization import Discretization

--- a/src/porepy/numerics/fv/mpsa.py
+++ b/src/porepy/numerics/fv/mpsa.py
@@ -16,6 +16,7 @@ from typing import Any, Literal, Optional
 
 import numpy as np
 import scipy.sparse as sps
+from warnings import warn
 
 import porepy as pp
 from porepy.numerics.discretization import Discretization
@@ -194,6 +195,14 @@ class Mpsa(Discretization):
         # either specified_cells, _faces or _nodes should also be given, or else a full
         # new discretization will be computed
         update: bool = parameter_dictionary.get("update_discretization", False)
+        if update:
+            # EK comment: The functionality to update discretizations has not been
+            # thoroughly tested and should be used with extreme care.
+            msg = "Discretization update is not fully tested"
+            msg += " and should be used with care.\n"
+            msg += "If you do not want to run into trouble, it is recommended to"
+            msg += " set 'update_discretization' to False in the parameter dictionary."
+            warn(msg)
 
         # The discretization can be limited to a specified set of cells, faces or nodes
         # If none of these are specified, the entire grid will be discretized.

--- a/src/porepy/numerics/fv/tpfa.py
+++ b/src/porepy/numerics/fv/tpfa.py
@@ -271,7 +271,7 @@ class Tpfa(pp.FVElliptic):
         vals = np.zeros((vector_source_dim, fi.size))
         vals[:, bnd.is_neu[fi]] = fc_cc[:vector_source_dim, bnd.is_neu[fi]]
         bound_pressure_vector_source = sps.coo_matrix(
-            (vals.ravel("f"), (rows, cols))
+            (vals.ravel("F"), (rows, cols))
         ).tocsr()
         matrix_dictionary[self.bound_pressure_vector_source_matrix_key] = (
             bound_pressure_vector_source

--- a/src/porepy/numerics/fv/tpsa.py
+++ b/src/porepy/numerics/fv/tpsa.py
@@ -555,7 +555,7 @@ class Tpsa:
         # the Cosserat parameter is non-zero. Since the rotation variable is scalar if
         # nd == 2 and vector if nd == 3, the type of boundary condition depends on the
         # dimension.
-        bnd_rot: pp.BoundaryCondition | pp.BoundaryConditionVectorial = (
+        bnd_rot: pp.BoundaryCondition | pp.BoundaryConditionVectorial | None = (
             parameter_dictionary.get("bc_rot", None)
         )
 
@@ -841,6 +841,11 @@ class Tpsa:
             if cosserat_values is not None:
                 # In 2d, the rotation is a scalar variable and we can treat this by
                 # what is essentially a tpfa discretization.
+
+                # EK note: The Cosserat option will be purged in a future update. For
+                # now we use this assert to ensure that the Cosserat option is not used
+                # with a non-empty boundary condition.
+                assert bnd_rot is not None
 
                 t_cosserat_bnd = np.zeros(nf)
                 t_cosserat_bnd[bnd_rot.is_dir] = t_cosserat[bnd_rot.is_dir]

--- a/src/porepy/utils/graph.py
+++ b/src/porepy/utils/graph.py
@@ -1,7 +1,8 @@
+from warnings import warn
+
 import numpy as np
 
 import porepy as pp
-from warnings import warn
 
 
 class Graph:

--- a/src/porepy/viz/exporter.py
+++ b/src/porepy/viz/exporter.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import os
 import sys
+import warnings
 import xml.etree.ElementTree as ET
 from collections import namedtuple
 from pathlib import Path
@@ -16,8 +17,6 @@ import meshio
 import numpy as np
 
 import porepy as pp
-
-import warnings
 
 # Object type to store data to export.
 Field = namedtuple("Field", ["name", "values"])

--- a/tests/compositional/test_materials.py
+++ b/tests/compositional/test_materials.py
@@ -17,9 +17,8 @@ import numpy as np
 import pytest
 
 import porepy as pp
-
-from porepy.examples.flow_benchmark_2d_case_1 import FractureSolidConstants
 from porepy.compositional.materials import FractureDamageSolidConstants
+from porepy.examples.flow_benchmark_2d_case_1 import FractureSolidConstants
 
 
 # TODO remove

--- a/tests/params/test_tensor.py
+++ b/tests/params/test_tensor.py
@@ -1,4 +1,5 @@
 from typing import Tuple
+
 import numpy as np
 import pytest
 

--- a/tests/utils/test_array_operations.py
+++ b/tests/utils/test_array_operations.py
@@ -8,7 +8,6 @@ import pytest
 import porepy as pp
 from porepy.applications.test_utils.arrays import compare_arrays
 
-
 coord_1 = [
     [[np.array([1])], np.array([42])],
     [[np.array([1]), np.array([0])], np.array([2, 3])],

--- a/tests/viz/test_exporter.py
+++ b/tests/viz/test_exporter.py
@@ -18,19 +18,19 @@ import shutil
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Generator
-import scipy.sparse as sps
 
 import numpy as np
 import pytest
+import scipy.sparse as sps
 
 import porepy as pp
+from porepy.applications.test_utils.grids import polytop_grid_2d, polytop_grid_3d
 from porepy.applications.test_utils.models import Thermoporomechanics
 from porepy.applications.test_utils.vtk import (
     PathLike,
     compare_pvd_files,
     compare_vtu_files,
 )
-from porepy.applications.test_utils.grids import polytop_grid_2d, polytop_grid_3d
 from porepy.fracs.utils import pts_edges_to_linefractures
 from tests.models.test_poromechanics import NonzeroFractureGapPoromechanics
 


### PR DESCRIPTION
## Proposed changes

Notable changes:
1. I had to make a minor adjustment to the GH action for static tests to allow for a mypy update. The new version of the file seems reasonable. For explanation, see documentation in the action setup.
2. Mypy found a bug related to update of Biot discretizations. In my understanding, this also indicates that test coverage of this part is not good enough (as expected). I added a warning statement related to the update option in mpfa, mpsa, and biot. Though we have not prioritized to fix this yet, it may become a more pressing issue in the future.

Besides this, the changes are rather small.

There is one remaining mypy issue for which I may need your assistance, @vlipovac: The `_MixtureDofHandler` defines a read-only property `overall_fraction_variables`, which is also declared (for typing purposes) in the class `SolutionStrategySchurComplement` (line 1719 in `compositional_flow.py`). This results in an error when the classes are mixed down in line 1995 in the same file (note that mypy has been updated, hence the pain). I guess the reason you use a read-only property is that the variable names returned by this method must be correct, or else everything breaks?

I really hope we can fix this with minor adjustments of the code - do you see a way do achieve this? We may need @IvarStefansson's input on this matter at some point as well.


## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [x] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [x] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
