### PR TITLE
allow int64 as input for _function_to_compile in sort_multiple_point_pairs

### DIFF
--- a/src/porepy/geometry/sort_points.py
+++ b/src/porepy/geometry/sort_points.py
@@ -126,7 +126,7 @@ def sort_multiple_point_pairs(lines: np.ndarray) -> np.ndarray:
     except ImportError:
         raise ImportError("Numba not available on the system")
 
-    @njit("i4[:,:](i4[:,:])", cache=True)
+    @njit(["i4[:,:](i4[:,:])", "i4[:,:](i8[:,:])"], cache=True)
     def _function_to_compile(lines):
         """
         Copy of pp.sort_points.sort_point_pairs. This version is extended to


### PR DESCRIPTION
## Proposed changes

Sometimes the the face_to_nodes map in a grid has type int32 and some other is an int64, the function _function_to_compile since is compiled it expect to have int32 as input. With this modification both versions are compiled and the problem is solved.


## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [X ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ X] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
