### PR TITLE
FV discretizations do not offer reconstruction of primary variables on internal faces

### DIFF
--- a/src/porepy/numerics/fv/_fvutils.py
+++ b/src/porepy/numerics/fv/_fvutils.py
@@ -355,6 +355,33 @@ def find_active_indices(
     return active_cells, active_faces
 
 
+def boundary_face_mask(sd: pp.Grid, internal_face_active: bool) -> sps.spmatrix:
+    """Construct a mask to be applied to the discretization matrices, to eliminate
+    contributions from internal faces if these are not active.
+
+    Parameters:
+        sd: Grid to be discretized.
+        internal_face_active: Whether the discretization should include contributions
+            from internal faces. If False, contributions from internal faces will be
+            eliminated by the mask.
+
+    Returns:
+        sps.spmatrix: Mask to be applied to the discretization matrices of shape
+            (sd.num_faces, sd.num_faces).
+
+    """
+
+    if internal_face_active:
+        filter_array = np.ones(sd.num_faces, dtype=bool)
+    else:
+        filter_array = np.zeros(sd.num_faces, dtype=bool)
+        filter_array[sd.get_all_boundary_faces()] = True
+    boundary_face_mask = sps.dia_matrix(
+        (filter_array, 0), shape=(sd.num_faces, sd.num_faces)
+    )
+    return boundary_face_mask
+
+
 def parse_partition_arguments(
     partition_arguments: Optional[dict[str, int]] = None,
 ) -> tuple[int | None, int | None]:

--- a/src/porepy/numerics/fv/mpfa.py
+++ b/src/porepy/numerics/fv/mpfa.py
@@ -96,6 +96,9 @@ class Mpfa(pp.FVElliptic):
                 'num_subproblems' in ``partition_arguments``). If none are given, the
                 default is to use 1e9 bytes of memory per subproblem. If both are given,
                 the maximal memory use is prioritized.
+            - reconstruct_on_internal_faces (``bool``): Optional. Whether to
+                reconstruct the pressure at internal faces. This is not needed in
+                most cases, but is kept for completeness.
 
         matrix_dictionary will be updated with the following entries:
             - ``flux: sps.csc_matrix (sd.num_faces, sd.num_cells)``
@@ -154,6 +157,9 @@ class Mpfa(pp.FVElliptic):
         eta: Optional[float] = parameter_dictionary.get("mpfa_eta", None)
         inverter: Literal["numba", "python"] = parameter_dictionary.get(
             "mpfa_inverter", "numba"
+        )
+        reconstruct_on_internal_faces = parameter_dictionary.get(
+            "reconstruct_on_internal_faces", False
         )
 
         # Control of the number of subdomanis.
@@ -293,6 +299,7 @@ class Mpfa(pp.FVElliptic):
                 eta=loc_eta,
                 inverter=inverter,
                 ambient_dimension=vector_source_dim,
+                reconstruct_on_internal_faces=reconstruct_on_internal_faces,
             )
 
             # Eliminate contribution from faces already discretized (the dual grids /
@@ -597,6 +604,7 @@ class Mpfa(pp.FVElliptic):
         inverter: Optional[Literal["python", "numba"]] = None,
         ambient_dimension: Optional[int] = None,
         eta: Optional[float] = None,
