### PR TITLE
1602 introduce tests for logging and progressbars

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,8 @@ development = [
 testing = [
     "pytest",
     "pytest-cov",
-    "pytest-runner"
+    "pytest-runner",
+    "tqdm"
 ]
 
 # Information for the build system.

--- a/src/porepy/models/model_runner.py
+++ b/src/porepy/models/model_runner.py
@@ -10,10 +10,11 @@ import numpy as np
 
 import porepy as pp
 from porepy.numerics.nonlinear.convergence_check import SimulationStatus
-from porepy.utils.ui_and_logging import DummyProgressBar, progressbar_class
+from porepy.utils.ui_and_logging import DummyProgressBar
 from porepy.utils.ui_and_logging import (
     logging_redirect_tqdm_with_level as logging_redirect_tqdm,
 )
+from porepy.utils.ui_and_logging import progressbar_class
 
 __all__ = ["ModelRunner"]
 

--- a/src/porepy/models/model_runner.py
+++ b/src/porepy/models/model_runner.py
@@ -10,11 +10,10 @@ import numpy as np
 
 import porepy as pp
 from porepy.numerics.nonlinear.convergence_check import SimulationStatus
-from porepy.utils.ui_and_logging import DummyProgressBar
+from porepy.utils.ui_and_logging import DummyProgressBar, progressbar_class
 from porepy.utils.ui_and_logging import (
     logging_redirect_tqdm_with_level as logging_redirect_tqdm,
 )
-from porepy.utils.ui_and_logging import progressbar_class
 
 __all__ = ["ModelRunner"]
 
@@ -204,7 +203,7 @@ class ModelRunner:
             # NOTE: If tqdm is not installed, this returns a DummyProgressBar instance.
             self.time_progressbar = progressbar_class(
                 range(expected_time_steps),
-                desc="time loop",
+                desc="Time loop",
                 position=0,
                 dynamic_ncols=True,
             )
@@ -254,8 +253,8 @@ class ModelRunner:
             + f" of {self.model.time_manager.time_final:.1e}"
             + f" with time step {self.model.time_manager.dt:.1e}"
         )
-        self.time_progressbar.set_description_str(
-            f"Time step {self.model.time_manager.time_index}"
+        self.time_progressbar.set_postfix_str(
+            f"Time step size {self.model.time_manager.dt:.2e}"
         )
 
     def after_time_step(self, solver_status: SimulationStatus) -> SimulationStatus:

--- a/src/porepy/models/run_models.py
+++ b/src/porepy/models/run_models.py
@@ -17,10 +17,11 @@ import numpy as np
 
 import porepy as pp
 from porepy.models.model_runner import ModelRunner
-from porepy.utils.ui_and_logging import DummyProgressBar, progressbar_class
+from porepy.utils.ui_and_logging import DummyProgressBar
 from porepy.utils.ui_and_logging import (
     logging_redirect_tqdm_with_level as logging_redirect_tqdm,
 )
+from porepy.utils.ui_and_logging import progressbar_class
 
 # Module-wide logger
 logger = logging.getLogger(__name__)

--- a/src/porepy/models/run_models.py
+++ b/src/porepy/models/run_models.py
@@ -17,11 +17,10 @@ import numpy as np
 
 import porepy as pp
 from porepy.models.model_runner import ModelRunner
-from porepy.utils.ui_and_logging import DummyProgressBar
+from porepy.utils.ui_and_logging import DummyProgressBar, progressbar_class
 from porepy.utils.ui_and_logging import (
     logging_redirect_tqdm_with_level as logging_redirect_tqdm,
 )
-from porepy.utils.ui_and_logging import progressbar_class
 
 # Module-wide logger
 logger = logging.getLogger(__name__)
@@ -173,7 +172,7 @@ def _run_iterative_model(model, params: dict) -> None:
             )
             time_progressbar = progressbar_class(
                 range(expected_time_steps),
-                desc="time loop",
+                desc="Time loop",
                 position=0,
                 dynamic_ncols=True,
             )
@@ -183,8 +182,8 @@ def _run_iterative_model(model, params: dict) -> None:
 
         # Time loop.
         while not model.time_manager.final_time_reached():
