### PR TITLE
1561 make block row information public

### DIFF
--- a/src/porepy/numerics/ad/equation_system.py
+++ b/src/porepy/numerics/ad/equation_system.py
@@ -313,6 +313,22 @@ class EquationSystem:
         return self._equations
 
     @property
+    def equation_image_space_composition(
+        self,
+    ) -> dict[str, dict[pp.GridLike, np.ndarray]]:
+        """Definition of image space for all equations.
+
+        Contains for every equation name (key) a dictionary, which provides again for
+        every involved grid (key) the indices of equations expressed through the
+        equation operator. The ordering of the items in the grid-array dictionaries is
+        consistent with the remaining PorePy framework. The ordering is local to the
+        equation, so it can be used to slice an eqution prior to concatenation of
+        equations into a global matrix.
+
+        """
+        return self._equation_image_space_composition
+
+    @property
     def variables(self) -> list[Variable]:
         """List containing all :class:`~porepy.numerics.ad.Variable`s known to this
         system.

--- a/src/porepy/numerics/ad/equation_system.py
+++ b/src/porepy/numerics/ad/equation_system.py
@@ -316,14 +316,9 @@ class EquationSystem:
     def equation_image_space_composition(
         self,
     ) -> dict[str, dict[pp.GridLike, np.ndarray]]:
-        """Definition of image space for all equations.
-
-        Contains for every equation name (key) a dictionary, which provides again for
-        every involved grid (key) the indices of equations expressed through the
-        equation operator. The ordering of the items in the grid-array dictionaries is
-        consistent with the remaining PorePy framework. The ordering is local to the
-        equation, so it can be used to slice an eqution prior to concatenation of
-        equations into a global matrix.
+        """Dictionary containing image space composition, including subdomains
+        and their block indices in the global system, for every equation
+        set in this EquationSystem.
 
         """
         return self._equation_image_space_composition
@@ -347,7 +342,6 @@ class EquationSystem:
     @property
     def equation_image_size_info(self) -> dict[str, dict["GridEntity", int]]:
         return self._equation_image_size_info
-
 
     ### Variable management ------------------------------------------------------------
 

--- a/src/porepy/numerics/ad/equation_system.py
+++ b/src/porepy/numerics/ad/equation_system.py
@@ -344,6 +344,11 @@ class EquationSystem:
             domains.add(var.domain)
         return list(domains)
 
