### PR TITLE
BUG: Fracture mappings did not properly account for constraints during 3d meshing

### DIFF
--- a/src/porepy/fracs/fracture_network_3d.py
+++ b/src/porepy/fracs/fracture_network_3d.py
@@ -372,15 +372,17 @@ class FractureNetwork3d(FractureNetwork):
 
         """
 
-        def _elliptic_fracture_outside_domain(
+        def _check_elliptic_fracture_outside_domain(
             loc_keep: np.ndarray,
             frac_ind: int,
+            sub_frac: tuple[int, int],
             partly_deleted: list[int],
             updated_map: dict[int, int],
         ) -> None:
-            # This is most likely a disc fracture, which has no bounding lines/points.
-            # Simply do a distance check between the fracture and the domain.
+            """Helper function to check if an elliptic fracture is outside the domain.
 
+            Updates to the fracture bookkeeping system are done in-place.
+            """
             # If this assertion fails, this indicates that we have produced a
             # non-disc domain without boundary lines/points. This case must be
             # handled if it ever arises.
@@ -401,13 +403,18 @@ class FractureNetwork3d(FractureNetwork):
                     frac_ind
                 ]
 
-        def _polygon_fracture_outside_domain(
+        def _check_polygon_fracture_outside_domain(
             loc_keep: np.ndarray,
             frac_ind: int,
+            sub_frac: tuple[int, int],
             part_of_fracture_deleted: list[int],
             updated_fracture_tag_map: dict[int, int],
             bounding_points: list[tuple[int, int]],
         ) -> None:
+            """Helper function to check if a polygonal fracture is outside the domain.
+
+            Updates to the fracture bookkeeping system are done in-place.
+            """
             # For each bounding point, compute the minimum distance to the different
             # parts of the domain (the domain may have been split in multiple parts
             # during fragmentation). Note to self: We cannot check the sub-surface
@@ -442,24 +449,27 @@ class FractureNetwork3d(FractureNetwork):
         def _update_constraints_after_deletions(
             constraints: np.ndarray, part_of_fracture_deleted: list[int]
         ) -> tuple[np.ndarray, dict[int, int]]:
+            """Helper function to update constraints and mapping between gmsh and porepy
+            fracture indices after deletion of fractures that are outside the domain.
+            """
             updated_constraints = []
-            num_frac_deleted = 0
+            num_fracs_deleted = 0
             for c in constraints:
                 num_deleted_subfrac = part_of_fracture_deleted.count(c)
                 if num_orig_subfrac[c] == num_deleted_subfrac:
                     # The full fracture has been removed. It is not among the surviving
                     # constraints, but we need to adjust the indices of the following
                     # ones.
-                    num_frac_deleted += 1
+                    num_fracs_deleted += 1
                 else:
                     # The fracture is still present, add it to the new constraints,
                     # adjusting the index accordingly. Constraints are known to be
                     # sorted.
-                    updated_constraints.append(int(c) - num_frac_deleted)
+                    updated_constraints.append(int(c) - num_fracs_deleted)
 
                     for key, value in updated_fracture_tag_map.items():
                         if value == c:
-                            updated_fracture_tag_map[key] = int(c) - num_frac_deleted
+                            updated_fracture_tag_map[key] = int(c) - num_fracs_deleted
             return np.asarray(updated_constraints), updated_fracture_tag_map
 
         nd = self.nd
@@ -518,16 +528,18 @@ class FractureNetwork3d(FractureNetwork):
                 ]
 
                 if len(bounding_points) == 0:
-                    _elliptic_fracture_outside_domain(
+                    _check_elliptic_fracture_outside_domain(
                         loc_keep,
                         frac_ind,
+                        sub_frac,
                         part_of_fracture_deleted,
                         updated_fracture_tag_map,
                     )
                 else:
-                    _polygon_fracture_outside_domain(
+                    _check_polygon_fracture_outside_domain(
                         loc_keep,
                         frac_ind,
+                        sub_frac,
                         part_of_fracture_deleted,
                         updated_fracture_tag_map,
                         bounding_points,

--- a/src/porepy/fracs/fracture_network_3d.py
+++ b/src/porepy/fracs/fracture_network_3d.py
@@ -510,10 +510,12 @@ class FractureNetwork3d(FractureNetwork):
             num_orig_subfrac.append(len(frac))
 
             for sfi, sub_frac in enumerate(frac):
-                bounding_lines = gmsh.model.get_boundary([sub_frac], oriented=False)
-                bounding_points = []
-                for line in bounding_lines:
-                    bounding_points += gmsh.model.get_boundary([line], oriented=False)
+                bounding_points = [
+                    pt
+                    for line in gmsh.model.get_boundary([sub_frac], oriented=False)
+                    if line[0] == 1
+                    for pt in gmsh.model.get_boundary([line], oriented=False)
+                ]
 
                 if len(bounding_points) == 0:
                     _elliptic_fracture_outside_domain(

--- a/src/porepy/fracs/fracture_network_3d.py
+++ b/src/porepy/fracs/fracture_network_3d.py
@@ -371,6 +371,30 @@ class FractureNetwork3d(FractureNetwork):
             -   Updated mapping from gmsh fracture tags to input fracture indices.
 
         """
