### PR TITLE
Fix bug in differentiable Tpfa with mpfa as base discretization

### DIFF
--- a/src/porepy/models/constitutive_laws.py
+++ b/src/porepy/models/constitutive_laws.py
@@ -1346,6 +1346,15 @@ class AdTpfaFlux(pp.PorePyModel):
         ) @ potential(domains)
         vector_source_difference = vector_source_c_to_f @ vector_source_cells
 
+        # Get boundary condition values and compose a boundary value operator that also
+        # includes the interface fluxes.
+        boundary_value_operator = boundary_operator(domains)
+        boundary_value = (
+            boundary_value_operator
+            + intf_projection.mortar_to_primary_int()
+            @ getattr(self, "interface_" + flux_name)(interfaces)
+        )
+
         # Fetch the discretization of the Darcy flux
         base_discr = getattr(self, flux_name + "_discretization")(domains)
 
@@ -1364,7 +1373,8 @@ class AdTpfaFlux(pp.PorePyModel):
             # To obtain a mixture of Tpfa and Mpfa, we utilize pp.ad.Function, one for
             # the flux and one for the vector source.
 
-            # Define the Ad function for the flux
+            # Define the Ad function for the flux, including the impact of boundary
+            # conditions internal and external.
             flux_p = pp.ad.Function(
                 # Mypy raises an error here since functool.partial returns a 'partial',
                 # while pp.ad.Function expects a Callable. partial.__call__ is a
@@ -1374,7 +1384,7 @@ class AdTpfaFlux(pp.PorePyModel):
                     self.__mpfa_flux_discretization, base_discr
                 ),
                 "differentiable_mpfa",