-            time_progressbar.set_description_str(
-                f"Time step {model.time_manager.time_index + 1}"
+            time_progressbar.set_postfix_str(
+                f"Time step size {model.time_manager.dt:.2e}"
             )
             time_step()
             # Update progressbar length. Currently, there is no convergence check

--- a/src/porepy/numerics/nonlinear/nonlinear_solvers.py
+++ b/src/porepy/numerics/nonlinear/nonlinear_solvers.py
@@ -19,11 +19,10 @@ from porepy.numerics.nonlinear.convergence_check import (
     DivergenceCriteria,
     SimulationStatus,
 )
-from porepy.utils.ui_and_logging import DummyProgressBar
+from porepy.utils.ui_and_logging import DummyProgressBar, progressbar_class
 from porepy.utils.ui_and_logging import (
     logging_redirect_tqdm_with_level as logging_redirect_tqdm,
 )
-from porepy.utils.ui_and_logging import progressbar_class
 
 # Module-wide logger
 logger = logging.getLogger(__name__)
@@ -64,7 +63,6 @@ class NewtonSolver:
 
         self.init_convergence_criteria()
         self.init_divergence_criteria()
-        self.init_solver_progressbar()
 
     def init_convergence_criteria(self) -> None:
         """Parse and initialize convergence criteria.
@@ -271,6 +269,9 @@ class NewtonSolver:
         # Prepare solver for nonlinear loop.
         self.iteration_index = 0
         self.convergence_criteria.reset()
+
+        # Reset solver progressbar.
+        self.init_solver_progressbar()
 
     def nonlinear_loop(
         self, model: SolutionStrategy
@@ -510,9 +511,10 @@ class NewtonSolver:
         # Update progress bar.
         self.solver_progressbar.update(n=1)
         self.solver_progressbar.set_postfix_str(
-            f"""Increment {nonlinear_increment_norm:.2e} """
-            f"""Residual {residual_norm:.2e}"""
+            f"Increment {nonlinear_increment_norm:.2e} Residual {residual_norm:.2e} t_i {model.time_manager.time_index}"
         )
+        if model.time_manager.time_index >= 2:
+            pass
 
     def update_solver_statistics(
         self,

--- a/src/porepy/numerics/nonlinear/nonlinear_solvers.py
+++ b/src/porepy/numerics/nonlinear/nonlinear_solvers.py
@@ -511,10 +511,8 @@ class NewtonSolver:
         # Update progress bar.
         self.solver_progressbar.update(n=1)
         self.solver_progressbar.set_postfix_str(
-            f"Increment {nonlinear_increment_norm:.2e} Residual {residual_norm:.2e} t_i {model.time_manager.time_index}"
+            f"Increment {nonlinear_increment_norm:.2e} Residual {residual_norm:.2e}"
         )
-        if model.time_manager.time_index >= 2:
-            pass
 
     def update_solver_statistics(
         self,

--- a/src/porepy/numerics/nonlinear/nonlinear_solvers.py
+++ b/src/porepy/numerics/nonlinear/nonlinear_solvers.py
@@ -19,10 +19,11 @@ from porepy.numerics.nonlinear.convergence_check import (
     DivergenceCriteria,
     SimulationStatus,
 )
-from porepy.utils.ui_and_logging import DummyProgressBar, progressbar_class
+from porepy.utils.ui_and_logging import DummyProgressBar
 from porepy.utils.ui_and_logging import (
     logging_redirect_tqdm_with_level as logging_redirect_tqdm,
 )
+from porepy.utils.ui_and_logging import progressbar_class
 
 # Module-wide logger
 logger = logging.getLogger(__name__)

--- a/tests/numerics/nonlinear/test_nonlinear_solvers.py
+++ b/tests/numerics/nonlinear/test_nonlinear_solvers.py
@@ -16,6 +16,7 @@ from porepy.numerics.nonlinear.convergence_check import (
     ConvergenceStatusCollection,
     SimulationStatus,
 )
+from porepy.utils.ui_and_logging import DummyProgressBar
 
 # ! ---- Auxiliary fixtures and classes ---- ! #
 
@@ -917,6 +918,10 @@ def test_after_nonlinear_loop(
     model = MockModel()
     solver = default_newton_solver
 
+    # Mock the solver progressbar. Usually it is initialized in
+    # NewtonSolver.before_nonlinear_loop, which is never called in this test.
+    solver.solver_progressbar = DummyProgressBar()
+
     # Minimal mimicking of loop.
     model.nonlinear_solver_statistics.simulation_status_history = [
         SimulationStatus.SUCCESSFUL
@@ -935,6 +940,10 @@ def test_before_nonlinear_iteration(default_newton_solver):
     # Init model and solver.
     model = MockModel(nonlinear_increment_history=[2.0], residual_history=[1.0])
     solver = default_newton_solver
+
+    # Mock the solver progressbar. Usually it is initialized in
+    # NewtonSolver.before_nonlinear_loop, which is never called in this test.
+    solver.solver_progressbar = DummyProgressBar()
 
     # Check initial iteration index.
     assert solver.iteration_index == 0
@@ -968,6 +977,10 @@ def test_after_nonlinear_iteration(
     # Init model and solver.
     model = MockModel()
     solver = default_newton_solver
+
+    # Mock the solver progressbar. Usually it is initialized in
+    # NewtonSolver.before_nonlinear_loop, which is never called in this test.
+    solver.solver_progressbar = DummyProgressBar()
 
     # Mock the nonlinear increment and residual for the last iteration.
     model.nonlinear_increment = np.array([inc])

--- a/tests/utils/test_ui_and_logging.py
+++ b/tests/utils/test_ui_and_logging.py
@@ -1,0 +1,88 @@
+import numpy as np
+import scipy.sparse as sps
+
+import porepy as pp
+from porepy.numerics.nonlinear.convergence_check import SimulationStatus
+
+
+class MockEquationSystem:
+    def __init__(self) -> None:
+        self.iteration_index = -1
+
+    def assemble(self, **kwargs) -> np.ndarray:
+        """Return a mock residual array."""
+        self.iteration_index += 2
+        return np.array([10 ** (-self.iteration_index)])
+
+    def get_variable_values(self, **kwargs) -> np.ndarray:
+        return np.array([1.0])
+
+
+class MockMDG:
+    def subdomains(self) -> list[pp.Grid]:
+        return [pp.CartGrid(np.array([1, 1]))]
+
+
+class MockModel:
+    """Mock model to test the progressbars interface in :mod:`~porepy.models.run_models`
+    and :mod:`~porepy.numerics.nonlinear.nonlinear_solvers`.
+
+    Does nothing but expose dummy hooks to
+    :func:`~porepy.models.run_models.run_time_dependent_model` and
+    :func:`~porepy.numerics.nonlinear.nonlinear_solvers.NewtonSolver`.
+
+    Does nothing but expose :attr:`time_manager` and :attr:`nonlinear_solver_statistics`
+    to relevant progressbar methods in
+    :func:`~porepy.models.run_models.run_time_dependent_model` and
+    :func:`~porepy.numerics.nonlinear.nonlinear_solvers.NewtonSolver` to ensure the
+    progressbars are updated correctly as the time and nonlinear loop progress,
+    respectively.
+
+    """
+
+    def __init__(self):
+        self.mdg = MockMDG()
+        self.equation_system = MockEquationSystem()
+        self.nonlinear_solver_statistics = pp.NonlinearSolverAndTimeStatistics()
+        self.time_manager = pp.TimeManager([0, 2], dt_init=1, constant_dt=True)
+
+    def _is_time_dependent(self) -> bool:
+        return True
+
+    def _is_nonlinear_problem(self) -> bool:
+        return True
+
+    def prepare_simulation(self) -> None:
+        pass
+
+    def after_simulation(self) -> None:
+        pass
+
+    def before_nonlinear_loop(self) -> None:
+        self.nonlinear_solver_statistics.increase_index()
+
+    def before_nonlinear_iteration(self) -> None:
+        pass
+
+    def after_nonlinear_iteration(self, nonlinear_increment: np.ndarray) -> None:
+        self.nonlinear_solver_statistics.num_iterations += 1
+
+    def after_nonlinear_convergence(self) -> None:
+        pass
+
+    def after_nonlinear_failure(self) -> SimulationStatus:
+        if self.time_manager.is_constant:
+            return SimulationStatus.STOPPED
+        else:
+            return SimulationStatus.FAILED
+
+    def assemble_linear_system(self) -> None:
+        pass
+
+    def solve_linear_system(self) -> np.ndarray:
+        return np.array([1.0])
+
+
+def test_mock_model():
+    model = MockModel()
+    pp.run_time_dependent_model(model)

--- a/tests/utils/test_ui_and_logging.py
+++ b/tests/utils/test_ui_and_logging.py
@@ -1,21 +1,22 @@
+import logging
+
 import numpy as np
+import pytest
 import scipy.sparse as sps
 
 import porepy as pp
 from porepy.numerics.nonlinear.convergence_check import SimulationStatus
 
+logger = logging.getLogger()
+
 
 class MockEquationSystem:
-    def __init__(self) -> None:
-        self.iteration_index = -1
-
     def assemble(self, **kwargs) -> np.ndarray:
-        """Return a mock residual array."""
-        self.iteration_index += 2
-        return np.array([10 ** (-self.iteration_index)])
+        # Artificially satisfy residual norm convergence criterion.
+        return np.array([1e-11])
 
     def get_variable_values(self, **kwargs) -> np.ndarray:
-        return np.array([1.0])
+        return np.array([0.0])
 
 
 class MockMDG:
@@ -31,6 +32,10 @@ class MockModel:
     :func:`~porepy.models.run_models.run_time_dependent_model` and
     :func:`~porepy.numerics.nonlinear.nonlinear_solvers.NewtonSolver`.
 
+    Nonlinear convergence is fully controlled by the size of the nonlinear increment as
+    the mock residual value is always below tolerance, cf.
+    :meth:`~MockEquationSystem.assemble`.
+
     Does nothing but expose :attr:`time_manager` and :attr:`nonlinear_solver_statistics`
     to relevant progressbar methods in
     :func:`~porepy.models.run_models.run_time_dependent_model` and
@@ -40,11 +45,14 @@ class MockModel:
 
     """
 
-    def __init__(self):
+    def __init__(self, num_time_steps: int, num_nl_iterations: int):
         self.mdg = MockMDG()
         self.equation_system = MockEquationSystem()
         self.nonlinear_solver_statistics = pp.NonlinearSolverAndTimeStatistics()
-        self.time_manager = pp.TimeManager([0, 2], dt_init=1, constant_dt=True)
+        self.time_manager = pp.TimeManager(
+            [0, num_time_steps], dt_init=1, constant_dt=True
+        )
+        self.num_nl_iterations = num_nl_iterations
 
     def _is_time_dependent(self) -> bool:
         return True
@@ -80,9 +88,100 @@ class MockModel:
         pass
 
     def solve_linear_system(self) -> np.ndarray:
-        return np.array([1.0])
+        # Artificially fail/satisfy Newton update norm convergence criterion.
+        # Implementation NOTE: nonlinear_solver_statistics.num_iterations lags behind
+        # one iteration at this point in the solver step.
+        if self.nonlinear_solver_statistics.num_iterations < self.num_nl_iterations - 1:
+            return np.array([1.0])
+        else:
+            return np.array([1e-11])
 
 
-def test_mock_model():
-    model = MockModel()
-    pp.run_time_dependent_model(model)
+@pytest.fixture
+def num_time_steps() -> int:
+    return 2
+
+
+@pytest.fixture
+def num_nl_iterations() -> int:
+    return 3
+
+
+@pytest.fixture
+def setup_model(num_time_steps: int, num_nl_iterations: int) -> MockModel:
+    return MockModel(num_time_steps, num_nl_iterations)
+
+
+@pytest.mark.parametrize("progressbars", [True, False])
+@pytest.mark.parametrize("logging_level", [logging.DEBUG, logging.CRITICAL])
+def test_line_count(
+    setup_model: MockModel,
+    progressbars: bool,
+    logging_level: bool,
+    num_time_steps: int,
+    num_nl_iterations: int,
+    capsys,
+) -> None:
+    # Fix progressbars and logging params.
+    params = {"progressbars": progressbars}
+    logging.basicConfig(level=logging_level)
+
+    pp.run_time_dependent_model(setup_model, params)
+
+    captured_stderr = capsys.readouterr().err
+    captured_stderr_carr_returns = captured_stderr.split("\r")
+
+    # NOTE: Some explanation on the inner workings of tqdm: Progressbars are updated by
+    # moving the cursor to the start of the line with "\r" and overwriting the previous
+    # output. For nested time/Newton progressbars, the cursor is moved to the upper
+    # level and down again with "\x1bA[" + "\n" before its moved to the beginning of the
+    # inner loop.
+
+    # IMPLEMENTATION NOTE: `captured_stderr` is hard to read for humans, as tqdm
+    # combines "\r" (carriage return), "\n" (new line), and "\x1bA[" (move cursor up one
+    # line) to overwrite (and therefore update) progressbars and navigate between nested
+    # bars.
+    # Instead of explicitly checking the entire logic, we separate by "\r" to get every
+    # occurence where a progressbar was written or updated. Then, we check that the
+    # number of lines that start with "Time loop"/"Newton loop" match the expected
+    # number of time steps/Newton steps.
+
+    num_time_progressbar_updates: int = 0
+    num_newton_progressbar_updates: int = 0
+    for line in captured_stderr_carr_returns:
+        if line.startswith("Time loop"):
+            num_time_progressbar_updates += 1
+        elif line.startswith("Newton loop"):
+            num_newton_progressbar_updates += 1
+
+    # NOTE: Whenever a tqdm bar is updated multiple times in short succession and
+    # without any other writes to stdout inbetween, all updates are combined in a single
+    # write to stdout.
+    # E.g., self.solver_progressbar.update and self.solver_progressbar.set_postfix_str
+    # in NewtonSolver.logging may be simultaneously written to stdout.
+    # On the other hand, time_progressbar.set_postfix_str and time_progressbar.update in
+    # run_time_dependent_model are separated by a call to time_step and during the first
+    # time step, both may be written independently to stdout. Afterwards,
+    # time_progressbar.update from the previous time step and
+    # time_progressbar.set_postfix_str from the current time step may be written
+    # simultaneously.
+
+    # This behavior seems to be not entirely deterministic, so we just check the number
+    # of progressbar updates against lower bounds.
+
+    if progressbars:
+        # Progressbar updates during time loop: 1 for initialization + 1 for all but the
+        # last time step.
+        min_expected_time_progressbar_updates = num_time_steps
+        # Progressbar updates per Newton loop: 1 for 0th step + 1 for each Newton step.
+        min_expected_newton_progressbar_updates = (
+            num_nl_iterations + 1
+        ) * num_time_steps
+    else:
+        min_expected_time_progressbar_updates = 0
+        min_expected_newton_progressbar_updates = 0
+
+    assert num_time_progressbar_updates >= min_expected_time_progressbar_updates
+    assert num_newton_progressbar_updates >= min_expected_newton_progressbar_updates
+
+    # TODO Implement logging check. These are not written to stdout?

--- a/tests/utils/test_ui_and_logging.py
+++ b/tests/utils/test_ui_and_logging.py
@@ -128,9 +128,14 @@ def test_logging_and_progressbars(
 ) -> None:
     """Test that progressbars and logging through tqdm work correctly.
 
+    :class:`~porepy.models.model_runner.ModelRunner` and
+    :class:`~porepy.numerics.nonlinear.nonlinear_solvers.NewtonSolver` can employ `tqdm`
+    progressbars to display simulation and solver progress, respectively. The first part
+    of the test checks that the nested progressbars are displayed and updated correctly.
+
     :func:`~porepy.utils.ui_and_logging.logging_redirect_tqdm_with_level` ensures that
-    the level of logging messages is kept when redirect through tqdm. Test that this
-    works for different levels.
+    the level of logging messages is kept when redirect through tqdm. The second part of
+    the test checks that this logging messages keep their models when passed through.
 
     """
     # IMPLEMENTATION NOTE This test is long and test both progressbar and logging

--- a/tests/utils/test_ui_and_logging.py
+++ b/tests/utils/test_ui_and_logging.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Any
 
 import numpy as np
 import pytest
@@ -106,46 +107,38 @@ class MockModel:
             return np.array([1e-11])
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def num_time_steps() -> int:
     return 2
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def num_nl_iterations() -> int:
     return 3
 
 
-@pytest.mark.parametrize("progressbars", [True, False])
-@pytest.mark.parametrize("logging_level", [logging.DEBUG, logging.ERROR])
-def test_logging_and_progressbars(
+@pytest.fixture
+def progressbars(request) -> bool:
+    return request.param
+
+
+@pytest.fixture
+def logging_level(request) -> bool:
+    return request.param
+
+
+# IMPLEMENTATION NOTE It is tempting to make this fixture module-scoped to avoid
+# running the model individually for each test, but because capsys and caplog are
+# function-scoped, this is not possible.
+@pytest.fixture
+def run_model_and_save_output(
     progressbars: bool,
-    logging_level: bool,
+    logging_level: int,
     num_time_steps: int,
     num_nl_iterations: int,
     capsys,
     caplog,
-) -> None:
-    """Test that progressbars and logging through tqdm work correctly.
-
-    :class:`~porepy.models.model_runner.ModelRunner` and
-    :class:`~porepy.numerics.nonlinear.nonlinear_solvers.NewtonSolver` can employ `tqdm`
-    progressbars to display simulation and solver progress, respectively. The first part
-    of the test checks that the nested progressbars are displayed and updated correctly.
-
-    :func:`~porepy.utils.ui_and_logging.logging_redirect_tqdm_with_level` ensures that
-    the level of logging messages is kept when redirect through tqdm. The second part of
-    the test checks this behavior.
-
-    """
-    # IMPLEMENTATION NOTE This test is long and test both progressbar and logging
-    # functionality. A cleaner approach would be to have a fixture run the model,
-    # capture stdout/stdlog, and then pass the result to separate tests for logging and
-    # progressbars.
-    # However, the capsys and caplog fixtures are function-scoped, so the model would
-    # have to be run once for each test. For the sake of efficiency, we combine
-    # everything into one test.
-
+) -> tuple[str, str]:
     # Initialize logging capture of the correct levels.
     caplog.set_level(logging_level)
 
@@ -155,8 +148,39 @@ def test_logging_and_progressbars(
     # MockModel has the wrong type. Ignore mypy.
     pp.ModelRunner(model, params).run()  # type: ignore
 
-    # 1. Check that progressbars were displayed correctly. These are written to stderr.
     captured_stderr = capsys.readouterr().err
+    captured_logging_records = caplog.records
+
+    return captured_stderr, captured_logging_records
+
+
+# Run with progressbars on and off.
+@pytest.mark.parametrize("progressbars", [True, False], indirect=True)
+# To test that logging messages do not interfere with displaying progressbars, one
+# logging level is sufficient.
+@pytest.mark.parametrize("logging_level", [logging.DEBUG], indirect=True)
+def test_progressbars(
+    progressbars: bool,
+    logging_level: int,
+    num_time_steps: int,
+    num_nl_iterations: int,
+    run_model_and_save_output: tuple[str, Any],
+) -> None:
+    """Test that nested progressbars are displayed correctly and work with logging.
+
+    :class:`~porepy.models.model_runner.ModelRunner` and
+    :class:`~porepy.numerics.nonlinear.nonlinear_solvers.NewtonSolver` can employ `tqdm`
+    progressbars to display simulation and solver progress, respectively. This test
+    checks that both nested progressbars are displayed and updated after each time step
+    and Newton iteration, respectively.
+
+    The test is run with varying logging levels to ensure that logging messages do
+    not interfere with the displaying of the progressbars, i.e., it checks that
+    :func:`~porepy.utils.ui_and_logging.logging_redirect_tqdm_with_level` works from the
+    progressbars side.
+
+    """
+    captured_stderr = run_model_and_save_output[0]
     captured_stderr_carr_returns = captured_stderr.split("\r")
 
     # IMPLEMENTATION NOTE `captured_stderr` is hard to read for humans, as tqdm
@@ -206,8 +230,30 @@ def test_logging_and_progressbars(
         assert num_time_progressbar_updates == 0
         assert num_newton_progressbar_updates == 0
 
-    # 2. Check that logging messages of all requested levels were redirected through
-    #    tqdm and displayed. Messages are written to stdlog.
+
+# Run with progressbars on and off to test that ``logging_redirect_tqdm_with_level``
+# works with real and placeholder progressbars.
+@pytest.mark.parametrize("progressbars", [True, False], indirect=True)
+# Run with different logging levels.
+@pytest.mark.parametrize("logging_level", [logging.DEBUG, logging.ERROR], indirect=True)
+def test_logging_redirect(
+    progressbars: bool,
+    logging_level: int,
+    num_time_steps: int,
+    num_nl_iterations: int,
+    run_model_and_save_output: tuple[str, Any],
+) -> None:
+    """Tests :func:`~porepy.utils.ui_and_logging.logging_redirect_tqdm_with_level`.
+
+    To avoid a visual mess when using both progressbars and logging, all logging
+    messages are redirected through a contextmanager. ``tqdm``s own implementation does
+    not redirect the logging level correctly, so we use
+    :func:`~porepy.utils.ui_and_logging.logging_redirect_tqdm_with_level` in PorePy.
+    This test checks that our implementation correctly handles logging messages with
+    their respective level.
+
+    """
+    captured_logging_records = run_model_and_save_output[1]
 
     # Count the number of "Starting Newton step" messages originating from
     # MockModel.before_nonlinear_iteration of each level.
@@ -216,7 +262,6 @@ def test_logging_and_progressbars(
     num_before_newton_step_warning_records: int = 0
     num_before_newton_step_error_records: int = 0
 
-    captured_logging_records = caplog.records
     for record in captured_logging_records:
         if record.msg == "Starting Newton step":
             if record.levelno == logging.DEBUG:

--- a/tests/utils/test_ui_and_logging.py
+++ b/tests/utils/test_ui_and_logging.py
@@ -2,7 +2,6 @@ import logging
 
 import numpy as np
 import pytest
-import scipy.sparse as sps
 
 import porepy as pp
 from porepy.numerics.nonlinear.convergence_check import SimulationStatus
@@ -67,7 +66,7 @@ class MockModel:
         self.nonlinear_solver_statistics.increase_index()
 
     def before_nonlinear_iteration(self) -> None:
-        # Implementation NOTE: Write logging messages of all levels. This way we can
+        # IMPLEMENTATION NOTE Write logging messages of all levels. This way we can
         # test in test_logging_and_progressbars that
         # pp.utils.ui_and_logging.logging_redirect_tqdm_with_level correctly redirects
         # messages of all levels through tqdm.
@@ -93,7 +92,7 @@ class MockModel:
 
     def solve_linear_system(self) -> np.ndarray:
         # Artificially fail/satisfy Newton update norm convergence criterion.
-        # Implementation NOTE: nonlinear_solver_statistics.num_iterations lags behind
+        # IMPLEMENTATION NOTE nonlinear_solver_statistics.num_iterations lags behind
         # one iteration at this point in the solver step.
         if self.nonlinear_solver_statistics.num_iterations < self.num_nl_iterations - 1:
             return np.array([1.0])
@@ -121,12 +120,20 @@ def test_logging_and_progressbars(
     capsys,
     caplog,
 ) -> None:
-    """Test that progressbars and logging through tqdm work correctly."""
-    # Implementation NOTE: The test function is long and does two different things. It
-    # would be cleaner to run the model and capture output in a fixture and then
-    # individual tests for logging and progressbars. However, the capsys and caplog
-    # fixtures are function-scoped, so for the sake of only having to run the model
-    # once, we combine everything into one test.
+    """Test that progressbars and logging through tqdm work correctly.
+
+    :func:`~porepy.utils.ui_and_logging.logging_redirect_tqdm_with_level` ensures that
+    the level of logging messages is kept when redirect through tqdm. Test that this
+    works for different levels.
+
+    """
+    # IMPLEMENTATION NOTE This test is long and test both progressbar and logging
+    # functionality. A cleaner approach would be to have a fixture run the model,
+    # capture stdout/stdlog, and then pass the result to separate tests for logging and
+    # progressbars.
+    # However, the capsys and caplog fixtures are function-scoped, so the model would
+    # have to be run once for each test. For the sake of efficiency, we combine
+    # everything into one test.
 
     # Initialize logging capture of the correct levels.
     caplog.set_level(logging_level)
@@ -139,19 +146,13 @@ def test_logging_and_progressbars(
     captured_stderr = capsys.readouterr().err
     captured_stderr_carr_returns = captured_stderr.split("\r")
 
-    # NOTE: Some explanation on the inner workings of tqdm: Progressbars are updated by
-    # moving the cursor to the start of the line with "\r" and overwriting the previous
-    # output. For nested time/Newton progressbars, the cursor is moved to the upper
-    # level and down again with "\x1bA[" + "\n" before its moved to the beginning of the
-    # inner loop.
-
-    # IMPLEMENTATION NOTE: `captured_stderr` is hard to read for humans, as tqdm
+    # IMPLEMENTATION NOTE `captured_stderr` is hard to read for humans, as tqdm
     # combines "\r" (carriage return), "\n" (new line), and "\x1bA[" (move cursor up one
     # line) to overwrite (and therefore update) progressbars and navigate between nested
     # bars.
     # Instead of explicitly checking the entire logic, we separate by "\r" to get every
     # occurence where a progressbar was written or updated. Then, we check that the
-    # number of lines that start with "Time loop"/"Newton loop" match the expected
+    # number of lines that start with "Time loop"/"Newton loop" matches the expected
     # number of time steps/Newton steps.
 
     num_time_progressbar_updates: int = 0
@@ -162,9 +163,9 @@ def test_logging_and_progressbars(
         elif line.startswith("Newton loop"):
             num_newton_progressbar_updates += 1
 
-    # NOTE: Whenever a tqdm bar is updated multiple times in short succession and
-    # without any other writes to stdout inbetween, all updates are combined in a single
-    # write to stdout.
+    # NOTE tqdm bars are refreshed at most every tqdm.mininterval (default = 0.1)
+    # seconds. If a progressbar is updated multiple times in short succession, the
+    # updates are compressed into a single refresh, i.e., into a single write to stdout.
     # E.g., self.solver_progressbar.update and self.solver_progressbar.set_postfix_str
     # in NewtonSolver.logging may be simultaneously written to stdout.
     # On the other hand, time_progressbar.set_postfix_str and time_progressbar.update in
@@ -174,8 +175,9 @@ def test_logging_and_progressbars(
     # time_progressbar.set_postfix_str from the current time step may be written
     # simultaneously.
 
-    # This behavior seems to be not entirely deterministic, so we just check the number
-    # of progressbar updates against lower bounds.
+    # The amount of writes to stdout during a time/Newton loop is therefore not
+    # deterministic. We just check the number of progressbar updates against lower
+    # bounds.
 
     if progressbars:
         # Progressbar updates during time loop: 1 for initialization + 1 for all but the
@@ -185,12 +187,11 @@ def test_logging_and_progressbars(
         min_expected_newton_progressbar_updates = (
             num_nl_iterations + 1
         ) * num_time_steps
+        assert num_time_progressbar_updates >= min_expected_time_progressbar_updates
+        assert num_newton_progressbar_updates >= min_expected_newton_progressbar_updates
     else:
-        min_expected_time_progressbar_updates = 0
-        min_expected_newton_progressbar_updates = 0
-
-    assert num_time_progressbar_updates >= min_expected_time_progressbar_updates
-    assert num_newton_progressbar_updates >= min_expected_newton_progressbar_updates
+        assert num_time_progressbar_updates == 0
+        assert num_newton_progressbar_updates == 0
 
     # 2. Check that logging messages of all requested levels were redirected through
     #    tqdm and displayed. Messages are written to stdlog.
@@ -216,12 +217,14 @@ def test_logging_and_progressbars(
 
     total_num_nl_iterations = num_nl_iterations * num_time_steps
 
-    # Debug, info, and warning messages are logged if logging_level == logging.DEBUG.
     if logging_level <= logging.DEBUG:
+        # If logging_level == logging.DEBUG, debug, info, and warning messages are
+        # logged.
         assert num_before_newton_step_debug_records == total_num_nl_iterations
         assert num_before_newton_step_info_records == total_num_nl_iterations
         assert num_before_newton_step_warning_records == total_num_nl_iterations
     else:
+        # If logging_level == logging.ERROR, only error messages are logged.
         assert num_before_newton_step_debug_records == 0
         assert num_before_newton_step_info_records == 0
         assert num_before_newton_step_warning_records == 0

--- a/tests/utils/test_ui_and_logging.py
+++ b/tests/utils/test_ui_and_logging.py
@@ -135,7 +135,7 @@ def test_logging_and_progressbars(
 
     :func:`~porepy.utils.ui_and_logging.logging_redirect_tqdm_with_level` ensures that
     the level of logging messages is kept when redirect through tqdm. The second part of
-    the test checks that this logging messages keep their models when passed through.
+    the test checks this behavior.
 
     """
     # IMPLEMENTATION NOTE This test is long and test both progressbar and logging

--- a/tests/utils/test_ui_and_logging.py
+++ b/tests/utils/test_ui_and_logging.py
@@ -59,6 +59,12 @@ class MockModel:
     def prepare_simulation(self) -> None:
         pass
 
+    def before_time_step(self) -> None:
+        pass
+
+    def after_time_step_convergence(self) -> None:
+        pass
+
     def after_simulation(self) -> None:
         pass
 
@@ -140,7 +146,9 @@ def test_logging_and_progressbars(
 
     model = MockModel(num_time_steps, num_nl_iterations)
     params = {"progressbars": progressbars}
-    pp.run_time_dependent_model(model, params)
+
+    # MockModel has the wrong type. Ignore mypy.
+    pp.ModelRunner(model, params).run()  # type: ignore
 
     # 1. Check that progressbars were displayed correctly. These are written to stderr.
     captured_stderr = capsys.readouterr().err

--- a/tests/utils/test_ui_and_logging.py
+++ b/tests/utils/test_ui_and_logging.py
@@ -7,7 +7,7 @@ import scipy.sparse as sps
 import porepy as pp
 from porepy.numerics.nonlinear.convergence_check import SimulationStatus
 
-logger = logging.getLogger()
+mock_logger = logging.getLogger(__name__)
 
 
 class MockEquationSystem:
@@ -25,23 +25,20 @@ class MockMDG:
 
 
 class MockModel:
-    """Mock model to test the progressbars interface in :mod:`~porepy.models.run_models`
-    and :mod:`~porepy.numerics.nonlinear.nonlinear_solvers`.
+    """Mock model to test the progressbars and logging interface in
+    :mod:`~porepy.models.run_models` and
+    :mod:`~porepy.numerics.nonlinear.nonlinear_solvers`.
 
-    Does nothing but expose dummy hooks to
+
+    Exposes mock hooks to
     :func:`~porepy.models.run_models.run_time_dependent_model` and
-    :func:`~porepy.numerics.nonlinear.nonlinear_solvers.NewtonSolver`.
+    :func:`~porepy.numerics.nonlinear.nonlinear_solvers.NewtonSolver` and writes mock
+    logging messages of all levels.
 
     Nonlinear convergence is fully controlled by the size of the nonlinear increment as
     the mock residual value is always below tolerance, cf.
     :meth:`~MockEquationSystem.assemble`.
 
-    Does nothing but expose :attr:`time_manager` and :attr:`nonlinear_solver_statistics`
-    to relevant progressbar methods in
-    :func:`~porepy.models.run_models.run_time_dependent_model` and
-    :func:`~porepy.numerics.nonlinear.nonlinear_solvers.NewtonSolver` to ensure the
-    progressbars are updated correctly as the time and nonlinear loop progress,
-    respectively.
 
     """
 
@@ -70,7 +67,14 @@ class MockModel:
         self.nonlinear_solver_statistics.increase_index()
 
     def before_nonlinear_iteration(self) -> None:
-        pass
+        # Implementation NOTE: Write logging messages of all levels. This way we can
+        # test in test_logging_and_progressbars that
+        # pp.utils.ui_and_logging.logging_redirect_tqdm_with_level correctly redirects
+        # messages of all levels through tqdm.
+        mock_logger.debug(f"Starting Newton step")
+        mock_logger.info(f"Starting Newton step")
+        mock_logger.warning(f"Starting Newton step")
+        mock_logger.error(f"Starting Newton step")
 
     def after_nonlinear_iteration(self, nonlinear_increment: np.ndarray) -> None:
         self.nonlinear_solver_statistics.num_iterations += 1
@@ -107,27 +111,31 @@ def num_nl_iterations() -> int:
     return 3
 
 
-@pytest.fixture
-def setup_model(num_time_steps: int, num_nl_iterations: int) -> MockModel:
-    return MockModel(num_time_steps, num_nl_iterations)
-
-
 @pytest.mark.parametrize("progressbars", [True, False])
-@pytest.mark.parametrize("logging_level", [logging.DEBUG, logging.CRITICAL])
-def test_line_count(
-    setup_model: MockModel,
+@pytest.mark.parametrize("logging_level", [logging.DEBUG, logging.ERROR])
+def test_logging_and_progressbars(
     progressbars: bool,
     logging_level: bool,
     num_time_steps: int,
     num_nl_iterations: int,
     capsys,
+    caplog,
 ) -> None:
-    # Fix progressbars and logging params.
+    """Test that progressbars and logging through tqdm work correctly."""
+    # Implementation NOTE: The test function is long and does two different things. It
+    # would be cleaner to run the model and capture output in a fixture and then
+    # individual tests for logging and progressbars. However, the capsys and caplog
+    # fixtures are function-scoped, so for the sake of only having to run the model
+    # once, we combine everything into one test.
+
+    # Initialize logging capture of the correct levels.
+    caplog.set_level(logging_level)
+
+    model = MockModel(num_time_steps, num_nl_iterations)
     params = {"progressbars": progressbars}
-    logging.basicConfig(level=logging_level)
+    pp.run_time_dependent_model(model, params)
 
-    pp.run_time_dependent_model(setup_model, params)
-
+    # 1. Check that progressbars were displayed correctly. These are written to stderr.
     captured_stderr = capsys.readouterr().err
     captured_stderr_carr_returns = captured_stderr.split("\r")
 
@@ -184,4 +192,40 @@ def test_line_count(
     assert num_time_progressbar_updates >= min_expected_time_progressbar_updates
     assert num_newton_progressbar_updates >= min_expected_newton_progressbar_updates
 
-    # TODO Implement logging check. These are not written to stdout?
+    # 2. Check that logging messages of all requested levels were redirected through
+    #    tqdm and displayed. Messages are written to stdlog.
+
+    # Count the number of "Starting Newton step" messages originating from
+    # MockModel.before_nonlinear_iteration of each level.
+    num_before_newton_step_debug_records: int = 0
+    num_before_newton_step_info_records: int = 0
+    num_before_newton_step_warning_records: int = 0
+    num_before_newton_step_error_records: int = 0
+
+    captured_logging_records = caplog.records
+    for record in captured_logging_records:
+        if record.msg == "Starting Newton step":
+            if record.levelno == logging.DEBUG:
+                num_before_newton_step_debug_records += 1
+            elif record.levelno == logging.INFO:
+                num_before_newton_step_info_records += 1
+            elif record.levelno == logging.WARNING:
+                num_before_newton_step_warning_records += 1
+            elif record.levelno == logging.ERROR:
+                num_before_newton_step_error_records += 1
+
+    total_num_nl_iterations = num_nl_iterations * num_time_steps
+
+    # Debug, info, and warning messages are logged if logging_level == logging.DEBUG.
+    if logging_level <= logging.DEBUG:
+        assert num_before_newton_step_debug_records == total_num_nl_iterations
+        assert num_before_newton_step_info_records == total_num_nl_iterations
+        assert num_before_newton_step_warning_records == total_num_nl_iterations
+    else:
+        assert num_before_newton_step_debug_records == 0
+        assert num_before_newton_step_info_records == 0
+        assert num_before_newton_step_warning_records == 0
+
+    # Error messages are logged for both logging_level == logging.DEBUG and
+    # logging_level == logging.ERROR.
+    assert num_before_newton_step_error_records == total_num_nl_iterations


### PR DESCRIPTION
## Proposed changes
Introduces tests checking that logging messages and progressbars are displayed according to the desired settings. Fixes a bug in the new `NewtonSolver` that showed the Newton progressbar only on the first time step. Closes #1602.

## Types of changes
- [ ] Minor change (e.g., dependency bumps, broken links).
- [x] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist
- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