+
+        def _update_constraints_after_deletions(
+            constraints: np.ndarray, part_of_fracture_deleted: list[int]
+        ) -> tuple[np.ndarray, dict[int, int]]:
+            updated_constraints = []
+            num_frac_deleted = 0
+            for c in constraints:
+                num_deleted_subfrac = part_of_fracture_deleted.count(c)
+                if num_orig_subfrac[c] == num_deleted_subfrac:
+                    # The full fracture has been removed. It is not among the surviving
+                    # constraints, but we need to adjust the indices of the following
+                    # ones.
+                    num_frac_deleted += 1
+                else:
+                    # The fracture is still present, add it to the new constraints,
+                    # adjusting the index accordingly. Constraints are known to be
+                    # sorted.
+                    updated_constraints.append(int(c) - num_frac_deleted)
+
+                    for key, value in updated_fracture_tag_map.items():
+                        if value == c:
+                            updated_fracture_tag_map[key] = int(c) - num_frac_deleted
+            return np.asarray(updated_constraints), updated_fracture_tag_map
+
         nd = self.nd
         dim_fracture_tags = [(nd - 1, tag) for tag in fracture_tags]
 
@@ -489,28 +513,9 @@ class FractureNetwork3d(FractureNetwork):
         # outside the domain.
         isect_mapping = [isect_mapping[i] for i in range(len(keep)) if keep[i]]
 
-        # Update the constraint indices to account for fully removed fractures.
-        updated_constraints = []
-        # If a fracture has been fully removed, we need to decrement the indices of
-        # all following constraints.
-        num_frac_deleted = 0
-        for c in constraints:
-            num_deleted_subfrac = part_of_fracture_deleted.count(c)
-            if num_orig_subfrac[c] == num_deleted_subfrac:
-                # The full fracture has been removed. It is not among the surviving
-                # constraints, but we need to adjust the indices of the following ones.
-                num_frac_deleted += 1
-            else:
-                # The fracture is still present, add it to the new constraints,
-                # adjusting the index accordingly. Constraints are known to be sorted.
-                updated_constraints.append(int(c) - num_frac_deleted)
-
-                for key, value in updated_fracture_tag_map.items():
-                    if value == c:
-                        updated_fracture_tag_map[key] = int(c) - num_frac_deleted
-
-        constraints = np.asarray(updated_constraints)
-        gmsh_to_porepy_fracture_ind_map = updated_fracture_tag_map
+        constraints, gmsh_to_porepy_fracture_ind_map = (
+            _update_constraints_after_deletions(constraints, part_of_fracture_deleted)
+        )
 
         # Count the number of fracture objects that survived both the fragmentation and
         # the distance-based domain trimming.