-            )(t_f, potential_difference, potential(domains))
+            )(t_f, potential_difference, potential(domains), boundary_value)
 
             # Define the Ad function for the vector source
             vector_source_d = pp.ad.Function(
@@ -1387,7 +1397,7 @@ class AdTpfaFlux(pp.PorePyModel):
         else:
             # The base discretization is Tpfa, so we can rely on the Ad machinery to
             # compose the full expression.
-            flux_p = t_f * potential_difference
+            flux_p = t_f * potential_difference + t_bnd * boundary_value
             vector_source_d = t_f * vector_source_difference
 
         # As the base discretization is only invoked inside a function, and then only by
@@ -1400,22 +1410,10 @@ class AdTpfaFlux(pp.PorePyModel):
         # have to do for now.
         flux_p = flux_p + pp.ad.Scalar(0) * base_discr.flux() @ potential(domains)
 
-        # Get boundary condition values
-        boundary_value_operator = boundary_operator(domains)
-
         # Compose the full discretization of the Darcy flux, which consists of three
         # terms: The flux due to pressure differences, the flux due to boundary
         # conditions, and the flux due to the vector source.
-        flux: pp.ad.Operator = (
-            flux_p
-            + t_bnd
-            * (
-                boundary_value_operator
-                + intf_projection.mortar_to_primary_int()
-                @ getattr(self, "interface_" + flux_name)(interfaces)
-            )
-            + vector_source_d
-        )
+        flux: pp.ad.Operator = flux_p + vector_source_d
         flux.set_name("Differentiable diffusive flux")
         return flux
 
@@ -1604,8 +1602,13 @@ class AdTpfaFlux(pp.PorePyModel):
         return t_f_full, diff_discr, hf_to_f, d_vec
 
     def __mpfa_flux_discretization(
-        self, base_discr: pp.ad.MpfaAd, T_f: ArrayType, p_diff: ArrayType, p: ArrayType
-    ) -> ArrayType:
+        self,
+        base_discr: pp.ad.MpfaAd,
+        T_f: ArrayType,
+        p_diff: ArrayType,
+        p: ArrayType,
+        bv,
+    ) -> tuple[ArrayType, ArrayType]:
         """Approximate the product rule for the expression d(T_MPFA * p), where T_MPFA
         is the transmissibility matrix for an Mpfa discretization.
 
@@ -1634,13 +1637,15 @@ class AdTpfaFlux(pp.PorePyModel):
         # We know that base_discr.flux is a sparse matrix, so we can call parse
         # directly.
         base_flux = base_discr.flux().parse(self.mdg)
+        base_bound_flux = base_discr.bound_flux().parse(self.mdg)
         # If the function has been called using .value, p is a numpy array and we pass
         # only the value.
         if not isinstance(p, pp.ad.AdArray):
-            return base_flux @ p
+            return base_flux @ p + base_bound_flux @ bv
         # Otherwise, at the time of evaluation, p will be an AdArray, thus we can access
         # its val and jac attributes.
-        val = base_flux @ p.val
+        val = base_flux @ p.val + base_bound_flux @ bv.val
+        # No contribution from differentiating the boundary flux, as bv is constant.
         jac = base_flux @ p.jac
 
         if hasattr(T_f, "jac"):
@@ -1648,7 +1653,7 @@ class AdTpfaFlux(pp.PorePyModel):
             # transmissibility matrix times the pressure difference. To see why this is
             # correct, it may be useful to consider the flux over a single face
             # (corresponding to one row in the Jacobian matrix).
-            jac += sps.diags(p_diff.val) @ T_f.jac
+            jac += sps.diags(p_diff.val + bv.val) @ T_f.jac
 
         return pp.ad.AdArray(val, jac)
 

--- a/src/porepy/models/constitutive_laws.py
+++ b/src/porepy/models/constitutive_laws.py
@@ -1384,8 +1384,7 @@ class AdTpfaFlux(pp.PorePyModel):
                     self.__mpfa_flux_discretization, base_discr
                 ),
                 "differentiable_mpfa",
-            )(t_f, potential_difference, potential(domains), boundary_value)
-
+            )(t_f, potential_difference, potential(domains), t_bnd, boundary_value)
             # Define the Ad function for the vector source
             vector_source_d = pp.ad.Function(
                 partial(  # type: ignore[arg-type]
@@ -1607,8 +1606,9 @@ class AdTpfaFlux(pp.PorePyModel):
         T_f: ArrayType,
         p_diff: ArrayType,
         p: ArrayType,
-        bv,
-    ) -> tuple[ArrayType, ArrayType]:
+        T_bnd: ArrayType,
+        bv: ArrayType,
+    ) -> ArrayType:
         """Approximate the product rule for the expression d(T_MPFA * p), where T_MPFA
         is the transmissibility matrix for an Mpfa discretization.
 
@@ -1622,9 +1622,16 @@ class AdTpfaFlux(pp.PorePyModel):
 
         Parameters:
             base_discr: Base discretization of the flux. T_f: Transmissibility matrix.
+            T_f: Tpfa-style transmissibilities on the internal faces, represented as
+                either an AdArray or a numpy array, depending on whether the method is
+                called for Jacbian evaluation or not.
             p_diff: Difference in potential between the two cells on either side of the
                 face.
-            p: Potential.
+            p: Cell potential.
+            T_bnd: Tpfa-style transmissibilities on the boundary faces, represented as
+                either an AdArray or a numpy array.
+            bv: Boundary value, including contributions from both external boundaries
+                and internal boundaries.
 
         Returns:
             AdArray with value and Jacobian matrix representing the flux associated with
@@ -1645,15 +1652,15 @@ class AdTpfaFlux(pp.PorePyModel):
         # Otherwise, at the time of evaluation, p will be an AdArray, thus we can access
         # its val and jac attributes.
         val = base_flux @ p.val + base_bound_flux @ bv.val
-        # No contribution from differentiating the boundary flux, as bv is constant.
         jac = base_flux @ p.jac + base_bound_flux @ bv.jac
 
         if hasattr(T_f, "jac"):
             # Add the contribution to the Jacobian matrix from the derivative of the
