### PR TITLE
Slip-tendency-refactor

### DIFF
--- a/src/porepy/viz/data_saving_model_mixin.py
+++ b/src/porepy/viz/data_saving_model_mixin.py
@@ -449,10 +449,13 @@ class FractureDeformationExporting(pp.PorePyModel):
 
         char = ensure_array(char)
         friction_coefficient = ensure_array(friction_coefficient)
-        traction = self.evaluate_and_scale(sds, "contact_traction", "-")
+        traction = self.evaluate_and_scale(sds, "contact_traction", "-").reshape(
+            (self.nd, -1), order="F"
+        )
         # Compute apertures, which are scalar quantities.
         cell_offsets = np.cumsum([0] + [sd.num_cells for sd in sds])
         apertures = self.evaluate_and_scale(sds, "aperture", "m")
+        slip_tendency = self.compute_slip_tendency(traction, friction_coefficient)
 
         # Loop over the fracture subdomains.
         for id, sd in enumerate(sds):
@@ -466,25 +469,15 @@ class FractureDeformationExporting(pp.PorePyModel):
             )
             # Export the slip tendency, defined as the ratio of the shear traction to
             # the normal traction.
-            traction_loc = traction[
-                cell_offsets_nd[id] : cell_offsets_nd[id + 1]
-            ].reshape((self.nd, -1), order="F")
-            # Avoid division by zero. If normal traction is zero (open fractures), we
-            # set it to 1.
-            zero_inds = np.isclose(traction_loc[-1], 0)
-            traction_loc[-1, zero_inds] = 1
-            # Minus to follow convention that positive slip tendency indicates slip and
-            # compressive normal traction is negative. Summing up:
-            # - regular values are positive for fractures in contact,
-            # - negative slip tendency is non-physical, except for
-            # - zero normal traction.
-            slip_tendency = -np.linalg.norm(traction_loc[:-1], axis=0) / (
-                traction_loc[-1]
-                * friction_coefficient[cell_offsets[id] : cell_offsets[id + 1]]
+            data.append(
+                (
+                    sd,
+                    "slip_tendency",
+                    slip_tendency[cell_offsets[id] : cell_offsets[id + 1]],
+                )
             )
-
-            data.append((sd, "slip_tendency", slip_tendency))
             # Rescale traction by characteristic contact traction.
+            traction_loc = traction[:, cell_offsets[id] : cell_offsets[id + 1]]
             traction_loc *= char[cell_offsets[id] : cell_offsets[id + 1]]
             data.append((sd, "contact_traction_in_Pa", traction_loc.ravel("F")))
 
@@ -496,3 +489,47 @@ class FractureDeformationExporting(pp.PorePyModel):
                 )
             )
         return data
+
+    @staticmethod
+    def compute_slip_tendency(
+        traction: np.ndarray,
+        friction_coefficient: np.ndarray,
+        atol: float = 1e-8,
+    ) -> np.ndarray:
+        """Compute slip tendency as the ratio of shear traction to normal traction.
+
+        For cells where normal traction is zero (open fractures), slip tendency is
+        physically undefined and set to NaN.
+
+        Parameters:
+            traction: Array of shape (nd, num_cells) containing the traction vector for
+                each cell.
+            friction_coefficient: Array of shape (num_cells,) containing the friction
+                coefficient for each cell.
+            atol: Absolute tolerance for detecting zero normal traction. Defaults to
+                1e-8, matching numpy's default.
+
+            Returns:
+                Array of shape (num_cells,) containing the slip tendency for each cell.
+                NaN values indicate cells with zero normal traction (open fractures).
+
+        Notes:
+            Slip tendency convention:
+            - Positive values indicate tendency to slip (shear traction exceeds
+              friction limit).
+            - Compressive normal traction is negative.
+            - Regular values are positive for fractures in contact.
+            - NaN indicates undefined slip tendency (zero normal traction).
+        """
+        # Compute slip tendency
+        # Minus to follow convention that positive slip tendency indicates slip and
+        # compressive normal traction is negative.
+        slip_tendency = -np.linalg.norm(traction[:-1], axis=0) / (
+            traction[-1] * friction_coefficient
+        )
+
+        # Set to NaN where normal traction is zero (undefined)
+        zero_inds = np.isclose(traction[-1], 0, atol=atol)
+        slip_tendency[zero_inds] = np.nan
+
+        return slip_tendency

