### PR TITLE
MAINT: Numpy scalars are not mixed with array

### DIFF
--- a/src/porepy/examples/mandel_biot.py
+++ b/src/porepy/examples/mandel_biot.py
@@ -211,10 +211,10 @@ class MandelDataSaving(pp.PorePyModel):
         approx_consolidation_degree = self.numerical_consolidation_degree()
         error_consolidation_degree_x = np.abs(
             approx_consolidation_degree[0] - exact_consolidation_degree
-        )
+        )[0]
         error_consolidation_degree_y = np.abs(
             approx_consolidation_degree[1] - exact_consolidation_degree
-        )
+        )[0]
         error_consolidation_degree = (
             float(error_consolidation_degree_x),
             float(error_consolidation_degree_y),

--- a/src/porepy/fracs/wells_3d.py
+++ b/src/porepy/fracs/wells_3d.py
@@ -401,7 +401,7 @@ class WellNetwork3d:
 
             for inds_seg, seg in w.segments():
                 tags_seg = [tags_w[i] for i in inds_seg]
-                length = pp.geometry.distances.point_pointset(seg[:, 0], seg[:, 1])
+                length = pp.geometry.distances.point_pointset(seg[:, 0], seg[:, 1])[0]
                 num_pts = int(length / self._mesh_size(w, inds_seg))
                 num_pts = max(num_pts, 2)
                 points_loc = np.linspace(seg[:, 0], seg[:, 1], num_pts).T

--- a/tests/numerics/ad/test_forward_mode.py
+++ b/tests/numerics/ad/test_forward_mode.py
@@ -227,7 +227,7 @@ def test_exp_scalar_times_ad_var(create_csc, create_diags):
 @pytest.mark.parametrize(
     "index,index_c",
     [  # indices and their complement for tested array
-        (1, [0, 2, 3, 4, 5, 6, 7, 8, 9]),
+        (np.array([1]), [0, 2, 3, 4, 5, 6, 7, 8, 9]),
         (slice(0, 10, 2), slice(1, 10, 2)),
         (np.array([0, 2, 4, 6, 8], dtype=int), np.array([1, 3, 5, 7, 9], dtype=int)),
     ],

--- a/tests/numerics/fv/test_tpfa.py
+++ b/tests/numerics/fv/test_tpfa.py
@@ -375,8 +375,8 @@ def test_transmissibility_calculation(vector_source: bool, base_discr: str):
 
         fc_cc_dist = np.linalg.norm(fc_cc)
 
-        trm = np.dot(n, np.dot(k, fc_cc) / np.power(fc_cc_dist, 2))
-        trm_diff = np.dot(n, np.dot(k_diff, fc_cc) / np.power(fc_cc_dist, 2))
+        trm = np.dot(n, np.dot(k, fc_cc) / np.power(fc_cc_dist, 2))[0]
+        trm_diff = np.dot(n, np.dot(k_diff, fc_cc) / np.power(fc_cc_dist, 2))[0]
         return trm, trm_diff
 
     def _project_vector_source(fi: int, ci: int) -> np.ndarray:
@@ -418,7 +418,7 @@ def test_transmissibility_calculation(vector_source: bool, base_discr: str):
 
             # If a vector source is present, the flux will be modified by the vector
             # source term.
-            flux_without_vs = flux[0]
+            flux_without_vs = flux
             flux += projected_vs * trm
 
             # Sanity check: The computed vector source flux, using the logic of the


### PR DESCRIPTION
This is needed to enable compatibility with numpy 2.4, which seems to have introduced stricter checks in this regard

## Proposed changes

Contributions to PorePy are highly appreciated. Clearly explain why this pull request (PR) is needed and why it should be accepted. If this PR solves an issue, explain how it is done. Please, also summarise the changes to the code.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
