### PR TITLE
SPEED: Caching of Ad operators for buoyancy flux computations

### DIFF
--- a/src/porepy/models/constitutive_laws.py
+++ b/src/porepy/models/constitutive_laws.py
@@ -717,6 +717,7 @@ class MassWeightedPermeability(ConstantPermeability):
             op = super().permeability(subdomains)
         return op
 
+    @pp.ad.cached_method
     def normal_permeability(self, interfaces: list[pp.MortarGrid]) -> pp.ad.Operator:
         """A constitutive law returning the normal permeability as
         :meth:`mass_mobility_weighted_permeability` on the lower-dimensional subdomain.

--- a/src/porepy/models/fluid_property_library.py
+++ b/src/porepy/models/fluid_property_library.py
@@ -769,8 +769,8 @@ class FluidBuoyancy(pp.PorePyModel):
 
         """
         normals = self.outwards_internal_boundary_normals(interfaces, unitary=True)
-
         subdomain_neighbors = self.interfaces_to_subdomains(interfaces)
+
         projection = pp.ad.MortarProjections(
             self.mdg, subdomain_neighbors, interfaces, dim=self.nd
         )
@@ -797,6 +797,7 @@ class FluidBuoyancy(pp.PorePyModel):
         w_flux.set_name("interface_density_driven_flux_" + density_metric.name)
         return w_flux
 
+    @pp.ad.cached_method
     def __entity_buoyancy_flux(
         self,
         advected_gamma_quantity: pp.ad.Operator,
@@ -903,6 +904,7 @@ class FluidBuoyancy(pp.PorePyModel):
             b_fluxes.append(b_intf_flux_gamma_delta)
         return b_fluxes
 
+    @pp.ad.cached_method
     def __entity_buoyancy_jump(
         self,
         advected_gamma_quantity: pp.ad.Operator,


### PR DESCRIPTION
## Proposed changes
These are really minor changes, but they give a notable speedup for buoyancy-related simulations.

NOTE: Slow tests must pass before this is merged.
EDIT: OK, test passed.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [x] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [x] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