--- a/src/porepy/viz/data_saving_model_mixin.py
+++ b/src/porepy/viz/data_saving_model_mixin.py
@@ -521,14 +521,14 @@ class FractureDeformationExporting(pp.PorePyModel):
             - Regular values are positive for fractures in contact.
             - NaN indicates undefined slip tendency (zero normal traction).
         """
-        # Compute slip tendency
+        # Compute slip tendency.
         # Minus to follow convention that positive slip tendency indicates slip and
         # compressive normal traction is negative.
         slip_tendency = -np.linalg.norm(traction[:-1], axis=0) / (
             traction[-1] * friction_coefficient
         )
 
-        # Set to NaN where normal traction is zero (undefined)
+        # Set to NaN where normal traction is zero (undefined).
         zero_inds = np.isclose(traction[-1], 0, atol=atol)
         slip_tendency[zero_inds] = np.nan
 

--- a/tests/viz/test_data_saving_model_mixin.py
+++ b/tests/viz/test_data_saving_model_mixin.py
@@ -5,6 +5,8 @@ The following is covered:
 - Test that only the specified exported times are exported.
 - Test that the physical times are exported, and that there is a match between the
   specified schedule and all exported files.
+- Test the compute_slip_tendency static method for a variety of cases, including edge
+  cases such as zero normal traction, positive normal traction, and custom tolerances.
 
 """
 
@@ -127,7 +129,7 @@ def test_exported_times_consistency_with_files(times_to_export, expected_times):
     assert np.allclose(model.time_manager.exported_times, expected_times)
 
     # Check that the correct number of files are exported.
-    # Parse the PVD file
+    # Parse the PVD file.
     pvd_file = Path(folder_name) / "data.pvd"
     tree = ET.parse(pvd_file)
     root = tree.getroot()
@@ -147,9 +149,8 @@ class TestComputeSlipTendency:
 
     def test_normal_contact(self):
         """Test slip tendency computation for normal contact conditions."""
-        # 2D case: traction shape (2, 3) for 3 cells
-        # Shear = [3, 4], Normal = -10, friction = 0.6
-        # Expected: -sqrt(3^2 + 4^2) / (-10 * 0.6) = -5 / -6 = 0.8333...
+        # 2D case: traction shape (2, 3) for 3 cells, one friction coefficient value for
+        # each cell.
         traction = np.array([[3.0, 0.0, 1.0], [-10.0, -5.0, -2.0]])
         friction = np.array([0.6, 0.5, 0.4])
 
@@ -173,7 +174,7 @@ class TestComputeSlipTendency:
 
         result = FractureDeformationExporting.compute_slip_tendency(traction, friction)
 
-        # First cell should be NaN, second should be valid
+        # First cell should be NaN, second should be valid.
         assert np.isnan(result[0])
         assert not np.isnan(result[1])
         assert np.isclose(result[1], -2.0 / (-5.0 * 0.5))
@@ -181,8 +182,8 @@ class TestComputeSlipTendency:
     def test_3d_case(self):
         """Test slip tendency computation in 3D."""
         # 3D case: traction shape (3, 2) for 2 cells
-        # Shear = [3, 4], Normal = -10, friction = 0.6
-        # Expected: -sqrt(3^2 + 4^2) / (-10 * 0.6) = -5 / -6 = 0.8333...
+        # First cell: Shear = [3, 4], Normal = -10, friction = 0.6
+        # Expected: -sqrt(3^2 + 4^2) / (-10 * 0.6) = -5 / -6 = 0.8333
         traction = np.array([[3.0, 1.0], [4.0, 2.0], [-10.0, -8.0]])
         friction = np.array([0.6, 0.4])
 
@@ -202,13 +203,13 @@ class TestComputeSlipTendency:
         traction = np.array([[1.0, 2.0], [0.0, -5.0]])
         friction = np.array([0.6, 0.5])
 
-        # Make copies to check against
+        # Make copies to check against.
         traction_orig = traction.copy()
         friction_orig = friction.copy()
 
         _ = FractureDeformationExporting.compute_slip_tendency(traction, friction)
 
-        # Verify inputs weren't modified
+        # Verify inputs weren't modified.
         assert np.array_equal(traction, traction_orig)
         assert np.array_equal(friction, friction_orig)
 
@@ -220,7 +221,7 @@ class TestComputeSlipTendency:
 
         result = FractureDeformationExporting.compute_slip_tendency(traction, friction)
 
-        # Should be NaN due to np.isclose tolerance
+        # Should be NaN due to np.isclose tolerance defaulting to 1e-8 in the method.
         assert np.isnan(result[0])
         assert not np.isnan(result[1])
 
@@ -234,7 +235,7 @@ class TestComputeSlipTendency:
 
         result = FractureDeformationExporting.compute_slip_tendency(traction, friction)
 
