### PR TITLE
Refactor solver status

### DIFF
--- a/src/porepy/models/solution_strategy.py
+++ b/src/porepy/models/solution_strategy.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import logging
 import time
-import warnings
 from functools import partial
 from pathlib import Path
 from typing import Any, Callable, Optional, cast
@@ -19,7 +18,6 @@ import numpy as np
 import scipy.sparse as sps
 
 import porepy as pp
-from porepy.numerics.nonlinear.convergence_check import SimulationStatus
 from porepy.viz.solver_statistics import SolverStatisticsFactory
 
 logger = logging.getLogger(__name__)
@@ -395,14 +393,8 @@ class SolutionStrategy(pp.PorePyModel):
     def after_nonlinear_convergence(self) -> None:
         """Called after the solver converges."""
 
-    def after_nonlinear_failure(self) -> SimulationStatus:
+    def after_nonlinear_failure(self) -> None:
         """Method to be called if the non-linear solver fails to converge."""
-        if self._is_nonlinear_problem():
-            warn("Failed to solve the nonlinear problem.")
-            return SimulationStatus.FAILED
-        else:
-            warn("Failed to solve linear system for the linear problem.")
-            return SimulationStatus.STOPPED
 
     def after_time_step_convergence(self) -> None:
         """Called after a new time step solution has been achieved.
@@ -792,7 +784,7 @@ class SolutionStrategy(pp.PorePyModel):
             except ImportError:
                 # Fall back on the standard scipy sparse solver.
                 sparse_solver = sps.linalg.spsolve
-                warnings.warn(
+                warn(
                     """PyPardiso could not be imported,
                     falling back on scipy.sparse.linalg.spsolve"""
                 )

--- a/src/porepy/numerics/linear_solvers.py
+++ b/src/porepy/numerics/linear_solvers.py
@@ -8,6 +8,7 @@ case, see numerics.nonlinear.nonlinear_solvers.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from warnings import warn
 
 from porepy.models.solution_strategy import SolutionStrategy
@@ -21,6 +22,9 @@ from porepy.numerics.nonlinear.convergence_check import (
     SimulationStatus,
 )
 from porepy.viz.solver_statistics import TimeStatistics
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 class LinearSolver:
@@ -115,10 +119,10 @@ class LinearSolver:
 
         Returns:
             Tuple containing:
-            - ConvergenceStatusCollection: Convergence status collection at the end of the
-              nonlinear iteration.
-            - ConvergenceStatusCollection: Divergence status collection at the end of the
-              nonlinear iteration.
+            - ConvergenceStatusCollection: Convergence status collection at the end of
+                the nonlinear iteration.
+            - ConvergenceStatusCollection: Divergence status collection at the end of
+                the nonlinear iteration.
 
         """
         # Combines "before, actual and after" iteration steps.
@@ -209,12 +213,12 @@ class LinearSolver:
         Returns:
             Tuple containing:
 
-            - ConvergenceStatusCollection: Convergence status collection at the end of the
-              nonlinear iteration.
-            - ConvergenceStatusCollection: Divergence status collection at the end of the
-              nonlinear iteration.
-            - ConvergenceInfoCollection: Convergence information collection at the end of
-              the nonlinear iteration.
+            - ConvergenceStatusCollection: Convergence status collection at the end of
+                the nonlinear iteration.
+            - ConvergenceStatusCollection: Divergence status collection at the end of
+                the nonlinear iteration.
+            - ConvergenceInfoCollection: Convergence information collection at the end
+                of the nonlinear iteration.
 
         """
         # Fetch the residual.

--- a/src/porepy/numerics/linear_solvers.py
+++ b/src/porepy/numerics/linear_solvers.py
@@ -70,6 +70,31 @@ class LinearSolver:
             SimulationStatus: The status of the simulation.
 
         """