+        reconstruct_on_internal_faces: bool = False,
     ) -> tuple[
         sps.spmatrix,
         sps.spmatrix,
@@ -1124,6 +1132,21 @@ class Mpfa(pp.FVElliptic):
             pressure_trace_bound = area_mat * pressure_trace_bound * hf2f.T
             pressure_trace_cell = area_mat * pressure_trace_cell
 
+            boundary_face_mask = _fvutils.boundary_face_mask(
+                sd, reconstruct_on_internal_faces
+            )
+
+            pressure_trace_bound = boundary_face_mask @ pressure_trace_bound
+            pressure_trace_cell = boundary_face_mask @ pressure_trace_cell
+        else:
+            if reconstruct_on_internal_faces:
+                # It should not be difficult to do this, but since we hardly ever set
+                # subface_rhs=True, we simply raise an error for now.
+                raise NotImplementedError(
+                    "Internal face reconstruction not implemented for subface rhs."
+                )
+            boundary_face_mask = sps.eye(sd.num_faces)
+
         # Also discretize vector source terms for Darcy's law. discr_div_vector_source
         # is the discretised vector source, which is interpreted as a force on a subface
         # due to imbalance in cell-center vector sources. This term is computed on a
@@ -1146,13 +1169,17 @@ class Mpfa(pp.FVElliptic):
         vector_source = hf2f * discr_vector_source * sc2c
         bound_pressure_vector_source = area_mat * vector_source_bound * sc2c
 
+        filtered_bound_pressure_vector_source = (
+            boundary_face_mask @ bound_pressure_vector_source
+        )
+
         return (
             flux,
             bound_flux,
             pressure_trace_cell,
             pressure_trace_bound,
             vector_source,
-            bound_pressure_vector_source,
+            filtered_bound_pressure_vector_source,
         )
 
     def _discretize_vector_source(

--- a/src/porepy/numerics/fv/mpsa.py
+++ b/src/porepy/numerics/fv/mpsa.py
@@ -155,6 +155,9 @@ class Mpsa(Discretization):
                 'num_subproblems' in ``partition_arguments``). If none are given, the
                 default is to use 1e9 bytes of memory per subproblem. If both are given,
                 the maximal memory use is prioritized.
+            - reconstruct_on_internal_faces (``bool``): Optional. Whether to
+                reconstruct the displacement at internal faces. This is not needed in
+                most cases, but is kept for completeness.
 
         matrix_dictionary will be updated with the following entries:
             - ``stress: sps.csc_matrix (sd.dim * sd.num_faces, sd.dim * sd.num_cells)``
@@ -186,6 +189,9 @@ class Mpsa(Discretization):
 
         inverter: Literal["python", "numba"] = parameter_dictionary.get(
             "inverter", "numba"
+        )
+        reconstruct_on_internal_faces = parameter_dictionary.get(
+            "reconstruct_on_internal_faces", False
         )
 
         # Control of the number of subdomanis.
@@ -309,7 +315,13 @@ class Mpsa(Discretization):
                 loc_bound_displacement_cell,
                 loc_bound_displacement_face,
             ) = self._stress_discretization(
-                sub_g, loc_c, loc_bnd, eta=loc_eta, inverter=inverter, hf_eta=hf_eta
+                sub_g,
+                loc_c,
+                loc_bnd,
+                eta=loc_eta,
+                inverter=inverter,
+                hf_eta=hf_eta,
+                reconstruct_on_internal_faces=reconstruct_on_internal_faces,
             )
 
             # Eliminate contribution from faces already discretized (the dual grids /
@@ -537,6 +549,7 @@ class Mpsa(Discretization):
         inverter: Optional[Literal["python", "numba"]] = None,
         hf_disp: bool = False,
         hf_eta: Optional[float] = None,
+        reconstruct_on_internal_faces: bool = False,
     ) -> tuple[sps.spmatrix, sps.spmatrix, sps.spmatrix, sps.spmatrix]:
         """
         Actual implementation of the MPSA W-method. To calculate the MPSA
@@ -603,6 +616,8 @@ class Mpsa(Discretization):
                 being for legacy reasons.
             hf_eta: If hf_disp is True, this parameter will be used instead of eta to
                 control the continuity of the displacement.
+            reconstruct_on_internal_faces: Whether to reconstruct the displacement on
+                internal faces.
 
         Returns:
             tuple of 4 sps.spmatrix:
@@ -758,7 +773,10 @@ class Mpsa(Discretization):
             hf_eta = eta
         # We obtain the reconstruction of displacments
         dist_grad, cell_centers = self._reconstruct_displacement(
-            sd, subcell_topology, hf_eta
+            sd,
+            subcell_topology,
+            hf_eta,
+            reconstruct_on_internal_faces=reconstruct_on_internal_faces,
         )
 
         hf_cell = dist_grad @ igrad @ rhs_cells + cell_centers
@@ -1189,6 +1207,8 @@ class Mpsa(Discretization):
         sd: pp.Grid,
         subcell_topology: _fvutils.SubcellTopology,
         eta: Optional[float] = None,
+        filter_internal_subfaces: bool = True,
+        reconstruct_on_internal_faces: bool = False,
     ) -> tuple[sps.csr_matrix, sps.csr_matrix]:
         """Function for reconstructing the displacement at the half faces given the
         local gradients.
