### PR TITLE
Expose configurable flux array key in Upwind and UpwindCoupling

### DIFF
--- a/src/porepy/numerics/fv/upwind.py
+++ b/src/porepy/numerics/fv/upwind.py
@@ -43,6 +43,14 @@ class Upwind(Discretization):
 
         """
 
+    @property
+    def flux_array_key(self) -> str:
+        return self._flux_array_key
+
+    @flux_array_key.setter
+    def flux_array_key(self, value: str) -> None:
+        self._flux_array_key = value
+
     def ndof(self, sd: pp.Grid) -> int:
         """Return the number of degrees of freedom associated to the method. In this
         case number of cells.
@@ -390,11 +398,13 @@ class UpwindCoupling(InterfaceDiscretization):
         """Keyword used to identify the parameter matrix for face fluxes.
         Defaults to 'darcy_flux'."""
 
-    def key(self) -> str:
-        return self.keyword + "_"
+    @property
+    def flux_array_key(self) -> str:
+        return self._flux_array_key
 
-    def discretization_key(self):
-        return self.key() + pp.DISCRETIZATION
+    @flux_array_key.setter
+    def flux_array_key(self, value: str) -> None:
+        self._flux_array_key = value
 
     def ndof(self, intf: pp.MortarGrid) -> int:
         return intf.num_cells

--- a/src/porepy/numerics/fv/upwind.py
+++ b/src/porepy/numerics/fv/upwind.py
@@ -398,6 +398,12 @@ class UpwindCoupling(InterfaceDiscretization):
         """Keyword used to identify the parameter matrix for face fluxes.
         Defaults to 'darcy_flux'."""
 
+    def key(self) -> str:
+        return self.keyword + "_"
+
+    def discretization_key(self):
+        return self.key() + pp.DISCRETIZATION
+
     @property
     def flux_array_key(self) -> str:
         return self._flux_array_key


### PR DESCRIPTION
## Proposed changes

This PR exposes the flux array key for both Upwind and UpwindCoupling. This enables reusing the Upwind class for advecting directions different from a Darcy flux.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [x] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