+    @property
+    def equation_image_size_info(self) -> dict[str, dict["GridEntity", int]]:
+        return self._equation_image_size_info
+
+
     ### Variable management ------------------------------------------------------------
 
     def md_variable(

--- a/src/porepy/numerics/ad/equation_system.py
+++ b/src/porepy/numerics/ad/equation_system.py
@@ -324,6 +324,14 @@ class EquationSystem:
         return self._equation_image_space_composition
 
     @property
+    def equation_image_size_info(self) -> dict[str, dict["GridEntity", int]]:
+        """Dictionary containing, for every equation set in this EquationSystem,
+        the number of equations per grid entity.
+
+        """
+        return self._equation_image_size_info
+
+    @property
     def variables(self) -> list[Variable]:
         """List containing all :class:`~porepy.numerics.ad.Variable`s known to this
         system.
@@ -338,10 +346,6 @@ class EquationSystem:
         for var in self.variables:
             domains.add(var.domain)
         return list(domains)
-
-    @property
-    def equation_image_size_info(self) -> dict[str, dict["GridEntity", int]]:
-        return self._equation_image_size_info
 
     ### Variable management ------------------------------------------------------------
 

--- a/src/porepy/viz/data_saving_model_mixin.py
+++ b/src/porepy/viz/data_saving_model_mixin.py
@@ -389,7 +389,7 @@ class ResidualExporting:
             # GridEntity = Literal["cells", "faces", "nodes"]
             image_info = self.equation_system._equation_image_size_info[name]
             dof_start, dof_end = 0, 0
-            for g in self.equation_system._equation_image_space_composition[
+            for g in self.equation_system.equation_image_space_composition[
                 name
             ].keys():
                 # Add number of dofs for each entity in image_info.

--- a/src/porepy/viz/data_saving_model_mixin.py
+++ b/src/porepy/viz/data_saving_model_mixin.py
@@ -387,7 +387,7 @@ class ResidualExporting:
 
             # Get image_info as dict[GridEntity, int], where
             # GridEntity = Literal["cells", "faces", "nodes"]
-            image_info = self.equation_system._equation_image_size_info[name]
+            image_info = self.equation_system.equation_image_size_info[name]
             dof_start, dof_end = 0, 0
             for g in self.equation_system.equation_image_space_composition[
                 name

--- a/src/porepy/viz/data_saving_model_mixin.py
+++ b/src/porepy/viz/data_saving_model_mixin.py
@@ -389,9 +389,7 @@ class ResidualExporting:
             # GridEntity = Literal["cells", "faces", "nodes"]
             image_info = self.equation_system.equation_image_size_info[name]
             dof_start, dof_end = 0, 0
-            for g in self.equation_system.equation_image_space_composition[
-                name
-            ].keys():
+            for g in self.equation_system.equation_image_space_composition[name].keys():
                 # Add number of dofs for each entity in image_info.
                 for entity, num in image_info.items():
                     dof_end += getattr(g, "num_" + entity) * num

--- a/src/porepy/viz/diagnostics_mixin.py
+++ b/src/porepy/viz/diagnostics_mixin.py
@@ -85,7 +85,7 @@ class DiagnosticsMixin:
 
         It is assumed that the full Jacobian matrix is stored in `self.linear_system`,
         and full information about the matrix indices is stored in
-        `self.equation_system._equation_image_space_composition`.
+        `self.equation_system.equation_image_space_composition`.
 
         Note:
             It is assumed that variables with the same name defined on different grids
@@ -310,13 +310,13 @@ class DiagnosticsMixin:
 
         assembled_equation_indices = self.equation_system.assembled_equation_indices
 
-        # `_equation_image_space_composition` has dof indices starting from zero for
+        # `equation_image_space_composition` has dof indices starting from zero for
         # each equation. We need to count the offset to get the global dof indices.
         block_indices = 0
 
         for eq_name, eq_dof_indices in assembled_equation_indices.items():
             equation_image_space = (
-                self.equation_system._equation_image_space_composition[eq_name]
+                self.equation_system.equation_image_space_composition[eq_name]
             )
             # Forming a block from required grids.
             for block_of_grids in grouping:

--- a/tests/numerics/ad/test_equation_system.py
+++ b/tests/numerics/ad/test_equation_system.py
@@ -945,7 +945,7 @@ def test_set_remove_equations(model: EquationSystemMockModel):
     )
 
     # Check that the equation size has been set correctly
-    blocks = equation_system._equation_image_space_composition
+    blocks = equation_system.equation_image_space_composition
     assert np.allclose(
         blocks[model.eq_single_subdomain.name][model.sd_top],
         np.arange(model.sd_top.num_cells * dof_info_subdomain["cells"]),
@@ -1475,7 +1475,7 @@ def test_schur_complement(eq_var_to_exclude):
         # kept on all subdomains (which we somewhat cumbersomely obtain from a private
         # variable of EquationSystem).
         equations = {
-            eq: list(equation_system._equation_image_space_composition[eq].keys())
+            eq: list(equation_system.equation_image_space_composition[eq].keys())
             for eq in eq_names
         }
         # In addition, we keep 'eq_all_subdomains' on the top subdomain.

--- a/tests/numerics/ad/test_equation_system.py
+++ b/tests/numerics/ad/test_equation_system.py
@@ -944,11 +944,19 @@ def test_set_remove_equations(model: EquationSystemMockModel):
         equations_per_grid_entity=dof_info_subdomain,
     )
 
-    # Check that the equation size has been set correctly
-    blocks = equation_system.equation_image_space_composition
+    # Check that the mapping of equation to subdomain to global dof
+    # indices is correctly set.
+    equation_subdomain_blocks = equation_system.equation_image_space_composition
     assert np.allclose(
-        blocks[model.eq_single_subdomain.name][model.sd_top],
+        equation_subdomain_blocks[model.eq_single_subdomain.name][model.sd_top],
         np.arange(model.sd_top.num_cells * dof_info_subdomain["cells"]),
+    )
+    # Check that the mapping of equation to grid entity block size
+    # is set correctly.
+    equation_grid_entity_blocks = equation_system.equation_image_size_info
+    assert (
+        equation_grid_entity_blocks[model.eq_single_subdomain.name]
+        == dof_info_subdomain
     )
 
     # Add a second equation, defined on both subdomains
@@ -960,7 +968,7 @@ def test_set_remove_equations(model: EquationSystemMockModel):
     offset = 0
     for sd in model.subdomains:
         assert np.allclose(
-            blocks[model.eq_all_subdomains.name][sd],
+            equation_subdomain_blocks[model.eq_all_subdomains.name][sd],
             offset + np.arange(sd.num_cells * dof_info_subdomain["cells"]),
         )
         offset += sd.num_cells * dof_info_subdomain["cells"]
@@ -977,7 +985,7 @@ def test_set_remove_equations(model: EquationSystemMockModel):
     offset = 0
     for intf in model.interfaces:
         assert np.allclose(
-            blocks[model.eq_all_interfaces.name][intf],
+            equation_subdomain_blocks[model.eq_all_interfaces.name][intf],
             offset + np.arange(intf.num_cells * dof_info_interface["cells"]),
         )
         offset += intf.num_cells * dof_info_interface["cells"]
@@ -997,7 +1005,7 @@ def test_set_remove_equations(model: EquationSystemMockModel):
     offset = 0
     for intf in model.interfaces:
         assert np.allclose(
-            blocks[model.eq_all_interfaces.name][intf],
+            equation_subdomain_blocks[model.eq_all_interfaces.name][intf],
             offset + np.arange(intf.num_cells * dof_all_interfaces["cells"]),
         )
         offset += intf.num_cells * dof_all_interfaces["cells"]
@@ -1011,12 +1019,14 @@ def test_set_remove_equations(model: EquationSystemMockModel):
     offset = 0
     for intf in model.interfaces:
         assert np.allclose(
-            blocks[model.eq_all_interfaces.name][intf],
+            equation_subdomain_blocks[model.eq_all_interfaces.name][intf],
             offset + np.arange(intf.num_cells * dof_all_interfaces["cells"]),
         )
         offset += intf.num_cells * dof_all_interfaces["cells"]
 
-    assert list(blocks["eq_all_interfaces"].keys()) == model.interfaces
+    assert (
+        list(equation_subdomain_blocks["eq_all_interfaces"].keys()) == model.interfaces
+    )
 
 
 def test_parse_variable_like(model: EquationSystemMockModel):


### PR DESCRIPTION
## Proposed changes

This PR solves issues 1561, by setting public property to access private methods in the EquationSystem class and then refactor codebase to use property accordingly, co-authored with @zhangyh0713


## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ x] Documentation (contribution related to adding, improving, or fixing documentation).
- [x ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
