### PR TITLE
Make tests of HM and THM models work for more general grids. 

### DIFF
--- a/tests/models/test_poromechanics.py
+++ b/tests/models/test_poromechanics.py
@@ -216,6 +216,11 @@ def create_model_with_fracture(
         "u_north": [0.0, uy_north],  # Note: List of length nd. Extend if used in 3d.
         "max_iterations": 20,
     }
+
+    if issubclass(model_class, TailoredPoromechanicsTpsa):
+        # Tpsa is only consistent with Cartesian grids.
+        model_params["cartesian"] = True
+
     model = model_class(model_params)
     return model
 

--- a/tests/models/test_poromechanics.py
+++ b/tests/models/test_poromechanics.py
@@ -152,7 +152,8 @@ class NonzeroFractureGapPoromechanics(pp.PorePyModel):
                 val = self.units.convert_units(
                     self.params["fracture_source_value"], "kg * s ^ -1"
                 )
-                vals.append(val * np.ones(sd.num_cells))
+                # Distribute source term over cells based on cell volumes.
+                vals.append(val * sd.cell_volumes / np.sum(sd.cell_volumes))
         fracture_source = pp.wrap_as_dense_ad_array(
             np.hstack(vals), name="fracture_fluid_source"
         )
@@ -483,7 +484,7 @@ def test_push_north_zero_opening():
 )
 def test_positive_p_frac_positive_opening(model_class):
     model = create_model_with_fracture({}, {}, {}, 0.0, model_class)
-    model.params["fracture_source_value"] = 0.001
+    model.params["fracture_source_value"] = 0.004
     pp.run_time_dependent_model(model)
     _, _, p_frac, jump, traction = get_variables(model)
 
@@ -501,19 +502,9 @@ def test_positive_p_frac_positive_opening(model_class):
     assert np.all(np.abs(traction) < 1e-7)
 
     # Fracture pressure is positive.
-    #
-    # EK: The original reference values are for mesh with 4 fracture cells. Since the
-    # fracture source is set constant per fracture cell, effectively acting as an
-    # intensive quantity, the total source term and hence the fracture pressure scales
-    # with the number of fracture cells. We do a (perhaps somewhat rough) correction
-    # here by scaling with the ratio between number of fracture cells in the current
-    # model and the original number of fracture cells (4).
-    orig_mean_pressure = 4.8e-4
-    orig_deviation = 2e-5
-    cell_ratio = model.mdg.subdomains(dim=model.nd - 1)[0].num_cells / 4
-
-    assert np.all(p_frac > (orig_mean_pressure - orig_deviation) * cell_ratio)
-    assert np.all(p_frac < (orig_mean_pressure + orig_deviation) * cell_ratio)
+    mean_pressure = 4.8e-4
+    deviation = 2e-5
+    assert np.allclose(p_frac, mean_pressure, atol=deviation)
 
 
 def test_pull_south_positive_reference_pressure():

--- a/tests/models/test_poromechanics.py
+++ b/tests/models/test_poromechanics.py
@@ -491,14 +491,24 @@ def test_positive_p_frac_positive_opening(model_class):
     tol = 1e-4 if model_class == TailoredPoromechanicsTpsa else 1e-5
     assert np.abs(np.sum(jump[0])) < tol
 
-    # The contact force in normal direction should be zero
-
+    # The contact force in normal direction should be zero.
     # NB: This assumes the contact force is expressed in local coordinates
     assert np.all(np.abs(traction) < 1e-7)
 
-    # Fracture pressure is positive
-    assert np.all(p_frac > 4.7e-4)
-    assert np.all(p_frac < 4.9e-4)
+    # Fracture pressure is positive.
+    #
+    # EK: The original reference values are for mesh with 4 fracture cells. Since the
+    # fracture source is set constant per fracture cell, effectively acting as an
+    # intensive quantity, the total source term and hence the fracture pressure scales
+    # with the number of fracture cells. We do a (perhaps somewhat rough) correction
+    # here by scaling with the ratio between number of fracture cells in the current
+    # model and the original number of fracture cells (4).
+    orig_mean_pressure = 4.8e-4
+    orig_deviation = 2e-5
+    cell_ratio = model.mdg.subdomains(dim=model.nd - 1)[0].num_cells / 4
+
+    assert np.all(p_frac > (orig_mean_pressure - orig_deviation) * cell_ratio)
+    assert np.all(p_frac < (orig_mean_pressure + orig_deviation) * cell_ratio)
 
 
 def test_pull_south_positive_reference_pressure():

--- a/tests/models/test_thermoporomechanics.py
+++ b/tests/models/test_thermoporomechanics.py
@@ -279,7 +279,7 @@ def test_push_north_zero_opening(model_class: type):
 )
 def test_positive_p_frac_positive_opening(model_class):
     model = create_fractured_model(
-        {}, {}, {"fracture_source_value": 0.001}, model_class
+        {}, {}, {"fracture_source_value": 0.004}, model_class
     )
     pp.run_time_dependent_model(model)
     _, _, p_frac, jump, traction, _, t_frac = get_variables(model)
