### PR TITLE
Ad speedups

### DIFF
--- a/src/porepy/numerics/ad/ad_utils.py
+++ b/src/porepy/numerics/ad/ad_utils.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import warnings
 from abc import ABCMeta
+from functools import lru_cache
 from typing import Any, Optional
 
 import numpy as np
@@ -308,6 +309,7 @@ def discretize_from_list(
                     pass
 
 
+@lru_cache
 def _validate_indices(
     time_step_index: Optional[int] = None,
     iterate_index: Optional[int] = None,

--- a/src/porepy/numerics/ad/equation_system.py
+++ b/src/porepy/numerics/ad/equation_system.py
@@ -5,6 +5,7 @@ using the AD framework.
 
 from __future__ import annotations
 
+from functools import lru_cache
 from typing import Any, Callable, Literal, Optional, Sequence, Union, cast, overload
 
 import numpy as np
@@ -853,6 +854,8 @@ class EquationSystem:
         self._variable_num_dofs = np.concatenate(
             [self._variable_num_dofs, np.array([num_dofs], dtype=int)]
         )
+        # Clear cache since the global variable dofs have changed.
+        self._global_variable_dofs.cache_clear()
 
     def _cluster_dofs_gridwise(self) -> None:
         """Re-arranges the DOFs grid-wise s.t. we obtain grid-blocks in the column sense
@@ -896,6 +899,8 @@ class EquationSystem:
         # Replace old block order
         self._variable_num_dofs = np.array(new_block_dofs, dtype=int)
         self._variable_numbers = new_variable_numbers
+        # Clear cache since the global variable dofs have changed.
+        self._global_variable_dofs.cache_clear()
 
     def _parse_variable_type(self, variables: Optional[VariableList]) -> list[Variable]:
         """Parse the input argument for the variable type.
@@ -978,7 +983,7 @@ class EquationSystem:
 
     def num_dofs(self) -> int:
         """Returns the total number of dofs managed by this system."""
-        return int(sum(self._variable_num_dofs))  # cast numpy.int64 into Python int
+        return self._global_variable_dofs()[-1]
 
     def projection_to(self, variables: Optional[VariableList] = None) -> sps.csr_matrix:
         """Create a projection matrix from the global vector of unknowns to a specified
@@ -1019,6 +1024,17 @@ class EquationSystem:
         else:
             return sps.csr_matrix((0, num_dofs))
 
+    @lru_cache
+    def _global_variable_dofs(self) -> np.ndarray:
+        """Compute the global DOF indices for each variable block.
+
+        Returns:
+            An array of indices corresponding to the global DOF indices for each
+            variable block.
+
+        """
+        return np.hstack((0, np.cumsum(self._variable_num_dofs)))
+
     def dofs_of(self, variables: VariableList) -> np.ndarray:
         """Get the indices in the global vector of unknowns belonging to the variables.
 
@@ -1034,7 +1050,7 @@ class EquationSystem:
 
         """
         variables = self._parse_variable_type(variables)
-        global_variable_dofs = np.hstack((0, np.cumsum(self._variable_num_dofs)))
+        global_variable_dofs = self._global_variable_dofs()
 
         indices: list[np.ndarray] = []
 
@@ -1081,7 +1097,7 @@ class EquationSystem:
         if not (0 <= dof < num_dofs):  # indices go from 0 to num_dofs - 1
             raise KeyError("Dof index out of range.")
 
-        global_variable_dofs = np.hstack((0, np.cumsum(self._variable_num_dofs)))
+        global_variable_dofs = self._global_variable_dofs()
         # Find the variable number belonging to this index
         variable_number = np.argmax(global_variable_dofs > dof) - 1
         # Get the variable key from _variable_numbers
@@ -1326,6 +1342,8 @@ class EquationSystem:
 
             # Update local counting
             self._variable_num_dofs[self._variable_numbers[id_]] = num_dofs
+        # Clear cache since the global variable dofs have changed.
+        self._global_variable_dofs.cache_clear()
 
     ### System assembly and discretization ---------------------------------------------
 

--- a/src/porepy/numerics/ad/forward_mode.py
+++ b/src/porepy/numerics/ad/forward_mode.py
@@ -87,10 +87,14 @@ class AdArray:
 
         # Enforce float format of all data to limit the number of cases we need to
         # handle and test.
-        self.val: np.ndarray = val.astype(float)
+        self.val: np.ndarray = val
+        if self.val.dtype != float:
+            self.val = self.val.astype(float)
         """The value of the AdArray, stored as a 1d numpy array."""
 
-        self.jac: sps.spmatrix = jac.astype(float)
+        self.jac: sps.spmatrix = jac
+        if self.jac.data.dtype != float:
+            self.jac.data = self.jac.data.astype(float)
         """The Jacobian matrix of the AdArray, stored as a sparse matrix."""
 
     def __str__(self) -> str:

--- a/src/porepy/numerics/ad/surrogate_operator.py
+++ b/src/porepy/numerics/ad/surrogate_operator.py
@@ -121,6 +121,7 @@ Example:
 
 from __future__ import annotations
 
+from functools import lru_cache
 from typing import Any, Callable, Optional, Sequence, cast
 
 import numpy as np
@@ -597,6 +598,7 @@ class SurrogateFactory:
         )
         return values
 
+    @lru_cache
     def _data_of(self, grid: pp.GridLike) -> dict:
         """Convenience function to get the data dictionary of any grid."""
         if isinstance(grid, pp.Grid):
@@ -616,6 +618,7 @@ class SurrogateFactory:
         This determines the number of required derivative values."""
         return len(self._dependencies)
 
+    @lru_cache
     def num_dofs_on_grid(self, grid: pp.GridLike) -> int:
         """Computes the number of DOFs based on the information provided during
         instantiation.

--- a/src/porepy/numerics/ad/surrogate_operator.py
+++ b/src/porepy/numerics/ad/surrogate_operator.py
@@ -566,13 +566,10 @@ class SurrogateFactory:
 
         """
         # arguments for utility function
-        kwargs: dict[Any, Any] = dict()
-        if get_derivatives:
-            kwargs["name"] = self._name_derivatives
-        else:
-            kwargs["name"] = self.name
 
-        kwargs["data"] = self._data_of(grid)
+        name = self._name_derivatives if get_derivatives else self.name
+
+        data = self._data_of(grid)
 
         if (op.is_previous_iterate or op.is_previous_time) and get_derivatives:
             raise ValueError(
@@ -581,11 +578,13 @@ class SurrogateFactory:
             )
 
         if op.is_previous_time:
-            kwargs["time_step_index"] = op.time_step_index
+            values = pp.get_solution_values(
+                name=name, data=data, time_step_index=op.time_step_index
+            )
         else:
-            kwargs["iterate_index"] = op.iterate_index
-
-        values = pp.get_solution_values(**kwargs)
+            values = pp.get_solution_values(
+                name=name, data=data, iterate_index=op.iterate_index
+            )
 
         # last check before parsing that it returns what it should
         target_shape: tuple[int, ...]
@@ -593,9 +592,14 @@ class SurrogateFactory:
             target_shape = (self.num_dependencies, self.num_dofs_on_grid(grid))
         else:
             target_shape = (self.num_dofs_on_grid(grid),)
-        _check_expected_values(
-            values, target_shape, grid, op.iterate_index, op.time_step_index
+        assert isinstance(values, np.ndarray), (
+            f"Expected to fetch a numpy array, but got type {type(values)}."
         )
+        assert values.shape == target_shape, (
+            f"Expected to fetch array of shape {target_shape}, but got shape"
+            f" {values.shape}."
+        )
+
         return values
 
     @lru_cache


### PR DESCRIPTION
## Proposed changes
This is a collection of minor changes to the Ad framework, mainly related to surrogate operators. 

My profiling (based on limited data) indicate that the time for evaluation of a SurrogateOperator can be halved by the changes here. No guarantees this holds in general.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