@@ -1211,6 +1231,10 @@ class Mpsa(Discretization):
                 point at which the displacement is evaluated. If ``eta`` is not given
                 the method will call ``:meth:~pp.numerics.fv._fvutils.determine_eta`` to
                 set it.
+            filter_internal_subfaces: If True, the contribution from internal subfaces
+                to the reconstruction will be filtered away.
+            reconstruct_on_internal_faces: If True, the displacement will be
+                reconstructed at all faces, including internal ones.
 
         Returns:
             ``scipy.sparse.csr_matrix (sd.dim*num_sub_faces, sd.dim*num_cells)``:
@@ -1242,18 +1266,38 @@ class Mpsa(Discretization):
             subcell_topology.subfno, return_inverse=True, return_counts=True
         )
 
+        # We will normally want to construct the displacement only at boundary faces.
+        # Hence we filter away internal sub-faces, unless the user explicitly requested
+        # they be kept.
+        if reconstruct_on_internal_faces:
+            filter_array = np.ones(subcell_topology.num_subfno_unique, dtype=bool)
+        else:
+            face_is_boundary = np.zeros(sd.num_faces, dtype=bool)
+            face_is_boundary[sd.get_all_boundary_faces()] = True
+            filter_array = face_is_boundary[subcell_topology.fno_unique]
+        subface_boundary_mask = sps.dia_matrix(
+            (filter_array, 0),
+            shape=(
+                subcell_topology.num_subfno_unique,
+                subcell_topology.num_subfno_unique,
+            ),
+        )
+
         avg_over_subfaces = sps.coo_matrix(
             (1 / counts[IC], (subcell_topology.subfno, subcell_topology.subhfno))
         )
-        D_g = avg_over_subfaces @ D_g
+        D_g = subface_boundary_mask @ avg_over_subfaces @ D_g
         # expand indices to x-y-z
         D_g = sps.kron(sps.eye(sd.dim), D_g)
         D_g = D_g.tocsr()
 
-        # Get a mapping from cell centers to half-faces
-        D_c = sps.coo_matrix(
-            (1 / counts[IC], (subcell_topology.subfno, subcell_topology.cno))
-        ).tocsr()
+        # Get a mapping from cell centers to half-faces.
+        D_c = (
+            subface_boundary_mask
+            @ sps.coo_matrix(
+                (1 / counts[IC], (subcell_topology.subfno, subcell_topology.cno))
+            ).tocsr()
+        )
         # Expand indices to x-y-z
         D_c = sps.kron(sps.eye(sd.dim), D_c)
         D_c = D_c.tocsc()

--- a/src/porepy/numerics/fv/tpfa.py
+++ b/src/porepy/numerics/fv/tpfa.py
@@ -12,6 +12,7 @@ import numpy as np
 import scipy.sparse as sps
 
 import porepy as pp
+from porepy.numerics.fv import _fvutils
 from porepy.numerics.linalg.matrix_operations import sparse_array_to_row_col_data
 
 
@@ -52,6 +53,9 @@ class Tpfa(pp.FVElliptic):
             ambient_dimension: (int) Optional. Ambient dimension, used in the
                 discretization of vector source terms. Defaults to the dimension of the
                 grid.