@@ -306,24 +306,14 @@ def test_positive_p_frac_positive_opening(model_class):
     # model and the original number of fracture cells (4). For the temperature we also
     # need to increase the tolerance to account for the non-linear relation between
     # the pressure and temperature.
-    orig_mean_pressure = 4.8e-4
-    orig_pressure_deviation = 2e-5
-    orig_mean_temperature = 8.3e-6
-    orig_temperature_deviation = 1e-7
-
-    cell_ratio = model.mdg.subdomains(dim=model.nd - 1)[0].num_cells / 4
+    mean_pressure = 4.8e-4
+    pressure_deviation = 2e-5
+    mean_temperature = 8.3e-6
+    temperature_deviation = 1e-6
 
     # Fracture pressure and temperature are both positive.
-    assert np.allclose(
-        p_frac,
-        orig_mean_pressure * cell_ratio,
-        atol=orig_pressure_deviation * cell_ratio,
-    )
-    assert np.allclose(
-        t_frac,
-        orig_mean_temperature * cell_ratio,
-        atol=orig_temperature_deviation * cell_ratio * 10,
-    )
+    assert np.allclose(p_frac, mean_pressure, atol=pressure_deviation)
+    assert np.allclose(t_frac, mean_temperature, atol=temperature_deviation)
 
 
 def test_robin_boundary_flux():

--- a/tests/models/test_thermoporomechanics.py
+++ b/tests/models/test_thermoporomechanics.py
@@ -294,9 +294,32 @@ def test_positive_p_frac_positive_opening(model_class):
     # NB: This assumes the contact force is expressed in local coordinates.
     assert np.all(np.abs(traction) < 1e-7)
 
+    # EK: The original reference values are for mesh with 4 fracture cells. Since the
+    # fracture source is set constant per fracture cell, effectively acting as an
+    # intensive quantity, the total source term and hence the fracture pressure scales
+    # with the number of fracture cells. We do a (perhaps somewhat rough) correction
+    # here by scaling with the ratio between number of fracture cells in the current
+    # model and the original number of fracture cells (4). For the temperature we also
+    # need to increase the tolerance to account for the non-linear relation between
+    # the pressure and temperature.
+    orig_mean_pressure = 4.8e-4
+    orig_pressure_deviation = 2e-5
+    orig_mean_temperature = 8.3e-6
+    orig_temperature_deviation = 1e-7
+
+    cell_ratio = model.mdg.subdomains(dim=model.nd - 1)[0].num_cells / 4
+
     # Fracture pressure and temperature are both positive.
-    assert np.allclose(p_frac, 4.8e-4, atol=1e-5)
-    assert np.allclose(t_frac, 8.3e-6, atol=1e-7)
+    assert np.allclose(
+        p_frac,
+        orig_mean_pressure * cell_ratio,
+        atol=orig_pressure_deviation * cell_ratio,
+    )
+    assert np.allclose(
+        t_frac,
+        orig_mean_temperature * cell_ratio,
+        atol=orig_temperature_deviation * cell_ratio * 10,
+    )
 
 
 def test_robin_boundary_flux():

--- a/tests/models/test_thermoporomechanics.py
+++ b/tests/models/test_thermoporomechanics.py
@@ -79,6 +79,10 @@ def create_fractured_model(
         "max_iterations": 20,
     }
     default.update(params)
+    if issubclass(model_class, TailoredThermoporomechanicsTpsa):
+        # Tpsa is only consistent with Cartesian grids.
+        default["cartesian"] = True
+
     model = model_class(default)
     return model
 


### PR DESCRIPTION
## Proposed changes
The test `test_poromechanics.py::test_positive_p_frac_positive_opening` is driven by a source term placed in the fracture. This term takes a fixed value for all fracture cells, without accounting for the cell volume. The computed solution is compared to a reference value. When changing the number of fracture cells, which I happened to do as part of the meshing project, the total source term increases, and hence the solutions cannot be expected to match the reference. The same carries over to the very similar `test_thermoporomechanics.py::test_positive_p_frac_positive_opening`.

This PR introduces two changes:
1. A scaling of the source term that allows for a varying number of the cells: Assuming that the solution scales linearly with the total source term (that is with the number of fracture cells), the reference value is adjusted accordingly.
2. An adjustment of the accepted deviations to make the tests pass with the new grids in the soon-to-be-placed meshing PR. In my understanding, these adjustments are needed because the solutions do not scale linearly with the source term. As expected, the pressure needs only a small adjustment, while the temperature sees a bigger change.

Comments:
1. The solution presented here is hacky, but I believe the alternative is to change the reference values whenever the grid undergoes even minor changes (in the upcoming meshing PR, with the current settings the cell count is doubled, but I can see this changing in the months ahead as we may make minor adjustments to the new meshing algorithm). I am far from 100% happy with the solution and open to discuss other approaches.
2. The actual change of the deviations logically belong to the meshing PR, it was just mentally and technically (shared git commits) easier to include them here. I would prefer to keep them here, but I am open to removing them again.

In addition, the tests of HM and THM with TPSA now runs only with Cartesian grids (where tpsa is consistent). This change was previously introduced for the test of momentum balance models, but for some reason, we (presumably be) did not follow through for the derived models.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
