### PR TITLE
Optimize get_variable_values method of EquationSystem class

### DIFF
--- a/src/porepy/numerics/ad/equation_system.py
+++ b/src/porepy/numerics/ad/equation_system.py
@@ -631,7 +631,7 @@ class EquationSystem:
             :meth:`num_dofs`.
 
         """
-        # Normalize the variable input
+        # Normalize the variable input.
         variables = self._parse_variable_type(variables)
         var_ids = {var.id for var in variables}
 

--- a/src/porepy/numerics/ad/equation_system.py
+++ b/src/porepy/numerics/ad/equation_system.py
@@ -599,7 +599,7 @@ class EquationSystem:
                         filtered_variables.append(var)
 
         return filtered_variables
-    
+
     def get_variable_values(
         self,
         variables: Optional[VariableList] = None,
@@ -629,7 +629,7 @@ class EquationSystem:
         Returns:
             The respective (sub) vector in numerical format, size anywhere between 0 and
             :meth:`num_dofs`.
-            
+
         """
         # Normalize the variable input
         variables = self._parse_variable_type(variables)
@@ -657,7 +657,7 @@ class EquationSystem:
                 )
                 # NOTE get_solution_values already returns a copy
                 values.append(val)
-                
+
         # If there are matching blocks, concatenate and return.
         # Else return an empty vector.
         return np.concatenate(values) if values else np.empty(0)


### PR DESCRIPTION
… data fetching

## Proposed changes

This PR contains a targeted optimization to the EquationSystem.get_variable_values() method, which can significantly reduce simulation time in cases with many variables and shared subdomains. Motivated by compositional simulations.

The updated method avoids redundant operations by:

- Using a set for faster lookup of variable IDs.
- Caching domain data to prevent repeated self._get_data() calls.
- Returning an empty vector via np.empty(0) instead of np.array([]).

These changes reduce unnecessary memory operations and domain-level lookups, which previously contributed substantial overhead during per-iteration routines such as thermodynamic property updates and auxiliary computations / evaluate() method.

Benchmarking: On a water–salt multiphase system with ~3222 mdg cells, the internal time spent in get_variable_values() was reduced by over ~42%.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ x] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x ] The documentation is up-to-date.
- [ x] Static typing is included in the update.
- [x ] This PR does not duplicate existing functionality.
- [ x] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
