### PR TITLE
BUG: Ad Operator add deals with scalar 0s

### DIFF
--- a/src/porepy/numerics/ad/operators.py
+++ b/src/porepy/numerics/ad/operators.py
@@ -665,8 +665,8 @@ class Operator:
 
         """
         # When using the sum operator on a list with a single item, Python will call the
-        # addition operator with other == 0. Convert that other to a an Ad Scalar with
-        # value 0, to avoid errors in the addition operator.
+        # addition operator with other == 0. Convert that other to an Ad Scalar with
+        # value 0 to avoid errors in the addition operator.
         if other == 0:
             other = Scalar(0)
 

--- a/src/porepy/numerics/ad/operators.py
+++ b/src/porepy/numerics/ad/operators.py
@@ -664,6 +664,12 @@ class Operator:
             The sum of self and other.
 
         """
+        # When using the sum operator on a list with a single item, Python will call the
+        # addition operator with other == 0. Convert that other to a an Ad Scalar with
+        # value 0, to avoid errors in the addition operator.
+        if other == 0:
+            other = Scalar(0)
+
         children = self._parse_other(other)
         return Operator(children=children, operation=Operations.add, name="+ operator")
 

--- a/tests/models/test_metric.py
+++ b/tests/models/test_metric.py
@@ -302,7 +302,7 @@ class DummyEquations(pp.PorePyModel):
         coeff = self.params.get("coeff", [0])
         exp_x = self.params.get("exp_x", [0])
         exp_y = self.params.get("exp_y", [0])
-        polynomial_expression = sum(
+        polynomial_expression = pp.ad.sum_operator_list(
             [
                 pp.ad.Scalar(c)
                 * variable_x ** pp.ad.Scalar(e_x)


### PR DESCRIPTION
This fixes an issue that arises when operator sum is called on a list with a single element. Python will then add '0' to the list element, which was not meaningful until this fix.

QUESTION: The previous workaround was to use pp.ad.sum_operator_list. Should we purge that method and use sum instead?


## Proposed changes

Contributions to PorePy are highly appreciated. Clearly explain why this pull request (PR) is needed and why it should be accepted. If this PR solves an issue, explain how it is done. Please, also summarise the changes to the code.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
