### PR TITLE
MAINT: Rename grid_bucket -> mdg in grid extrusion module

### DIFF
--- a/src/porepy/grids/grid_extrusion.py
+++ b/src/porepy/grids/grid_extrusion.py
@@ -6,7 +6,7 @@ dimension of the highest-dimensional grid should be 2 at most.
 
 The two functions performing above are
 
-- :func:`extrude_grid_bucket`,
+- :func:`extrude_mdg`,
 - :func:`extrude_grid`.
 
 """
@@ -24,7 +24,7 @@ from porepy.grids import mortar_grid
 from porepy.numerics.linalg.matrix_operations import sparse_array_to_row_col_data
 
 
-def extrude_grid_bucket(
+def extrude_mdg(
     mdg: pp.MixedDimensionalGrid, z: np.ndarray
 ) -> tuple[pp.MixedDimensionalGrid, dict]:
     """Extrude a mixed-dimensional grid by extending all fixed-dimensional grids in the
@@ -804,7 +804,7 @@ def _create_mappings(
     g: pp.Grid, g_new: pp.Grid, num_cell_layers: int
 ) -> tuple[np.ndarray, np.ndarray]:
     """Auxiliary function to create the extruded cell and face maps for
-    :func:`extrude_grid` and :func:`extrude_grid_bucket`."""
+    :func:`extrude_grid` and :func:`extrude_mdg`."""
 
     cell_map = np.empty(g.num_cells, dtype=object)
     for c in range(g.num_cells):

--- a/tests/grids/test_grid_extrusion.py
+++ b/tests/grids/test_grid_extrusion.py
@@ -585,7 +585,7 @@ def test_extrusion_with_single_fracture():
     sd_1 = mdg.subdomains(dim=1)[0]
 
     z = np.array([0, 1, 2])
-    mdg_new, _ = pp.grid_extrusion.extrude_grid_bucket(mdg, z)
+    mdg_new, _ = pp.grid_extrusion.extrude_mdg(mdg, z)
 
     for dim in range(mdg.dim_max()):
         assert len(mdg.subdomains(dim=dim)) == len(mdg_new.subdomains(dim=dim + 1))
@@ -679,7 +679,7 @@ def test_extrusion_with_T_intersection():
     mdg = pp.meshing.cart_grid(f, [4, 3])
 
     z = np.array([0, 1])
-    mdg_new, _ = pp.grid_extrusion.extrude_grid_bucket(mdg, z)
+    mdg_new, _ = pp.grid_extrusion.extrude_mdg(mdg, z)
 
     # Do a simple test on grid geometry; if this fails, there is a more fundamental
     # problem that should be picked up by simpler tests.


### PR DESCRIPTION
## Proposed changes
Follow-up of name change (carried out 3 years ago).

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [x] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