--- a/src/porepy/fracs/fracture_network_3d.py
+++ b/src/porepy/fracs/fracture_network_3d.py
@@ -417,9 +417,7 @@ class FractureNetwork3d(FractureNetwork):
             """
             # For each bounding point, compute the minimum distance to the different
             # parts of the domain (the domain may have been split in multiple parts
-            # during fragmentation). Note to self: We cannot check the sub-surface
-            # itself, since for fractures partially inside the domain, the
-            # sub-surface that should be excluded will still be inside the domain.
+            # during fragmentation).
             distances = np.zeros(len(bounding_points))
             if domain_tag > 0:
                 # Only do this if we have a domain. If not, all distances are zero,

--- a/src/porepy/fracs/fracture_network_3d.py
+++ b/src/porepy/fracs/fracture_network_3d.py
@@ -401,6 +401,44 @@ class FractureNetwork3d(FractureNetwork):
                     frac_ind
                 ]
 
+        def _polygon_fracture_outside_domain(
+            loc_keep: np.ndarray,
+            frac_ind: int,
+            part_of_fracture_deleted: list[int],
+            updated_fracture_tag_map: dict[int, int],
+            bounding_points: list[tuple[int, int]],
+        ) -> None:
+            # For each bounding point, compute the minimum distance to the different
+            # parts of the domain (the domain may have been split in multiple parts
+            # during fragmentation). Note to self: We cannot check the sub-surface
+            # itself, since for fractures partially inside the domain, the
+            # sub-surface that should be excluded will still be inside the domain.
+            distances = np.zeros(len(bounding_points))
+            if domain_tag > 0:
+                # Only do this if we have a domain. If not, all distances are zero,
+                # and the above if statement will not trigger.
+                for i, pt in enumerate(bounding_points):
+                    distances[i] = min(
+                        gmsh.model.occ.get_distance(*pt, nd, dtag)[0]
+                        for dtag in domain_tags
+                    )
+            # If any bounding point is outside all parts of the domain, we drop this
+            # sub-fracture.
+            if np.any(distances > self._tol) or self._entity_on_domain_boundary(
+                0, [bp[1] for bp in bounding_points]
+            ):
+                loc_keep[sfi] = False
+                # Take note that part of this fracture (mapping back to the input
+                # fracture index system) has been deleted.
+                part_of_fracture_deleted.append(
+                    gmsh_to_porepy_fracture_ind_map[frac_ind]
+                )
+            else:
+                if frac_ind in gmsh_to_porepy_fracture_ind_map:
+                    updated_fracture_tag_map[sub_frac[1]] = (
+                        gmsh_to_porepy_fracture_ind_map[frac_ind]
+                    )
+
         def _update_constraints_after_deletions(
             constraints: np.ndarray, part_of_fracture_deleted: list[int]
         ) -> tuple[np.ndarray, dict[int, int]]:
@@ -484,38 +522,15 @@ class FractureNetwork3d(FractureNetwork):
                         part_of_fracture_deleted,
                         updated_fracture_tag_map,
                     )
-                    continue
-
-                # For each bounding point, compute the minimum distance to the different
-                # parts of the domain (the domain may have been split in multiple parts
-                # during fragmentation). Note to self: We cannot check the sub-surface
-                # itself, since for fractures partially inside the domain, the
-                # sub-surface that should be excluded will still be inside the domain.
-                distances = np.zeros(len(bounding_points))
-                if domain_tag > 0:
-                    # Only do this if we have a domain. If not, all distances are zero,
-                    # and the above if statement will not trigger.
-                    for i, pt in enumerate(bounding_points):
-                        distances[i] = min(
-                            gmsh.model.occ.get_distance(*pt, nd, domain_tag)[0]
-                            for domain_tag in domain_tags
-                        )
-                # If any bounding point is outside all parts of the domain, we drop this
-                # sub-fracture.
-                if np.any(distances > self._tol) or self._entity_on_domain_boundary(
-                    0, [bp[1] for bp in bounding_points]
-                ):
-                    loc_keep[sfi] = False
-                    # Take note that part of this fracture (mapping back to the input
-                    # fracture index system) has been deleted.
-                    part_of_fracture_deleted.append(
-                        gmsh_to_porepy_fracture_ind_map[frac_ind]
-                    )
                 else:
-                    if frac_ind in gmsh_to_porepy_fracture_ind_map:
-                        updated_fracture_tag_map[sub_frac[1]] = (
-                            gmsh_to_porepy_fracture_ind_map[frac_ind]
-                        )
+                    _polygon_fracture_outside_domain(
+                        loc_keep,
+                        frac_ind,
+                        part_of_fracture_deleted,
+                        updated_fracture_tag_map,
+                        bounding_points,
+                    )
+
             # Keep only the sub-fractures that are within the domain.
             isect_mapping[fi] = [frac[i] for i in range(len(frac)) if loc_keep[i]]
             # If any sub-fracture is kept, we keep the fracture.

--- a/src/porepy/fracs/fracture_network_3d.py
+++ b/src/porepy/fracs/fracture_network_3d.py
@@ -504,6 +504,11 @@ class FractureNetwork3d(FractureNetwork):
                 # The fracture is still present, add it to the new constraints,
                 # adjusting the index accordingly. Constraints are known to be sorted.
                 updated_constraints.append(int(c) - num_frac_deleted)
+
+                for key, value in updated_fracture_tag_map.items():
+                    if value == c:
+                        updated_fracture_tag_map[key] = int(c) - num_frac_deleted
+
         constraints = np.asarray(updated_constraints)
         gmsh_to_porepy_fracture_ind_map = updated_fracture_tag_map
 

--- a/src/porepy/fracs/fracture_network_3d.py
+++ b/src/porepy/fracs/fracture_network_3d.py
@@ -372,6 +372,35 @@ class FractureNetwork3d(FractureNetwork):
 
         """
 
