### PR TITLE
BUG: Logical error in grid diameter computation

### DIFF
--- a/src/porepy/grids/grid.py
+++ b/src/porepy/grids/grid.py
@@ -993,19 +993,35 @@ class Grid:
                 [ind[ptr[i] + template[sz]] for i, sz in enumerate(num_nodes)]
             )
 
-            # In-place sort of the columns.
-            all_node_pairs.sort(axis=0)
-
-            # We only need the unique pairs of nodes.
-            unique_pairs = np.unique(all_node_pairs, axis=1)
             # Compute the diameter of each unique pair of nodes.
             dist = np.linalg.norm(
-                self.nodes[:, unique_pairs[0]] - self.nodes[:, unique_pairs[1]], axis=0
+                self.nodes[:, all_node_pairs[0]] - self.nodes[:, all_node_pairs[1]],
+                axis=0,
             )
+            # The cell diameter is the maximum of the distances associated to a cell. To
+            # find this, we first make an array of cell indices for all elements in
+            # dist. Spelled out: For each element in num_nodes (the number of nodes in
+            # each cell), create an array of cell indices (ci). The size of this array
+            # should be the number of node-node combinations within that cell (given by
+            # the number of columns in the corresponding template). Concatenate the
+            # arrays created for all cells by using np.hstack.
+            cell_index = np.hstack(
+                [np.full(template[sz].shape[1], ci) for ci, sz in enumerate(num_nodes)]
+            )
+            # Take the maximum over all distances associated with a cell. We will store
+            # the maximum in cell_diam.
+            cell_diam = np.zeros(self.num_cells)
+            # By numpy magic and copilot cleverness, the following two lines efficiently
+            # takes the cell-wise maximum. It is equivalent to (but much faster than)
+            # the following code:
+            #   cell_diam = np.array([np.max(dist[cell_index == ci])
+            #                         for ci in range(self.num_cells)])
+            _, inverse_indices = np.unique(cell_index, return_inverse=True)
+            np.maximum.at(cell_diam, inverse_indices, dist)
 
             assert func is not None  # For mypy.
             # Apply the function to the computed diameters.
