### PR TITLE
Fix and consolidate model geometries

### DIFF
--- a/src/porepy/applications/md_grids/model_geometries.py
+++ b/src/porepy/applications/md_grids/model_geometries.py
@@ -78,6 +78,19 @@ class CubeDomainOrthogonalFractures(pp.PorePyModel):
         """Set the cube domain."""
         self._domain = domains.nd_cube_domain(3, self.domain_size)
 
+    def meshing_arguments(self) -> dict:
+        """Set default cell sizes for subdomains."""
+        # Length scale:
+        ls = self.units.convert_units(1, "m")
+
+        mesh_sizes = {
+            "cell_size": 0.5 * ls,
+            "cell_size_fracture": 0.5 * ls,
+            "cell_size_boundary": 0.5 * ls,
+            "cell_size_min": 0.2 * ls,
+        }
+        return mesh_sizes
+
 
 class RectangularDomainThreeFractures(pp.PorePyModel):
     """A rectangular domain with up to three fractures.
@@ -131,31 +144,6 @@ class RectangularDomainThreeFractures(pp.PorePyModel):
         phys_dims = np.array([2, 1]) * ls
         box = {"xmin": 0, "xmax": phys_dims[0], "ymin": 0, "ymax": phys_dims[1]}
         self._domain = pp.Domain(box)
-
-
-class OrthogonalFractures3d(CubeDomainOrthogonalFractures):
-    """A 3d domain of the unit cube with up to three orthogonal fractures.
-
-    The fractures have constant `x`, `y` and `z` coordinates equal to 0.5, respectively,
-    and are situated in a unit cube domain. The number of fractures is controlled by
-    the parameter ``num_fracs``, which can be 0, 1, 2 or 3.
-
-    """
-
-    params: dict
-    """Model parameters."""
-
-    def meshing_arguments(self) -> dict:
-        # Length scale:
-        ls = self.units.convert_units(1, "m")
-
-        mesh_sizes = {
-            "cell_size": 0.5 * ls,
-            "cell_size_fracture": 0.5 * ls,
-            "cell_size_boundary": 0.5 * ls,
-            "cell_size_min": 0.2 * ls,
-        }
-        return mesh_sizes
 
 
 class NonMatchingSquareDomainOrthogonalFractures(SquareDomainOrthogonalFractures):

--- a/src/porepy/applications/md_grids/model_geometries.py
+++ b/src/porepy/applications/md_grids/model_geometries.py
@@ -132,10 +132,8 @@ class RectangularDomainThreeFractures(pp.PorePyModel):
         return mesh_sizes
 
     def set_domain(self) -> None:
-        if not self.params.get("cartesian", False):
-            self.params["grid_type"] = "simplex"
-        else:
-            self.params["grid_type"] = "cartesian"
+
+        self.params["grid_type"] = self.params.get("grid_type", "simplex")
 
         # Length scale:
         ls = self.units.convert_units(1, "m")

--- a/src/porepy/applications/md_grids/model_geometries.py
+++ b/src/porepy/applications/md_grids/model_geometries.py
@@ -132,6 +132,7 @@ class RectangularDomainThreeFractures(pp.PorePyModel):
         return mesh_sizes
 
     def set_domain(self) -> None:
+        """A default grid type ('simplex') is set if none is provided."""
 
         self.params["grid_type"] = self.params.get("grid_type", "simplex")
 

--- a/src/porepy/applications/md_grids/model_geometries.py
+++ b/src/porepy/applications/md_grids/model_geometries.py
@@ -78,19 +78,6 @@ class CubeDomainOrthogonalFractures(pp.PorePyModel):
         """Set the cube domain."""
         self._domain = domains.nd_cube_domain(3, self.domain_size)
 
-    def meshing_arguments(self) -> dict:
-        """Set default cell sizes for subdomains."""
-        # Length scale:
-        ls = self.units.convert_units(1, "m")
-
-        mesh_sizes = {
-            "cell_size": 0.5 * ls,
-            "cell_size_fracture": 0.5 * ls,
-            "cell_size_boundary": 0.5 * ls,
-            "cell_size_min": 0.2 * ls,
-        }
-        return mesh_sizes
-
 
 class RectangularDomainThreeFractures(pp.PorePyModel):
     """A rectangular domain with up to three fractures.

--- a/src/porepy/applications/test_utils/models.py
+++ b/src/porepy/applications/test_utils/models.py
@@ -9,7 +9,7 @@ import numpy as np
 
 import porepy as pp
 from porepy.applications.md_grids.model_geometries import (
-    OrthogonalFractures3d,
+    CubeDomainOrthogonalFractures,
     RectangularDomainThreeFractures,
 )
 from porepy.models.contact_mechanics import ContactMechanics
@@ -134,7 +134,7 @@ def model(model_type: str, dim: int, num_fracs: int = 1) -> pp.PorePyModel:
     if dim == 2:
         geometry = RectangularDomainThreeFractures
     elif dim == 3:
