### PR TITLE
Maint: Error handling in `plot_grid`

### DIFF
--- a/src/porepy/viz/plot_grid.py
+++ b/src/porepy/viz/plot_grid.py
@@ -51,6 +51,9 @@ def plot_grid(
             cells: boolean array with length number of cells. Only plot cells c where
             cells[c]=True. Not valid for a MixedDimensionalGrid.
 
+    Raises:
+        ValueError: if the user passed neither a Grid nor a MixedDimensional grid.
+
     Example:
     # if grid is a single grid:
     cell_id = np.arange(grid.num_cells)
@@ -68,10 +71,15 @@ def plot_grid(
         plot_sd(grid, cell_value, vector_value, info, **kwargs)
 
     # Grid is a mixed-dimensional grid
-    if isinstance(grid, pp.MixedDimensionalGrid):
+    elif isinstance(grid, pp.MixedDimensionalGrid):
         assert cell_value is None or isinstance(cell_value, str)
         assert vector_value is None or isinstance(vector_value, str)
         plot_mdg(grid, cell_value, vector_value, info, **kwargs)
+
+    else:
+        raise ValueError(
+            f"You must pass either a Grid or a MixedDimensionalGrid, not {grid}."
+        )
 
 
 def save_img(


### PR DESCRIPTION
This makes `plot_grid` raise an error if an incorrect argument was passed. Previously, it returned successfully and did nothing, which was confusing (at least for me).

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [x] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