+        # Prepare solving.
+        self.before_linear_solve(model)
+
+        # For linear problems, the tolerance is irrelevant.
+        # FIXME: This assumes a direct solver is applied, but it may also be that
+        # parameters for linear solvers should be a property of the model, not the
+        # solver. This needs clarification at some point.
+
+        # Perform a single (Newton) iteration.
+        convergence_status, divergence_status = self.linear_solve(model)
+
+        # Conclude on the solver status.
+        solver_status = self.summarize_solver_status(
+            model, convergence_status, divergence_status
+        )
+
+        return solver_status
+
+    def before_linear_solve(self, model: SolutionStrategy) -> None:
+        """Prepare the linear solve.
+
+        Parameters:
+            model: The model instance specifying the problem to be solved.
+
+        """
         # Make sure the model is nonlinear.
         if not model._is_nonlinear_problem():
             raise ValueError(
@@ -80,43 +105,101 @@ class LinearSolver:
         # Prepare model for solving.
         model.before_nonlinear_loop()
 
-        # For linear problems, the tolerance is irrelevant.
-        # FIXME: This assumes a direct solver is applied, but it may also be that
-        # parameters for linear solvers should be a property of the model, not the
-        # solver. This needs clarification at some point.
+    def linear_solve(
+        self, model: SolutionStrategy
+    ) -> tuple[ConvergenceStatusCollection, ConvergenceStatusCollection]:
+        """Perform a single linear solve and check convergence and divergence.
 
-        # Perform a single (Newton) iteration.
+        Parameters:
+            model: The model instance specifying the problem to be solved.
+
+        Returns:
+            Tuple containing:
+            - ConvergenceStatusCollection: Convergence status collection at the end of the
+              nonlinear iteration.
+            - ConvergenceStatusCollection: Divergence status collection at the end of the
+              nonlinear iteration.
+
+        """
+        # Combines "before, actual and after" iteration steps.
         model.before_nonlinear_iteration()
         model.assemble_linear_system()
         nonlinear_increment = model.solve_linear_system()
+        convergence_status, divergence_status = self.after_linear_iteration(
+            model, nonlinear_increment
+        )
 
+        return convergence_status, divergence_status
+
+    def summarize_solver_status(
+        self,
+        model: SolutionStrategy,
+        convergence_status: ConvergenceStatusCollection,
+        divergence_status: ConvergenceStatusCollection,
+    ) -> SimulationStatus:
+        """Conclude on the overall solver status.
+
+        NOTE: Convergence status takes precedence over divergence status.
+
+        Args:
+            model: The model instance specifying the problem to be solved.
+            convergence_status (ConvergenceStatusCollection): Convergence statuses.
+            divergence_status (ConvergenceStatusCollection): Divergence statuses.
+
+        Returns:
+            SimulationStatus: The overall status of the nonlinear solver.
+
+        """
+        if convergence_status.is_converged():
+            solver_status = SimulationStatus.SUCCESSFUL
+            self.update_solver_statistics(model, solver_status)
+            model.after_nonlinear_convergence()
+        elif divergence_status.is_diverged():
+            solver_status = SimulationStatus.FAILED
+            self.update_solver_statistics(model, solver_status)
+            model.after_nonlinear_failure()
+            warn("Failed to solve the (non)linear problem.", UserWarning)
+        else:
+            raise ValueError(
+                "Invalid convergence status: "
+                f"{convergence_status.union(divergence_status)}"
+            )
+
+        return solver_status
+
+    def after_linear_iteration(
+        self, model: SolutionStrategy, nonlinear_increment: np.ndarray
+    ) -> tuple[ConvergenceStatusCollection, ConvergenceStatusCollection]:
+        """Finalize the linear iteration.
+
+        Parameters:
+            model: The model instance specifying the problem to be solved.
+            nonlinear_increment: Newly obtained solution increment vector.
+
+        Returns:
+            tuple[ConvergenceStatusCollection, ConvergenceStatusCollection]:
+                Convergence and divergence status.
+
+        """
         # Update model status (iterate) before checking convergence, so that the
         # convergence check uses the updated state. Also, after_nonlinear_convergence
         # may expect the converged solution to already be stored as an iterate.
         model.after_nonlinear_iteration(nonlinear_increment)
 
         # Monitor convergence.
-        status, _ = self.check_convergence(model, nonlinear_increment)
+        convergence_status, divergence_status, _ = self.check_convergence(
+            model, nonlinear_increment
+        )
 
-        # React to convergence status.
-        if status.is_converged():
-            solver_status = SimulationStatus.SUCCESSFUL
-            model.after_nonlinear_convergence()
-        elif status.is_diverged():
-            solver_status = SimulationStatus.FAILED
-            model.after_nonlinear_failure()
-            warn("Failed to solve the (non)linear problem.", UserWarning)
-        else:
-            raise ValueError(f"Unknown convergence status: {status}")
-
-        # Update (global) solver statistics.
-        self.update_solver_statistics(model, solver_status)
-
-        return solver_status
+        return convergence_status, divergence_status
 
     def check_convergence(
         self, model: SolutionStrategy, nonlinear_increment
-    ) -> tuple[ConvergenceStatusCollection, ConvergenceInfoCollection]:
+    ) -> tuple[
+        ConvergenceStatusCollection,
+        ConvergenceStatusCollection,
+        ConvergenceInfoCollection,
+    ]:
         """Check convergence and divergence based on passed criteria.
 
         Parameters:
@@ -124,8 +207,14 @@ class LinearSolver:
             nonlinear_increment: The current nonlinear increment.
 
         Returns:
-            tuple[ConvergenceStatusCollection, ConvergenceInfoCollection]: Status
-                and info about convergence.
+            Tuple containing:
+
+            - ConvergenceStatusCollection: Convergence status collection at the end of the
+              nonlinear iteration.
+            - ConvergenceStatusCollection: Divergence status collection at the end of the
+              nonlinear iteration.
+            - ConvergenceInfoCollection: Convergence information collection at the end of
+              the nonlinear iteration.
 
         """
         # Fetch the residual.
