### PR TITLE
Stop simulation when using constant dt and observing divergence

### DIFF
--- a/src/porepy/models/solution_strategy.py
+++ b/src/porepy/models/solution_strategy.py
@@ -679,7 +679,7 @@ class SolutionStrategy(pp.PorePyModel):
             return SimulationStatus.STOPPED
 
         if self.time_manager.is_constant:
-            warn("Failed to solve linear system for the linear problem.")
+            warn("Failed to solve the nonlinear problem.")
             return SimulationStatus.STOPPED
         else:
             # Update the time step magnitude if the dynamic scheme is used.

--- a/src/porepy/models/solution_strategy.py
+++ b/src/porepy/models/solution_strategy.py
@@ -678,7 +678,10 @@ class SolutionStrategy(pp.PorePyModel):
             warn("Failed to solve linear system for the linear problem.")
             return SimulationStatus.STOPPED
 
-        if not self.time_manager.is_constant:
+        if self.time_manager.is_constant:
+            warn("Failed to solve linear system for the linear problem.")
+            return SimulationStatus.STOPPED
+        else:
             # Update the time step magnitude if the dynamic scheme is used.
             # Note: It will also raise a ValueError if the minimal time step is reached.
             try:


### PR DESCRIPTION
I was observed (thanks @IngridKJ) that the simulation does not stop when the max number of iterations was reached, and constant time step size is used within the `TimeManager`. This PR enforces now a "crash".

## Proposed changes

Contributions to PorePy are highly appreciated. Clearly explain why this pull request (PR) is needed and why it should be accepted. If this PR solves an issue, explain how it is done. Please, also summarise the changes to the code.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [X] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
