### PR TITLE
BUG: Return from Gmsh.get_boundary should not be oriented

### DIFF
--- a/src/porepy/fracs/fracture_network.py
+++ b/src/porepy/fracs/fracture_network.py
@@ -349,14 +349,16 @@ class FractureNetwork(ABC):
         # having been split into multiple parts.
         domain_entities = gmsh.model.get_entities(self.nd)
         boundary_entities = gmsh.model.get_boundary(
-            [(self.nd, tag) for _, tag in domain_entities]
+            [(self.nd, tag) for _, tag in domain_entities], oriented=False
         )
         # Get hold of the boundary points of the entity to check.
         if target_dim == 0:
             boundary_points = [(target_dim, i) for i in ind]
         else:
             assert len(ind) == 1, "Only single entity indices are supported."
-            boundary_points = gmsh.model.get_boundary([(target_dim, ind[0])])
+            boundary_points = gmsh.model.get_boundary(
+                [(target_dim, ind[0])], oriented=False
+            )
 
         # For each boundary surface of the domain, compute the distance between the
         # entity and all boundary points to check if they are all zero.
@@ -405,7 +407,7 @@ class FractureNetwork(ABC):
         ### Get hold of entities representing fractures and boundaries.
         domain_entities = gmsh.model.get_entities(self.nd)
         boundaries = gmsh.model.get_boundary(
-            [(self.nd, tag) for _, tag in domain_entities]
+            [(self.nd, tag) for _, tag in domain_entities], oriented=False
         )
         fractures = [
             f for f in gmsh.model.get_entities(self.nd - 1) if f not in boundaries
@@ -433,7 +435,9 @@ class FractureNetwork(ABC):
         # Take note of the boundary points of all entities, to avoid inserting points
         # there (doing so may confuse Gmsh).
         for ent in entities:
-            bp = gmsh.model.get_boundary([(self.nd - 1, ent)], recursive=True)
+            bp = gmsh.model.get_boundary(
+                [(self.nd - 1, ent)], recursive=True, oriented=False
+            )
             for b in bp:
                 if b[0] != 0:
                     continue

--- a/src/porepy/fracs/fracture_network_2d.py
+++ b/src/porepy/fracs/fracture_network_2d.py
@@ -384,7 +384,10 @@ class FractureNetwork2d(FractureNetwork):
             boundary_tags = []
         else:
             boundary_tags = [
-                t for _, t in gmsh.model.get_boundary([(self.nd, domain_tag)])
+                t
+                for _, t in gmsh.model.get_boundary(
+                    [(self.nd, domain_tag)], oriented=False
+                )
             ]
 
         # Mapping from the new fracture tags (gmsh assigned) to the input fractures.
@@ -441,7 +444,7 @@ class FractureNetwork2d(FractureNetwork):
                     updated_mesh_size_points[segment[1]] = mesh_size_points[
                         old_gmsh_tag
                     ]
-                pt_index = gmsh.model.get_boundary([segment])
+                pt_index = gmsh.model.get_boundary([segment], oriented=False)
 
                 if fi not in constraints:
                     # If this is not a constraint, collect the boundary points for
@@ -507,7 +510,7 @@ class FractureNetwork2d(FractureNetwork):
         ### Get hold of lines representing fractures and boundaries.
         domain_entities = gmsh.model.get_entities(2)
         boundaries = gmsh.model.get_boundary(
-            [(self.nd, tag) for _, tag in domain_entities]
+            [(self.nd, tag) for _, tag in domain_entities], oriented=False
         )
 
         line_tags = set(tag for _, tag in gmsh.model.getEntities(self.nd - 1))
@@ -540,7 +543,9 @@ class FractureNetwork2d(FractureNetwork):
             end_points = np.array(
                 [
                     gmsh.model.occ.get_bounding_box(0, p[1])[:3]
-                    for p in gmsh.model.get_boundary([(1, line)], combined=False)
+                    for p in gmsh.model.get_boundary(
+                        [(1, line)], combined=False, oriented=False
+                    )
                 ]
             ).T
             length = np.linalg.norm(end_points[:, 1] - end_points[:, 0])

--- a/src/porepy/fracs/fracture_network_3d.py
+++ b/src/porepy/fracs/fracture_network_3d.py
@@ -419,10 +419,10 @@ class FractureNetwork3d(FractureNetwork):
             num_orig_subfrac.append(len(frac))
 
             for sfi, sub_frac in enumerate(frac):
-                bounding_lines = gmsh.model.get_boundary([sub_frac])
+                bounding_lines = gmsh.model.get_boundary([sub_frac], oriented=False)
                 bounding_points = []
                 for line in bounding_lines:
-                    bounding_points += gmsh.model.get_boundary([line])
+                    bounding_points += gmsh.model.get_boundary([line], oriented=False)
 
                 if len(bounding_points) == 0:
                     # This is most likely a disc fracture, which has no bounding
@@ -636,7 +636,7 @@ class FractureNetwork3d(FractureNetwork):
                 # At most one of the parents was not a constraint. This line should not
                 # produce a point.
                 continue
-            for bp in gmsh.model.get_boundary([(1, line)]):
+            for bp in gmsh.model.get_boundary([(1, line)], oriented=False):
                 points_of_intersection_lines.append(bp[1])
 
         num_point_occ = np.bincount(points_of_intersection_lines)
@@ -736,7 +736,9 @@ class FractureNetwork3d(FractureNetwork):
         ### Get hold of lines representing fractures and boundaries.
         domain_entities = gmsh.model.get_entities(nd)
         # Get the boundaries.
-        boundaries = gmsh.model.get_boundary([(nd, tag) for _, tag in domain_entities])
+        boundaries = gmsh.model.get_boundary(
+            [(nd, tag) for _, tag in domain_entities], oriented=False
+        )
 
         surface_tags = set(tag for _, tag in gmsh.model.get_entities(nd - 1))
         boundary_tags = set(tag for _, tag in boundaries)


### PR DESCRIPTION
Introduced that change throughout the codebase, just to be sure.

Resolves 1639

## Proposed changes

Contributions to PorePy are highly appreciated. Clearly explain why this pull request (PR) is needed and why it should be accepted. If this PR solves an issue, explain how it is done. Please, also summarise the changes to the code.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
