### PR TITLE
BUG: Mark failed time steps when exporting

### DIFF
--- a/src/porepy/models/protocol.py
+++ b/src/porepy/models/protocol.py
@@ -488,9 +488,6 @@ else:
         """This protocol provides the declarations of the methods and the properties,
         typically defined in SolutionStrategy."""
 
-        convergence_status: bool
-        """Whether the non-linear iteration has converged."""
-
         equation_system: pp.ad.EquationSystem
         """Equation system manager.
 

--- a/src/porepy/models/solution_strategy.py
+++ b/src/porepy/models/solution_strategy.py
@@ -48,10 +48,6 @@ class SolutionStrategy(pp.PorePyModel):
         self.params = default_params
         """Dictionary of parameters."""
 
-        # Set a convergence status. Not sure if a boolean is sufficient, or whether
-        # we should have an enum here.
-        self.convergence_status = False
-        """Whether the non-linear iteration has converged."""
         self._nonlinear_discretizations: list[pp.ad._ad_utils.MergedOperator] = []
         """See :meth:`add_nonlinear_discretization`."""
         self._nonlinear_diffusive_flux_discretizations: list[
@@ -176,7 +172,9 @@ class SolutionStrategy(pp.PorePyModel):
         self._initialize_linear_solver()
         self.set_nonlinear_discretizations()
 
-        # Export initial condition
+        # Export initial condition. To avoid marking the initial condition as a "failed"
+        # time step, we set the nonlinear convergence status to True.
+        self.nonlinear_solver_statistics.nl_is_converged = True
         self.save_data_time_step()
 
     def initialize_previous_iterate_and_time_step_values(self) -> None:
@@ -609,7 +607,7 @@ class SolutionStrategy(pp.PorePyModel):
             )
         self.update_solution(solution)
 
-        self.convergence_status = True
+        self.nonlinear_solver_statistics.nl_is_converged = True
         self.save_data_time_step()
 
     def update_solution(self, solution: np.ndarray) -> None:

--- a/src/porepy/viz/data_saving_model_mixin.py
+++ b/src/porepy/viz/data_saving_model_mixin.py
@@ -62,16 +62,16 @@ class DataSavingMixin(pp.PorePyModel):
 
         # Collecting and storing data in runtime for analysis. If default value of None
         # is returned, nothing is stored to not burden memory.
-        if not self._is_time_dependent():  # stationary problem
+        if not self._is_time_dependent():  # Stationary problem
             if (
                 self.nonlinear_solver_statistics.num_iteration > 0
             ):  # avoid saving initial condition
                 collected_data = self.collect_data()
                 if collected_data is not None:
                     self.results.append(collected_data)
-        else:  # time-dependent problem
+        else:  # Time-dependent problem
             t = self.time_manager.time  # current time
-            scheduled = self.time_manager.schedule[1:]  # scheduled times except t_init
+            scheduled = self.time_manager.schedule[1:]  # Scheduled times except t_init.
             if any(np.isclose(t, scheduled)):
                 collected_data = self.collect_data()
                 if collected_data is not None:
@@ -99,7 +99,11 @@ class DataSavingMixin(pp.PorePyModel):
         self.time_manager.write_time_information(
             Path(self.params["folder_name"]) / "times.json"
         )
-        self.exporter.write_vtu(self.data_to_export(), time_dependent=True)
+        self.exporter.write_vtu(
+            self.data_to_export(),
+            time_dependent=True,
+            converged=self.nonlinear_solver_statistics.nl_is_converged,
+        )
         times = np.array(self.time_manager.exported_times)
         if self.restart_options.get("restart", False):
             # For a pvd file addressing all time steps (before and after restart

--- a/src/porepy/viz/solver_statistics.py
+++ b/src/porepy/viz/solver_statistics.py
@@ -43,6 +43,8 @@ class SolverStatistics:
     """List of increment magnitudes for each non-linear iteration."""
     residual_norms: list[float] = field(default_factory=list)
     """List of residual for each non-linear iteration."""
+    nl_is_converged: bool = False
+    """Flag indicating whether the non-linear solver converged."""
     path: Optional[Path] = None
     """Path to save the statistics object to."""
 
@@ -63,6 +65,7 @@ class SolverStatistics:
     def reset(self) -> None:
         """Reset the statistics object."""
         self.num_iteration = 0
+        self.nl_is_converged = False
         self.nonlinear_increment_norms.clear()
         self.residual_norms.clear()
 
@@ -79,6 +82,7 @@ class SolverStatistics:
             # Append data - assume the index corresponds to time step
             ind = len(data) + 1
             data[ind] = {
+                "nl_is_converged": self.nl_is_converged,
                 "num_iteration": self.num_iteration,
                 "nonlinear_increment_norms": self.nonlinear_increment_norms,
                 "residual_norms": self.residual_norms,


### PR DESCRIPTION
## Proposed changes
Attempt at fixing #1421.

The idea is to have `SolverStatistics` keep track of whether the current nonlinear loop has converged. When calling `DataSavingMixin.save_data_time_step`, `SolverStatistics.save` stores the convergence flag in the JSON file.  `DataSavingMixin.write_pvd_and_vtu`  then prefixes exported files with `failed_` in the case of non-convergence. Lastly, only the files corresponding to converged time steps are included in the `data.pvd` file for the full simulation.

The code works, except for the last part. To track failed time steps, I added `Exporter._exported_timesteps_convergence`, which masks non-converged steps before writing `data.pvd`. However, when `DataSavingMixin.write_pvd_and_vtu` calls `Exporter.write_pvd`, it passes `TimeManager.exported_times` for `times` and `None` for `file_extension`. The latter parameter is then replaced by `Exporter._exported_timesteps`. As far as I see, tracking exported time steps at two different places and coupling both in `Exporter.write_pvd` is prone to bugs.

Before I make this even more convoluted, we should discuss whether it is worth to clean this up and unify bookkeeping of exported time steps.

## Types of changes

- [ ] Minor change (e.g., dependency bumps, broken links).
- [x] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
