### PR TITLE
MAINT: Avoid creating default TimeManager if one is passed to Model

### DIFF
--- a/src/porepy/models/solution_strategy.py
+++ b/src/porepy/models/solution_strategy.py
@@ -73,12 +73,17 @@ class SolutionStrategy(pp.PorePyModel):
         Reference values can be provided through ``params['reference_values']``.
 
         """
+        # The explicit check (not get with a default) is to avoid instantiating a
+        # TimeManager if it is not needed. This is done to avoid unnecessary checks
+        # run in the manager.
+        if "time_manager" not in params:
+            self.time_manager = pp.TimeManager(
+                schedule=[0, 1], dt_init=1, constant_dt=True
+            )
+            """Time manager for the simulation."""
+        else:
+            self.time_manager = params["time_manager"]
 
-        self.time_manager = params.get(
-            "time_manager",
-            pp.TimeManager(schedule=[0, 1], dt_init=1, constant_dt=True),
-        )
-        """Time manager for the simulation."""
         self.restart_options = params.get(
             "restart_options",
             {


### PR DESCRIPTION
## Proposed changes

Slightly improve performance by avoiding to create default TimeManager if one is passed in Model parameters.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [x] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
