### PR TITLE
STY: Update formatting after upgrading to ruff 0.15

### DIFF
--- a/tests/numerics/vem/test_dual_vem.py
+++ b/tests/numerics/vem/test_dual_vem.py
@@ -952,19 +952,15 @@ class TestMVEMRHS:
             np.sin(2 * np.pi * pt[0, :]), np.sin(2 * np.pi * pt[1, :])
         )
         p_ex = lambda pt: rhs_ex(pt) / a
-        u_ex_0 = (
-            lambda pt: np.multiply(
-                -np.cos(2 * np.pi * pt[0, :]), np.sin(2 * np.pi * pt[1, :])
-            )
+        u_ex_0 = lambda pt: (
+            np.multiply(-np.cos(2 * np.pi * pt[0, :]), np.sin(2 * np.pi * pt[1, :]))
             * 2
             * np.pi
             / a
             + 1
         )
-        u_ex_1 = (
-            lambda pt: np.multiply(
-                -np.sin(2 * np.pi * pt[0, :]), np.cos(2 * np.pi * pt[1, :])
-            )
+        u_ex_1 = lambda pt: (
+            np.multiply(-np.sin(2 * np.pi * pt[0, :]), np.cos(2 * np.pi * pt[1, :]))
             * 2
             * np.pi
             / a
@@ -1053,8 +1049,8 @@ class TestMVEMRHS:
 
     def test_convergence_mvem_2d_ani_simplex(self):
         rhs_ex = lambda pt: 14
-        p_ex = (
-            lambda pt: 2 * np.power(pt[0, :], 2)
+        p_ex = lambda pt: (
+            2 * np.power(pt[0, :], 2)
             - 6 * np.power(pt[1, :], 2)
             + np.multiply(pt[0, :], pt[1, :])
         )

--- a/tests/numerics/vem/test_rt0.py
+++ b/tests/numerics/vem/test_rt0.py
@@ -773,18 +773,14 @@ class TestRaviartThomasDiscretization:
             np.sin(2 * np.pi * pt[0, :]), np.sin(2 * np.pi * pt[1, :])
         )
         p_ex = lambda pt: rhs_ex(pt) / a
-        u_ex_0 = (
-            lambda pt: np.multiply(
-                -np.cos(2 * np.pi * pt[0, :]), np.sin(2 * np.pi * pt[1, :])
-            )
+        u_ex_0 = lambda pt: (
+            np.multiply(-np.cos(2 * np.pi * pt[0, :]), np.sin(2 * np.pi * pt[1, :]))
             * 2
             * np.pi
             / a
         )
-        u_ex_1 = (
-            lambda pt: np.multiply(
-                -np.sin(2 * np.pi * pt[0, :]), np.cos(2 * np.pi * pt[1, :])
-            )
+        u_ex_1 = lambda pt: (
+            np.multiply(-np.sin(2 * np.pi * pt[0, :]), np.cos(2 * np.pi * pt[1, :]))
             * 2
             * np.pi
             / a
@@ -870,8 +866,8 @@ class TestRaviartThomasDiscretization:
 
     def test_convergence_2d_anisotropic_permeability_constant_rhs(self):
         rhs_ex = lambda pt: 14
-        p_ex = (
-            lambda pt: 2 * np.power(pt[0, :], 2)
+        p_ex = lambda pt: (
+            2 * np.power(pt[0, :], 2)
             - 6 * np.power(pt[1, :], 2)
             + np.multiply(pt[0, :], pt[1, :])
         )
@@ -2244,19 +2240,15 @@ class TestRaviartThomasRHS:
             np.sin(2 * np.pi * pt[0, :]), np.sin(2 * np.pi * pt[1, :])
         )
         p_ex = lambda pt: rhs_ex(pt) / a
-        u_ex_0 = (
-            lambda pt: np.multiply(
-                -np.cos(2 * np.pi * pt[0, :]), np.sin(2 * np.pi * pt[1, :])
-            )
+        u_ex_0 = lambda pt: (
+            np.multiply(-np.cos(2 * np.pi * pt[0, :]), np.sin(2 * np.pi * pt[1, :]))
             * 2
             * np.pi
             / a
             + 1
         )
-        u_ex_1 = (
-            lambda pt: np.multiply(
-                -np.sin(2 * np.pi * pt[0, :]), np.cos(2 * np.pi * pt[1, :])
-            )
+        u_ex_1 = lambda pt: (
+            np.multiply(-np.sin(2 * np.pi * pt[0, :]), np.cos(2 * np.pi * pt[1, :]))
             * 2
             * np.pi
             / a
@@ -2347,8 +2339,8 @@ class TestRaviartThomasRHS:
 
     def test_convergence_2d_anisotropic_permeability_constant_rhs(self):
         rhs_ex = lambda pt: 14
-        p_ex = (
-            lambda pt: 2 * np.power(pt[0, :], 2)
+        p_ex = lambda pt: (
+            2 * np.power(pt[0, :], 2)
             - 6 * np.power(pt[1, :], 2)
             + np.multiply(pt[0, :], pt[1, :])
         )


### PR DESCRIPTION
## Proposed changes
The ruff ugrade required fixes to two tests.

The changes seem to be backwards compatible, so running ruff 0.14 (the old version) with the newly updated files should leave no changes.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