+            reconstruct_on_internal_faces (``bool``): Optional. Whether to
+                reconstruct the pressure at internal faces. This is not needed in
+                most cases, but is kept for completeness.
 
         matrix_dictionary will be updated with the following entries:
             flux: sps.csc_matrix (sd.num_faces, sd.num_cells)
@@ -83,6 +87,9 @@ class Tpfa(pp.FVElliptic):
 
         # Ambient dimension of the grid
         vector_source_dim: int = parameter_dictionary.get("ambient_dimension", sd.dim)
+        reconstruct_on_internal_faces = parameter_dictionary.get(
+            "reconstruct_on_internal_faces", False
+        )
 
         if sd.dim == 0:
             # Shortcut for 0d grids
@@ -238,12 +245,18 @@ class Tpfa(pp.FVElliptic):
         v_face[bnd.is_neu] = -1 / t_full[bnd.is_neu]
         v_cell[bnd.is_neu[fi]] = 1
 
-        bound_pressure_cell = sps.coo_matrix(
-            (v_cell, (fi, ci)), (sd.num_faces, sd.num_cells)
-        ).tocsr()
-        bound_pressure_face = sps.dia_matrix(
-            (v_face, 0), (sd.num_faces, sd.num_faces)
-        ).tocsr()
+        boundary_face_mask = _fvutils.boundary_face_mask(
+            sd, reconstruct_on_internal_faces
+        )
+
+        bound_pressure_cell = (
+            boundary_face_mask
+            @ sps.coo_matrix((v_cell, (fi, ci)), (sd.num_faces, sd.num_cells)).tocsr()
+        )
+        bound_pressure_face = (
+            boundary_face_mask
+            @ sps.dia_matrix((v_face, 0), (sd.num_faces, sd.num_faces)).tocsr()
+        )
         matrix_dictionary[self.bound_pressure_cell_matrix_key] = bound_pressure_cell
         matrix_dictionary[self.bound_pressure_face_matrix_key] = bound_pressure_face
 
@@ -270,9 +283,9 @@ class Tpfa(pp.FVElliptic):
         # source and the distance vector from cell to face centers.
         vals = np.zeros((vector_source_dim, fi.size))
         vals[:, bnd.is_neu[fi]] = fc_cc[:vector_source_dim, bnd.is_neu[fi]]
-        bound_pressure_vector_source = sps.coo_matrix(
-            (vals.ravel("F"), (rows, cols))
-        ).tocsr()
+        bound_pressure_vector_source = (
+            boundary_face_mask @ sps.coo_matrix((vals.ravel("F"), (rows, cols))).tocsr()
+        )
         matrix_dictionary[self.bound_pressure_vector_source_matrix_key] = (
             bound_pressure_vector_source
         )

--- a/tests/numerics/fv/test_mpfa.py
+++ b/tests/numerics/fv/test_mpfa.py
@@ -968,7 +968,13 @@ class TestMpfaPressureReconstructionMatrices:
         P_f = p_t_cell * P + p_t_bound * p_b
 
         assert np.all(np.abs(P - np.sum(g.cell_centers, axis=0) - p0) < 1e-10)
-        assert np.all(np.abs(P_f - np.sum(g.face_centers, axis=0) - p0) < 1e-10)
+        # Check that the reconstructed face pressures are correct at the boundary.
+        assert np.all(
+            np.abs(
+                (P_f - np.sum(g.face_centers, axis=0))[g.get_all_boundary_faces()] - p0
+            )
+            < 1e-10
+        )
 
     def test_simplex_3d_boundary(self):
         """


### PR DESCRIPTION
## Proposed changes
The mpsa, mpfa and tpfa discretization used to construct matrices for reconstruction of the primary variables (displacement, pressure), on all faces. In practice we only use this for external faces, hence storing the quantities needed for the computation on internal faces is a not needed. This PR does away with these extra fields.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