-            # transmissibility matrix times the pressure difference. To see why this is
-            # correct, it may be useful to consider the flux over a single face
+            # transmissibility matrix times the pressure difference, and similarly for
+            # boundary face transmissibilities and the boundary values. To see why this
+            # is correct, it may be useful to consider the flux over a single face
             # (corresponding to one row in the Jacobian matrix).
-            jac += sps.diags(p_diff.val + bv.val) @ T_f.jac
+            jac += sps.diags(p_diff.val) @ T_f.jac + sps.diags(bv.val) @ T_bnd.jac
 
         return pp.ad.AdArray(val, jac)
 

--- a/src/porepy/models/constitutive_laws.py
+++ b/src/porepy/models/constitutive_laws.py
@@ -1646,7 +1646,7 @@ class AdTpfaFlux(pp.PorePyModel):
         # its val and jac attributes.
         val = base_flux @ p.val + base_bound_flux @ bv.val
         # No contribution from differentiating the boundary flux, as bv is constant.
-        jac = base_flux @ p.jac
+        jac = base_flux @ p.jac + base_bound_flux @ bv.jac
 
         if hasattr(T_f, "jac"):
             # Add the contribution to the Jacobian matrix from the derivative of the

--- a/tests/numerics/fv/test_tpfa.py
+++ b/tests/numerics/fv/test_tpfa.py
@@ -6,9 +6,11 @@ The tests fall into two categories:
 
 """
 
+from typing import Literal
 import numpy as np
 import pytest
 import scipy.sparse as sps
+from copy import deepcopy
 
 import porepy as pp
 from porepy.applications.discretizations.flux_discretization import FluxDiscretization
@@ -16,6 +18,7 @@ from porepy.applications.md_grids import model_geometries
 from porepy.applications.md_grids.model_geometries import CubeDomainOrthogonalFractures
 from porepy.applications.test_utils import common_xpfa_tests as xpfa_tests
 from porepy.applications.test_utils import well_models
+from porepy.applications.test_utils.models import add_mixin
 
 """Local utility functions."""
 
@@ -693,7 +696,8 @@ def test_diff_tpfa_on_grid_with_all_dimensions(base_discr: str, grid_type: str):
 
 class WithoutDiffTpfa(
     FluxDiscretization,
-    pp.MassAndEnergyBalance,
+    # pp.MassAndEnergyBalance,
+    pp.SinglePhaseFlow,
 ):
     """Helper class to test that the methods for differentiating diffusive fluxes and
     potential reconstructions work on grids of all dimensions.
@@ -766,6 +770,163 @@ def test_diff_tpfa_and_standard_tpfa_give_same_linear_system(base_discr: str):
 
     assert np.allclose(matrix[0].toarray(), matrix[1].toarray())
     assert np.allclose(vector[0], vector[1])
