### PR TITLE
STY: Fix syntax errors in doc strings

### DIFF
--- a/tests/grids/test_grid.py
+++ b/tests/grids/test_grid.py
@@ -901,7 +901,7 @@ def test_copy_grids():
 
 
 def test_merge_single_grid():
-    """
+    r"""
     Test coupling from one grid to itself. An example setting:
                     |--|--|--| ( grid )
                     0  1  2  3
@@ -929,7 +929,7 @@ def test_merge_single_grid():
 
 
 def test_merge_two_grids():
-    """
+    r"""
     Test coupling from one grid of three faces to grid of two faces.
     An example setting:
                     0  1  2

--- a/tests/numerics/fv/test_tpsa.py
+++ b/tests/numerics/fv/test_tpsa.py
@@ -257,7 +257,7 @@ def test_robin_neumann_dirichlet_consistency(g: pp.Grid):
 
 @pytest.mark.parametrize("neu_bcs", [False, True])
 def test_3d_linear_displacement(neu_bcs: bool):
-    """Test of a 3d linear displacement problem, for which Tpsa should be exact.
+    r"""Test of a 3d linear displacement problem, for which Tpsa should be exact.
 
     The analytical solution is u = [z, 0, 0], which results in \sigma_{1,3} =
     \sigma{3,1} = 1, with all other stress components equal to zero. The rotation will


### PR DESCRIPTION
Use raw strings for doc strings that abuse python syntax to represent mathematical symbols

## Proposed changes

Contributions to PorePy are highly appreciated. Clearly explain why this pull request (PR) is needed and why it should be accepted. If this PR solves an issue, explain how it is done. Please, also summarise the changes to the code.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
