### PR TITLE
1477 methods for exporting fracs domains gmsh

### DIFF
--- a/src/porepy/fracs/fracture_network_2d.py
+++ b/src/porepy/fracs/fracture_network_2d.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import gmsh
 import copy
 import csv
 import logging
@@ -135,6 +136,37 @@ class FractureNetwork2d:
             )
         if domain is not None:
             logger.info(f"Domain specification : {str(domain)}")
+
+
+    def export_domain_to_gmsh(self):
+        """Export the rectangular domain to Gmsh using the OpenCASCADE kernel.
+
+        This method creates a rectangle corresponding to the bounding box of the
+        fracture network domain and adds it to the current Gmsh model. The OpenCASCADE
+        CAD kernel is used for the geometry representation.
+
+        Returns:
+            The Gmsh tag ID of the created rectangle. This can be used to reference the
+            rectangle in further Gmsh operations, such as meshing or boolean operations.
+
+        Notes:
+            * Ensure that `gmsh.initialize()` has been called before using this method,
+                or call it in the method if starting a fresh Gmsh session.
+            * The `gmsh.model.occ.synchronize()` call is required to update the model
+                so that the rectangle can be used in subsequent operations.
+            * This method currently only supports rectangular domains.
+
+    """
+        bb = self.domain.bounding_box
+        xmin, xmax = bb["xmin"], bb["xmax"]
+        ymin, ymax = bb["ymin"], bb["ymax"]
+
+        gmsh_representation_of_domain = gmsh.model.occ.addRectangle(
+            xmin, ymin, 0, xmax - xmin, ymax - ymin
+        )
+        gmsh.model.occ.synchronize()
+        return gmsh_representation_of_domain
+
 
     def mesh(
         self,

--- a/src/porepy/fracs/fracture_network_2d.py
+++ b/src/porepy/fracs/fracture_network_2d.py
@@ -168,7 +168,7 @@ class FractureNetwork2d:
         )
         return domain_tag
 
-    def fractures_to_gmsh_2D(self):
+    def fractures_to_gmsh_2D(self) -> list[int]:
         """WIP: Take the tags of all fractures in the fracture network.
         
         By using the method for exporting a single fracture tag, we here collect the

--- a/src/porepy/fracs/fracture_network_2d.py
+++ b/src/porepy/fracs/fracture_network_2d.py
@@ -169,7 +169,7 @@ class FractureNetwork2d:
         return domain_tag
 
     def fractures_to_gmsh_2D(self) -> list[int]:
-        """WIP: Take the tags of all fractures in the fracture network.
+        """Take the tags of all fractures in the fracture network.
         
         By using the method for exporting a single fracture tag, we here collect the
         tags of all the fractures in the fracture network. The tags are returned as
@@ -184,10 +184,8 @@ class FractureNetwork2d:
             decided.
         
         """
