### PR TITLE
TST: Improved calculation of errors for convergence rate analysis

### DIFF
--- a/tests/applications/test_convergence_analysis.py
+++ b/tests/applications/test_convergence_analysis.py
@@ -830,51 +830,24 @@ def face_error(
         L2-error.
 
     """
-    face_nodes = sd.face_nodes
     meas = np.zeros(sd.num_faces)
     for face_number in range(sd.num_faces):
-        # Obtain the coordinates of the nodes of the face.
-        face_node_indices = face_nodes.indices[
-            face_nodes.indptr[face_number] : face_nodes.indptr[face_number + 1]
-        ]
+        fc = sd.face_centers[:, face_number]
+        normal = sd.face_normals[:, face_number] / sd.face_areas[face_number]
 
-        node_coordinates = []
-        for node in face_node_indices:
-            node_coordinates.append(sd.nodes[:, node])
         # Obtain the neighboring cells of the face.
         neighboring_cells = np.where(sd.cell_faces[face_number].todense() != 0)[
             1
         ].tolist()
 
-        def compute_volume(sd, cell, nodes):
-            """Compute the volume of a pyramid."""
-            cc = sd.cell_centers[:, cell].reshape(-1, 1)
-            # Compute the normal distance from the cell center to the face.
-            polygon = np.stack(nodes, axis=1)
-            distance = pp.geometry.distances.points_polygon(
-                p=cc, poly=polygon, tol=1e-8
-            )[0]
-            area = 1 / 3 * distance * sd.face_areas[face_number]
-            return area
-
-        def compute_area(sd, cell, nodes):
-            """Compute the area of a triangle."""
-            cc = sd.cell_centers[:, cell]
-            starting_point = nodes[0]
-            end_point = nodes[1]
-            # Compute the normal distance from the cell center to the face.
-            distance, _ = pp.geometry.distances.points_segments(
-                p=cc, start=starting_point, end=end_point
-            )
-            area = 1 / 2 * distance * sd.face_areas[face_number]
-            return area
-
         area_local = 0
         for cell in neighboring_cells:
-            if sd.dim == 3:
-                area_local += compute_volume(sd, cell, node_coordinates)
-            elif sd.dim == 2:
-                area_local += compute_area(sd, cell, node_coordinates)
+            cc = sd.cell_centers[:, cell]
+            # Compute the distance between face center and cell center in the normal
+            # direction.
+            distance = np.abs(normal.ravel().dot((fc - cc).ravel()))
+            area_local += distance * sd.face_areas[face_number] / sd.dim
+
         meas[face_number] = area_local
 
     if parameter_weight is not None:


### PR DESCRIPTION
The previous code tacitly assumed that the normal projection of the cell centers onto faces fell inside the faces. This turned out not to be the case for all grids of interest after the update of the meshing methodology.

The price to be paid is that the test now is closer to the code to be tested. However, this is a computation of a geometric distance normal to a line/plane, and there is only one natural way of doing this.

## Proposed changes

Contributions to PorePy are highly appreciated. Clearly explain why this pull request (PR) is needed and why it should be accepted. If this PR solves an issue, explain how it is done. Please, also summarise the changes to the code.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