+        def _elliptic_fracture_outside_domain(
+            loc_keep: np.ndarray,
+            frac_ind: int,
+            partly_deleted: list[int],
+            updated_map: dict[int, int],
+        ) -> None:
+            # This is most likely a disc fracture, which has no bounding lines/points.
+            # Simply do a distance check between the fracture and the domain.
+
+            # If this assertion fails, this indicates that we have produced a
+            # non-disc domain without boundary lines/points. This case must be
+            # handled if it ever arises.
+            assert len(frac) == 1
+            distances = np.array(
+                [
+                    gmsh.model.occ.get_distance(*sub_frac, self.nd, dtag)[0]
+                    for dtag in domain_tags
+                ]
+            )
+            if np.all(distances > self._tol):
+                loc_keep[sfi] = False
+                part_of_fracture_deleted.append(
+                    gmsh_to_porepy_fracture_ind_map[frac_ind]
+                )
+            else:
+                updated_fracture_tag_map[sub_frac[1]] = gmsh_to_porepy_fracture_ind_map[
+                    frac_ind
+                ]
+
         def _update_constraints_after_deletions(
             constraints: np.ndarray, part_of_fracture_deleted: list[int]
         ) -> tuple[np.ndarray, dict[int, int]]:
@@ -418,7 +447,7 @@ class FractureNetwork3d(FractureNetwork):
         keep = np.ones(len(isect_mapping), dtype=bool)
         # Keep track of which fractures have had parts deleted. If all parts of a
         # fracture have been deleted, we need to update the constraint indices.
-        part_of_fracture_deleted = []
+        part_of_fracture_deleted: list[int] = []
         # Count the number of sub-fractures each fracture has been split into. Used to
         # figure out if the full fracture has been deleted as outside the domain, or
         # only parts of it; which again is used to update the constraint indices.
@@ -449,29 +478,12 @@ class FractureNetwork3d(FractureNetwork):
                     bounding_points += gmsh.model.get_boundary([line], oriented=False)
 
                 if len(bounding_points) == 0:
