### PR TITLE
Simplify WellBoundaryConditions.well_protocols

### DIFF
--- a/src/porepy/examples/geothermal_reservoir.py
+++ b/src/porepy/examples/geothermal_reservoir.py
@@ -81,7 +81,6 @@ class WellBoundaryConditions(pp.PorePyModel):
         if self.is_well_grid(sd):
             well = self.well_network.wells[sd.tags["parent_well_index"]]
             well_tag = well.tags["well_name"]
-            protocol = self.well_protocols()[well_tag]
             # Find indices of the well boundary sides.
             domain_sides = self.domain_boundary_sides(bg)
             # The top of the domain is '.top' in 3d, '.north' in 2d.
@@ -89,7 +88,7 @@ class WellBoundaryConditions(pp.PorePyModel):
             # Set pressure values according to the well protocol.
             values[inds] = self.units.convert_units(
                 self.get_well_value(
-                    protocol["pressures"],
+                    self.well_protocols(well_tag, "pressures"),
                     self.time_manager.schedule,
                     self.time_manager.time,
                 ),
@@ -109,16 +108,14 @@ class WellBoundaryConditions(pp.PorePyModel):
         sd = bg.parent
         values = super().bc_values_temperature(bg)  # type: ignore[misc]
         if self.is_well_grid(sd):
-            # Retrieve well protocol.
             well_tag = self.well_names[sd.tags["parent_well_index"]]
-            protocol = self.well_protocols()[well_tag]
             # Find indices of the well boundary sides.
             domain_sides = self.domain_boundary_sides(bg)
             inds = domain_sides.top if self.nd == 3 else domain_sides.north
             # Set temperature values according to the well protocol.
             values[inds] = self.units.convert_units(
                 self.get_well_value(
-                    protocol["temperatures"],
+                    self.well_protocols(well_tag, "temperatures"),
                     self.time_manager.schedule,
                     self.time_manager.time,
                 ),
@@ -153,45 +150,31 @@ class WellBoundaryConditions(pp.PorePyModel):
         else:
             return float(np.interp(current_time, times, values))
 
-    def well_protocols(self) -> dict[str, dict[str, NDArray[np.float64]]]:
-        """Dictionary mapping well tags to well protocols.
+    def well_protocols(self, well_tag: str, variable: str) -> NDArray[np.float64]:
+        """Return the time-dependent protocol array for a given well and variable.
+
+        The value is read from ``self.params`` under the key ``"{well_tag}_{variable}"``.
+        A scalar is broadcast to all schedule times; an array must match schedule length.
+
+        Parameters:
+            well_tag: Name of the well (e.g. ``"injection_well"``).
+            variable: Protocol variable name (e.g. ``"pressures"``, ``"temperatures"``,
+                ``"mass_rates"``).
 
         Returns:
-            Dictionary with well protocols, each containing a dictionary with
-            time-dependent temperatures and pressures, with each value being an array of
-            size equal to the number of scheduled times in the time manager.
+            Array of protocol values, one entry per scheduled time point.
         """
         num_times = self.time_manager.schedule.size
-        protocols: dict[str, dict[str, NDArray[np.float64]]] = {}
-        # Construct protocols for each well.
-        for well_tag in self.well_names:
-            # Initialize protocol dictionary for the well.
-            protocols[well_tag] = {}
-            # Set values for temperatures and pressures.
-            for variable in ["temperatures", "pressures"]:
-                input_values = self.params.get(f"{well_tag}_{variable}", 0.0)
-                if isinstance(input_values, (float, int)):
-                    # Broadcast single value to all time steps for convenient user
-                    # definition of well protocols.
-                    values = np.full(num_times, input_values, dtype=float)
-
-                elif isinstance(input_values, (list, np.ndarray)):
-                    # Enforce array of float values.
-                    values = np.array(input_values, dtype=float)
-                    if values.size != num_times:
-                        raise ValueError(
-                            f"Well protocol for {well_tag} {variable} has size "
-                            f"{values.size}, expected {num_times}."
-                        )
-                else:
-                    raise TypeError(
-                        f"Well protocol for {well_tag} {variable} has unsupported "
-                        f"type {type(input_values)}."
-                    )
-                # Populate well dictionary for the current variable.
-                protocols[well_tag][variable] = values
-
-        return protocols
+        raw = self.params.get(f"{well_tag}_{variable}", 0.0)
+        if isinstance(raw, (int, float)):
+            return np.full(num_times, float(raw))
+        values = np.asarray(raw, dtype=float)
+        if values.size != num_times:
+            raise ValueError(
+                f"Protocol '{well_tag}_{variable}' has {values.size} entries, "
+                f"expected {num_times} (one per schedule point)."
+            )
+        return values
 
 
 class NeumannWellBCsFirstTimeInterval(pp.PorePyModel):

--- a/src/porepy/examples/geothermal_reservoir.py
+++ b/src/porepy/examples/geothermal_reservoir.py
@@ -153,8 +153,9 @@ class WellBoundaryConditions(pp.PorePyModel):
     def well_protocols(self, well_tag: str, variable: str) -> NDArray[np.float64]:
         """Return the time-dependent protocol array for a given well and variable.
 
-        The value is read from ``self.params`` under the key ``"{well_tag}_{variable}"``.
-        A scalar is broadcast to all schedule times; an array must match schedule length.
+        The value is read from ``self.params`` under the key
+        ``"{well_tag}_{variable}"``. A scalar is broadcast to all schedule times; an
+        array must match schedule length.
 
         Parameters:
             well_tag: Name of the well (e.g. ``"injection_well"``).


### PR DESCRIPTION
## Proposed changes

Changes well_protocols() from returning a [dict[str, dict[str, ndarray]]](http://vscodecontentref/3) to well_protocols(well_tag, variable) -> ndarray. This removes the hardcoded iteration over ["temperatures", "pressures"] and allows any variable (e.g. "mass_rates" for flux-controlled wells) to be retrieved without modifying the method. Call sites in bc_values_pressure and bc_values_temperature are updated accordingly.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