+
+
+class DiffTpfaNewtonPerformanceGeometry(
+    FluxDiscretization,
+    pp.applications.boundary_conditions.model_boundary_conditions.HydrostaticBoundaryPressureValues,
+    pp.SinglePhaseFlow,
+):
+    """Model class to test the performance of Newton's method with and without the
+    differentiable tpfa mixin.
+
+    """
+
+    def set_fractures(self) -> None:
+        """Set the fractures in the domain.
+
+        TODO: This can be done by one of the standard geometry mixins
+        """
+        if self.params["include_fracture"]:
+            # TODO IVAR: Do we want to allow for rotations of the fracture, or should
+            # we just hardcode the geometry without preparing for a parametrized angle?
+            angle = self.params.get("fracture_angle", 2) * np.pi / 180
+            length = self.domain.bounding_box["xmax"] / 3
+            r = self.units.convert_units(length / 2, "m")
+
+            points = np.array(
+                [
+                    [-r * np.cos(angle), -r * np.sin(angle)],
+                    [r * np.cos(angle), r * np.sin(angle)],
+                ]
+            ).T
+            self._fractures = [pp.LineFracture(points)]
+        else:
+            self._fractures = []
+
+    def domain_size(self) -> float:
+        """Return the size of the domain."""
+        return 2
+
+    def set_domain(self) -> None:
+        """Set the cube domain."""
+        sz = self.domain_size() / 2
+        bounding_box = {
+            "xmin": self.units.convert_units(-sz, "m"),
+            "xmax": self.units.convert_units(sz, "m"),
+            "ymin": self.units.convert_units(-sz, "m"),
+            "ymax": self.units.convert_units(sz, "m"),
+        }
+        self._domain = pp.Domain(bounding_box)
+
+    def permeability(self, subdomains: list[pp.Grid]) -> pp.ad.Operator:
+        if self.params["constant_permeability"]:
+            return super().permeability(subdomains)
+        else:
+            f_max = pp.ad.Function(pp.ad.maximum, "maximum_function")
+            permeability = pp.ad.Scalar(self.solid.permeability) * f_max(
+                self.pressure(subdomains), pp.ad.Scalar(1e-5)
+            )
+            return self.isotropic_second_order_tensor(subdomains, permeability)
+
+    def add_nonlinear_darcy_flux_discretization(self) -> None:
+        """Poromechanics rely by default on Darcy flux re-discretization.
+
+        The re-discretization is performed only on subdomains with
+        ``dim < nd`` due to changes in aperture!
+        The default behavior defined here concerns only those domains.
+
+        """
+
+        self.add_nonlinear_diffusive_flux_discretization(
+            self.darcy_flux_discretization(self.mdg.subdomains()).flux(),
+        )
+
+
+# @pytest.mark.skipped  # reason: slow
+@pytest.mark.parametrize("base_scheme", ["tpfa", "mpfa"])
+@pytest.mark.parametrize("gravity", [True, False])
+@pytest.mark.parametrize("include_fracture", [True, False])
+@pytest.mark.parametrize("constant_permeability", [True, False])
+def test_diff_tpfa_newton_performance(
+    base_scheme: Literal["mpfa", "tpfa"],
+    gravity: bool,
+    include_fracture: bool,
+    constant_permeability: bool,
+):
+    """Verify that the solutions computed with and without diff-tpfa are consistent,
+    and that inclusion of the diffenetiable tpfa does not increase the number of
+    Newton iteration.
+
+    Parameters:
+        base_scheme: Spatial discretization scheme for diffusive equations.
+        gravity: Whether to include gravity.
+        include_fracture: If True, a single fracture will be included in the domain.
+        constant_permeability: If False, a non-linearity will be included in the
+            permeability tensor.
+
+    """
+    model_params = {
+        "time_manager": pp.TimeManager(
+            schedule=[0, pp.DAY],
+            dt_init=pp.DAY,
+            constant_dt=True,
+        ),
+        "include_fracture": include_fracture,
+        "meshing_arguments": {"cell_size": 0.3},
+        "darcy_flux_discretization": base_scheme,
+        "grid_type": "simplex",
+        "constant_permeability": constant_permeability,
+    }
+
+    # Solver parameters. TODO IVAR: We need to check that these values do what we
+    # actually want.
+    solver_params = {
+        "nl_convergence_inc_atol": 1e-6,
+        "nl_convergence_res_atol": np.inf,
+        "nl_max_iterations": 25,
+    }
+
+    models = []
+    num_iters = []
+    pressures = []
+
+    if include_fracture:
+        interface_darcy_fluxes = []
+
+    # Solve problem with and without differentiable tpfa, gather statistics.
+    for differentiable in [True, False]:
+        model_class = DiffTpfaNewtonPerformanceGeometry
+        if gravity:
+            model_class = add_mixin(pp.constitutive_laws.GravityForce, model_class)
+        if differentiable:
+            model_class = add_mixin(pp.constitutive_laws.DarcysLawAd, model_class)
+
+        m = model_class(deepcopy(model_params))
+        pp.run_time_dependent_model(m, solver_params)
+        num_iters.append(m.nonlinear_solver_statistics.num_iterations)
+
+        sds = m.mdg.subdomains()
+        intfs = m.mdg.interfaces()
+
+        equation_system = m.equation_system
+        pressures.append(equation_system.evaluate(m.pressure(sds)))
+
+        if include_fracture:
+            interface_darcy_fluxes.append(
+                equation_system.evaluate(m.interface_darcy_flux(intfs))
+            )
+
+    if constant_permeability:
+        assert num_iters[0] == num_iters[1]
+    else:
+        # TODO IVAR: Achiving strict inequality may require some tuning of the permeability
+        # tensor, and I am a bit afraid such a criterion will be sensitive to changes
+        # in a broad sonse to the model and numerics. What do you think?
+        assert num_iters[0] < num_iters[1]
+    assert np.allclose(pressures[0], pressures[1])
+    if include_fracture:
+        assert np.allclose(interface_darcy_fluxes[0], interface_darcy_fluxes[1])
 
 
 class DiffTpfaFractureTipsInternalBoundaries(

--- a/tests/numerics/fv/test_tpfa.py
+++ b/tests/numerics/fv/test_tpfa.py
@@ -845,7 +845,7 @@ def test_diff_tpfa_newton_performance(
 ):
     """Verify that the solutions computed with and without diff-tpfa are consistent,
     and that inclusion of the diffenetiable tpfa does not increase the number of
-    Newton iteration.
+    Newton iterations.
 
     Parameters:
         base_scheme: Spatial discretization scheme for diffusive equations.

--- a/tests/numerics/fv/test_tpfa.py
+++ b/tests/numerics/fv/test_tpfa.py
@@ -966,12 +966,13 @@ class DiffTpfaFractureTipsInternalBoundaries(
             "cell_size": 1.0 * ls,
             "cell_size_fracture": 1.0 * ls,
             "cell_size_boundary": 1.0 * ls,
+            "refinement_proximity_multiplier": 1e-6,
+            "refinement_size_multiplier": 1.0,
         }
         return mesh_sizes
 
 
-@pytest.mark.parametrize("base_discr", ["tpfa", "mpfa"])
-def test_flux_potential_trace_on_tips_and_internal_boundaries(base_discr: str):
+def test_flux_potential_trace_on_tips_and_internal_boundaries():
     """Test that the flux and potential trace can be computed on fracture tips and
     internal boundaries.
 
@@ -982,11 +983,25 @@ def test_flux_potential_trace_on_tips_and_internal_boundaries(base_discr: str):
     assigned a Neumann boundary condition). On tips we also test that the potential
     trace is equal to the pressure in the adjacent cell.
 