-        geometry = OrthogonalFractures3d
+        geometry = CubeDomainOrthogonalFractures
     else:
         raise ValueError(f"Unknown dimension {dim}")
 

--- a/tests/models/test_constitutive_laws.py
+++ b/tests/models/test_constitutive_laws.py
@@ -479,8 +479,8 @@ def test_perturbation_from_reference(
 @pytest.mark.parametrize(
     "geometry, domain_dimension, expected",
     [
-        (models.OrthogonalFractures3d, 1, [0.02, 0.02**2, 0.02]),
-        (models.OrthogonalFractures3d, 0, [0.02, 0.02**3, 0.02**2]),
+        (models.CubeDomainOrthogonalFractures, 1, [0.02, 0.02**2, 0.02]),
+        (models.CubeDomainOrthogonalFractures, 0, [0.02, 0.02**3, 0.02**2]),
         (models.RectangularDomainThreeFractures, 0, [0.02, 0.02**2, 0.02]),
         (models.RectangularDomainThreeFractures, 2, [1, 1, 42]),
     ],

--- a/tests/models/test_energy_balance.py
+++ b/tests/models/test_energy_balance.py
@@ -280,7 +280,7 @@ def test_unit_conversion(units):
 
 class MassAndEnergyWellModel(
     well_models.OneVerticalWell,
-    models.OrthogonalFractures3d,
+    models.CubeDomainOrthogonalFractures,
     well_models.BoundaryConditionsWellSetup,
     well_models.WellPermeability,
     pp.MassAndEnergyBalance,
@@ -314,7 +314,7 @@ def test_energy_conservation():
                 normal_thermal_conductivity=1e-6,
             ),
         },
-        # Use only the horizontal fracture of OrthogonalFractures3d
+        # Use only the horizontal fracture of CubeDomainOrthogonalFractures
         "fracture_indices": [2],
         "time_manager": pp.TimeManager(schedule=[0, dt], dt_init=dt, constant_dt=True),
         "grid_type": "cartesian",

--- a/tests/models/test_fluid_mass_balance.py
+++ b/tests/models/test_fluid_mass_balance.py
@@ -631,7 +631,7 @@ def test_unit_conversion(units, grid_class):
 
 class WellModel(
     well_models.OneVerticalWell,
-    models.OrthogonalFractures3d,
+    models.CubeDomainOrthogonalFractures,
     well_models.BoundaryConditionsWellSetup,
     well_models.WellPermeability,
     pp.SinglePhaseFlow,
@@ -651,7 +651,7 @@ def test_well_incompressible_pressure_values():
         "material_constants": {
             "solid": pp.SolidConstants(permeability=1e-6 / 4, well_radius=0.01)
         },
-        # Use only the horizontal fracture of OrthogonalFractures3d
+        # Use only the horizontal fracture of CubeDomainOrthogonalFractures
         "fracture_indices": [2],
         "times_to_export": [],
     }

--- a/tests/models/test_geometry.py
+++ b/tests/models/test_geometry.py
@@ -35,7 +35,7 @@ geometry_list: list[type[pp.ModelGeometry]] = [
         pp.ModelGeometry,
     ),
     models.add_mixin(
-        porepy.applications.md_grids.model_geometries.OrthogonalFractures3d,
+        porepy.applications.md_grids.model_geometries.CubeDomainOrthogonalFractures,
         pp.ModelGeometry,
     ),
 ]

--- a/tests/models/test_momentum_balance.py
+++ b/tests/models/test_momentum_balance.py
@@ -167,7 +167,7 @@ def test_unit_conversion(units: dict, uy_north: float):
     params = {
         "times_to_export": [],  # Suppress output for tests
         "fracture_indices": [0, 1],
-        "cartesian": True,
+        "grid_type": "cartesian",
         "u_north": [0.0, uy_north],
         "material_constants": {"solid": solid, "numerical": numerical},
         "reference_variable_values": reference_values,

--- a/tests/models/test_poromechanics.py
+++ b/tests/models/test_poromechanics.py
@@ -378,7 +378,7 @@ def test_without_fracture(biot_coefficient, model_class):
         "fracture_indices": [],
         "material_constants": {"fluid": fluid, "solid": solid},
         "u_north": [0.0, 0.001],
-        "cartesian": True,
+        "grid_type": "cartesian",
         "times_to_export": [],
     }
     model = model_class(params)
