### PR TITLE
Minor fix exporting of iterations and fracture quantities

### DIFF
--- a/src/porepy/viz/data_saving_model_mixin.py
+++ b/src/porepy/viz/data_saving_model_mixin.py
@@ -470,7 +470,7 @@ class FractureDeformationExporting(pp.PorePyModel):
             # the normal traction.
             traction_loc = traction[
                 cell_offsets_nd[id] : cell_offsets_nd[id + 1]
-            ].reshape((3, -1), order="F")
+            ].reshape((self.nd, -1), order="F")
             # Avoid division by zero. If normal traction is zero (open fractures), we
             # set it to 1.
             zero_inds = np.isclose(traction_loc[-1], 0)

--- a/src/porepy/viz/data_saving_model_mixin.py
+++ b/src/porepy/viz/data_saving_model_mixin.py
@@ -300,10 +300,13 @@ class IterationExporting(pp.PorePyModel):
         super().initialize_data_saving()
         # Having a separate exporter for iterations avoids distinguishing between
         # iterations and time steps in the regular exporter's history.
+        folder = Path(self.params["folder_name"])
+        folder_iterations = folder.parent / (folder.name + "_iterations")
         self.iteration_exporter = pp.Exporter(
             self.mdg,
             file_name=self.params["file_name"],
-            folder_name=self.params["folder_name"] + "_iterations",
+            folder_name=folder_iterations,
+            length_scale=self.units.m,
         )
 
     def data_to_export_iteration(self):
@@ -332,7 +335,7 @@ class IterationExporting(pp.PorePyModel):
             self.data_to_export_iteration(),
             time_dependent=True,
             time_step=self.nonlinear_solver_statistics.num_iteration
-            + r * self.time_manager.time_index,
+            + 10**r * self.time_manager.time_index,
         )
 
     def after_nonlinear_iteration(self, solution_vector: np.ndarray) -> None:


### PR DESCRIPTION
## Proposed changes

I noticed some minor issues when using the new functionality for exporting iterations and fracture quantities:

- The folder definition for the exported iterations does not work for `Path` objects.
- The numbering of exported data was wrong.
- Iteration exporting did not take care of non-unitary length scale units.
- The exporting of tractions was hardcoded for 3d.

This PR aims at fixing these issues.


## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [X] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [X] The documentation is up-to-date.
- [X] Static typing is included in the update.
- [X] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.

Tests have been ignored (as before for these convenience classes).