-            return func(dist)
+            return func(cell_diam)
 
     def cell_faces_as_dense(self) -> np.ndarray:
         """Obtain the cell-face relation in the form of two rows, rather than a

--- a/src/porepy/grids/grid.py
+++ b/src/porepy/grids/grid.py
@@ -1012,7 +1012,7 @@ class Grid:
             # the maximum in cell_diam.
             cell_diam = np.zeros(self.num_cells)
             # By numpy magic and copilot cleverness, the following two lines efficiently
-            # takes the cell-wise maximum. It is equivalent to (but much faster than)
+            # take the cell-wise maximum. It is equivalent to (but much faster than)
             # the following code:
             #   cell_diam = np.array([np.max(dist[cell_index == ci])
             #                         for ci in range(self.num_cells)])

--- a/src/porepy/grids/grid.py
+++ b/src/porepy/grids/grid.py
@@ -993,7 +993,7 @@ class Grid:
                 [ind[ptr[i] + template[sz]] for i, sz in enumerate(num_nodes)]
             )
 
-            # Compute the diameter of each unique pair of nodes.
+            # Compute the diameter of each pair of nodes.
             dist = np.linalg.norm(
                 self.nodes[:, all_node_pairs[0]] - self.nodes[:, all_node_pairs[1]],
                 axis=0,

--- a/tests/grids/test_grid.py
+++ b/tests/grids/test_grid.py
@@ -7,6 +7,8 @@
 import os
 import pickle
 
+from typing import Callable
+
 import numpy as np
 import pytest
 import scipy.sparse as sps
@@ -18,24 +20,61 @@ from porepy.numerics.linalg.matrix_operations import sparse_array_to_row_col_dat
 
 
 @pytest.mark.parametrize(
-    "grid, expected_diameter",
+    "g, expected_diameters",
     [
         (
-            pp.CartGrid(np.array([3, 2]), np.array([1, 1])),
-            np.sqrt(0.5**2 + 1.0 / 3.0**2),
+            pp.CartGrid(np.array([2, 1]), np.array([1, 1])),  # 2d grid.
+            np.array(
+                [
+                    np.sqrt(1**2 + 0.5**2),  # Cell 0 has dx=0.5, dy=1.
+                    np.sqrt(1.5**2 + 2**2),  # Cell 1 is perturbed to have dx=1.5, dy=2.
+                ]
+            ),
         ),
-        (pp.CartGrid(np.array([3, 2, 1])), np.sqrt(3)),
+        (
+            pp.CartGrid(np.array([2, 1, 1]), np.array([1, 1, 1])),  # 3d grid.
+            np.array(
+                [
+                    np.sqrt(0.5**2 + 1**2 + 1**2),  # Cell 0 has dx=0.5, dy=dz=1.
+                    np.sqrt(1.5**2 + 2**2 + 1**2),  # Cell 1 has dx=1.5, dy=2, dz=1.
+                ]
+            ),
+        ),
     ],
 )
 @pytest.mark.parametrize("cell_wise", [True, False])
-def test_cell_diameters(grid, expected_diameter, cell_wise):
+@pytest.mark.parametrize("func", [np.max, np.min, np.mean])
+def test_cell_diameters(
+    g: pp.Grid, expected_diameters: np.ndarray, cell_wise: bool, func: Callable
+):
+    """Test the computation of cell diameters.
+
+    Parameters:
+        g: Grid to be tested. This is expected to be of uniform size. The node of one of
+            the cells will be moved so that the cells have non-uniform diameter.
+        expected_diameters: Array of expected diameter for each cell.
+        cell_wise: Whether to compute the diameter cell-wise or not.
+        func: Function to apply to the expected diameters. Will only be used if
+            cell_wise=False, see Grid.cell_diameters() for details.
+
+    """
+    # Move the last node of the grid (it is easier to do this here than to modify the
+    # grid in the test parametrization). Since the grid is expected to be Cartesian,
+    # this will impact the diameter of cell 1, but not cell 0. Do not perturb the
+    # z-coordinate, so that a 2d grid stays 2d.
+    g.nodes[:2, -1] = 2
+
     # The test is run for a 2d grid and a 3d grid.
-    cell_diameters = grid.cell_diameters(cell_wise=cell_wise, func=np.max)
+    cell_diameters = g.cell_diameters(cell_wise=cell_wise, func=func)
     if cell_wise:
-        known = np.repeat(expected_diameter, grid.num_cells)
+        # The returned array is an element-wise array of cell diameters, we can do a
+        # direct comparison.
+        assert np.allclose(cell_diameters, expected_diameters)
     else:
-        known = expected_diameter
-    assert np.allclose(cell_diameters, known)
+        # The returned value is a single value obtained by applying 'func' to the
+        # calculated cell diameters. Apply 'func' also to the expected diameters before
+        # comparing.
+        assert np.allclose(cell_diameters, func(expected_diameters))
 
 
 def test_repr():

--- a/tests/grids/test_grid.py
+++ b/tests/grids/test_grid.py
@@ -64,8 +64,13 @@ def test_cell_diameters(
     # z-coordinate, so that a 2d grid stays 2d.
     g.nodes[:2, -1] = 2
 
-    # The test is run for a 2d grid and a 3d grid.
-    cell_diameters = g.cell_diameters(cell_wise=cell_wise, func=func)
+    if cell_wise:
+        # When cell_wise is True, 'func' will not be used and a warning should be raised
+        # if func is not None. Check this.
+        with pytest.warns(UserWarning):
+            cell_diameters = g.cell_diameters(cell_wise=cell_wise, func=func)
+    else:
+        cell_diameters = g.cell_diameters(cell_wise=cell_wise, func=func)
     if cell_wise:
         # The returned array is an element-wise array of cell diameters, we can do a
         # direct comparison.


### PR DESCRIPTION
## Proposed changes
This fixes an error introduced in #1475: When calculating cell diameters it is necessary, first to take the maximum of all diameters (node-node distances) within a cell, and then apply a user-defined function (say, `np.min`) to get the quantity (say, minimum diameter) in the entire grid. In #1475, the step of calculating cell-wise diameter was skipped; hence the code in some cases gave wrong results for non-simplicial grids.

I am starting to think that the new implementation may be sufficiently general to replace the old implementation, which is activated when setting `cell_wise=True`. However, I am not fully confident that this is really the case, so I would prefer not to do that generalization now, but return to the matter if the cell diameter calculation is taken into much more frequent use than what is  now the case.


## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
