### PR TITLE
Add comment about inconsistent recomputation count

### DIFF
--- a/src/porepy/numerics/time_step_control.py
+++ b/src/porepy/numerics/time_step_control.py
@@ -157,9 +157,8 @@ class TimeManager:
         recomp_factor: Failed-to-converge solution recomputation factor.
             Factor by which the time step will be multiplied in case the solution must
             be recomputed. We require `recomp_factor` to be strictly less than one.
-        recomp_max: Failed-to-converge maximum recomputation attempts. The maximum
-        allowable
-            number of consecutive recomputation attempts.
+        recomp_max: Maximum recomputation attempts. The maximum allowable
+            number of recomputation attempts.
         print_info. Whether to print on-the-fly time-stepping information or not.
         rtol: Relative tolerance parameter for float point equality.
         atol: Absolute tolerance parameter for float point equality.
@@ -382,8 +381,10 @@ class TimeManager:
         # Time index
         self.time_index: int = 0
 
-        # Private attributes
-        # Number of times the solution has been recomputed
+        # Private attributes 
+        # Number of times the solution has been recomputed. 
+        # The count is inconsistent: it may represent recomputations per time-step or
+        # for the entire simulation depending on the method used.
         self._recomp_num: int = 0
 
         # Index of the next scheduled time


### PR DESCRIPTION
## Proposed changes

The _recomp_num-attribute of the TimeManager counts either for the time-step or for the entire simulation. Added a comment about this. 

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [x] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
