### PR TITLE
TST: Sneddon test is less restrictive to reduce sensitivity to Gmsh updates

### DIFF
--- a/tests/functional/test_sneddon_2d.py
+++ b/tests/functional/test_sneddon_2d.py
@@ -74,4 +74,8 @@ def test_order_of_convergence(actual_ooc: dict) -> None:
     # tip treatment and the inner domain. Raising the threshold to 15% yielded a
     # convergence order of ~2. Decreasing the threshold to 0% yielded a convergence
     # order of ~0.85.
-    assert np.isclose(1.66752, actual_ooc["ooc_displacement"])
+    # EK: Absolute tolerance is set to 1e-2 to account for discrepancies in grids as
+    # Gmsh is updated.
+    assert np.isclose(1.67, actual_ooc["ooc_displacement"], atol=1e-2), (
+        "Observed order of convergence for displacement does not match expected value."
+    )


### PR DESCRIPTION
…pdates

The old setting turned out to give an error when Gmsh was updated to version 4.14. Updated both the reference value for order of convergence and increased the tolerance, in the hope that we will be less sensitive to Gmsh updates in the future.

Resolves #1463.

## Proposed changes

Contributions to PorePy are highly appreciated. Clearly explain why this pull request (PR) is needed and why it should be accepted. If this PR solves an issue, explain how it is done. Please, also summarise the changes to the code.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
