### PR TITLE
Ad operator equality is defined by the operator's key

### DIFF
--- a/src/porepy/numerics/ad/_ad_parser.py
+++ b/src/porepy/numerics/ad/_ad_parser.py
@@ -227,8 +227,6 @@ class AdParser:
             else:
                 # Mypy complains because the return type of parse is Any.
                 res = op.parse(equation_system.mdg)  # type:ignore
-                # Profiling indicated that in this case, caching actually pays off, so
-                # we keep it.
                 return res
 
         if isinstance(op, pp.ad.ProjectionList):

--- a/src/porepy/numerics/ad/_ad_parser.py
+++ b/src/porepy/numerics/ad/_ad_parser.py
@@ -229,7 +229,6 @@ class AdParser:
                 res = op.parse(equation_system.mdg)  # type:ignore
                 # Profiling indicated that in this case, caching actually pays off, so
                 # we keep it.
-                self._cache[op] = res
                 return res
 
         if isinstance(op, pp.ad.ProjectionList):

--- a/src/porepy/numerics/ad/operators.py
+++ b/src/porepy/numerics/ad/operators.py
@@ -1021,6 +1021,9 @@ class TimeDependentOperator(Operator):
         assert steps > 0, "Number of steps backwards must be strictly positive."
         # TODO copy or deepcopy? Is this enough for every operator class?
         op = copy.copy(self)
+        # Delete the cached key, so that this must be regenerated for the new operator,
+        # which is different from the original one.
+        op._cached_key = None
 
         # NOTE Use private time step index, because it is always an integer
         # The public time step index is NONE for current time
@@ -1140,6 +1143,9 @@ class IterativeOperator(Operator):
         assert steps > 0, "Number of steps backwards must be strictly positive."
         # See TODO in TimeDependentOperator.previous_timestep
         op = copy.copy(self)
+        # Delete the cached key, so that this must be regenerated for the new operator,
+        # which is different from the original one.
+        op._cached_key = None
         op._iterate_index = self._iterate_index + int(steps)
 
         # keeping track to the very first one
@@ -1428,9 +1434,12 @@ class TimeDependentDenseArray(TimeDependentOperator):
     def _key(self) -> str:
         if self._cached_key is None:
             domain_ids = [domain.id for domain in self.domains]
-            self._cached_key = (
-                f"(time_dependent_dense_array, name={self.name}, domains={domain_ids})"
+            key = (
+                f"(time_dependent_dense_array, name={self.name}, domains={domain_ids} "
+                f"previous_time={self.is_previous_time},"
+                f"time_step_index={self.time_step_index})"
             )
+            self._cached_key = key
         return self._cached_key
 
     def parse(self, mdg: pp.MixedDimensionalGrid) -> np.ndarray:

--- a/src/porepy/numerics/ad/operators.py
+++ b/src/porepy/numerics/ad/operators.py
@@ -883,6 +883,11 @@ class Operator:
     def __hash__(self):
         return hash(self._key())
 
+    def __eq__(self, other):
+        if not isinstance(other, Operator):
+            return False
+        return self._key() == other._key()
+
     def _key(self) -> str:
         """String representation for hashing.
 

--- a/tests/numerics/ad/test_operators.py
+++ b/tests/numerics/ad/test_operators.py
@@ -93,7 +93,7 @@ def test_copy_operator_tree():
     assert c.operation == c_deepcopy.operation
 
     # The operator version of scalars and dense arrays calculates the hash based on the
-    # value of the underlying object, henc ethe comparison operator for pp.ad.Operator
+    # value of the underlying object, hence the comparison operator for pp.ad.Operator
     # should evaluate for True for both the copy and the deepcopy. The id of the
     # underlying object should be the same for the copy, but different for the deepcopy.
     for c1, c2 in zip(c.children, c_copy.children):

--- a/tests/numerics/ad/test_operators.py
+++ b/tests/numerics/ad/test_operators.py
@@ -59,8 +59,11 @@ def test_elementary_operations(operator):
     # Check that the combined operator has the expected structure.
     assert c.operation == operator[1]
 
-    assert c.children[0] == a
-    assert c.children[1] == b
+    # Need to check the id of the objects since the equality of pp.ad.Operator (or
+    # rather the _key method which is called by eq) does not allow for generic void
+    # operators like a and b.
+    assert id(c.children[0]) == id(a)
+    assert id(c.children[1]) == id(b)
 
 
 def test_copy_operator_tree():
@@ -89,17 +92,16 @@ def test_copy_operator_tree():
     assert c.operation == c_copy.operation
     assert c.operation == c_deepcopy.operation
 
-    # The deep copy should have made a new list of children.
-    # The shallow copy should have the same list.
-    assert c.children == c_copy.children
-    assert not c.children == c_deepcopy.children
-
-    # Check that the shallow copy also has the same children, while
-    # the deep copy has copied these as well.
+    # The operator version of scalars and dense arrays calculates the hash based on the
+    # value of the underlying object, henc ethe comparison operator for pp.ad.Operator
+    # should evaluate for True for both the copy and the deepcopy. The id of the
+    # underlying object should be the same for the copy, but different for the deepcopy.
     for c1, c2 in zip(c.children, c_copy.children):
         assert c1 == c2
+        assert id(c1) == id(c2)
     for c1, c2 in zip(c.children, c_deepcopy.children):
-        assert not c1 == c2
+        assert c1 == c2
+        assert id(c1) != id(c2)
 
     # As a second test, also validate that the operators are parsed correctly.
     # This should not be strictly necessary - the above test should be sufficient,


### PR DESCRIPTION
## Proposed changes
Make the equality method of an Ad operator use its _key method for comparison, as this gives a more meaningful comparison than does the standard behavior.

The change is motivated by work on #1497.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
