### PR TITLE
Avoid unnecessary memory use in discretization matrices

### DIFF
--- a/src/porepy/numerics/ad/equation_system.py
+++ b/src/porepy/numerics/ad/equation_system.py
@@ -1590,6 +1590,8 @@ class EquationSystem:
         # Uniquify to save computational time, then discretize.
         unique_discr = pp.ad.uniquify_discretization_list(discr)
         pp.ad.discretize_from_list(unique_discr, self.mdg)
+        # Reduce the memory footprint of discretization matrices.
+        pp.matrix_operations.prune_discretization_matrices(self.mdg)
 
     @overload
     def assemble(

--- a/src/porepy/numerics/linalg/matrix_operations.py
+++ b/src/porepy/numerics/linalg/matrix_operations.py
@@ -1505,6 +1505,82 @@ def invert_diagonal_blocks(
     return ia
 
 
+def prune_matrix(A: sps.spmatrix) -> None:
+    """Prune sparse matrix to reduce memory usage.
+
+    Two changes are considered:
+        1. If the matrix does not own its own data, as can happen if scipy has created
+           a view of the matrix, the data array is copied; a byproduct of this is that
+           the data array will not occupy more space than necessary.
+        2. The data types for row and column indices/index pointers are adjusted to the
+           size of the matrix.
+
+    Parameters:
+        A: The matrix to be pruned. Should be of csr or csc format. The matrix is
+           modified in place.
+
+    """
+    MAX_I16 = np.iinfo(np.int16).max
+    MAX_I32 = np.iinfo(np.int32).max
+
+    # A small buffer is used to avoid overflow when the size is close to the limit.
+    buffer = 10
+
+    num_rows, num_cols = A.shape
+    if A.format == "csr" or A.format == "csc":
+        if not A.data.flags.owndata:
+            # We could probably do this with matrix types beyond csr/csc as well, but
+            # there are hardly any practical use of this (except from diagonal matrices,
+            # where the utility of this fix is questionable), and we don't have
+            # sufficient test coverage of those cases to know it is safe. Hence, we
+            # limit to csr/csc.
+            A.data = A.data.copy()
+        if A.format == "csr":
+            if num_cols < MAX_I16:
+                A.indices = A.indices.astype(np.int16)
+            elif num_cols <= MAX_I32:
+                A.indices = A.indices.astype(np.int32)
+        else:  # A.format == 'csc'
+            if num_rows < MAX_I16 - 10:
+                A.indices = A.indices.astype(np.int16)
+            elif num_rows <= MAX_I32 - 10:
+                A.indices = A.indices.astype(np.int32)
+        if A.data.size < MAX_I16 - buffer:
+            A.indptr = A.indptr.astype(np.int16)
+        elif A.data.size <= MAX_I32 - buffer:
+            A.indptr = A.indptr.astype(np.int32)
+
+
+def prune_matrices_in_dict(data: dict[str, sps.spmatrix]) -> None:
+    """Prune all sparse matrices in a dictionary to reduce memory usage.
+
+    Parameters:
+        data: The dictionary containing the matrices to be pruned. The matrices are
+            modified in place. Only matrices of csr or csc format are pruned.
+
+    """
+    for value in data.values():
+        if isinstance(value, sps.spmatrix):
+            prune_matrix(value)
+        elif isinstance(value, dict):
+            prune_matrices_in_dict(value)
+
+
+def prune_discretization_matrices(mdg: pp.MixedDimensionalGrid) -> None:
+    """Prune all discretization matrices of a mixed-dimensional grid.
+
+    Parameters:
+        mdg: Mixed-dimensional grid whose discretization matrices are to be pruned. The
+            matrices are modified in place. Only matrices of csr or csc format are
+            pruned.
+
+    """
+    for _, data in mdg.subdomains(return_data=True):
+        prune_matrices_in_dict(data.get(pp.DISCRETIZATION_MATRICES, {}))
+    for _, data in mdg.interfaces(return_data=True):
+        prune_matrices_in_dict(data.get(pp.DISCRETIZATION_MATRICES, {}))
+
+
 def block_diag_matrix(vals: np.ndarray, sz: np.ndarray) -> sps.spmatrix:
     """Construct block diagonal matrix based on matrix elements and block sizes.
 

--- a/src/porepy/numerics/linalg/matrix_operations.py
+++ b/src/porepy/numerics/linalg/matrix_operations.py
@@ -994,6 +994,9 @@ def _csx_matrix_from_sparse_blocks(
     # Calculate the size of the block matrix.
     num_rows = sum([m.shape[0] for m in blocks])
     num_cols = sum([m.shape[1] for m in blocks])
+    tot_size = sum([m.data.size for m in blocks])
+
+    _safe_data_types_of_index_arrays(blocks, max(num_rows, num_cols), tot_size)
 
     # CSC and CSR matrices are constructed and operated on in a very similar way; the
     # difference is in which dimension the indices represent. We need this to get the
@@ -1016,6 +1019,47 @@ def _csx_matrix_from_sparse_blocks(
         shape=(num_rows, num_cols),
     )
     return block_mat
+
+
+def _safe_data_types_of_index_arrays(
+    blocks: list[sps.spmatrix], max_size: int, tot_size: int
+) -> None:
+    """Helper function to ensure the data types of a set of matrices.
+
+    This is needed to guard against cases where the indices of individual matrices
+    can be represented in reduced precision (int16 or int32), but where the stacked
+    matrix require higher precision.
+
+    Parameters:
+        blocks: List of matrices to be converted. The matrices are modified in place.
+        max_int: Maximum of the number of rows and columns.
+        tot_size: Total number of non-zero elements in the stacked matrix.
+
+    """
+    # Use a small buffer to avoid overflow issues when close to the maximum size.
+    buffer = 10
+
+    # For mypy.
+    dtype_indices: type[np.integer]
+    dtype_indptr: type[np.integer]
+
+    if max_size < np.iinfo(np.int16).max - buffer:
+        dtype_indices = np.int16
+    elif max_size < np.iinfo(np.int32).max - buffer:
+        dtype_indices = np.int32
+    else:
+        dtype_indices = np.int64
+
+    if tot_size < np.iinfo(np.int16).max - buffer:
+        dtype_indptr = np.int16
+    elif tot_size < np.iinfo(np.int32).max - buffer:
+        dtype_indptr = np.int32
+    else:
+        dtype_indptr = np.int64
+
+    for mat in blocks:
+        mat.indices = mat.indices.astype(dtype_indices)
+        mat.indptr = mat.indptr.astype(dtype_indptr)
 
 
 def csr_matrix_from_dense_blocks(

--- a/tests/utils/test_matrix_operations.py
+++ b/tests/utils/test_matrix_operations.py
@@ -680,25 +680,97 @@ def test_diagonal_matrix_from_sparse_blocks():
     assert np.all(known == value.toarray())
 
 
-@pytest.mark.parametrize(
-    "mat", [np.arange(6).reshape((3, 2)), np.arange(6).reshape((2, 3))]
-)
-def test_optimized_storage(mat):
-    """Check that the optimized sparse storage chooses format according to whether the
-    matrix has more columns or rows or opposite.
+class TestOptimizedStorage:
+    """Class to test various aspects of the optimized storage of sparse matrices."""
 
-    Convert input matrix to sparse storage. For the moment, the matrix format is chosen
-    according to the number of rows and columns only, thus the lack of true sparsity
-    does not matter.
-    """
-    A = sps.csc_matrix(mat)
+    @pytest.mark.parametrize(
+        "mat", [np.arange(6).reshape((3, 2)), np.arange(6).reshape((2, 3))]
+    )
+    def test_csr_csc_selection(self, mat):
+        """Check that the optimized sparse storage chooses format according to whether
+        the matrix has more columns or rows or opposite.
 
-    optimized = matrix_operations.optimized_compressed_storage(A)
+        Convert input matrix to sparse storage. For the moment, the matrix format is
+        chosen according to the number of rows and columns only, thus the lack of true
+        sparsity does not matter.
+        """
+        A = sps.csc_matrix(mat)
 
-    if A.shape[0] > A.shape[1]:
-        assert optimized.getformat() == "csc"
-    else:
-        assert optimized.getformat() == "csr"
+        optimized = matrix_operations.optimized_compressed_storage(A)
+
+        if A.shape[0] > A.shape[1]:
+            assert optimized.getformat() == "csc"
+        else:
+            assert optimized.getformat() == "csr"
+
+    def mat(self):
+        """Helper method to construct a sparse matrix with specific properties."""
+        mat = sps.csr_matrix(np.array([[1.1, 0], [3, 2]]))
+        mat.indices = mat.indices.astype(np.int64)
+        mat.indptr = mat.indptr.astype(np.int64)
+        # Do some slicing and modification to make scipy take ownnership of mat.data
+        # away from the original array.
+        mat.data[:] = mat.data[:] + 2.0
+        assert not mat.data.flags.owndata  # Need this for the test to be meaningful.
+        return mat
+
+    def dictionary(self):
+        """Helper method to construct a dictionary of matrices."""
+        return {"mat_1": self.mat().copy(), "mat_2": self.mat().copy()}
+
+    def mdg(self):
+        """Helper method to construct an MDG with discretization matrices in the
+        subdomain and interface data."""
+        # Generate a grid with a single fracture, hence one interface grid.
+        mdg, _ = pp.mdg_library.square_with_orthogonal_fractures(
+            grid_type="cartesian", meshing_args={"cell_size": 0.5}, fracture_indices=[0]
+        )
+        for _, data in mdg.subdomains(return_data=True):
+            data[pp.DISCRETIZATION_MATRICES] = self.dictionary()
+        for _, data in mdg.interfaces(return_data=True):
+            # For the interface we add a second layer to check the recursive pruning of
+            # the discretization matrices.
+            data[pp.DISCRETIZATION_MATRICES] = {"foo": self.dictionary()}
+        return mdg
+
+    def check_matrix_after_pruning(self, A):
+        """Helper method to check that a matrix has the expected properties after
+        pruning."""
+        assert A.data.size == 3
+        assert A.data.dtype == float
+        assert A.data.flags.owndata == True
+        assert np.allclose(A.data, [3.1, 5, 4])
+
+        # We only consider small matrices which can be represented by int16. Testing
+        # larger matrices is possible, but not considered worthwhile.
+        assert A.indptr.dtype == np.int16
+        assert np.allclose(A.indptr, [0, 1, 3])
+        assert A.indices.dtype == np.int16
+        assert np.allclose(A.indices, [0, 0, 1])
+
+    def test_matrix_pruning(self):
+        """Test the pruning of a single sparse matrix."""
+        mat = self.mat()
+        pp.matrix_operations.prune_matrix(mat)
+        self.check_matrix_after_pruning(mat)
+
+    def test_matrix_pruning_in_dictionary(self):
+        """Test the pruning of matrices in a dictionary."""
+        d = self.dictionary()
+        pp.matrix_operations.prune_matrices_in_dict(d)
+        for A in d.values():
+            self.check_matrix_after_pruning(A)
+
+    def test_matrix_pruning_in_mdg(self):
+        """Test the pruning of matrices in a mixed-dimensional grid."""
+        m = self.mdg()
+        pp.matrix_operations.prune_discretization_matrices(m)
+        for _, data in m.subdomains(return_data=True):
+            for A in data[pp.DISCRETIZATION_MATRICES].values():
+                self.check_matrix_after_pruning(A)
+        for _, data in m.interfaces(return_data=True):
+            for A in data[pp.DISCRETIZATION_MATRICES]["foo"].values():
+                self.check_matrix_after_pruning(A)
 
 
 # ------------------ Test inverting matrices -----------------------


### PR DESCRIPTION
## Proposed changes
Introduce a pruning method that i) makes sure that the data of a sparse matrix does not claim unnecessarily much space, ii) use i16/i32 data types to represent indices and index pointers where relevant.

Only csc/csr matrices are covered, since these are the ones that we struggle with.

I am sure we can do similar optimizations elsewhere, in particular on the index/index pointer side, but profiling indicated that the current fixes handle the excessive memory usage. 

Note that I did not include testing when the matrix pruning is called from the EquationSystem. The actual functionality should be covered by the lower-level methods which are tested, while the tests of models confirm that the method does not break. That leaves untested that the pruning methods actually prune when called from EquationSystem, but the probability of a failure specifically there seems so low I opted not to introduce extra tests.

Resolves #1611. 

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