-        # Result should be negative (non-physical but mathematically correct)
+        # Result should be negative (non-physical but mathematically correct).
         expected = -3.0 / (5.0 * 0.6)
         assert np.isclose(result[0], expected)
         assert result[0] < 0  # Negative slip tendency
@@ -244,7 +245,7 @@ class TestComputeSlipTendency:
         traction = np.array([[1.0, 2.0, 3.0], [-2.0, -4.0, -6.0]])
         friction = 0.5  # Scalar - should be broadcast
 
-        # Should work with scalar friction coefficient
+        # Should work with scalar friction coefficient.
         friction_array = np.full(3, friction)
         result = FractureDeformationExporting.compute_slip_tendency(
             traction, friction_array
@@ -255,11 +256,11 @@ class TestComputeSlipTendency:
 
     def test_custom_tolerance(self):
         """Test that custom tolerance parameter works correctly."""
-        # Test with a value that is within default tolerance but outside custom one
+        # Test with a value that is within default tolerance but outside custom one.
         traction = np.array([[1.0, 2.0, 3.0], [1e-6, 1e-10, -5.0]])
         friction = np.array([0.6, 0.5, 0.4])
 
-        # With default tolerance (1e-8), first value should not be NaN
+        # With default tolerance (1e-8), first value should not be NaN.
         result_default = FractureDeformationExporting.compute_slip_tendency(
             traction, friction
         )
@@ -275,7 +276,7 @@ class TestComputeSlipTendency:
         assert np.isnan(result_strict[1])
         assert not np.isnan(result_strict[2])
 
-        # With looser tolerance (1e-12), second value should not be NaN
+        # With looser tolerance (1e-12), second value should not be NaN.
         result_loose = FractureDeformationExporting.compute_slip_tendency(
             traction, friction, atol=1e-12
         )

--- a/tests/viz/test_data_saving_model_mixin.py
+++ b/tests/viz/test_data_saving_model_mixin.py
@@ -20,6 +20,7 @@ from porepy.applications.md_grids.model_geometries import (
     SquareDomainOrthogonalFractures,
 )
 from porepy.models.momentum_balance import MomentumBalance
+from porepy.viz.data_saving_model_mixin import FractureDeformationExporting
 
 
 class DataSavingModelMixinModel(SquareDomainOrthogonalFractures, MomentumBalance):
@@ -139,3 +140,145 @@ def test_exported_times_consistency_with_files(times_to_export, expected_times):
 
     # Compare unique timesteps with times.json.
     assert np.allclose(sorted(timesteps), times_data["time"])
+
+
+class TestComputeSlipTendency:
+    """Test suite for the compute_slip_tendency static method."""
+
+    def test_normal_contact(self):
+        """Test slip tendency computation for normal contact conditions."""
+        # 2D case: traction shape (2, 3) for 3 cells
+        # Shear = [3, 4], Normal = -10, friction = 0.6
+        # Expected: -sqrt(3^2 + 4^2) / (-10 * 0.6) = -5 / -6 = 0.8333...
+        traction = np.array([[3.0, 0.0, 1.0], [-10.0, -5.0, -2.0]])
+        friction = np.array([0.6, 0.5, 0.4])
+
+        result = FractureDeformationExporting.compute_slip_tendency(traction, friction)
+
+        expected = np.array(
+            [
+                -np.linalg.norm([3.0]) / (-10.0 * 0.6),  # 0.5
+                -np.linalg.norm([0.0]) / (-5.0 * 0.5),  # 0.0
+                -np.linalg.norm([1.0]) / (-2.0 * 0.4),  # 1.25
+            ]
+        )
+
+        assert np.allclose(result, expected)
+
+    def test_zero_normal_traction_gives_nan(self):
+        """Test that zero normal traction results in NaN slip tendency."""
+        # Open fracture: normal traction = 0
+        traction = np.array([[1.0, 2.0], [0.0, -5.0]])  # First cell has zero normal
+        friction = np.array([0.6, 0.5])
+
+        result = FractureDeformationExporting.compute_slip_tendency(traction, friction)
+
+        # First cell should be NaN, second should be valid
+        assert np.isnan(result[0])
+        assert not np.isnan(result[1])
+        assert np.isclose(result[1], -2.0 / (-5.0 * 0.5))
+
+    def test_3d_case(self):
+        """Test slip tendency computation in 3D."""
+        # 3D case: traction shape (3, 2) for 2 cells
+        # Shear = [3, 4], Normal = -10, friction = 0.6
+        # Expected: -sqrt(3^2 + 4^2) / (-10 * 0.6) = -5 / -6 = 0.8333...
+        traction = np.array([[3.0, 1.0], [4.0, 2.0], [-10.0, -8.0]])
+        friction = np.array([0.6, 0.4])
+
+        result = FractureDeformationExporting.compute_slip_tendency(traction, friction)
+
+        expected = np.array(
+            [
+                -np.linalg.norm([3.0, 4.0]) / (-10.0 * 0.6),  # 5/6 = 0.8333...
+                -np.linalg.norm([1.0, 2.0]) / (-8.0 * 0.4),  # sqrt(5)/3.2 = 0.6989...
+            ]
+        )
+
+        assert np.allclose(result, expected)
+
+    def test_no_input_modification(self):
+        """Test that input arrays are not modified."""
+        traction = np.array([[1.0, 2.0], [0.0, -5.0]])
+        friction = np.array([0.6, 0.5])
+
+        # Make copies to check against
+        traction_orig = traction.copy()
+        friction_orig = friction.copy()
+
+        _ = FractureDeformationExporting.compute_slip_tendency(traction, friction)
+
+        # Verify inputs weren't modified
+        assert np.array_equal(traction, traction_orig)
+        assert np.array_equal(friction, friction_orig)
+
+    def test_near_zero_normal_traction(self):
+        """Test that near-zero normal traction (within tolerance) gives NaN."""
+        # Use a value that is close to zero but not exactly zero
+        traction = np.array([[1.0, 2.0], [1e-12, -5.0]])
+        friction = np.array([0.6, 0.5])
+
+        result = FractureDeformationExporting.compute_slip_tendency(traction, friction)
+
+        # Should be NaN due to np.isclose tolerance
+        assert np.isnan(result[0])
+        assert not np.isnan(result[1])
+
+    def test_positive_normal_traction(self):
+        """Test behavior with positive (tensile) normal traction.
+
+        Note: This is non-physical for contact mechanics but mathematically valid.
+        """
+        traction = np.array([[3.0], [5.0]])  # Positive (tensile) normal traction
+        friction = np.array([0.6])
+
+        result = FractureDeformationExporting.compute_slip_tendency(traction, friction)
+
+        # Result should be negative (non-physical but mathematically correct)
+        expected = -3.0 / (5.0 * 0.6)
+        assert np.isclose(result[0], expected)
+        assert result[0] < 0  # Negative slip tendency
+
+    def test_uniform_friction_coefficient(self):
+        """Test with uniform friction coefficient across all cells."""
+        traction = np.array([[1.0, 2.0, 3.0], [-2.0, -4.0, -6.0]])
+        friction = 0.5  # Scalar - should be broadcast
+
+        # Should work with scalar friction coefficient
+        friction_array = np.full(3, friction)
+        result = FractureDeformationExporting.compute_slip_tendency(
+            traction, friction_array
+        )
+
+        expected = -np.array([1.0, 2.0, 3.0]) / (-np.array([2.0, 4.0, 6.0]) * 0.5)
+        assert np.allclose(result, expected)
+
+    def test_custom_tolerance(self):
+        """Test that custom tolerance parameter works correctly."""
+        # Test with a value that is within default tolerance but outside custom one
+        traction = np.array([[1.0, 2.0, 3.0], [1e-6, 1e-10, -5.0]])
+        friction = np.array([0.6, 0.5, 0.4])
+
+        # With default tolerance (1e-8), first value should not be NaN
+        result_default = FractureDeformationExporting.compute_slip_tendency(
+            traction, friction
+        )
+        assert not np.isnan(result_default[0])  # 1e-6 > 1e-8
+        assert np.isnan(result_default[1])  # 1e-10 < 1e-8
+        assert not np.isnan(result_default[2])
+
+        # With stricter tolerance (1e-5), first value should be NaN
+        result_strict = FractureDeformationExporting.compute_slip_tendency(
+            traction, friction, atol=1e-5
+        )
+        assert np.isnan(result_strict[0])  # 1e-6 < 1e-5
+        assert np.isnan(result_strict[1])
+        assert not np.isnan(result_strict[2])
+
+        # With looser tolerance (1e-12), second value should not be NaN
+        result_loose = FractureDeformationExporting.compute_slip_tendency(
+            traction, friction, atol=1e-12
+        )
+        assert not np.isnan(result_loose[0])
+        assert not np.isnan(result_loose[1])  # 1e-10 > 1e-12
+        assert not np.isnan(result_loose[2])


### PR DESCRIPTION
## Proposed changes

Extracts a static method for computing slip tendency from traction and friction coefficient. Also adds testing. Note that the new method uses NaN to indicate zero normal traction (open fractures). This is more explicit than the old value of 1. Could be contentious, though.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [x] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
