### PR TITLE
Adjust eta length

### DIFF
--- a/src/porepy/numerics/fv/_fvutils.py
+++ b/src/porepy/numerics/fv/_fvutils.py
@@ -592,7 +592,7 @@ def remove_nonlocal_contribution(
 
 
 def adjust_eta_length(
-    eta: np.ndarray, sub_sd: pp.Grid, l2g_faces: np.ndarray, sd: pp.Grid
+    eta: np.ndarray, l2g_faces: np.ndarray, parent_grid: pp.Grid
 ) -> np.ndarray:
     """Adjusts length of vector valued eta for problems partitioned into subproblems.
 
@@ -603,12 +603,10 @@ def adjust_eta_length(
 
     Parameters:
         eta: MPFA/MPSA-eta.
-        sub_sd: A subgrid of the domain. Eta is adjusted according to the subfaces in
-            sub_sd.
         l2g_faces: Indices (in the global grid) of all faces in the subgrid. Represented
             as a numpy array, so that element i gives the global index of the i-th face
             in the subgrid.
-        sd: The global (parent) grid. Used to determine global subface offsets per face.
+        parent_grid: The global (parent) grid. Used to determine global subface offsets per face.
 
     Returns:
         An array of eta values corresponding to a grid that arises from from domain
@@ -618,7 +616,7 @@ def adjust_eta_length(
     # Use the global grid's face_nodes indptr to look up, for each face in l2g_faces,
     # the range of global subface indices belonging to that face. This correctly handles
     # grids where faces have different numbers of nodes.
-    global_indptr = sd.face_nodes.tocsc().indptr
+    global_indptr = parent_grid.face_nodes.tocsc().indptr
     indices = np.concatenate(
         [np.arange(global_indptr[f], global_indptr[f + 1]) for f in l2g_faces]
     )

--- a/src/porepy/numerics/fv/_fvutils.py
+++ b/src/porepy/numerics/fv/_fvutils.py
@@ -606,7 +606,8 @@ def adjust_eta_length(
         l2g_faces: Indices (in the global grid) of all faces in the subgrid. Represented
             as a numpy array, so that element i gives the global index of the i-th face
             in the subgrid.
-        parent_grid: The global (parent) grid. Used to determine global subface offsets per face.
+        parent_grid: The global (parent) grid. Used to determine global subface offsets
+            per face.
 
     Returns:
         An array of eta values corresponding to a grid that arises from from domain

--- a/src/porepy/numerics/fv/_fvutils.py
+++ b/src/porepy/numerics/fv/_fvutils.py
@@ -592,7 +592,7 @@ def remove_nonlocal_contribution(
 
 
 def adjust_eta_length(
-    eta: np.ndarray, sub_sd: pp.Grid, l2g_faces: np.ndarray
+    eta: np.ndarray, sub_sd: pp.Grid, l2g_faces: np.ndarray, sd: pp.Grid
 ) -> np.ndarray:
     """Adjusts length of vector valued eta for problems partitioned into subproblems.
 
@@ -608,20 +608,21 @@ def adjust_eta_length(
         l2g_faces: Indices (in the global grid) of all faces in the subgrid. Represented
             as a numpy array, so that element i gives the global index of the i-th face
             in the subgrid.
+        sd: The global (parent) grid. Used to determine global subface offsets per face.
 
     Returns:
         An array of eta values corresponding to a grid that arises from from domain
         partitioning.
 
     """
-    # Use information in the sparse formatting to find the number of nodes per face
-    num_nodes_per_face = np.diff(sub_sd.face_nodes.tocsc().indptr)
-    # Verify that all faces have equally many nodes
-    assert np.unique(num_nodes_per_face).size == 1
-    expansion_index = num_nodes_per_face[0]
-
-    indices = pp.array_operations.expand_indices_nd(l2g_faces, expansion_index)
-    loc_eta = np.array([eta[i] for i in indices])
+    # Use the global grid's face_nodes indptr to look up, for each face in l2g_faces,
+    # the range of global subface indices belonging to that face. This correctly handles
+    # grids where faces have different numbers of nodes.
+    global_indptr = sd.face_nodes.tocsc().indptr
+    indices = np.concatenate(
+        [np.arange(global_indptr[f], global_indptr[f + 1]) for f in l2g_faces]
+    )
+    loc_eta = eta[indices]
     return loc_eta
 
 

--- a/src/porepy/numerics/fv/mpfa.py
+++ b/src/porepy/numerics/fv/mpfa.py
@@ -212,7 +212,7 @@ class Mpfa(pp.FVElliptic):
         # indexes eta correctly.
         if isinstance(eta, np.ndarray) and active_cells.size < sd.num_cells:
             eta = _fvutils.adjust_eta_length(
-                eta=eta, sub_sd=active_grid, l2g_faces=extracted_faces, sd=sd
+                eta=eta, l2g_faces=extracted_faces, parent_grid=sd
             )
 
         # Bookkeeping.
@@ -293,7 +293,7 @@ class Mpfa(pp.FVElliptic):
             # partitioned subgrid.
             if isinstance(eta, np.ndarray):
                 loc_eta = _fvutils.adjust_eta_length(
-                    eta=eta, sub_sd=sub_sd, l2g_faces=l2g_faces, sd=active_grid
+                    eta=eta, l2g_faces=l2g_faces, parent_grid=active_grid
                 )
 
             # Non-array eta suggests eta is scalar. Thus no changes happen to eta.

--- a/src/porepy/numerics/fv/mpfa.py
+++ b/src/porepy/numerics/fv/mpfa.py
@@ -206,6 +206,15 @@ class Mpfa(pp.FVElliptic):
             active_k = k
             active_bound = bnd
 
+        # If eta is a vector it is indexed over the subfaces of sd. When active_grid is
+        # a proper subgrid of sd, restrict eta to the subfaces of active_grid so that
+        # the inner subproblems loop (which uses active_grid's local face numbering)
+        # indexes eta correctly.
+        if isinstance(eta, np.ndarray) and active_cells.size < sd.num_cells:
+            eta = _fvutils.adjust_eta_length(
+                eta=eta, sub_sd=active_grid, l2g_faces=extracted_faces, sd=sd
+            )
+
         # Bookkeeping.
         nf = active_grid.num_faces
         nc = active_grid.num_cells
@@ -284,7 +293,7 @@ class Mpfa(pp.FVElliptic):
             # partitioned subgrid.
             if isinstance(eta, np.ndarray):
                 loc_eta = _fvutils.adjust_eta_length(
-                    eta=eta, sub_sd=sub_sd, l2g_faces=l2g_faces
+                    eta=eta, sub_sd=sub_sd, l2g_faces=l2g_faces, sd=active_grid
                 )
 
             # Non-array eta suggests eta is scalar. Thus no changes happen to eta.

--- a/src/porepy/numerics/fv/mpsa.py
+++ b/src/porepy/numerics/fv/mpsa.py
@@ -233,6 +233,15 @@ class Mpsa(Discretization):
             bound, active_grid, extracted_faces
         )
 
+        # If eta is a vector it is indexed over the subfaces of sd. Restrict eta to the
+        # subfaces of active_grid so that the inner subproblems loop (which uses
+        # active_grid's local face numbering) indexes eta correctly. When all cells are
+        # active, extracted_faces = arange(sd.num_faces) and this is a no-op.
+        if isinstance(eta, np.ndarray):
+            eta = _fvutils.adjust_eta_length(
+                eta=eta, sub_sd=active_grid, l2g_faces=extracted_faces, sd=sd
+            )
+
         # Bookkeeping.
         nd = active_grid.dim
         nf = active_grid.num_faces
@@ -301,7 +310,7 @@ class Mpsa(Discretization):
             # partitioned subgrid.
             if isinstance(eta, np.ndarray):
                 loc_eta = _fvutils.adjust_eta_length(
-                    eta=eta, sub_sd=sub_g, l2g_faces=l2g_faces
+                    eta=eta, sub_sd=sub_g, l2g_faces=l2g_faces, sd=active_grid
                 )
 
             # Non-array eta suggests eta is scalar. Thus no changes happen to eta.

--- a/src/porepy/numerics/fv/mpsa.py
+++ b/src/porepy/numerics/fv/mpsa.py
@@ -239,7 +239,7 @@ class Mpsa(Discretization):
         # active, extracted_faces = arange(sd.num_faces) and this is a no-op.
         if isinstance(eta, np.ndarray):
             eta = _fvutils.adjust_eta_length(
-                eta=eta, sub_sd=active_grid, l2g_faces=extracted_faces, sd=sd
+                eta=eta, l2g_faces=extracted_faces, parent_grid=sd
             )
 
         # Bookkeeping.
@@ -310,7 +310,7 @@ class Mpsa(Discretization):
             # partitioned subgrid.
             if isinstance(eta, np.ndarray):
                 loc_eta = _fvutils.adjust_eta_length(
-                    eta=eta, sub_sd=sub_g, l2g_faces=l2g_faces, sd=active_grid
+                    eta=eta, l2g_faces=l2g_faces, parent_grid=active_grid
                 )
 
             # Non-array eta suggests eta is scalar. Thus no changes happen to eta.

--- a/tests/numerics/fv/test_fvutils.py
+++ b/tests/numerics/fv/test_fvutils.py
@@ -317,7 +317,7 @@ def test_adjust_eta_length_uniform_faces():
     l2g_faces = np.array([0, 2])
 
     # Call with a trivial sub_sd (not used in the new implementation).
-    loc_eta = _fvutils.adjust_eta_length(eta=eta, sub_sd=sd, l2g_faces=l2g_faces, sd=sd)
+    loc_eta = _fvutils.adjust_eta_length(eta=eta, l2g_faces=l2g_faces, parent_grid=sd)
 
     # Face 0 occupies slots 0-1, face 2 occupies slots 4-5 in the indptr
     # (each face has 2 nodes, so face f starts at slot 2*f).
@@ -369,7 +369,7 @@ def test_adjust_eta_length_mixed_nodes_per_face():
     # Request f0 (triangle, 3 nodes) and f2 (quad, 4 nodes).
     l2g_faces = np.array([0, 2])
 
-    loc_eta = _fvutils.adjust_eta_length(eta=eta, sub_sd=sd, l2g_faces=l2g_faces, sd=sd)
+    loc_eta = _fvutils.adjust_eta_length(eta=eta, l2g_faces=l2g_faces, parent_grid=sd)
 
     # fn_indptr = [0, 3, 6, 10, 14, 18], so:
     #   f0 (triangle) occupies slots 0-2  -> eta values [0, 1, 2]

--- a/tests/numerics/fv/test_fvutils.py
+++ b/tests/numerics/fv/test_fvutils.py
@@ -298,3 +298,80 @@ def test_bound_exclusion():
     dir_ind = dir_ind[is_dir_nd[dir_ind]]
 
     assert np.all(dir_ind == reference["dir_inds"])
+
+
+def test_adjust_eta_length_uniform_faces():
+    """Check that adjust_eta_length correctly extracts subface eta values when all faces
+    have the same number of nodes (standard 2d Cartesian grid).
+    """
+    # 2x1 Cartesian grid: 3 vertical faces (2 nodes each) + 4 horizontal faces
+    # (2 nodes each) = 7 faces, 14 entries in the global face_nodes CSC indptr.
+    sd = pp.CartGrid([2, 1])
+    sd.compute_geometry()
+
+    # Build a global eta vector: one distinct value per subface slot.
+    n_global_subfaces = sd.face_nodes.tocsc().indptr[-1]
+    eta = np.arange(n_global_subfaces, dtype=float)
+
+    # Select a subset of faces (e.g. face 0 and face 2).
+    l2g_faces = np.array([0, 2])
+
+    # Call with a trivial sub_sd (not used in the new implementation).
+    loc_eta = _fvutils.adjust_eta_length(eta=eta, sub_sd=sd, l2g_faces=l2g_faces, sd=sd)
+
+    # Face 0 occupies slots 0-1, face 2 occupies slots 4-5 in the indptr
+    # (each face has 2 nodes, so face f starts at slot 2*f).
+    assert np.array_equal(loc_eta, np.array([0.0, 1.0, 4.0, 5.0]))
+
+
+def test_adjust_eta_length_mixed_nodes_per_face():
+    """adjust_eta_length works correctly when faces have different numbers of nodes.
+
+    In 3D, faces can be e.g. triangles (3 nodes) or quadrilaterals (4 nodes). This test
+    uses a triangular prism, which has 2 triangular faces and 3 quadrilateral faces (as
+    would be the result of a grid extrusion type 3d grid).
+
+    This test verifies that adjust_eta_length correctly gathers the subface eta values
+    for a subset of faces, even when the faces have different numbers of nodes (and thus
+    different numbers of subface slots in the global eta vector).
+    """
+    # Triangular prism: 6 nodes, 5 faces, 1 cell.
+    #   Bottom triangle: nodes 0, 1, 2
+    #   Top triangle:    nodes 3, 4, 5
+    nodes = np.array(
+        [[0, 1, 0.5, 0, 1, 0.5], [0, 0, 1, 0, 0, 1], [0, 0, 0, 1, 1, 1]],
+        dtype=float,
+    )
+
+    # face_nodes (CSC, 6 nodes x 5 faces):
+    #   f0 (bottom triangle): nodes [0, 1, 2]    -> 3 entries
+    #   f1 (top triangle):    nodes [3, 4, 5]    -> 3 entries
+    #   f2 (front quad):      nodes [0, 1, 3, 4] -> 4 entries
+    #   f3 (right quad):      nodes [1, 2, 4, 5] -> 4 entries
+    #   f4 (left quad):       nodes [0, 2, 3, 5] -> 4 entries
+    fn_indptr = np.array([0, 3, 6, 10, 14, 18])
+    fn_indices = np.array([0, 1, 2, 3, 4, 5, 0, 1, 3, 4, 1, 2, 4, 5, 0, 2, 3, 5])
+    face_nodes = sps.csc_matrix(
+        (np.ones(18, dtype=bool), fn_indices, fn_indptr), shape=(6, 5)
+    )
+
+    # cell_faces: all 5 faces belong to the single cell.
+    cell_faces = sps.csc_matrix(
+        (np.ones(5), (np.arange(5), np.zeros(5, dtype=int))), shape=(5, 1)
+    )
+
+    sd = pp.Grid(3, nodes, face_nodes, cell_faces, "prism")
+
+    # Assign a distinct eta value per global subface (node-face incidence).
+    # Total: 3 + 3 + 4 + 4 + 4 = 18 entries.
+    eta = np.arange(18, dtype=float)
+
+    # Request f0 (triangle, 3 nodes) and f2 (quad, 4 nodes).
+    l2g_faces = np.array([0, 2])
+
+    loc_eta = _fvutils.adjust_eta_length(eta=eta, sub_sd=sd, l2g_faces=l2g_faces, sd=sd)
+
+    # fn_indptr = [0, 3, 6, 10, 14, 18], so:
+    #   f0 (triangle) occupies slots 0-2  -> eta values [0, 1, 2]
+    #   f2 (quad)     occupies slots 6-9  -> eta values [6, 7, 8, 9]
+    assert np.array_equal(loc_eta, np.array([0.0, 1.0, 2.0, 6.0, 7.0, 8.0, 9.0]))


### PR DESCRIPTION
## Proposed changes

1. Removes limitation in eta adjustment and 2. fixes a bug when active_grid *and* subproblems are invoked. Also adds tests.

1. Is achieved by considering the parent grid, not the subgrid, and looping over face mapping, extending according to number of nodes for each face.
2. Involves adding restriction from sd to active_grid before the restriction from active_grid to sub_grid, as per mp terminology.

Note to reviewer: Please consider whether to remove unused sub_sd from signature of adjust_eta_length.


Resolves #1658. 
## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [x] Bugfix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
