### PR TITLE
Codespace

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+{
+  "name": "porepy-stable",
+  "build": {
+    "dockerfile": "../dockerfiles/stable/Dockerfile"
+  },
+  "remoteUser": "root",
+  "workspaceFolder": "/workdir/porepy",
+  "runArgs": ["-it"],
+  "waitFor": "updateContentCommand",
+  "updateContentCommand": "python -m pip install jupyter ipykernel notebook",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "ms-python.mypy-type-checker",
+        "ms-toolsai.jupyter",
+        "eamodio.gitlens",
+        "davidanson.vscode-markdownlint",
+        "charliermarsh.ruff"
+      ],
+      "settings": {
+        "python.defaultInterpreterPath": "/usr/local/bin/python",
+        "jupyter.kernels.excludePythonEnvironments": [
+          "/bin/python3",
+          "/usr/bin/python3"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #1546 

## Proposed changes

Introduces devcontainer setup to build an image used for creating codespaces.
The image is based on the `porepy\stable` image.

Adds basic python setup for vscode in the codespace lowering entry barrier.
Installs everything needed to run jupyter notebooks, narrows down available python interpreters to highest version (3.13.9), which is the default python in the image (this was done to avoid users accidently chosing an intepreter where the tutorial execution will fail. Consider removing 2 redundant python installations from image)