-        fracture_tags = []
-        for fracture in self.fractures:
-            tag = fracture.fracture_to_gmsh_2D()
-            fracture_tags.append(tag)
+        fracture_tags = [fracture.fracture_to_gmsh_2D() for fracture in self.fractures]
+
         return fracture_tags
 
     def mesh(

--- a/src/porepy/fracs/fracture_network_2d.py
+++ b/src/porepy/fracs/fracture_network_2d.py
@@ -161,8 +161,8 @@ class FractureNetwork2d:
         xmin, xmax = bb["xmin"], bb["xmax"]
         ymin, ymax = bb["ymin"], bb["ymax"]
 
-        # Reasonable assumption that z is always the zero coordinate when working in
-        # 2D??
+        # We assume that z is the zero coordinate when working in 2D, and thus the third
+        # input to addRectangle is set to be 0:
         domain_tag = gmsh.model.occ.addRectangle(
             xmin, ymin, 0, xmax - xmin, ymax - ymin
         )

--- a/src/porepy/fracs/fracture_network_2d.py
+++ b/src/porepy/fracs/fracture_network_2d.py
@@ -138,7 +138,7 @@ class FractureNetwork2d:
             logger.info(f"Domain specification : {str(domain)}")
 
 
-    def export_domain_to_gmsh(self):
+    def domain_to_gmsh_2D(self):
         """Export the rectangular domain to Gmsh using the OpenCASCADE kernel.
 
         This method creates a rectangle corresponding to the bounding box of the
@@ -156,17 +156,39 @@ class FractureNetwork2d:
                 so that the rectangle can be used in subsequent operations.
             * This method currently only supports rectangular domains.
 
-    """
+        """
         bb = self.domain.bounding_box
         xmin, xmax = bb["xmin"], bb["xmax"]
         ymin, ymax = bb["ymin"], bb["ymax"]
 
-        gmsh_representation_of_domain = gmsh.model.occ.addRectangle(
+        # Reasonable assumption that z is always the zero coordinate when working in
+        # 2D??
+        domain_tag = gmsh.model.occ.addRectangle(
             xmin, ymin, 0, xmax - xmin, ymax - ymin
         )
-        gmsh.model.occ.synchronize()
-        return gmsh_representation_of_domain
+        return domain_tag
 
+    def fractures_to_gmsh_2D(self):
+        """WIP: Take the tags of all fractures in the fracture network.
+        
+        By using the method for exporting a single fracture tag, we here collect the
+        tags of all the fractures in the fracture network. The tags are returned as
+        elements in a list.
+
+        Returns:
+            A list of integers which represent all fracture tags in the fracture
+            network.
+
+        NOTE:
+            The method fracture_to_gmsh_2D() does not exist yet, nor is its name
+            decided.
+        
+        """
+        fracture_tags = []
+        for fracture in self.fractures:
+            tag = fracture.fracture_to_gmsh_2D()
+            fracture_tags.append(tag)
+        return fracture_tags
 
     def mesh(
         self,

--- a/src/porepy/fracs/fracture_network_3d.py
+++ b/src/porepy/fracs/fracture_network_3d.py
@@ -155,7 +155,7 @@ class FractureNetwork3d(object):
     def domain_to_gmsh_3D(self) -> int:
         """Export the box domain to Gmsh using the OpenCASCADE kernel.
 
-        This method creates a rectangle corresponding to the bounding box of the
+        This method creates a box corresponding to the bounding box of the
         fracture network domain and adds it to the current Gmsh model. The OpenCASCADE
         CAD kernel is used for the geometry representation.
 
@@ -188,10 +188,8 @@ class FractureNetwork3d(object):
             network.
             
         """
-        fracture_tags = []
-        for fracture in self.fractures:
-            tag = fracture.fracture_to_gmsh_3D()
-            fracture_tags.append(tag)
+        fracture_tags = [fracture.fracture_to_gmsh_3D() for fracture in self.fractures]
+
         return fracture_tags
 
     def copy(self) -> FractureNetwork3d:

--- a/src/porepy/fracs/fracture_network_3d.py
+++ b/src/porepy/fracs/fracture_network_3d.py
@@ -6,6 +6,7 @@ The model relies heavily on functions in the computational geometry library.
 
 from __future__ import annotations
 
+import gmsh
 import copy
 import csv
 import logging
@@ -150,6 +151,52 @@ class FractureNetwork3d(object):
         Necessary pre-processing before meshing. Added by :meth:`split_intersections`.
 
         """
+
+    def domain_to_gmsh_3D(self):
+        """Export the box domain to Gmsh using the OpenCASCADE kernel.
+
+        This method creates a rectangle corresponding to the bounding box of the
+        fracture network domain and adds it to the current Gmsh model. The OpenCASCADE
+        CAD kernel is used for the geometry representation.
+
+        Returns:
+            The Gmsh tag ID of the created box. This can be used to reference the
+            box in further Gmsh operations, such as meshing or boolean operations.
+
+
+        """
+        bb = self.domain.bounding_box
+
+        xmin, xmax = bb["xmin"], bb["xmax"]
+        ymin, ymax = bb["ymin"], bb["ymax"]
+        zmin, zmax = bb["zmin"], bb["zmax"]
+
+        domain_tag = gmsh.model.occ.addBox(
+            xmin, ymin, zmin, xmax - xmin, ymax - ymin, zmax - zmin
+        )
+        return domain_tag
+
+    def fractures_to_gmsh_3D(self):
+        """WIP: Take the tags of all fractures in the fracture network.
+        
+        By using the method for exporting a single fracture tag, we here collect the
+        tags of all the fractures in the fracture network. The tags are returned as
+        elements in a list.
+
+        Returns:
+            A list of integers which represent all fracture tags in the fracture
+            network.
+            
+        NOTE:
+            The method fracture_to_gmsh_3D() does not exist yet, nor is its name
+            decided.
+
+        """
+        fracture_tags = []
+        for fracture in self.fractures:
+            tag = fracture.fracture_to_gmsh_3D()
+            fracture_tags.append(tag)
+        return fracture_tags
 
     def copy(self) -> FractureNetwork3d:
         """Create a deep copy of the fracture network.

--- a/src/porepy/fracs/fracture_network_3d.py
+++ b/src/porepy/fracs/fracture_network_3d.py
@@ -152,7 +152,7 @@ class FractureNetwork3d(object):
 
         """
 
-    def domain_to_gmsh_3D(self):
+    def domain_to_gmsh_3D(self) -> int:
         """Export the box domain to Gmsh using the OpenCASCADE kernel.
 
         This method creates a rectangle corresponding to the bounding box of the
@@ -176,7 +176,7 @@ class FractureNetwork3d(object):
         )
         return domain_tag
 
-    def fractures_to_gmsh_3D(self):
+    def fractures_to_gmsh_3D(self) -> list[int]:
         """WIP: Take the tags of all fractures in the fracture network.
         
         By using the method for exporting a single fracture tag, we here collect the
@@ -187,10 +187,6 @@ class FractureNetwork3d(object):
             A list of integers which represent all fracture tags in the fracture
             network.
             
-        NOTE:
-            The method fracture_to_gmsh_3D() does not exist yet, nor is its name
-            decided.
-
         """
         fracture_tags = []
         for fracture in self.fractures:

--- a/src/porepy/fracs/line_fracture.py
+++ b/src/porepy/fracs/line_fracture.py
@@ -5,6 +5,7 @@ That is, manifolds of dimension 1 embedded in 2Dd
 
 from __future__ import annotations
 
+import gmsh
 import numpy as np
 
 from .fracture import Fracture
@@ -17,6 +18,22 @@ class LineFracture(Fracture):
     For a description of constructor arguments, see base class.
 
     """
+
+    def fracture_to_gmsh_2D(self) -> int:
+        """Creates a gmsh representation of the fracture and exports its tag.
+
+        Returns:
+            An integer representing the tag of the fracture.
+
+        """
+        endpoint_1 = gmsh.model.occ.addPoint(
+            float(self.pts[0, 0]), float(self.pts[1, 0]), 0.0
+        )
+        endpoint_2 = gmsh.model.occ.addPoint(
+            float(self.pts[0, 1]), float(self.pts[1, 1]), 0.0
+        )
+        fracture_id = gmsh.model.occ.addLine(endpoint_1, endpoint_2)
+        return fracture_id
 
     def sort_points(self) -> np.ndarray:
         """Sort the vertices.


### PR DESCRIPTION
## Proposed changes

Addressing the bulletpoints mentioned in issue 1477:
- Let a FractureNetwork2d export its own domain. Rectangular domains only.
- Let a LineFracture export itself, let the fracture class iterate over its fractures for export.
- Let a FractureNetwork3d export its own domain, boxes only.
- Let a PlaneFracture export itself, fracture network class iterate over fractures for export.

The methods create a gmsh version of the fracture/domain, and return its entity tag.

Note: The documentation is in a sketch stadium. 

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
