### PR TITLE
BUG: Replace trange with tqdm to avoid a logging bug

### DIFF
--- a/src/porepy/models/run_models.py
+++ b/src/porepy/models/run_models.py
@@ -121,7 +121,7 @@ def run_time_dependent_model(model, params: Optional[dict] = None) -> None:
                 )
             )
             time_progressbar = progressbar_class(
-                expected_time_steps,
+                range(expected_time_steps),
                 desc="time loop",
                 position=0,
                 dynamic_ncols=True,
@@ -222,7 +222,7 @@ def _run_iterative_model(model, params: dict) -> None:
                 )
             )
             time_progressbar = progressbar_class(
-                expected_time_steps,
+                range(expected_time_steps),
                 desc="time loop",
                 position=0,
                 dynamic_ncols=True,

--- a/src/porepy/numerics/nonlinear/nonlinear_solvers.py
+++ b/src/porepy/numerics/nonlinear/nonlinear_solvers.py
@@ -113,7 +113,7 @@ class NewtonSolver:
             if self.progress_bar:
                 # Length is the maximal number of Newton iterations.
                 solver_progressbar = progressbar_class(  # type: ignore
-                    self.params["max_iterations"],
+                    range(self.params["max_iterations"]),
                     desc="Newton loop",
                     position=self.progress_bar_position,
                     leave=False,

--- a/src/porepy/numerics/nonlinear/nonlinear_solvers.py
+++ b/src/porepy/numerics/nonlinear/nonlinear_solvers.py
@@ -113,7 +113,7 @@ class NewtonSolver:
             if self.progress_bar:
                 # Length is the maximal number of Newton iterations.
                 solver_progressbar = progressbar_class(  # type: ignore
-                    range(self.params["max_iterations"]),
+                    range(int(self.params["max_iterations"])),
                     desc="Newton loop",
                     position=self.progress_bar_position,
                     leave=False,

--- a/src/porepy/utils/ui_and_logging.py
+++ b/src/porepy/utils/ui_and_logging.py
@@ -42,7 +42,7 @@ class DummyProgressBar:
 # ``tqdm`` is not a dependency. Up to the user to install it.
 try:
     # Avoid some mypy trouble due to missing library stubs for tqdm.
-    from tqdm.autonotebook import trange as progressbar_class  # type: ignore
+    from tqdm.autonotebook import tqdm as progressbar_class  # type: ignore
     from tqdm.contrib.logging import (  # type: ignore
         _get_first_found_console_logging_handler,
         _TqdmLoggingHandler,


### PR DESCRIPTION
## Proposed changes
`tqdm` with another weird bug again. In `ui_and_logging.py`, `progressbar_class` was either `trange` or `DummyProgressbarClass`. At some point, `_TqdmLoggingHandler.emit` calls `progressbar_class.write`. This raises an error, as `trange` is not actually a class, but a function that returns an instance of the `tqdm.tqdm` class. 

I fixed this s.t. `progressbar_class` is now either `tqdm` or `DummyProgressbarClass`, which comes at the miniscule cost that the progressbars have to be initialized with a range instead of an int.

Not sure how this slipped through tbh. When I tested things for #1450, this error never appeared for some reason that I do not understand.

Thanks for catching the bug @jwboth !

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [x] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