@@ -560,7 +560,7 @@ def test_unit_conversion(units, model_class):
     model_params = {
         "times_to_export": [],  # Suppress output for tests
         "num_fracs": 1,
-        "cartesian": True,
+        "grid_type": "cartesian",
         "u_north": [0.0, 1e-5],
         "material_constants": {"solid": solid, "fluid": fluid, "numerical": numerical},
         "reference_variable_values": reference_values,

--- a/tests/models/test_poromechanics.py
+++ b/tests/models/test_poromechanics.py
@@ -596,7 +596,7 @@ def test_unit_conversion(units, model_class):
 
 class PoromechanicsWell(
     well_models.OneVerticalWell,
-    porepy.applications.md_grids.model_geometries.OrthogonalFractures3d,
+    porepy.applications.md_grids.model_geometries.CubeDomainOrthogonalFractures,
     well_models.BoundaryConditionsWellSetup,
     pp.Poromechanics,
 ):

--- a/tests/models/test_thermoporomechanics.py
+++ b/tests/models/test_thermoporomechanics.py
@@ -500,7 +500,7 @@ def test_unit_conversion(units: dict, model_class: type):
 
 class ThermoporomechanicsWell(
     well_models.OneVerticalWell,
-    model_geometries.OrthogonalFractures3d,
+    model_geometries.CubeDomainOrthogonalFractures,
     well_models.BoundaryConditionsWellSetup,
     pp.Thermoporomechanics,
 ):

--- a/tests/models/test_thermoporomechanics.py
+++ b/tests/models/test_thermoporomechanics.py
@@ -456,7 +456,7 @@ def test_unit_conversion(units: dict, model_class: type):
     model_params = {
         "times_to_export": [],  # Suppress output for tests
         "fracture_indices": [0],
-        "cartesian": True,
+        "grid_type": "cartesian",
         "u_north": [0.0, -1e-5],
         "material_constants": {"solid": solid, "fluid": fluid, "numerical": numerical},
         "reference_variable_values": reference_values,

--- a/tests/numerics/fv/test_tpfa.py
+++ b/tests/numerics/fv/test_tpfa.py
@@ -769,7 +769,7 @@ def test_diff_tpfa_and_standard_tpfa_give_same_linear_system(base_discr: str):
 
 
 class DiffTpfaFractureTipsInternalBoundaries(
-    model_geometries.OrthogonalFractures3d,
+    model_geometries.CubeDomainOrthogonalFractures,
     well_models.OneVerticalWell,
     well_models.BoundaryConditionsWellSetup,
     FluxDiscretization,

--- a/tutorials/benchmark_simulation.ipynb
+++ b/tutorials/benchmark_simulation.ipynb
@@ -370,7 +370,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "python 3",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/tutorials/benchmark_simulation.ipynb
+++ b/tutorials/benchmark_simulation.ipynb
@@ -370,7 +370,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "porepyDev",
+   "display_name": "python 3",
    "language": "python",
    "name": "python3"
   },
@@ -384,7 +384,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.2"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,

--- a/tutorials/benchmark_simulation.ipynb
+++ b/tutorials/benchmark_simulation.ipynb
@@ -370,7 +370,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "porepyDev",
    "language": "python",
    "name": "python3"
   },
@@ -384,7 +384,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.12.2"
   }
  },
  "nbformat": 4,

--- a/tutorials/solution_strategies.ipynb
+++ b/tutorials/solution_strategies.ipynb
@@ -21,17 +21,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "OMP: Info #276: omp_set_nested routine deprecated, please use omp_set_max_active_levels instead.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import porepy as pp\n",
     "\n",

--- a/tutorials/solution_strategies.ipynb
+++ b/tutorials/solution_strategies.ipynb
@@ -21,9 +21,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "OMP: Info #276: omp_set_nested routine deprecated, please use omp_set_max_active_levels instead.\n"
+     ]
+    }
+   ],
    "source": [
     "import porepy as pp\n",
     "\n",
@@ -41,7 +49,7 @@
     "    # Base class\n",
     "    pp.Poromechanics,\n",
     "):\n",
-    "    \"\"\"Combine mixins with the poromechanics class.\"\"\"\n"
+    "    \"\"\"Combine mixins with the poromechanics class.\"\"\""
    ]
   },
   {
@@ -53,16 +61,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
     "model_params = {\n",
-    "    \"fracture_indices\": [1], # Fracture with constant y-coordinate\n",
+    "    \"fracture_indices\": [1],  # Fracture with constant y-coordinate\n",
     "    \"meshing_arguments\": {\"cell_size\": 1 / 4},\n",
     "}\n",
     "solver_params = {\n",
-    "    \"nl_convergence_tol_res\": 1e-10, # Since the line search reduces the update, a residual based tolerance is needed\n",
+    "    \"nl_convergence_tol_res\": 1e-10,  # Since the line search reduces the update, a residual based tolerance is needed\n",
     "    \"nonlinear_solver\": line_search.ConstraintLineSearchNonlinearSolver,\n",
     "    \"global_line_search\": 0,  # Set to 1 to use turn on a residual-based line search\n",
     "    \"local_line_search\": 1,  # Set to 0 to use turn off the tailored line search\n",
@@ -88,7 +96,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "porepyDev",
    "language": "python",
    "name": "python3"
   },
@@ -102,7 +110,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.12.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Proposed changes

Issue: #1590
We replaced the class "OrthogonalFractures3d" with "CubeDomainOrthorgonalFracture" and a mesh_argument method in the codespace.
In addition, we modified "RectangularDomainThreeFractures" and used the parameter "grid_type" to determine the grid type, co-authored with @mikeljordan

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [x] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [x] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [x] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