+    Note for posterity: The test is only performed with Tpfa as a base discretization,
+    since the tested properties will not hold for Mpfa in general. Specifically:
+    - The flux expression for a Neumann face will depend on the pressures (and
+      permeabilties) in multiple nearby cells, and hence pick up non-zero terms in the
+      Jacobian matrix. The only constraint Mpfa puts on these dependencies is that, for
+      a solution computed with Mpfa, the flux contributions from these cells will cancel
+      out, but save from this, they can be non-zero (and so can the derivatives of the
+      permability). This is in contrast with the tpfa discretization, where a single
+      interior cell contributes to the flux over the Neumann face, hence this must be
+      zero for the flux to be dependent on the given boundary condition only.
+    - The potential trace on a tip or internal boundary will in general depend on the
+      pressures in multiple nearby cells, and hence not be equal to the pressure in the
+      adjacent cell.
+
     """
     model = DiffTpfaFractureTipsInternalBoundaries(
         {
-            "darcy_flux_discretization": base_discr,
-            "fourier_flux_discretization": base_discr,
+            "darcy_flux_discretization": "tpfa",
+            "fourier_flux_discretization": "tpfa",
             "times_to_export": [],
         }
     )
@@ -1004,55 +1019,49 @@ def test_flux_potential_trace_on_tips_and_internal_boundaries(base_discr: str):
             model.darcy_flux([sd]), derivative=True
         )
         assert np.allclose(darcy_flux.jac[bc_darcy.is_neu].data, 0)
-
         bc_fourier = data[pp.PARAMETERS][model.fourier_keyword]["bc"]
         fourier_flux = model.equation_system.evaluate(
             model.fourier_flux([sd]), derivative=True
         )
         assert np.allclose(fourier_flux.jac[bc_fourier.is_neu].data, 0)
 
-        if base_discr == "tpfa":
-            # On immersed fracture tips, we know that the flux is zero (homogeneous
-            # Neumann condition). For TPFA, we can thus verify that the reconstructed
-            # potential trace is equal to the pressure in the adjacent cell, since this
-            # is the only way to get zero flux with that scheme. We cannot do a similar
-            # test for MPFA, since the potential trace reconstruction involves other
-            # cells and boundary conditions on other faces - meaning that the potential
-            # trace on the tip face is not necessarily equal to the pressure in the
-            # adjacent cell.
+        # On immersed fracture tips, we know that the flux is zero (homogeneous Neumann
+        # condition). For TPFA, we can thus verify that the reconstructed potential
+        # trace is equal to the pressure in the adjacent cell, since this is the only
+        # way to get zero flux with that scheme.
 
-            # Get the indices of the fracture tip faces and that of the adjacent cell.
-            tip_faces = np.where(
-                np.logical_and(
-                    sd.tags["tip_faces"],
-                    np.logical_not(sd.tags["domain_boundary_faces"]),
-                )
-            )[0]
-            _, tip_cells = sd.signs_and_cells_of_boundary_faces(tip_faces)
+        # Get the indices of the fracture tip faces and that of the adjacent cell.
+        tip_faces = np.where(
+            np.logical_and(
+                sd.tags["tip_faces"],
+                np.logical_not(sd.tags["domain_boundary_faces"]),
+            )
+        )[0]
+        _, tip_cells = sd.signs_and_cells_of_boundary_faces(tip_faces)
 
-            # Check that the pressure trace is equal to the pressure in the adjacent
-            # cell.
-            pressure_trace = model.equation_system.evaluate(
-                model.potential_trace(
-                    [sd],
-                    model.pressure,
-                    model.permeability,
-                    model.combine_boundary_operators_darcy_flux,
-                    "darcy_flux",
-                )
+        # Check that the pressure trace is equal to the pressure in the adjacent
+        # cell.
+        pressure_trace = model.equation_system.evaluate(
+            model.potential_trace(
+                [sd],
+                model.pressure,
+                model.permeability,
+                model.combine_boundary_operators_darcy_flux,
+                "darcy_flux",
             )
-            p = model.equation_system.evaluate(model.pressure([sd]))
-            assert np.allclose(pressure_trace[tip_faces], p[tip_cells])
-            # Check that the temperature trace is equal to the temperature in the
-            # adjacent cell.
-            temperature_trace = model.equation_system.evaluate(
-                model.potential_trace(
-                    [sd],
-                    model.temperature,
-                    model.thermal_conductivity,
-                    model.combine_boundary_operators_fourier_flux,
-                    "fourier_flux",
-                )
+        )
+        p = model.equation_system.evaluate(model.pressure([sd]))
+        assert np.allclose(pressure_trace[tip_faces], p[tip_cells])
+        # Check that the temperature trace is equal to the temperature in the
+        # adjacent cell.
+        temperature_trace = model.equation_system.evaluate(
+            model.potential_trace(
+                [sd],
+                model.temperature,
+                model.thermal_conductivity,
+                model.combine_boundary_operators_fourier_flux,
+                "fourier_flux",
             )
-            T = model.equation_system.evaluate(model.temperature([sd]))
-            assert np.allclose(temperature_trace[tip_faces], T[tip_cells])
+        )
+        T = model.equation_system.evaluate(model.temperature([sd]))
+        assert np.allclose(temperature_trace[tip_faces], T[tip_cells])

--- a/tests/numerics/fv/test_tpfa.py
+++ b/tests/numerics/fv/test_tpfa.py
@@ -6,11 +6,12 @@ The tests fall into two categories:
 
 """
 