-                    # This is most likely a disc fracture, which has no bounding
-                    # lines/points. Simply do a distance check between the fracture and
-                    # the domain.
-                    #
-                    # If this assertion fails, this indicates that we have produced a
-                    # non-disc domain without boundary lines/points. This case must be
-                    # handled if it ever arises.
-                    assert len(frac) == 1
-                    distances = np.array(
-                        [
-                            gmsh.model.occ.get_distance(*sub_frac, self.nd, dtag)[0]
-                            for dtag in domain_tags
-                        ]
+                    _elliptic_fracture_outside_domain(
+                        loc_keep,
+                        frac_ind,
+                        part_of_fracture_deleted,
+                        updated_fracture_tag_map,
                     )
-                    if np.all(distances > self._tol):
-                        loc_keep[sfi] = False
-                        part_of_fracture_deleted.append(
-                            gmsh_to_porepy_fracture_ind_map[frac_ind]
-                        )
-                    else:
-                        updated_fracture_tag_map[sub_frac[1]] = (
-                            gmsh_to_porepy_fracture_ind_map[frac_ind]
-                        )
                     continue
 
                 # For each bounding point, compute the minimum distance to the different

--- a/tests/fracs/test_fracture_network_2d.py
+++ b/tests/fracs/test_fracture_network_2d.py
@@ -98,8 +98,12 @@ def _verify_1d_grid_geometry(sd: pp.Grid, frac: pp.LineFracture) -> None:
         ([-0.5, 0.2], [False, False]),
         # One fracture inside, one outside, both constraints.
         ([0.2, -0.5], [True, True]),
+        ([-0.5, 0.2], [True, True]),
         # One fracture inside, one outside. Constraint first on the list.
         ([-0.5, 0.2], [True, False]),
+        ([-0.5, 0.2], [False, True]),
+        ([0.2, -0.5], [True, False]),
+        ([0.2, -0.5], [False, True]),
     ],
 )
 def test_meshing_no_intersections(

--- a/tests/fracs/test_fracture_network_2d.py
+++ b/tests/fracs/test_fracture_network_2d.py
@@ -99,7 +99,8 @@ def _verify_1d_grid_geometry(sd: pp.Grid, frac: pp.LineFracture) -> None:
         # One fracture inside, one outside, both constraints.
         ([0.2, -0.5], [True, True]),
         ([-0.5, 0.2], [True, True]),
-        # One fracture inside, one outside. Constraint first on the list.
+        # One fracture inside, one outside. Constraint first on the list. Similar logic
+        # on the next three cases.
         ([-0.5, 0.2], [True, False]),
         ([-0.5, 0.2], [False, True]),
         ([0.2, -0.5], [True, False]),

--- a/tests/fracs/test_fracture_network_3d.py
+++ b/tests/fracs/test_fracture_network_3d.py
@@ -129,8 +129,13 @@ def _find_intersection_line(mdg, frac_num_0, frac_num_1):
         ([-0.5, 0.2], [False, False]),
         # One fracture inside, one outside, both constraints.
         ([0.2, -0.5], [True, True]),
+        ([-0.5, 0.2], [True, True]),
         # One fracture inside, one outside. Constraint first on the list.
         ([-0.5, 0.2], [True, False]),
+        # One fracture on the outside, one inside. Both constraints.
+        ([-0.5, 0.2], [False, True]),
+        ([0.2, -0.5], [True, False]),
+        ([0.2, -0.5], [False, True]),
     ],
 )
 def test_meshing_no_intersections(


### PR DESCRIPTION
## Proposed changes
This PR resolves the issue described in #1656. The test suite is also expanded, including a case that failed on the previous version of the code. In parallel I also expanded the 2d test coverage, but no failures there (the 2d and 3d cases are treated separately).

I also did some refactoring of the code to make the control flow easier to follow by introducing helper methods. This is purely moving the code around, there are no changes in logic. The outer function (impose_boundary_process_interactions) is still far too long and complex, but it is a step in the right direction.

Resolves #1656.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
