### PR TITLE
Update helper method to create 1d grids (not necessarily aligned with the x-axis) 

### DIFF
--- a/src/porepy/fracs/msh_2_grid.py
+++ b/src/porepy/fracs/msh_2_grid.py
@@ -457,41 +457,38 @@ def create_0d_grids(
 
 
 def create_embedded_line_grid(
-    loc_coord: np.ndarray, glob_id: np.ndarray, tol: float = 1e-4
+    loc_coord: np.ndarray,
+    glob_id: np.ndarray | None = None,
+    sort: bool = True,
+    tol: float = 1e-4,
 ) -> pp.Grid:
     """Create a 1d grid embedded in a higher dimensional space.
 
     Parameters:
         loc_coord: Coordinates of points to be used in the grid.
         glob_id : Global indexes of the points. Typically refers to a global mesh, where
-            the points of this grid is a subset.
+            the points of this grid is a subset. If provided, the returned grid will
+            have an attribute ``global_point_ind`` that maps from local to global point
+            numbering.
+        sort: Whether to sort the points. The sorting assumes the points are colinear.
         tol: Tolerance used for check of collinearity of the points.
 
     Returns:
         g: 1d grid.
 
     """
-    loc_center = np.mean(loc_coord, axis=1).reshape((-1, 1))
-    (
-        sorted_coord,
-        rot,
-        active_dimension,
-        sort_ind,
-    ) = pp.map_geometry.project_points_to_line(loc_coord, tol)
-    g = pp.TensorGrid(sorted_coord)
+    if sort:
+        *_, sort_ind = pp.map_geometry.project_points_to_line(loc_coord, tol=tol)
+        loc_coord = loc_coord[:, sort_ind]
+    else:
+        sort_ind = np.arange(loc_coord.shape[1])
 
-    # Project back to active dimension.
-    nodes = np.zeros(g.nodes.shape)
-    nodes[active_dimension] = g.nodes[0]
-    g.nodes = nodes
-
-    # Project back again to 3d coordinates.
-    irot = rot.transpose()
-    g.nodes = irot.dot(g.nodes)
-    g.nodes += loc_center
+    g = pp.TensorGrid(np.arange(loc_coord.shape[1]))
+    g.nodes = loc_coord
 
     # Add mapping to global point numbers.
-    g.global_point_ind = glob_id[sort_ind]
+    if glob_id is not None:
+        g.global_point_ind = glob_id[sort_ind]
     return g
 
 

--- a/src/porepy/fracs/msh_2_grid.py
+++ b/src/porepy/fracs/msh_2_grid.py
@@ -470,7 +470,7 @@ def create_embedded_line_grid(
             the points of this grid is a subset. If provided, the returned grid will
             have an attribute ``global_point_ind`` that maps from local to global point
             numbering.
-        sort: Whether to sort the points. The sorting assumes the points are colinear.
+        sort: Whether to sort the points. The sorting assumes the points are collinear.
         tol: Tolerance used for check of collinearity of the points.
 
     Returns:

--- a/src/porepy/geometry/intersections.py
+++ b/src/porepy/geometry/intersections.py
@@ -106,13 +106,13 @@ def segments_2d(
     # Check if lines are parallel.
     # The tolerance should be relative to the length of d_1 and d_2
     if np.abs(discr) < tol * length_1 * length_2:
-        # The lines are parallel, and will only cross if they are also colinear
+        # The lines are parallel, and will only cross if they are also collinear
         logger.debug("The segments are parallel")
         # Cross product between line 1 and line between start points on line
         start_cross_line = d_s[0] * d_1[1] - d_s[1] * d_1[0]
         if np.abs(start_cross_line) < tol * max(length_1, length_2):
-            logger.debug("Lines are colinear")
-            # The lines are co-linear
+            logger.debug("Lines are collinear")
+            # The lines are collinear.
 
             # Write l1 on the form start_1 + t * d_1, find the parameter value needed
             # for equality with start_2 and end_2
@@ -140,17 +140,17 @@ def segments_2d(
                 # It seems this can only happen if they are also equal to 0 or 1, that
                 # is, the lines share a single point
                 p_1 = start_1 + d_1 * t_min
-                logger.debug("Colinear lines share a single point")
+                logger.debug("Collinear lines share a single point")
                 return p_1.reshape((-1, 1))
 
-            logger.debug("Colinear lines intersect along segment")
+            logger.debug("Collinear lines intersect along segment")
             p_1 = start_1 + d_1 * t_min
             p_2 = start_1 + d_1 * t_max
             return np.array([[p_1[0], p_2[0]], [p_1[1], p_2[1]]])
 
         else:
-            logger.debug("Lines are not colinear")
-            # Lines are parallel, but not colinear
+            logger.debug("Lines are not collinear")
+            # Lines are parallel, but not collinear
             return None
     else:
         # Solve linear system using Cramer's rule

--- a/src/porepy/geometry/map_geometry.py
+++ b/src/porepy/geometry/map_geometry.py
@@ -145,18 +145,18 @@ def project_points_to_line(
     int,
     np.ndarray[Any, np.dtype[np.int64]],
 ]:
-    """Project a set of colinear points onto a line.
+    """Project a set of collinear points onto a line.
 
-    The points should be co-linear such that a 1d description is meaningful.
+    The points should be collinear such that a 1d description is meaningful.
 
     Parameters:
         p: ``shape=(nd, np)``
 
-            An array representation of coordinates of the points. Should be co-linear,
+            An array representation of coordinates of the points. Should be collinear,
             but can have random ordering along the common line.
         tol: ``default=1e-4``
 
-            Tolerance used for testing of co-linearity.
+            Tolerance used for testing of collinearity.
 
     Raises:
         ValueError: If the points are not aligned on a line.
@@ -189,7 +189,7 @@ def project_points_to_line(
 
     # Check that the points indeed form a line
     if not pp.geometry_property_checks.points_are_collinear(p, tol):
-        raise ValueError("Elements are not colinear")
+        raise ValueError("Elements are not collinear")
     # Find the tangent of the line
     tangent = compute_tangent(p)
     # Projection matrix

--- a/src/porepy/geometry/sort_points.py
+++ b/src/porepy/geometry/sort_points.py
@@ -264,7 +264,7 @@ def sort_points_on_line(
 
     dx = p.max(axis=1) - p.min(axis=1)
     active_dim = np.where(dx > tol)[0]
-    assert active_dim.size == 1, "Points should be co-linear"
+    assert active_dim.size == 1, "Points should be collinear"
     return np.argsort(p[active_dim])[0]
 
 

--- a/src/porepy/grids/grid_extrusion.py
+++ b/src/porepy/grids/grid_extrusion.py
@@ -683,22 +683,21 @@ def _extrude_0d(
     # Number of nodes
     num_pt = z.size
 
-    # x and y coordinates of the right size
-    x = g.cell_centers[0, 0] * np.ones(num_pt)
-    y = g.cell_centers[1, 0] * np.ones(num_pt)
-
-    # Initial 1d grid. Coordinates are wrong, but this we will fix later. There is no
-    # need to do anything special with tags here; the tags of a 0d grid are trivial, and
-    # the 1d extrusion can be based on this.
-    name = f"{g.name} extruded 0d->1d"
-    g_new = pp.TensorGrid(x, name=name)
-
-    g_info = g.history.copy()
-    g_info.append("Extruded 0d->1d")
-    g_new.history = g_info
-
+    g_new = pp.fracs.msh_2_grid.create_embedded_line_grid(
+        np.vstack(
+            (
+                g.cell_centers[0, 0] * np.ones(num_pt),
+                g.cell_centers[1, 0] * np.ones(num_pt),
+                z,
+            )
+        ),
+        sort=False,
+    )
+    g_new.name = f"{g.name} extruded 0d->1d"
     # Update coordinates
-    g_new.nodes = np.vstack((x, y, z))
+    history = g.history.copy()
+    history.append("Updated node coordinates for extrusion")
+    g_new.history = history
 
     g_new.compute_geometry()
 

--- a/src/porepy/grids/match_grids.py
+++ b/src/porepy/grids/match_grids.py
@@ -310,8 +310,7 @@ def match_grids_along_1d_mortar(
         sort_ind = pp.sort_points.sort_points_on_line(nodes, tol=tol)
         n = nodes[:, sort_ind]
         unique_nodes, _, _ = pp.array_operations.uniquify_point_set(n, tol=tol)
-        g = TensorGrid(np.arange(unique_nodes.shape[1]))
-        g.nodes = unique_nodes
+        g = pp.fracs.msh_2_grid.create_embedded_line_grid(unique_nodes, sort=False)
         g.compute_geometry()
         return g, sort_ind
 

--- a/src/porepy/grids/match_grids.py
+++ b/src/porepy/grids/match_grids.py
@@ -304,9 +304,9 @@ def match_grids_along_1d_mortar(
 
     def create_1d_from_nodes(nodes):
         # From a set of nodes, create a 1d grid. duplicate nodes are removed
-        # and we verify that the nodes are indeed colinear
+        # and we verify that the nodes are indeed collinear
         if not pp.geometry_property_checks.points_are_collinear(nodes, tol=tol):
-            raise ValueError("Nodes are not colinear")
+            raise ValueError("Nodes are not collinear")
         sort_ind = pp.sort_points.sort_points_on_line(nodes, tol=tol)
         n = nodes[:, sort_ind]
         unique_nodes, _, _ = pp.array_operations.uniquify_point_set(n, tol=tol)

--- a/src/porepy/grids/refinement.py
+++ b/src/porepy/grids/refinement.py
@@ -337,8 +337,7 @@ def remesh_1d(g_old: pp.Grid, num_nodes: int, tol: float = 1e-6) -> pp.Grid:
     ] * (1.0 - theta)
 
     # Create the new grid, and assign nodes.
-    g = TensorGrid(nodes[0, :])
-    g.nodes = nodes
+    g = pp.fracs.msh_2_grid.create_embedded_line_grid(nodes, sort=False)
     g.compute_geometry()
 
     # Map the tags from the old grid to the new one

--- a/tests/fracs/test_msh_2_grid.py
+++ b/tests/fracs/test_msh_2_grid.py
@@ -379,7 +379,7 @@ def test_create_1d_grid_from_nodes(
 
     Parameters:
         nodes: The nodes to be used in the grid. Should be of shape (3, num_nodes).
-        is_linear: Whether the points are colinear.
+        is_linear: Whether the points are collinear.
         shuffle: Whether to shuffle the order of the points.
 
     """

--- a/tests/fracs/test_msh_2_grid.py
+++ b/tests/fracs/test_msh_2_grid.py
@@ -18,6 +18,7 @@ import numpy as np
 import pytest
 
 import porepy as pp
+from porepy.applications.test_utils.arrays import compare_arrays
 from porepy.fracs.fracture_network_2d import FractureNetwork2d
 from porepy.fracs.fracture_network_3d import FractureNetwork3d
 from porepy.fracs.msh_2_grid import (
@@ -352,3 +353,43 @@ def test_create_grids_with_high_dim_inclusion(
 
         else:
             assert INCLUSION_NAME not in g.tags
+
+
+@pytest.mark.parametrize(
+    "nodes,is_linear",
+    [
+        # Equidistant, alingned with axes.
+        (np.array([[0, 1, 2], [0, 0, 0], [0, 0, 0]]), True),
+        # Non-equidistant, aligned with axes.
+        (np.array([[0, 1, 3], [0, 0, 0], [0, 0, 0]]), True),
+        # Not aligned with axes.
+        (np.array([[0, 1, 2], [0, 1, 2], [0, 0, 0]]), True),
+        # Not a straight line.
+        (np.array([[0, 1, 2], [0, 1, 2], [0, 0, 1]]), False),
+    ],
+)
+@pytest.mark.parametrize("shuffle", [True, False])
+def test_create_1d_grid_from_nodes(
+    nodes: np.ndarray, is_linear: bool, shuffle: bool
+) -> None:
+    """Test that create_embedded_line_grid creates a grid with the correct nodes.
+
+    We do no check of the actual grid structure beyond the node coordinates as this is
+    not a primary concern for the tested function.
+
+    Parameters:
+        nodes: The nodes to be used in the grid. Should be of shape (3, num_nodes).
+        is_linear: Whether the points are colinear.
+        shuffle: Whether to shuffle the order of the points.
+
+    """
+    if shuffle:
+        nodes = nodes[:, [2, 0, 1]]
+
+    # Only sort if the points are linear (otherwise, we would mess up the geometry). No
+    # need to sort if the points are not shuffled.
+    g = pp.fracs.msh_2_grid.create_embedded_line_grid(
+        nodes, None, sort=shuffle and is_linear
+    )
+    assert isinstance(g, pp.Grid)
+    assert compare_arrays(g.nodes, nodes)

--- a/tests/geometry/test_intersections.py
+++ b/tests/geometry/test_intersections.py
@@ -126,7 +126,7 @@ class TestLinesIntersect:
         pi = intersections.segments_2d(s0, e0, s1, e1)
         assert pi is None or len(pi) == 0
 
-    def test_parallel_not_colinear(self):
+    def test_parallel_not_collinear(self):
         s0 = np.array([0, 0])
         e0 = np.array([1, 0])
         s1 = np.array([0, 1])
@@ -135,7 +135,7 @@ class TestLinesIntersect:
         pi = intersections.segments_2d(s0, e0, s1, e1)
         assert pi is None
 
-    def test_colinear_not_intersecting(self):
+    def test_collinear_not_intersecting(self):
         s0 = np.array([0, 0])
         e0 = np.array([1, 0])
         s1 = np.array([2, 0])


### PR DESCRIPTION
## Proposed changes
Simplified the implementation of the function `create_embedded_line_grid`, which generates a 1d grid from a set of points. The old implementation forced a sorting of the nodes, and thereby required that the nodes were collinear. The new implementation keeps the option to sort (and the requirement of collinearity), but also allows for points that are not aligned (to the price of no sorting). This allows for a future application to multilinear grids, e.g. along multi-segment wells.

Also introduced a test of the helper function and took the function into use in other parts of the code. For the latter, I tried to make judgements on where this gave a real improvement, and where the existing code was best left as is.

**Question for review:** Neither the name of the helper function nor its placement is ideal. My best suggestion for name is `create_1d_grid_from_nodes`, but I am open for suggestions. Placement: Perhaps move to `grids/_structured.py`?

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