@@ -143,11 +232,7 @@ class LinearSolver:
             residual=residual,
         )
 
-        # Combine convergence and divergence status.
-        return (
-            convergence_status.union(divergence_status),
-            convergence_info,
-        )
+        return convergence_status, divergence_status, convergence_info
 
     def update_solver_statistics(
         self,

--- a/src/porepy/numerics/linear_solvers.py
+++ b/src/porepy/numerics/linear_solvers.py
@@ -93,19 +93,19 @@ class LinearSolver:
 
         # React to convergence status.
         if status.is_converged():
-            simulation_status = SimulationStatus.SUCCESSFUL
+            solver_status = SimulationStatus.SUCCESSFUL
             model.after_nonlinear_convergence()
         elif status.is_diverged():
-            simulation_status = SimulationStatus.FAILED
+            solver_status = SimulationStatus.FAILED
             model.after_nonlinear_failure()
             warn("Failed to solve the (non)linear problem.", UserWarning)
         else:
             raise ValueError(f"Unknown convergence status: {status}")
 
         # Update (global) solver statistics.
-        self.update_solver_statistics(model, simulation_status)
+        self.update_solver_statistics(model, solver_status)
 
-        return simulation_status
+        return solver_status
 
     def check_convergence(
         self, model: SolutionStrategy, nonlinear_increment
@@ -145,18 +145,18 @@ class LinearSolver:
     def update_solver_statistics(
         self,
         model: SolutionStrategy,
-        simulation_status: SimulationStatus,
+        solver_status: SimulationStatus,
     ) -> None:
         """Update the solver statistics in the model.
 
         Parameters:
             model: The model instance specifying the problem to be solved.
-            simulation_status: Simulation status of the solver.
+            solver_status: Simulation status of the solver.
             info: Dictionary containing norms and other information.
 
         """
         # Basic discretization-related information and overall simulation status.
-        model.nonlinear_solver_statistics.log_simulation_status(simulation_status)
+        model.nonlinear_solver_statistics.log_simulation_status(solver_status)
         model.nonlinear_solver_statistics.log_mesh_information(model.mdg.subdomains())
         if model._is_time_dependent():
             assert isinstance(model.nonlinear_solver_statistics, TimeStatistics)

--- a/src/porepy/numerics/linear_solvers.py
+++ b/src/porepy/numerics/linear_solvers.py
@@ -70,6 +70,13 @@ class LinearSolver:
             SimulationStatus: The status of the simulation.
 
         """
+        # Make sure the model is nonlinear.
+        if not model._is_nonlinear_problem():
+            raise ValueError(
+                "The linear solver is only applicable to linear problems. "
+                "Please use a nonlinear solver for nonlinear problems."
+            )
+
         # Prepare model for solving.
         model.before_nonlinear_loop()
 

--- a/src/porepy/numerics/linear_solvers.py
+++ b/src/porepy/numerics/linear_solvers.py
@@ -100,7 +100,7 @@ class LinearSolver:
 
         """
         # Make sure the model is nonlinear.
-        if not model._is_nonlinear_problem():
+        if model._is_nonlinear_problem():
             raise ValueError(
                 "The linear solver is only applicable to linear problems. "
                 "Please use a nonlinear solver for nonlinear problems."

--- a/src/porepy/numerics/linear_solvers.py
+++ b/src/porepy/numerics/linear_solvers.py
@@ -145,10 +145,10 @@ class LinearSolver:
 
         NOTE: Convergence status takes precedence over divergence status.
 
-        Args:
+        Parameters:
             model: The model instance specifying the problem to be solved.
-            convergence_status (ConvergenceStatusCollection): Convergence statuses.
-            divergence_status (ConvergenceStatusCollection): Divergence statuses.
+            convergence_status: Convergence statuses.
+            divergence_status: Divergence statuses.
 
         Returns:
             SimulationStatus: The overall status of the nonlinear solver.

--- a/src/porepy/numerics/linear_solvers.py
+++ b/src/porepy/numerics/linear_solvers.py
@@ -8,7 +8,7 @@ case, see numerics.nonlinear.nonlinear_solvers.
 
 from __future__ import annotations
 
-from typing import Optional
+from warnings import warn
 
 from porepy.models.solution_strategy import SolutionStrategy
 from porepy.numerics.nonlinear.convergence_check import (
@@ -96,7 +96,9 @@ class LinearSolver:
             simulation_status = SimulationStatus.SUCCESSFUL
             model.after_nonlinear_convergence()
         elif status.is_diverged():
-            simulation_status = model.after_nonlinear_failure()
+            simulation_status = SimulationStatus.FAILED
+            model.after_nonlinear_failure()
+            warn("Failed to solve the (non)linear problem.", UserWarning)
         else:
             raise ValueError(f"Unknown convergence status: {status}")
 

--- a/src/porepy/numerics/nonlinear/nonlinear_solvers.py
+++ b/src/porepy/numerics/nonlinear/nonlinear_solvers.py
@@ -321,10 +321,10 @@ class NewtonSolver:
 
         NOTE: Convergence status takes precedence over divergence status.
 
-        Args:
+        Parameters:
             model: The model instance specifying the problem to be solved.
-            convergence_status (ConvergenceStatusCollection): Convergence statuses.
-            divergence_status (ConvergenceStatusCollection): Divergence statuses.
+            convergence_status: Convergence statuses.
+            divergence_status: Divergence statuses.
 
         Returns:
             SimulationStatus: The overall status of the nonlinear solver.

--- a/src/porepy/numerics/nonlinear/nonlinear_solvers.py
+++ b/src/porepy/numerics/nonlinear/nonlinear_solvers.py
@@ -12,7 +12,6 @@ import numpy as np
 
 import porepy as pp
 from porepy.models.solution_strategy import SolutionStrategy
-from porepy.numerics.linear_solvers import LinearSolver
 from porepy.numerics.nonlinear.convergence_check import (
     ConvergenceCriteria,
     ConvergenceInfoCollection,
@@ -251,12 +250,15 @@ class NewtonSolver:
         # Actual Newton loop.
         convergence_status, divergence_status = self.nonlinear_loop(model)
 
-        # Finalize the nonlinear loop.
-        simulation_status = self.after_nonlinear_loop(
+        # Conclude on the solver status.
+        solver_status = self.summarize_solver_status(
             model, convergence_status, divergence_status
         )
 
-        return simulation_status
+        # Finalize the nonlinear loop.
+        self.after_nonlinear_loop()
+
+        return solver_status
 
     def before_nonlinear_loop(self, model: SolutionStrategy) -> None:
         """Prepare for the nonlinear loop.
@@ -299,8 +301,8 @@ class NewtonSolver:
                 nonlinear_increment = self.nonlinear_iteration(model)
 
                 # Finalize nonlinear iteration and determine status.
-                (convergence_status, divergence_status) = (
-                    self.after_nonlinear_iteration(model, nonlinear_increment)
+                convergence_status, divergence_status = self.after_nonlinear_iteration(
+                    model, nonlinear_increment
                 )
 
                 # Exit the Newton loop.
@@ -309,54 +311,62 @@ class NewtonSolver:
 
         return convergence_status, divergence_status
 
-    def after_nonlinear_loop(
+    def summarize_solver_status(
         self,
         model: SolutionStrategy,
         convergence_status: ConvergenceStatusCollection,
         divergence_status: ConvergenceStatusCollection,
     ) -> SimulationStatus:
-        """Finalize the nonlinear loop.
+        """Conclude on the overall solver status.
 
-        Parameters:
+        NOTE: Convergence status takes precedence over divergence status.
+
+        Args:
             model: The model instance specifying the problem to be solved.
-            convergence_status: The convergence status collection.
-            divergence_status: The divergence status collection.
+            convergence_status (ConvergenceStatusCollection): Convergence statuses.
+            divergence_status (ConvergenceStatusCollection): Divergence statuses.
 
         Returns:
-            SimulationStatus: The status of the nonlinear solver.
+            SimulationStatus: The overall status of the nonlinear solver.
 
         """
-        # React to convergence status. Let convergence trump divergence.
+
+        # Conclude on the overall solver status.
         if convergence_status.is_converged():
-            simulation_status = SimulationStatus.SUCCESSFUL
-            self.update_solver_statistics(model, simulation_status=simulation_status)
+            solver_status = SimulationStatus.SUCCESSFUL
+            self.update_solver_statistics(model, solver_status=solver_status)
             model.after_nonlinear_convergence()
         elif divergence_status.is_diverged():
-            simulation_status = SimulationStatus.FAILED
-            self.update_solver_statistics(model, simulation_status=simulation_status)
+            solver_status = SimulationStatus.FAILED
+            self.update_solver_statistics(model, solver_status=solver_status)
+            model.after_nonlinear_failure()
             if model._is_nonlinear_problem():
+                # NOTE: While FAILED on solver level, IN_PROGRESS on simulation level.
                 warn("Failed to solve the nonlinear problem.", UserWarning)
             else:
-                # Declare total failure which shall result in stopping the simulation.
+                # NOTE: FAILED on solver level, and FAILED on simulation level.
                 # TODO: Get back to this when reimplementing time stepping.
-                # NOTE: Currently, if a simulation fully stopps, this is not logged in
+                # NOTE: Currently, if a simulation fully stops, this is not logged in
                 # SolverStatistics. For this, better coordination between solver and time
-                # stepping is needed.
-                # NOTE: Should possible be handled on the level above the solver,
-                # as a reaction to the FAILED solver status.
+                # stepping is needed. Should possible be handled on the level above the
+                # solver, as a reaction to the FAILED solver status.
+
+                # Declare total failure which shall result in stopping the simulation.
                 warn(
                     "Failed to solve linear system for the linear problem. "
                     "Stopping the simulation.",
                     UserWarning,
                 )
-                simulation_status = SimulationStatus.STOPPED
+                solver_status = SimulationStatus.STOPPED
         else:
-            raise ValueError(f"Unknown convergence status: {convergence_status}")
+            raise ValueError(f"Invalid convergence status: {convergence_status}")
 
+        return solver_status
+
+    def after_nonlinear_loop(self) -> None:
+        """Finalize the nonlinear loop."""
         # Close the progress bar.
         self.solver_progressbar.close()
-
-        return simulation_status
 
     def before_nonlinear_iteration(self, model: SolutionStrategy) -> None:
         """Prepare for a nonlinear iteration.
@@ -411,10 +421,8 @@ class NewtonSolver:
             nonlinear_increment: Newly obtained solution increment vector.
 
         Returns:
-            tuple[
-                ConvergenceStatusCollection,
-                ConvergenceStatusCollection,
-            ]: Convergence and divergence status.
+            tuple[ConvergenceStatusCollection, ConvergenceStatusCollection]:
+                Convergence and divergence status.
 
         """
         # Update model status.
@@ -454,9 +462,11 @@ class NewtonSolver:
             nonlinear_increment: Newly obtained solution increment vector.
 
         Returns:
-            tuple[ConvergenceStatusCollection, ConvergenceStatusCollection,
-            ConvergenceInfoCollection]: Status and
-                info about convergence and divergence.
+            Tuple containing:
+                - ConvergenceStatusCollection: Status and info about convergence.
+                - ConvergenceStatusCollection: Status and info about divergence.
+                - ConvergenceInfoCollection: Detailed information about the
+                    convergence process.
 
         """
         # Fetch the residual and current iterate.
@@ -530,7 +540,7 @@ class NewtonSolver:
     def update_solver_statistics(
         self,
         model: SolutionStrategy,
-        simulation_status: SimulationStatus | None = None,
+        solver_status: SimulationStatus | None = None,
         convergence_status: ConvergenceStatusCollection | None = None,
         convergence_info: ConvergenceInfoCollection | None = None,
     ) -> None:
@@ -538,7 +548,7 @@ class NewtonSolver:
 
         Parameters:
             model: The model instance specifying the problem to be solved.
-            simulation_status: Simulation status of the solver.
+            solver_status: Status of the solver.
             convergence_status: Convergence (and divergence) status of the solver.
             convergence_info: Dictionary containing norms and other information.
 
@@ -553,7 +563,7 @@ class NewtonSolver:
             model.nonlinear_solver_statistics.log_convergence_info(convergence_info)
 
         # Basic discretization-related information and overall simulation status.
-        if simulation_status is not None:
+        if solver_status is not None:
             pp.LinearSolver.update_solver_statistics(
-                cast(pp.LinearSolver, self), model, simulation_status
+                cast(pp.LinearSolver, self), model, solver_status
             )

--- a/src/porepy/numerics/nonlinear/nonlinear_solvers.py
+++ b/src/porepy/numerics/nonlinear/nonlinear_solvers.py
@@ -357,7 +357,10 @@ class NewtonSolver:
                 )
                 solver_status = SimulationStatus.STOPPED
         else:
-            raise ValueError(f"Invalid convergence status: {convergence_status}")
+            raise ValueError(
+                "Invalid convergence status: "
+                f"{convergence_status.union(divergence_status)}"
+            )
 
         return solver_status
 
@@ -423,7 +426,9 @@ class NewtonSolver:
                 Convergence and divergence status.
 
         """
-        # Update model status.
+        # Update model status (iterate) before checking convergence, so that the
+        # convergence check uses the updated state. Also, after_nonlinear_convergence
+        # may expect the converged solution to already be stored as an iterate.
         model.after_nonlinear_iteration(nonlinear_increment)
 
         # Monitor convergence.

--- a/src/porepy/numerics/nonlinear/nonlinear_solvers.py
+++ b/src/porepy/numerics/nonlinear/nonlinear_solvers.py
@@ -6,6 +6,7 @@ Implemented classes
 
 import logging
 from typing import cast
+from warnings import warn
 
 import numpy as np
 
@@ -333,11 +334,22 @@ class NewtonSolver:
         elif divergence_status.is_diverged():
             simulation_status = SimulationStatus.FAILED
             self.update_solver_statistics(model, simulation_status=simulation_status)
-            # TODO: Get back to this when reimplementing time stepping.
-            # NOTE: Currently, if a simulation fully stopps, this is not logged in
-            # SolverStatistics. For this, better coordination between solver and time
-            # stepping is needed.
-            simulation_status = model.after_nonlinear_failure()
+            if model._is_nonlinear_problem():
+                warn("Failed to solve the nonlinear problem.", UserWarning)
+            else:
+                # Declare total failure which shall result in stopping the simulation.
+                # TODO: Get back to this when reimplementing time stepping.
+                # NOTE: Currently, if a simulation fully stopps, this is not logged in
+                # SolverStatistics. For this, better coordination between solver and time
+                # stepping is needed.
+                # NOTE: Should possible be handled on the level above the solver,
+                # as a reaction to the FAILED solver status.
+                warn(
+                    "Failed to solve linear system for the linear problem. "
+                    "Stopping the simulation.",
+                    UserWarning,
+                )
+                simulation_status = SimulationStatus.STOPPED
         else:
             raise ValueError(f"Unknown convergence status: {convergence_status}")
 

--- a/src/porepy/numerics/nonlinear/nonlinear_solvers.py
+++ b/src/porepy/numerics/nonlinear/nonlinear_solvers.py
@@ -345,8 +345,8 @@ class NewtonSolver:
                 # NOTE: FAILED on solver level, and FAILED on simulation level.
                 # Should possible be handled on the level above the solver.
                 # NOTE: Currently, if a simulation fully stops, this is not logged in
-                # SolverStatistics. For this, better coordination between solver and time
-                # stepping is needed.
+                # SolverStatistics. For this, better coordination between solver and
+                # time stepping is needed.
                 # TODO: Get back to this when reimplementing time stepping.
 
                 # Declare total failure which shall result in stopping the simulation.

--- a/src/porepy/numerics/nonlinear/nonlinear_solvers.py
+++ b/src/porepy/numerics/nonlinear/nonlinear_solvers.py
@@ -330,26 +330,24 @@ class NewtonSolver:
             SimulationStatus: The overall status of the nonlinear solver.
 
         """
-
-        # Conclude on the overall solver status.
         if convergence_status.is_converged():
             solver_status = SimulationStatus.SUCCESSFUL
             self.update_solver_statistics(model, solver_status=solver_status)
             model.after_nonlinear_convergence()
         elif divergence_status.is_diverged():
+            # NOTE: While FAILED on solver level, IN_PROGRESS on simulation level.
             solver_status = SimulationStatus.FAILED
             self.update_solver_statistics(model, solver_status=solver_status)
             model.after_nonlinear_failure()
-            if model._is_nonlinear_problem():
-                # NOTE: While FAILED on solver level, IN_PROGRESS on simulation level.
-                warn("Failed to solve the nonlinear problem.", UserWarning)
-            else:
+            warn("Failed to solve the nonlinear problem.", UserWarning)
+
+            if not model._is_nonlinear_problem():
                 # NOTE: FAILED on solver level, and FAILED on simulation level.
-                # TODO: Get back to this when reimplementing time stepping.
+                # Should possible be handled on the level above the solver.
                 # NOTE: Currently, if a simulation fully stops, this is not logged in
                 # SolverStatistics. For this, better coordination between solver and time
-                # stepping is needed. Should possible be handled on the level above the
-                # solver, as a reaction to the FAILED solver status.
+                # stepping is needed.
+                # TODO: Get back to this when reimplementing time stepping.
 
                 # Declare total failure which shall result in stopping the simulation.
                 warn(

--- a/src/porepy/numerics/nonlinear/nonlinear_solvers.py
+++ b/src/porepy/numerics/nonlinear/nonlinear_solvers.py
@@ -351,7 +351,7 @@ class NewtonSolver:
 
                 # Declare total failure which shall result in stopping the simulation.
                 warn(
-                    "Failed to solve linear system for the linear problem. "
+                    "Failed to solve linear system for the nonlinear problem. "
                     "Stopping the simulation.",
                     UserWarning,
                 )

--- a/tests/numerics/nonlinear/test_nonlinear_solvers.py
+++ b/tests/numerics/nonlinear/test_nonlinear_solvers.py
@@ -111,6 +111,9 @@ class MockModel:
     def _is_time_dependent(self):
         return False
 
+    def _is_nonlinear_problem(self):
+        return True
+
 
 class TimeDependentMockModel(MockModel):
     """Use nested lists for convergence history and adapted statistics."""
@@ -147,6 +150,9 @@ class TimeDependentMockModel(MockModel):
         self.residuals = self.residuals[1:]
 
     def _is_time_dependent(self):
+        return True
+
+    def _is_nonlinear_problem(self):
         return True
 
 

--- a/tests/numerics/nonlinear/test_nonlinear_solvers.py
+++ b/tests/numerics/nonlinear/test_nonlinear_solvers.py
@@ -100,7 +100,6 @@ class MockModel:
 
     def after_nonlinear_failure(self):
         self.nonlinear_solver_statistics.save()
-        return SimulationStatus.FAILED
 
     def assemble_linear_system(self):
         pass
@@ -933,7 +932,9 @@ def test_summarize_solver_status(
         SimulationStatus.SUCCESSFUL
     ]
 
-    solver_status = solver.summarize_solver_status(model, convergence_status, divergence_status)
+    solver_status = solver.summarize_solver_status(
+        model, convergence_status, divergence_status
+    )
 
     # Check that the returned simulation status matches expected value.
     assert solver_status == expected_solver_status

--- a/tests/numerics/nonlinear/test_nonlinear_solvers.py
+++ b/tests/numerics/nonlinear/test_nonlinear_solvers.py
@@ -263,10 +263,10 @@ def test_solve_convergence(default_newton_solver):
     solver = default_newton_solver
 
     # Call solve.
-    simulation_status = solver.solve(model)
+    solver_status = solver.solve(model)
 
     # Check simulation status.
-    assert simulation_status == SimulationStatus.SUCCESSFUL
+    assert solver_status == SimulationStatus.SUCCESSFUL
 
 
 def test_solve_convergence_statistics(default_newton_solver):
@@ -352,18 +352,18 @@ def test_solve_convergence_time_dependent(default_newton_solver):
     # First time step - advance time to log the time step.
     model.time_manager.increase_time()
     model.time_manager.increase_time_index()
-    simulation_status = solver.solve(model)
+    solver_status = solver.solve(model)
 
     # Check simulation status.
-    assert simulation_status == SimulationStatus.SUCCESSFUL
+    assert solver_status == SimulationStatus.SUCCESSFUL
 
     # Second time step.
     model.time_manager.increase_time()
     model.time_manager.increase_time_index()
-    simulation_status = solver.solve(model)
+    solver_status = solver.solve(model)
 
     # Check simulation status.
-    assert simulation_status == SimulationStatus.SUCCESSFUL
+    assert solver_status == SimulationStatus.SUCCESSFUL
 
 
 def test_solve_convergence_time_dependent_statistics(default_newton_solver):
@@ -509,10 +509,10 @@ def test_solve_failure(default_newton_solver):
         residual_history=[1.0, np.nan],
     )
     solver = default_newton_solver
-    simulation_status = solver.solve(model)
+    solver_status = solver.solve(model)
 
     # Check simulation status.
-    assert simulation_status == SimulationStatus.FAILED
+    assert solver_status == SimulationStatus.FAILED
 
 
 def test_solve_failure_statistics(default_newton_solver):
@@ -527,10 +527,10 @@ def test_solve_failure_statistics(default_newton_solver):
         path=Path("solver_statistics.json"),
     )
     solver = default_newton_solver
-    simulation_status = solver.solve(model)
+    solver_status = solver.solve(model)
 
     # Check simulation status.
-    assert simulation_status == SimulationStatus.FAILED
+    assert solver_status == SimulationStatus.FAILED
 
     # Check solver statistics.
     with open("solver_statistics.json", "r") as f:
@@ -598,27 +598,27 @@ def test_solve_failure_time_dependent(default_newton_solver):
     # First time step - advance time to log the time step.
     model.time_manager.increase_time()
     model.time_manager.increase_time_index()
-    simulation_status = solver.solve(model)
+    solver_status = solver.solve(model)
 
     # Check simulation status.
     assert not model.time_manager.final_time_reached()
-    assert simulation_status == SimulationStatus.FAILED
+    assert solver_status == SimulationStatus.FAILED
 
     # Retry time step, so do not increase time.
-    simulation_status = solver.solve(model)
+    solver_status = solver.solve(model)
 
     # Check simulation status.
     assert not model.time_manager.final_time_reached()
-    assert simulation_status == SimulationStatus.SUCCESSFUL
+    assert solver_status == SimulationStatus.SUCCESSFUL
 
     # First time step - advance time to log the time step.
     model.time_manager.increase_time()
     model.time_manager.increase_time_index()
-    simulation_status = solver.solve(model)
+    solver_status = solver.solve(model)
 
     # Check simulation status.
     assert model.time_manager.final_time_reached()
-    assert simulation_status == SimulationStatus.SUCCESSFUL
+    assert solver_status == SimulationStatus.SUCCESSFUL
 
 
 def test_solve_failure_time_dependent_statistics(default_newton_solver):
@@ -894,7 +894,7 @@ def test_nonlinear_loop(
 
 
 @pytest.mark.parametrize(
-    "convergence_status, divergence_status, expected_simulation_status",
+    "convergence_status, divergence_status, expected_solver_status",
     [
         (
             ConvergenceStatus.CONVERGED,
@@ -913,13 +913,13 @@ def test_nonlinear_loop(
         ),
     ],
 )
-def test_after_nonlinear_loop(
+def test_summarize_solver_status(
     convergence_status,
     divergence_status,
-    expected_simulation_status,
+    expected_solver_status,
     default_newton_solver,
 ):
-    """Unit test for the after_nonlinear_loop method of the Newton solver."""
+    """Unit test for the summarize_solver_status method of the Newton solver."""
     # Init model and solver.
     model = MockModel()
     solver = default_newton_solver
@@ -933,12 +933,10 @@ def test_after_nonlinear_loop(
         SimulationStatus.SUCCESSFUL
     ]
 
-    simulation_status = solver.after_nonlinear_loop(
-        model, convergence_status, divergence_status
-    )
+    solver_status = solver.summarize_solver_status(model, convergence_status, divergence_status)
 
     # Check that the returned simulation status matches expected value.
-    assert simulation_status == expected_simulation_status
+    assert solver_status == expected_solver_status
 
 
 def test_before_nonlinear_iteration(default_newton_solver):


### PR DESCRIPTION
## Proposed changes

Minor clean up on the solver level:
- Consistent naming of solver_status (not simulation_status which should be handled one level above). NB: inconsistency remains at statistics level and requires a clearer distinction between solver and simulation status (suggested for future).
- Cleaner method design with separate responsibility for providing the solver status as a result of the convergence status.
- (Attempt of) identical logics and structure in linear and nonlinear solver.

Not done:
- No further tests were added (one has been renamed after introducing more granularity but essentially testing the same) - this PR does not introduce new functionality.
- Clean distinction between solver and simulation status (in particular no new classes). Some NOTE and TODO comments have been modified to indicate the status.
- Further processing on the time stepping level.
- Further streamlining with a common mother class for LinearSolver and NonlinearSolver exploiting the similar structure.

Contributions to PorePy are highly appreciated. Clearly explain why this pull request (PR) is needed and why it should be accepted. If this PR solves an issue, explain how it is done. Please, also summarise the changes to the code.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [x] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.

