### PR TITLE
Fix test_buoyancy_flow

### DIFF
--- a/src/porepy/__init__.py
+++ b/src/porepy/__init__.py
@@ -256,6 +256,7 @@ from porepy import applications
 # Metrics for assessing convergence
 from porepy.models.metric import (
     EuclideanMetric,
+    LebesgueMetric,
     VariableBasedEuclideanMetric,
     EquationBasedEuclideanMetric,
     VariableBasedLebesgueMetric,

--- a/src/porepy/numerics/nonlinear/convergence_check.py
+++ b/src/porepy/numerics/nonlinear/convergence_check.py
@@ -328,6 +328,11 @@ class AbsoluteCriterion:
         self.metric = metric
         """Metric to compute the convergence measure."""
 
+    def __repr__(self) -> str:
+        s = f"{self.__class__.__name__}(tol={self.tol}, "
+        s += f"metric={self.metric.__class__.__name__})"
+        return s
+
 
 class AbsoluteConvergenceCriterion(AbsoluteCriterion, ConvergenceCriterion):
     """Absolute convergence criterion."""
@@ -422,6 +427,15 @@ class RelativeCriterion:
         else:  # float
             if self.reference_value is None and not np.isclose(reference_value, 0.0):
                 self.reference_value = reference_value
+
+    def __repr__(self) -> str:
+        s = f"{self.__class__.__name__}(tol={self.tol}, "
+        s += f"metric={self.metric.__class__.__name__}, "
+        if self.reference_value is not None:
+            s += f"reference_value={self.reference_value})"
+        else:
+            s += "reference_value=None)"
+        return s
 
 
 class RelativeConvergenceCriterion(RelativeCriterion, ConvergenceCriterion):

--- a/tests/examples/test_geothermal_reservoir.py
+++ b/tests/examples/test_geothermal_reservoir.py
@@ -398,8 +398,8 @@ def test_geothermal_reservoir():
         "prepare_simulation": True,
         "max_iterations": 25,  # Max iterations of a nonlinear solver (Newton)
         "nl_divergence_tol": 1e20,
-        "nl_convergence_tol": 1e-7,  # Increment norm
-        "nl_convergence_tol_res": 1e-7,  # Residual norm
+        "nl_convergence_inc_atol": 1e-7,  # Increment norm
+        "nl_convergence_res_atol": 1e-7,  # Residual norm
         "nonlinear_solver": line_search.ConstraintLineSearchNonlinearSolver,
         "global_line_search": 0,
         "local_line_search": 1,

--- a/tests/functional/test_buoyancy_flow.py
+++ b/tests/functional/test_buoyancy_flow.py
@@ -21,11 +21,13 @@ time step the following are tested:
    discretization of the energy convective buoyancy terms.
 """
 
-import numpy as np
-import pytest
 from typing import Literal
 
+import numpy as np
+import pytest
+
 import porepy as pp
+from porepy.applications.test_utils.models import add_mixin
 from tests.functional.setups.buoyancy_flow_model import (
     BuoyancyFlowModel2N,
     BuoyancyFlowModel3N,
@@ -35,7 +37,6 @@ from tests.functional.setups.buoyancy_flow_model import (
     ModelMDGeometry3D,
     to_Mega,
 )
-from porepy.applications.test_utils.models import add_mixin
 
 # Parameterization list for both tests
 Parameterization = [
@@ -83,23 +84,32 @@ def _run_buoyancy_model(
         iter_max=50,
         print_info=True,
     )
-    params = {
+    model_params = {
         "fractional_flow": True,
         "enable_buoyancy_effects": True,
         "material_constants": {"solid": solid_constants},
         "time_manager": time_manager,
         "apply_schur_complement_reduction": False,
-        "nl_max_iterations": 50,
-        "nl_convergence_inc_atol": np.inf,
-        "nl_convergence_res_atol": residual_tolerance,
         "expected_order_loss": expected_order_loss,
     }
-    # Combine geometry with model class
+    # Combine geometry with model class.
     geometry_class = geometry2d if dim == 2 else geometry3d
     model_class = add_mixin(geometry_class, model_class)
-    model = model_class(params)
+    model = model_class(model_params)
+    # Use a Lebesgue metric for the residual convergence criterion, since this will
+    # strictly bound the residual error in the mass conservation equations.
+    solver_params = {
+        "nl_convergence_criteria": {
+            "res_abs": pp.ResidualBasedAbsoluteCriterion(
+                tol=residual_tolerance, metric=pp.EquationBasedLebesgueMetric(model)
+            ),
+        },
+        "nl_divergence_criteria": {
+            "max_iter": pp.MaxIterationsCriterion(max_iterations=50),
+        },
+    }
 
-    pp.run_time_dependent_model(model, params)
+    pp.run_time_dependent_model(model, solver_params)
 
 
 @pytest.mark.skipped  # reason: slow

--- a/tests/functional/test_buoyancy_flow.py
+++ b/tests/functional/test_buoyancy_flow.py
@@ -23,6 +23,7 @@ time step the following are tested:
 
 import numpy as np
 import pytest
+from typing import Literal
 
 import porepy as pp
 from tests.functional.setups.buoyancy_flow_model import (
@@ -34,23 +35,27 @@ from tests.functional.setups.buoyancy_flow_model import (
     ModelMDGeometry3D,
     to_Mega,
 )
+from porepy.applications.test_utils.models import add_mixin
 
 # Parameterization list for both tests
 Parameterization = [
-    (BuoyancyFlowModel2N, True, 4),
-    (BuoyancyFlowModel2N, False, 4),
-    (BuoyancyFlowModel3N, True, 4),
-    (BuoyancyFlowModel3N, False, 4),
+    (BuoyancyFlowModel2N, 2, 4),
+    (BuoyancyFlowModel2N, 3, 4),
+    (BuoyancyFlowModel3N, 2, 4),
+    (BuoyancyFlowModel3N, 3, 4),
 ]
 
 
 def _run_buoyancy_model(
     model_class: type,
-    mesh_2d_Q: bool,
+    dim: Literal[2, 3],
     expected_order_loss: int,
     md: bool = False,
 ) -> None:
     """Run buoyancy flow simulation for given parameters."""
+
+    # The residual tolerance for Newton should be related to the expected (requested)
+    # order loss.
     residual_tolerance = 10.0 ** (-expected_order_loss)
     day = 86400
     if md:
@@ -90,26 +95,16 @@ def _run_buoyancy_model(
         "expected_order_loss": expected_order_loss,
     }
     # Combine geometry with model class
-    if mesh_2d_Q:
+    geometry_class = geometry2d if dim == 2 else geometry3d
+    model_class = add_mixin(geometry_class, model_class)
+    model = model_class(params)
 
-        class Model2D(geometry2d, model_class):
-            pass
-
-        model = Model2D(params)
-    else:
-
-        class Model3D(geometry3d, model_class):
-            pass
-
-        model = Model3D(params)
     pp.run_time_dependent_model(model, params)
 
 
 @pytest.mark.skipped  # reason: slow
-@pytest.mark.parametrize(
-    "model_class, mesh_2d_Q, expected_order_loss", Parameterization
-)
+@pytest.mark.parametrize("model_class, dim, expected_order_loss", Parameterization)
 @pytest.mark.parametrize("md", [True])  # False skipped to limit computational cost.
-def test_buoyancy_model(model_class, mesh_2d_Q, expected_order_loss, md):
+def test_buoyancy_model(model_class, dim: Literal[2, 3], expected_order_loss, md):
     """Test buoyancy-driven flow model (FD)."""
-    _run_buoyancy_model(model_class, mesh_2d_Q, expected_order_loss, md=md)
+    _run_buoyancy_model(model_class, dim, expected_order_loss, md=md)


### PR DESCRIPTION
## Proposed changes
This PR fixes an issue related to the slow `test_buoyancy_flows` that was introduced in connection with the new convergence criteria. The test now uses a Lebesgue integral to ensure that the computed residual norm actually is an upper bound on the mass conservation error, which is what is tested for.

The PR also makes the Lebesgue error measure available for the top-level init and introduce repr methods for some of the convergence measures

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