+from copy import deepcopy
 from typing import Literal
+
 import numpy as np
 import pytest
 import scipy.sparse as sps
-from copy import deepcopy
 
 import porepy as pp
 from porepy.applications.discretizations.flux_discretization import FluxDiscretization

--- a/tests/numerics/fv/test_tpfa.py
+++ b/tests/numerics/fv/test_tpfa.py
@@ -783,23 +783,12 @@ class DiffTpfaNewtonPerformanceGeometry(
     """
 
     def set_fractures(self) -> None:
-        """Set the fractures in the domain.
-
-        TODO: This can be done by one of the standard geometry mixins
-        """
+        """Set the fractures in the domain."""
         if self.params["include_fracture"]:
-            # TODO IVAR: Do we want to allow for rotations of the fracture, or should
-            # we just hardcode the geometry without preparing for a parametrized angle?
-            angle = self.params.get("fracture_angle", 2) * np.pi / 180
             length = self.domain.bounding_box["xmax"] / 3
             r = self.units.convert_units(length / 2, "m")
 
-            points = np.array(
-                [
-                    [-r * np.cos(angle), -r * np.sin(angle)],
-                    [r * np.cos(angle), r * np.sin(angle)],
-                ]
-            ).T
+            points = np.array([[-r, 0], [r, 0]]).T
             self._fractures = [pp.LineFracture(points)]
         else:
             self._fractures = []
@@ -878,9 +867,6 @@ def test_diff_tpfa_newton_performance(
         "grid_type": "simplex",
         "constant_permeability": constant_permeability,
     }
-
-    # Solver parameters. TODO IVAR: We need to check that these values do what we
-    # actually want.
     solver_params = {
         "nl_convergence_inc_atol": 1e-6,
         "nl_convergence_res_atol": np.inf,
@@ -920,10 +906,7 @@ def test_diff_tpfa_newton_performance(
     if constant_permeability:
         assert num_iters[0] == num_iters[1]
     else:
-        # TODO IVAR: Achiving strict inequality may require some tuning of the permeability
-        # tensor, and I am a bit afraid such a criterion will be sensitive to changes
-        # in a broad sonse to the model and numerics. What do you think?
-        assert num_iters[0] < num_iters[1]
+        assert num_iters[0] <= num_iters[1]
     assert np.allclose(pressures[0], pressures[1])
     if include_fracture:
         assert np.allclose(interface_darcy_fluxes[0], interface_darcy_fluxes[1])


### PR DESCRIPTION
## Proposed changes
This PR fixes two minor bugs related to the differentiable two-point flux approximation. In both cases, terms related to the discretization of boundary conditions were missing, with the scheme using mpfa as base discretization was mainly suffering.

The bugfix revealed a mistaken assumption in a test related to the sparsity of Jacobian matrices on faces with Neumann boundary conditions. The tested condition is only true when using tpfa as a base discretization, though the bug had made the test pass also for mpfa. The test now only runs for tpfa.

Also added is a test that verifies that the number of Newton iterations with the differentiable scheme is not larger than the number with standard discretizations. In practice, the number of iterations is the same for most if not all of the test parametrizations. I made some attempts at finding a permeability function that gave a strict improvement with the differentiable scheme, but did not succeed. This does not imply that such a function does not exist though, so I am open for a discussion on whether to try once more. _Please consider this question in particular in the review._

Resolves #1556.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
