### PR TITLE
Remove option to pass cell nodes to cell_diameters()

### DIFF
--- a/src/porepy/grids/grid.py
+++ b/src/porepy/grids/grid.py
@@ -893,17 +893,12 @@ class Grid:
     @lru_cache
     def cell_diameters(
         self,
-        cn: Optional[sps.spmatrix] = None,
         cell_wise: bool = True,
         func: Optional[Callable[[np.ndarray], np.ndarray]] = None,
     ) -> np.ndarray:
         """Computes the cell diameters.
 
         Parameters:
-            cn: ``default=None``
-                Cell-to-nodes map, already computed previously. If None, a call to
-                :meth:`cell_nodes` is provided.
-
             cell_wise:
                 If True, returns the cell diameters. If False, the parameter ``func``
                 must be provided to specify the aggregation function.
@@ -941,9 +936,6 @@ class Grid:
         if cell_wise and func is not None:
             warn("The parameter func is ignored when cell_wise is True")
 
-        if cn is None:
-            cn = self.cell_nodes()
-
         def comb(n):
             # Helper function to get all combinations of two elements in n.
             return np.fromiter(
@@ -955,6 +947,8 @@ class Grid:
             return np.amax(
                 np.linalg.norm(self.nodes[:, n[0, :]] - self.nodes[:, n[1, :]], axis=0)
             )
+
+        cn = self.cell_nodes()
 
         if cell_wise:
             # Compute the diameter for each cell by 1) getting all node combinations for


### PR DESCRIPTION
## Proposed changes

Addresses issue #1492. The signature of cell_diameters() has now been changed such that it is no longer possible to pass cell nodes.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
