### PR TITLE
Different dimensions of grid and quantity in error computation

### DIFF
--- a/src/porepy/applications/convergence_analysis.py
+++ b/src/porepy/applications/convergence_analysis.py
@@ -487,6 +487,7 @@ class ConvergenceAnalysis:
         p: pp.number = 2,
         relative: bool = False,
         parameter_weight: Optional[np.ndarray] = None,
+        nd_error_computation: bool = True,
     ) -> pp.number:
         """Computes the discrete :math:`L_p`-error as given in [1].
 
@@ -518,11 +519,20 @@ class ConvergenceAnalysis:
             parameter_weight: Array containing the parameter weight, producing a
                 weighted norm. If given, the array size must equal the number of faces
                 or cells in the grid.
+            nd_error_computation: Boolean flag to indicate whether the error
+                computation should be performed using the dimension of the passed grid
+                or the dimension of the passed arrays. This is relevant for vector
+                quantities defined on grids of different dimension than themselves
+                (e.g. fracture contact traction in two dimensions: a 2D vector defined
+                on a 1D grid). If ``False`` the error is computed using the grid
+                dimension.
 
         Raises:
             NotImplementedError: If a mortar grid is given and is_cc is False.
             ZeroDivisionError: If the denominator in the relative error is zero.
             ValueError: If the parameter weight has an invalid size.
+            ValueError: If the dimension of the passed arrays does not match the choice
+                of ``nd_error_computation``.
 
         Returns:
             (Discrete) :math:`L_p`-error between the true and approximated arrays.
@@ -538,6 +548,11 @@ class ConvergenceAnalysis:
         if is_cc:
             num_faces_or_cells = grid.num_cells
             meas = grid.cell_volumes
+
+            # If the quantity is a cell-centered vector, we may need to repeat the
+            # measure according to the dimension of the vector. For a cell-centered
+            # quantity:
+            repetitions = int(len(true_array) / grid.num_cells)
         else:
             assert isinstance(grid, pp.Grid)  # to please mypy
             num_faces_or_cells = grid.num_faces
@@ -558,14 +573,28 @@ class ConvergenceAnalysis:
             # by the grid dimension. This corresponds to the volume of a n-dimensional
             # pyramid, see https://en.wikipedia.org/wiki/Hyperpyramid.
             meas = dist_cc_cc / grid.dim
+
+            # If the quantity is a face-centered vector, we may need to repeat the
+            # measure according to the dimension of the vector. For a face-centered
+            # quantity:
+            repetitions = int(len(true_array) / grid.num_faces)
         if parameter_weight is not None:
             # The parameter weight is denoted by \gamma in Eq. A1.12 from [1].
             if parameter_weight.size != num_faces_or_cells:
                 raise ValueError("Invalid size of parameter weight.")
             meas *= parameter_weight
         if not is_scalar:
-            meas = meas.repeat(grid.dim)
-
+            if not nd_error_computation:
+                # If the error computation is to be performed using the dimension of the
+                # passed grid, we need to re-define the repetitions variable to be
+                # grid.dim.
+                repetitions = grid.dim
+            meas = meas.repeat(repetitions)
+            if len(meas) != len(true_array):
+                raise ValueError(
+                    f"Incompatible sizes for error computation. "
+                    f"nd_error_computation may be wrongly set."
+                )
         # Obtain numerator and denominator to determine the error.
         numerator = ConvergenceAnalysis.lp_norm(
             true_array - approx_array,

--- a/src/porepy/applications/convergence_analysis.py
+++ b/src/porepy/applications/convergence_analysis.py
@@ -482,12 +482,10 @@ class ConvergenceAnalysis:
         grid: pp.GridLike,
         true_array: np.ndarray,
         approx_array: np.ndarray,
-        is_scalar: bool,
         is_cc: bool,
         p: pp.number = 2,
         relative: bool = False,
         parameter_weight: Optional[np.ndarray] = None,
-        nd_error_computation: bool = True,
     ) -> pp.number:
         """Computes the discrete :math:`L_p`-error as given in [1].
 
@@ -501,11 +499,14 @@ class ConvergenceAnalysis:
 
         Parameters:
             grid: Either a subdomain grid or a mortar grid.
-            true_array: Array containing the true values of a given variable.
-            approx_array: Array containing the approximate values of a given variable.
-            is_scalar: Whether the variable is a scalar quantity. Use ``False`` for
-                vector quantities. For example, ``is_scalar=True`` for pressure, whereas
-                ``is_scalar=False`` for displacement.
+            true_array: Array containing the true values of a given variable. The
+                values should be ordered as follows: For a solution of dimension N, the
+                first N values in the array should correspond to all components of the
+                solution in the first cell/face in the grid. For example, for vector
+                quantities in 2d, the first two values should correspond to the x- and
+                y-components of the solution in the first cell/face, and so on.
+            approx_array: Array containing the approximate values of a given variable. 
+                The values should be ordered in the same way as ``true_array``.
             is_cc: Whether the variable is associated to cell centers. Use ``False``
                 for variables associated to face centers. For example, ``is_cc=True``
                 for pressures, whereas ``is_cc=False`` for subdomain fluxes.
@@ -519,28 +520,31 @@ class ConvergenceAnalysis:
             parameter_weight: Array containing the parameter weight, producing a
                 weighted norm. If given, the array size must equal the number of faces
                 or cells in the grid.
-            nd_error_computation: Boolean flag to indicate whether the error
-                computation should be performed using the dimension of the passed grid
-                or the dimension of the passed arrays. This is relevant for vector
-                quantities defined on grids of different dimension than themselves
-                (e.g. fracture contact traction in two dimensions: a 2D vector defined
-                on a 1D grid). If ``False`` the error is computed using the grid
-                dimension.
 
         Raises:
             NotImplementedError: If a mortar grid is given and is_cc is False.
+            ValueError: If the passed arrays have invalid dimensions and/or different
+                size.
             ZeroDivisionError: If the denominator in the relative error is zero.
             ValueError: If the parameter weight has an invalid size.
-            ValueError: If the dimension of the passed arrays does not match the choice
-                of ``nd_error_computation``.
+            ValueError: If the array size does not match the expected size based on the
+                grid and the number of components per face/cell.
 
         Returns:
             (Discrete) :math:`L_p`-error between the true and approximated arrays.
 
         """
-        # Sanity check.
+        # Sanity checks
         if isinstance(grid, pp.MortarGrid) and not is_cc:
             raise NotImplementedError("Interface variables can only be cell-centered.")
+        if (
+            true_array.size != approx_array.size
+            or true_array.ndim != 1
+            or approx_array.ndim != 1
+        ):
+            raise ValueError(
+                "true_array and approx_array must be 1d and have the same size."
+            )
 
         # Obtain proper measure, e.g., cell volumes for cell-centered quantities and the
         # volume of the pyramids spanned by the face and its neighboring cell centers
@@ -548,11 +552,6 @@ class ConvergenceAnalysis:
         if is_cc:
             num_faces_or_cells = grid.num_cells
             meas = grid.cell_volumes
-
-            # If the quantity is a cell-centered vector, we may need to repeat the
-            # measure according to the dimension of the vector. For a cell-centered
-            # quantity:
-            repetitions = int(len(true_array) / grid.num_cells)
         else:
             assert isinstance(grid, pp.Grid)  # to please mypy
             num_faces_or_cells = grid.num_faces
@@ -574,27 +573,32 @@ class ConvergenceAnalysis:
             # pyramid, see https://en.wikipedia.org/wiki/Hyperpyramid.
             meas = dist_cc_cc / grid.dim
 
-            # If the quantity is a face-centered vector, we may need to repeat the
-            # measure according to the dimension of the vector. For a face-centered
-            # quantity:
-            repetitions = int(len(true_array) / grid.num_faces)
         if parameter_weight is not None:
             # The parameter weight is denoted by \gamma in Eq. A1.12 from [1].
             if parameter_weight.size != num_faces_or_cells:
                 raise ValueError("Invalid size of parameter weight.")
             meas *= parameter_weight
-        if not is_scalar:
-            if not nd_error_computation:
-                # If the error computation is to be performed using the dimension of the
-                # passed grid, we need to re-define the repetitions variable to be
-                # grid.dim.
-                repetitions = grid.dim
-            meas = meas.repeat(repetitions)
-            if len(meas) != len(true_array):
-                raise ValueError(
-                    f"Incompatible sizes for error computation. "
-                    f"nd_error_computation may be wrongly set."
-                )
+
+        # In case the arrays represent vector quantities, we need to repeat the measure
+        # for each component of the vector. For example, if we have meas = [m1, m2] and
+        # repetitions = 3, then meas.repeat(repetitions) will give [m1, m1, m1, m2, m2,
+        # m2].
+        repetitions = int(true_array.size / num_faces_or_cells)
+
+        # Ensure array size matches num_faces_or_cells * repetitions. This check will
+        # fail if true_array does not have an integer number of components per
+        # face/cell.
+        if true_array.size != num_faces_or_cells * repetitions:
+            raise ValueError(
+                f"Array size must equal num_faces_or_cells times repetitions."
+            )
+
+        meas = meas.repeat(repetitions)
+        if meas.size != true_array.size:
+            raise ValueError(
+                f"Incompatible sizes for error computation. "
+                f"nd_error_computation may be wrongly set."
+            )
         # Obtain numerator and denominator to determine the error.
         numerator = ConvergenceAnalysis.lp_norm(
             true_array - approx_array,

--- a/src/porepy/applications/convergence_analysis.py
+++ b/src/porepy/applications/convergence_analysis.py
@@ -499,14 +499,16 @@ class ConvergenceAnalysis:
 
         Parameters:
             grid: Either a subdomain grid or a mortar grid.
-            true_array: Array containing the true values of a given variable. The
-                values should be ordered as follows: For a solution of dimension N, the
-                first N values in the array should correspond to all components of the
-                solution in the first cell/face in the grid. For example, for vector
-                quantities in 2d, the first two values should correspond to the x- and
-                y-components of the solution in the first cell/face, and so on.
-            approx_array: Array containing the approximate values of a given variable. 
-                The values should be ordered in the same way as ``true_array``.
+            true_array: Array containing the true values of a given N-dimensional
+                variable. The array has shape (N*num_faces_or_cells,) and should be
+                ordered as follows: The first N values in the array should correspond to
+                all components of the solution in the first cell/face in the grid. For
+                example, for vector quantities in 2d, the first two values should
+                correspond to the x- and y-components of the solution in the first
+                cell/face, the next two values to x- and y-components of the second
+                cell/face, and so on.
+            approx_array: Array containing the approximate values of a given variable.
+                The values should be shaped and ordered like ``true_array``.
             is_cc: Whether the variable is associated to cell centers. Use ``False``
                 for variables associated to face centers. For example, ``is_cc=True``
                 for pressures, whereas ``is_cc=False`` for subdomain fluxes.
@@ -523,28 +525,26 @@ class ConvergenceAnalysis:
 
         Raises:
             NotImplementedError: If a mortar grid is given and is_cc is False.
-            ValueError: If the passed arrays have invalid dimensions and/or different
-                size.
+            ValueError: If the passed arrays have invalid dimensions.
+            ValueError: If the passed arrays have different sizes.
             ZeroDivisionError: If the denominator in the relative error is zero.
             ValueError: If the parameter weight has an invalid size.
-            ValueError: If the array size does not match the expected size based on the
+            ValueError: If the array sizes do not match the expected size based on the
                 grid and the number of components per face/cell.
 
         Returns:
             (Discrete) :math:`L_p`-error between the true and approximated arrays.
 
         """
-        # Sanity checks
+        # Sanity checks.
         if isinstance(grid, pp.MortarGrid) and not is_cc:
             raise NotImplementedError("Interface variables can only be cell-centered.")
-        if (
-            true_array.size != approx_array.size
-            or true_array.ndim != 1
-            or approx_array.ndim != 1
-        ):
-            raise ValueError(
-                "true_array and approx_array must be 1d and have the same size."
-            )
+
+        if true_array.ndim != 1 or approx_array.ndim != 1:
+            raise ValueError("true_array and approx_array must be 1-dimensional.")
+
+        if true_array.size != approx_array.size:
+            raise ValueError("true_array and approx_array must have the same size.")
 
         # Obtain proper measure, e.g., cell volumes for cell-centered quantities and the
         # volume of the pyramids spanned by the face and its neighboring cell centers
@@ -579,26 +579,18 @@ class ConvergenceAnalysis:
                 raise ValueError("Invalid size of parameter weight.")
             meas *= parameter_weight
 
+        # Ensure array size matches num_faces_or_cells. This check will fail if
+        # true_array does not have an integer number of components per face/cell.
+        if not true_array.size % num_faces_or_cells == 0:
+            raise ValueError(f"Array size is not divisible by number of cells/faces.")
+
         # In case the arrays represent vector quantities, we need to repeat the measure
         # for each component of the vector. For example, if we have meas = [m1, m2] and
         # repetitions = 3, then meas.repeat(repetitions) will give [m1, m1, m1, m2, m2,
         # m2].
         repetitions = int(true_array.size / num_faces_or_cells)
-
-        # Ensure array size matches num_faces_or_cells * repetitions. This check will
-        # fail if true_array does not have an integer number of components per
-        # face/cell.
-        if true_array.size != num_faces_or_cells * repetitions:
-            raise ValueError(
-                f"Array size must equal num_faces_or_cells times repetitions."
-            )
-
         meas = meas.repeat(repetitions)
-        if meas.size != true_array.size:
-            raise ValueError(
-                f"Incompatible sizes for error computation. "
-                f"nd_error_computation may be wrongly set."
-            )
+
         # Obtain numerator and denominator to determine the error.
         numerator = ConvergenceAnalysis.lp_norm(
             true_array - approx_array,

--- a/src/porepy/examples/fracture_damage.py
+++ b/src/porepy/examples/fracture_damage.py
@@ -336,7 +336,6 @@ class DamageDataSaving(pp.PorePyModel):
             grid=sd,
             true_array=exact_damage,
             approx_array=cast(np.ndarray, approx_damage),
-            is_scalar=True,
             is_cc=True,
         )
         friction_damage = self.exact_sol.friction_damage(sd, n)
@@ -361,7 +360,6 @@ class DamageDataSaving(pp.PorePyModel):
                 grid=sd,
                 true_array=friction_damage,
                 approx_array=approx_friction_damage,
-                is_scalar=True,
                 is_cc=True,
             )
         dilation_damage = self.exact_sol.dilation_damage(sd, n)
@@ -380,7 +378,6 @@ class DamageDataSaving(pp.PorePyModel):
                 grid=sd,
                 true_array=dilation_damage,
                 approx_array=approx_dilation_damage,
-                is_scalar=True,
                 is_cc=True,
             )
         collected_data = DamageSaveData(

--- a/src/porepy/examples/mandel_biot.py
+++ b/src/porepy/examples/mandel_biot.py
@@ -165,7 +165,6 @@ class MandelDataSaving(pp.PorePyModel):
             grid=sd,
             true_array=exact_pressure,
             approx_array=cast(np.ndarray, approx_pressure),
-            is_scalar=True,
             is_cc=True,
             relative=True,
         )
@@ -177,7 +176,6 @@ class MandelDataSaving(pp.PorePyModel):
             grid=sd,
             true_array=exact_displacement,
             approx_array=cast(np.ndarray, approx_displacement),
-            is_scalar=False,
             is_cc=True,
             relative=True,
         )
@@ -190,7 +188,6 @@ class MandelDataSaving(pp.PorePyModel):
             grid=sd,
             true_array=exact_flux,
             approx_array=cast(np.ndarray, approx_flux),
-            is_scalar=True,
             is_cc=False,
             relative=True,
         )
@@ -202,7 +199,6 @@ class MandelDataSaving(pp.PorePyModel):
             grid=sd,
             true_array=exact_force,
             approx_array=cast(np.ndarray, approx_force),
-            is_scalar=False,
             is_cc=False,
             relative=True,
         )

--- a/src/porepy/examples/terzaghi_biot.py
+++ b/src/porepy/examples/terzaghi_biot.py
@@ -157,7 +157,6 @@ class TerzaghiDataSaving(pp.PorePyModel):
             grid=sd,
             true_array=exact_pressure,
             approx_array=cast(np.ndarray, approx_pressure),
-            is_scalar=True,
             is_cc=True,
             relative=True,
         )

--- a/tests/applications/test_convergence_analysis.py
+++ b/tests/applications/test_convergence_analysis.py
@@ -865,6 +865,7 @@ def face_error(
 
     return numerator / denominator
 
+
 @pytest.mark.parametrize("is_relative", [False, True])
 @pytest.mark.parametrize(
     (
@@ -922,7 +923,7 @@ def test_l2_error(
         is_scalar: Whether the array is corresponds to a scalar quantity. False
             implies a vector quantity.
         parameter_weight: Whether a parameter weight should be used.
-        nd_error_computation: Whether the dimension of the array should be used for the 
+        nd_error_computation: Whether the dimension of the array should be used for the
             error computation, or the dimension of the passed grid.
 
     """
@@ -988,6 +989,7 @@ def test_l2_error(
 
     # Compare
     assert np.isclose(actual_l2_error, true_l2_error)
+
 
 def test_l2_error_division_by_zero_error(grids: list[pp.Grid, pp.MortarGrid]) -> None:
     """Test whether a division by zero error is raised.

--- a/tests/applications/test_convergence_analysis.py
+++ b/tests/applications/test_convergence_analysis.py
@@ -811,6 +811,7 @@ def face_error(
     is_scalar: bool,
     relative: bool = False,
     parameter_weight: np.ndarray | None = None,
+    nd_error_computation: int = None,
 ) -> pp.number:
     """Compute the L2-error for face-centered quantities.
 
@@ -853,7 +854,10 @@ def face_error(
     if parameter_weight is not None:
         meas *= parameter_weight
     if not is_scalar:
-        meas = meas.repeat(sd.dim)
+        if not nd_error_computation:
+            meas = meas.repeat(sd.dim)
+        else:
+            meas = meas.repeat(int(len(true_array) / sd.num_faces))
 
     # Obtain numerator and denominator to determine the error.
     numerator = np.sqrt(np.sum(meas * np.abs(true_array - approx_array) ** 2))
@@ -861,37 +865,54 @@ def face_error(
 
     return numerator / denominator
 
-
 @pytest.mark.parametrize("is_relative", [False, True])
 @pytest.mark.parametrize(
-    "is_sd, is_cc, is_scalar, parameter_weight",
+    (
+        "is_sd",
+        "is_cc",
+        "is_scalar",
+        "parameter_weight",
+        "nd_error_computation",
+    ),
     [
-        (True, True, True, False),
-        (True, False, True, False),
-        (True, True, False, False),
-        (True, False, False, False),
-        (False, True, True, False),
-        (False, True, False, True),
+        (True, True, True, False, False),
+        (True, False, True, False, False),
+        (True, True, False, False, False),
+        (True, False, False, False, False),
+        (False, True, True, False, False),
+        (False, True, False, True, False),
+        (True, True, False, True, True),
+        (True, True, False, True, False),
+        (True, False, False, True, False),
+        (True, False, False, False, True),
+        (True, False, False, True, True),
     ],
 )
 @pytest.mark.parametrize(
-    "grid_fixture", ["grids", "grids_3d"]
-)  # Use both 2D and 3D grid fixtures
+    "grid_fixture",
+    ["grids", "grids_3d"],
+)
 def test_l2_error(
     is_sd: bool,
     is_cc: bool,
     is_scalar: bool,
     is_relative: bool,
     parameter_weight: bool,
+    nd_error_computation: bool,
     grid_fixture: str,
     request: pytest.FixtureRequest,
 ) -> None:
     """Test whether the discrete L2-error is computed correctly.
 
-    The test sets arrays of ones as for the true array, and arrays of zeros for the
-    approximate arrays. The absolute l2-error is thus the square root of the sum of the
-    measure of each element (cell_volume when is_cc=True and face_area when is_cc=False)
-    in each grid. The relative l2-error is always 1.0 in all cases.
+    The test compares the output of ``ConvergenceAnalysis.lp_error`` against a
+    manually computed reference value for several combinations of:
+    * subdomain and interface grids,
+    * cell-centered and face-centered quantities,
+    * scalar and vector quantities,
+    * absolute and relative errors,
+    * weighted and unweighted norms.
+
+    Both 2D and 3D grid fixtures are tested.
 
     Parameters:
         is_sd: Whether the error should be evaluated in a subdomain grid. False
@@ -901,7 +922,8 @@ def test_l2_error(
         is_scalar: Whether the array is corresponds to a scalar quantity. False
             implies a vector quantity.
         parameter_weight: Whether a parameter weight should be used.
-        grid_fixture: Name of the fixture that provides the list of grids.
+        nd_error_computation: Whether the dimension of the array should be used for the 
+            error computation, or the dimension of the passed grid.
 
     """
     # Retrieve grid list from the fixture.
@@ -914,7 +936,14 @@ def test_l2_error(
         grid = grid_list[1]  # interface grid
 
     # Define true and approximated values.
-    vec = 1 if is_scalar else grid.dim
+    if nd_error_computation:
+        # Adding 1 to vec will later give true and approximated arrays of one dimension
+        # higher than the grid.
+        vec = grid.dim + 1
+        is_scalar = False
+    else:
+        vec = 1 if is_scalar else grid.dim
+
     num_dof = grid.num_cells if is_cc else grid.num_faces
     np.random.seed(42)
     true_array = np.random.random(num_dof * vec)
@@ -924,7 +953,8 @@ def test_l2_error(
         _weight = np.random.random(num_dof)
     else:
         _weight = np.ones(num_dof)
-    # Retrieve number of degrees of freedom and set the true array.
+
+    # Compute reference error.
     if is_cc:
         meas = np.repeat(grid.cell_volumes * _weight, vec)
         true_l2_error = np.sqrt(np.sum(meas * diff**2))
@@ -933,12 +963,18 @@ def test_l2_error(
             true_l2_error /= np.sqrt(np.sum(meas * true_array**2))
     else:
         true_l2_error = face_error(
-            grid, true_array, approx_array, is_scalar, is_relative, _weight
+            grid,
+            true_array,
+            approx_array,
+            is_scalar,
+            is_relative,
+            _weight,
+            vec if nd_error_computation else None,
         )
 
     # Compute actual error.
-    # Use the parameter_weight if provided, otherwise set it to None.
     parameter_weight = _weight if parameter_weight else None
+
     actual_l2_error = ConvergenceAnalysis.lp_error(
         grid=grid,
         true_array=true_array,
@@ -947,11 +983,11 @@ def test_l2_error(
         is_scalar=is_scalar,
         relative=is_relative,
         parameter_weight=parameter_weight,
+        nd_error_computation=nd_error_computation,
     )
 
     # Compare
     assert np.isclose(actual_l2_error, true_l2_error)
-
 
 def test_l2_error_division_by_zero_error(grids: list[pp.Grid, pp.MortarGrid]) -> None:
     """Test whether a division by zero error is raised.

--- a/tests/applications/test_convergence_analysis.py
+++ b/tests/applications/test_convergence_analysis.py
@@ -1005,9 +1005,8 @@ class TestL2ErrorWithInvalidArrays:
 
         """
         grid = grids[0]
-        np.random.seed(24)
-        true_array = np.random.random(grid.num_cells * 2)
-        approx_array = np.random.random(grid.num_cells)
+        true_array = np.ones(grid.num_cells * 2)
+        approx_array = np.ones(grid.num_cells)
 
         expected_error_message = "true_array and approx_array must have the same size."
 
@@ -1029,9 +1028,8 @@ class TestL2ErrorWithInvalidArrays:
 
         """
         grid = grids[0]
-        np.random.seed(42)
-        true_array = np.random.random((2, grid.num_cells))
-        approx_array = np.random.random(grid.num_cells * 2)
+        true_array = np.ones((2, grid.num_cells))
+        approx_array = np.ones(grid.num_cells * 2)
 
         expected_error_message = "true_array and approx_array must be 1-dimensional."
 
@@ -1053,9 +1051,8 @@ class TestL2ErrorWithInvalidArrays:
 
         """
         grid = grids[0]
-        np.random.seed(42)
-        true_array = np.random.random(grid.num_cells + 1)
-        approx_array = np.random.random(grid.num_cells + 1)
+        true_array = np.ones(grid.num_cells + 1)
+        approx_array = np.ones(grid.num_cells + 1)
 
         expected_error_message = "Array size is not divisible by number of cells/faces."
         self._assert_lp_error_raises(

--- a/tests/applications/test_convergence_analysis.py
+++ b/tests/applications/test_convergence_analysis.py
@@ -963,53 +963,104 @@ def test_l2_error(
     assert np.isclose(actual_l2_error, true_l2_error)
 
 
-@pytest.mark.parametrize(
-    ("true_array", "approx_array"),
-    [
-        (np.array([1.0, 5.0]), np.array([1.0, 5.0, 2.0, 3.0, 1.0])),
-        (np.array([[1.0, 5.0], [2.0, 3.0]]), np.array([1.0, 5.0, 2.0, 3.0])),
-        (np.array([1.0, 5.0, 2.0]), np.array([1.0, 8.0, 2.0])),
-    ],
-)
-@pytest.mark.parametrize(
-    "grid_fixture",
-    ["grids", "grids_3d"],
-)
-def test_l2_error_with_invalid_arrays(
-    true_array: np.ndarray,
-    approx_array: np.ndarray,
-    grid_fixture: str,
-    request: pytest.FixtureRequest,
-) -> None:
-    """Test that only arrays of same size are accepted in lp_error().
+class TestL2ErrorWithInvalidArrays:
+    """Collection of tests to verify that lp_error() rejects invalid array inputs."""
 
-    Verifies that the expected errors are raised for different invalid true_array and
-    approx_array.
+    @staticmethod
+    def _assert_lp_error_raises(
+        grid: pp.GridLike,
+        true_array: np.ndarray,
+        approx_array: np.ndarray,
+        expected_error_message: str,
+    ) -> None:
+        """Helper method to assert that lp_error raises ValueError for invalid arrays.
 
-    Parameters:
-        true_array: True array for error computation.
-        approx_array: Approximated array for error computation.
+        Parameters:
+            grid: The grid where the error is to be computed.
+            true_array: True array for error computation.
+            approx_array: Approximated array for error computation.
+            expected_error_msg: The expected error message to be raised.
 
-    """
-    # Retrieve grid list from the fixture.
-    grid_list = request.getfixturevalue(grid_fixture)
+        """
+        with pytest.raises(ValueError) as excinfo:
+            ConvergenceAnalysis.lp_error(
+                grid=grid,
+                true_array=true_array,
+                approx_array=approx_array,
+                is_cc=True,
+            )
+        assert expected_error_message in str(excinfo.value)
 
-    # Retrieve grid.
-    grid = grid_list[0]
+    def test_l2_error_mismatched_sizes(
+        self,
+        grids: list[pp.Grid, pp.MortarGrid],
+    ) -> None:
+        """Test that arrays with different sizes are rejected.
 
-    with pytest.raises(ValueError) as excinfo:
-        ConvergenceAnalysis.lp_error(
-            grid=grid,
-            true_array=true_array,
-            approx_array=approx_array,
-            is_cc=True,
-            relative=True,
+        This case tests that even though true_array and approx_array have the correct
+        dimension, they are rejected due to their different sizes.
+
+        Parameters:
+            grids: List of grids containing a subdomain grid and an interface grid.
+
+        """
+        grid = grids[0]
+        np.random.seed(24)
+        true_array = np.random.random(grid.num_cells * 2)
+        approx_array = np.random.random(grid.num_cells)
+
+        expected_error_message = "true_array and approx_array must have the same size."
+
+        self._assert_lp_error_raises(
+            grid, true_array, approx_array, expected_error_message
         )
-    error_msg = str(excinfo.value)
-    assert (
-        "must be 1d and have the same size" in error_msg
-        or "Array size must equal num_faces_or_cells times repetitions" in error_msg
-    )
+
+    def test_l2_error_non_flattened_array(
+        self,
+        grids: list[pp.Grid, pp.MortarGrid],
+    ) -> None:
+        """Test that 2D arrays are rejected.
+
+        This case tests when true_array is passed as a 2D array instead of a
+        flattened 1D array.
+
+        Parameters:
+            grids: List of grids containing a subdomain grid and an interface grid.
+
+        """
+        grid = grids[0]
+        np.random.seed(42)
+        true_array = np.random.random((2, grid.num_cells))
+        approx_array = np.random.random(grid.num_cells * 2)
+
+        expected_error_message = "true_array and approx_array must be 1-dimensional."
+
+        self._assert_lp_error_raises(
+            grid, true_array, approx_array, expected_error_message
+        )
+
+    def test_l2_error_array_incompatible_with_grid(
+        self,
+        grids: list[pp.Grid, pp.MortarGrid],
+    ) -> None:
+        """Test that arrays of same length but invalid for grid are rejected.
+
+        This case tests when true_array and approx_array have the same length but
+        do not match the expected number of DOFs for the grid.
+
+        Parameters:
+            grids: List of grids containing a subdomain grid and an interface grid.
+
+        """
+        grid = grids[0]
+        np.random.seed(42)
+        true_array = np.random.random(grid.num_cells + 1)
+        approx_array = np.random.random(grid.num_cells + 1)
+
+        expected_error_message = "Array size is not divisible by number of cells/faces."
+        self._assert_lp_error_raises(
+            grid, true_array, approx_array, expected_error_message
+        )
 
 
 def test_l2_error_division_by_zero_error(grids: list[pp.Grid, pp.MortarGrid]) -> None:

--- a/tests/applications/test_convergence_analysis.py
+++ b/tests/applications/test_convergence_analysis.py
@@ -873,21 +873,18 @@ def face_error(
         "is_cc",
         "is_scalar",
         "parameter_weight",
-        "nd_error_computation",
     ),
     [
-        (True, True, True, False, False),
-        (True, False, True, False, False),
-        (True, True, False, False, False),
-        (True, False, False, False, False),
-        (False, True, True, False, False),
-        (False, True, False, True, False),
-        (True, True, False, True, True),
-        (True, True, False, True, False),
-        (True, False, False, True, False),
-        (True, False, False, False, True),
-        (True, False, False, True, True),
+        (True, True, True, False),
+        (True, False, True, False),
+        (True, True, False, False),
+        (True, False, False, False),
+        (False, True, True, False),
+        (False, True, False, True),
     ],
+)
+@pytest.mark.parametrize(
+    "nd_error_computation",    [False, True],
 )
 @pytest.mark.parametrize(
     "grid_fixture",

--- a/tests/applications/test_convergence_analysis.py
+++ b/tests/applications/test_convergence_analysis.py
@@ -808,10 +808,8 @@ def face_error(
     sd: pp.GridLike,
     true_array: np.ndarray,
     approx_array: np.ndarray,
-    is_scalar: bool,
     relative: bool = False,
     parameter_weight: np.ndarray | None = None,
-    nd_error_computation: int = None,
 ) -> pp.number:
     """Compute the L2-error for face-centered quantities.
 
@@ -853,11 +851,8 @@ def face_error(
 
     if parameter_weight is not None:
         meas *= parameter_weight
-    if not is_scalar:
-        if not nd_error_computation:
-            meas = meas.repeat(sd.dim)
-        else:
-            meas = meas.repeat(int(len(true_array) / sd.num_faces))
+
+    meas = meas.repeat(int(len(true_array) / sd.num_faces))
 
     # Obtain numerator and denominator to determine the error.
     numerator = np.sqrt(np.sum(meas * np.abs(true_array - approx_array) ** 2))
@@ -871,21 +866,16 @@ def face_error(
     (
         "is_sd",
         "is_cc",
-        "is_scalar",
-        "parameter_weight",
+        "use_weight",
     ),
     [
-        (True, True, True, False),
-        (True, False, True, False),
-        (True, True, False, False),
-        (True, False, False, False),
-        (False, True, True, False),
-        (False, True, False, True),
+        (True, True, False),
+        (True, False, False),
+        (False, True, False),
+        (False, True, True),
     ],
 )
-@pytest.mark.parametrize(
-    "nd_error_computation",    [False, True],
-)
+@pytest.mark.parametrize("vector_problem", [False, True])
 @pytest.mark.parametrize(
     "grid_fixture",
     ["grids", "grids_3d"],
@@ -893,10 +883,9 @@ def face_error(
 def test_l2_error(
     is_sd: bool,
     is_cc: bool,
-    is_scalar: bool,
+    use_weight: bool,
+    vector_problem: bool,
     is_relative: bool,
-    parameter_weight: bool,
-    nd_error_computation: bool,
     grid_fixture: str,
     request: pytest.FixtureRequest,
 ) -> None:
@@ -917,44 +906,34 @@ def test_l2_error(
             implies evaluation in an interface grid.
         is_cc: Whether the array is a cell-centered quantity. False implies a
             face-centered quantity.
-        is_scalar: Whether the array is corresponds to a scalar quantity. False
-            implies a vector quantity.
-        parameter_weight: Whether a parameter weight should be used.
-        nd_error_computation: Whether the dimension of the array should be used for the
-            error computation, or the dimension of the passed grid.
+        use_weight: Whether a parameter weight should be used.
+        vector_problem: Whether the array represents vector quantities.
+        is_relative: Whether to compute relative or absolute error.
 
     """
     # Retrieve grid list from the fixture.
     grid_list = request.getfixturevalue(grid_fixture)
 
     # Retrieve grid.
-    if is_sd:
-        grid = grid_list[0]  # subdomain grid
-    else:
-        grid = grid_list[1]  # interface grid
+    grid = grid_list[0] if is_sd else grid_list[1]
 
     # Define true and approximated values.
-    if nd_error_computation:
-        # Adding 1 to vec will later give true and approximated arrays of one dimension
-        # higher than the grid.
-        vec = grid.dim + 1
-        is_scalar = False
-    else:
-        vec = 1 if is_scalar else grid.dim
-
     num_dof = grid.num_cells if is_cc else grid.num_faces
+    vec_size = grid.dim + 1 if vector_problem else 1
+
     np.random.seed(42)
-    true_array = np.random.random(num_dof * vec)
-    approx_array = np.random.random(num_dof * vec)
+    true_array = np.random.random(num_dof * vec_size)
+    approx_array = np.random.random(num_dof * vec_size)
     diff = true_array - approx_array
-    if parameter_weight:
-        _weight = np.random.random(num_dof)
+
+    if use_weight:
+        weight = np.random.random(num_dof)
     else:
-        _weight = np.ones(num_dof)
+        weight = np.ones(num_dof)
 
     # Compute reference error.
     if is_cc:
-        meas = np.repeat(grid.cell_volumes * _weight, vec)
+        meas = np.repeat(grid.cell_volumes * weight, vec_size)
         true_l2_error = np.sqrt(np.sum(meas * diff**2))
 
         if is_relative:
@@ -964,28 +943,73 @@ def test_l2_error(
             grid,
             true_array,
             approx_array,
-            is_scalar,
-            is_relative,
-            _weight,
-            vec if nd_error_computation else None,
+            relative=is_relative,
+            parameter_weight=weight,
         )
 
     # Compute actual error.
-    parameter_weight = _weight if parameter_weight else None
+    parameter_weight = weight if use_weight else None
 
     actual_l2_error = ConvergenceAnalysis.lp_error(
         grid=grid,
         true_array=true_array,
         approx_array=approx_array,
         is_cc=is_cc,
-        is_scalar=is_scalar,
         relative=is_relative,
         parameter_weight=parameter_weight,
-        nd_error_computation=nd_error_computation,
     )
 
     # Compare
     assert np.isclose(actual_l2_error, true_l2_error)
+
+
+@pytest.mark.parametrize(
+    ("true_array", "approx_array"),
+    [
+        (np.array([1.0, 5.0]), np.array([1.0, 5.0, 2.0, 3.0, 1.0])),
+        (np.array([[1.0, 5.0], [2.0, 3.0]]), np.array([1.0, 5.0, 2.0, 3.0])),
+        (np.array([1.0, 5.0, 2.0]), np.array([1.0, 8.0, 2.0])),
+    ],
+)
+@pytest.mark.parametrize(
+    "grid_fixture",
+    ["grids", "grids_3d"],
+)
+def test_l2_error_with_invalid_arrays(
+    true_array: np.ndarray,
+    approx_array: np.ndarray,
+    grid_fixture: str,
+    request: pytest.FixtureRequest,
+) -> None:
+    """Test that only arrays of same size are accepted in lp_error().
+
+    Verifies that the expected errors are raised for different invalid true_array and
+    approx_array.
+
+    Parameters:
+        true_array: True array for error computation.
+        approx_array: Approximated array for error computation.
+
+    """
+    # Retrieve grid list from the fixture.
+    grid_list = request.getfixturevalue(grid_fixture)
+
+    # Retrieve grid.
+    grid = grid_list[0]
+
+    with pytest.raises(ValueError) as excinfo:
+        ConvergenceAnalysis.lp_error(
+            grid=grid,
+            true_array=true_array,
+            approx_array=approx_array,
+            is_cc=True,
+            relative=True,
+        )
+    error_msg = str(excinfo.value)
+    assert (
+        "must be 1d and have the same size" in error_msg
+        or "Array size must equal num_faces_or_cells times repetitions" in error_msg
+    )
 
 
 def test_l2_error_division_by_zero_error(grids: list[pp.Grid, pp.MortarGrid]) -> None:
@@ -1007,7 +1031,6 @@ def test_l2_error_division_by_zero_error(grids: list[pp.Grid, pp.MortarGrid]) ->
             true_array=np.zeros(4),
             approx_array=np.random.random(4),
             is_cc=True,
-            is_scalar=True,
             relative=True,
         )
     assert msg in str(excinfo.value)
@@ -1032,7 +1055,6 @@ def test_l2_error_not_implemented_error(grids: list[pp.Grid, pp.MortarGrid]) -> 
             true_array=np.ones(6),
             approx_array=np.random.random(6),
             is_cc=False,
-            is_scalar=True,
         )
     assert msg in str(excinfo.value)
 

--- a/tests/functional/setups/linear_tracer.py
+++ b/tests/functional/setups/linear_tracer.py
@@ -292,7 +292,6 @@ class LinearTracerDataSaving_1p(pp.PorePyModel):
                 subdomains[0],
                 exact_z_tracer,
                 approx_z_tracer,
-                is_scalar=True,
                 is_cc=True,
                 p=1,
             ),
@@ -300,14 +299,12 @@ class LinearTracerDataSaving_1p(pp.PorePyModel):
                 subdomains[0],
                 exact_p,
                 approx_p,
-                is_scalar=True,
                 is_cc=True,
             ),
             error_diffused_z_tracer=ConvergenceAnalysis.lp_error(
                 subdomains[0],
                 diffused_z_tracer,
                 approx_z_tracer,
-                is_scalar=True,
                 is_cc=True,
                 p=1,
             ),
@@ -579,14 +576,12 @@ class LinearTracerDataSaving_3p(LinearTracerDataSaving_1p):
             subdomains[0],
             exact_h,
             approx_h,
-            is_scalar=True,
             is_cc=True,
         )
         data.error_T = ConvergenceAnalysis.lp_error(
             subdomains[0],
             exact_T,
             approx_T,
-            is_scalar=True,
             is_cc=True,
         )
 
@@ -605,7 +600,6 @@ class LinearTracerDataSaving_3p(LinearTracerDataSaving_1p):
                     subdomains[0],
                     exact_sy,
                     approx_s,
-                    is_scalar=True,
                     is_cc=True,
                 )
             )
@@ -614,7 +608,6 @@ class LinearTracerDataSaving_3p(LinearTracerDataSaving_1p):
                     subdomains[0],
                     exact_sy,
                     approx_y,
-                    is_scalar=True,
                     is_cc=True,
                 )
             )
@@ -629,7 +622,7 @@ class LinearTracerDataSaving_3p(LinearTracerDataSaving_1p):
                 exact_x = component.fraction(subdomains).value(self.equation_system)
                 errors_x[-1].append(
                     ConvergenceAnalysis.lp_error(
-                        subdomains[0], exact_x, approx_x, is_scalar=True, is_cc=True
+                        subdomains[0], exact_x, approx_x, is_cc=True
                     )
                 )
 

--- a/tests/functional/setups/manu_flow_comp_2d_frac.py
+++ b/tests/functional/setups/manu_flow_comp_2d_frac.py
@@ -118,7 +118,6 @@ class ManuCompDataSaving(pp.PorePyModel):
             grid=sd_matrix,
             true_array=exact_matrix_pressure,
             approx_array=approx_matrix_pressure,
-            is_scalar=True,
             is_cc=True,
             relative=True,
         )
@@ -130,7 +129,6 @@ class ManuCompDataSaving(pp.PorePyModel):
             grid=sd_matrix,
             true_array=exact_matrix_flux,
             approx_array=approx_matrix_flux,
-            is_scalar=True,
             is_cc=False,
             relative=True,
         )
@@ -142,7 +140,6 @@ class ManuCompDataSaving(pp.PorePyModel):
             grid=sd_frac,
             true_array=exact_frac_pressure,
             approx_array=approx_frac_pressure,
-            is_scalar=True,
             is_cc=True,
             relative=True,
         )
@@ -154,7 +151,6 @@ class ManuCompDataSaving(pp.PorePyModel):
             grid=sd_frac,
             true_array=exact_frac_flux,
             approx_array=approx_frac_flux,
-            is_scalar=True,
             is_cc=False,
             relative=True,
         )
@@ -166,7 +162,6 @@ class ManuCompDataSaving(pp.PorePyModel):
             grid=intf,
             true_array=exact_intf_flux,
             approx_array=approx_intf_flux,
-            is_scalar=True,
             is_cc=True,
             relative=True,
         )

--- a/tests/functional/setups/manu_flow_incomp_frac_2d.py
+++ b/tests/functional/setups/manu_flow_incomp_frac_2d.py
@@ -138,7 +138,6 @@ class ManuIncompDataSaving(pp.PorePyModel):
             grid=sd_matrix,
             true_array=exact_matrix_pressure,
             approx_array=approx_matrix_pressure,
-            is_scalar=True,
             is_cc=True,
             relative=True,
         )
@@ -150,7 +149,6 @@ class ManuIncompDataSaving(pp.PorePyModel):
             grid=sd_matrix,
             true_array=exact_matrix_flux,
             approx_array=approx_matrix_flux,
-            is_scalar=True,
             is_cc=False,
             relative=True,
         )
@@ -161,8 +159,6 @@ class ManuIncompDataSaving(pp.PorePyModel):
         error_frac_pressure = ConvergenceAnalysis.lp_error(
             grid=sd_frac,
             true_array=exact_frac_pressure,
-            approx_array=approx_frac_pressure,
-            is_scalar=True,
             is_cc=True,
             relative=True,
         )
@@ -174,7 +170,6 @@ class ManuIncompDataSaving(pp.PorePyModel):
             grid=sd_frac,
             true_array=exact_frac_flux,
             approx_array=approx_frac_flux,
-            is_scalar=True,
             is_cc=False,
             relative=True,
         )
@@ -186,7 +181,6 @@ class ManuIncompDataSaving(pp.PorePyModel):
             grid=intf,
             true_array=exact_intf_flux,
             approx_array=approx_intf_flux,
-            is_scalar=True,
             is_cc=True,
             relative=True,
         )

--- a/tests/functional/setups/manu_flow_incomp_frac_2d.py
+++ b/tests/functional/setups/manu_flow_incomp_frac_2d.py
@@ -159,6 +159,7 @@ class ManuIncompDataSaving(pp.PorePyModel):
         error_frac_pressure = ConvergenceAnalysis.lp_error(
             grid=sd_frac,
             true_array=exact_frac_pressure,
+            approx_array=approx_frac_pressure,
             is_cc=True,
             relative=True,
         )

--- a/tests/functional/setups/manu_poromech_nofrac_2d.py
+++ b/tests/functional/setups/manu_poromech_nofrac_2d.py
@@ -156,7 +156,6 @@ class ManuPoroMechDataSaving(pp.PorePyModel):
             grid=sd,
             true_array=exact_pressure,
             approx_array=approx_pressure,
-            is_scalar=True,
             is_cc=True,
             relative=True,
         )
@@ -168,7 +167,6 @@ class ManuPoroMechDataSaving(pp.PorePyModel):
             grid=sd,
             true_array=exact_displacement,
             approx_array=approx_displacement,
-            is_scalar=False,
             is_cc=True,
             relative=True,
         )
@@ -180,7 +178,6 @@ class ManuPoroMechDataSaving(pp.PorePyModel):
             grid=sd,
             true_array=exact_flux,
             approx_array=approx_flux,
-            is_scalar=True,
             is_cc=False,
             relative=True,
         )
@@ -192,7 +189,6 @@ class ManuPoroMechDataSaving(pp.PorePyModel):
             grid=sd,
             true_array=exact_force,
             approx_array=approx_force,
-            is_scalar=False,
             is_cc=False,
             relative=True,
         )

--- a/tests/functional/setups/manu_sneddon_2d.py
+++ b/tests/functional/setups/manu_sneddon_2d.py
@@ -371,7 +371,7 @@ class ManuSneddonDataSaving(pp.PorePyModel):
         u_n[close_to_fracture_tips] = 0
 
         e = ConvergenceAnalysis.lp_error(
-            frac_sd[0], u_a, u_n, is_scalar=False, is_cc=True, relative=True
+            frac_sd[0], u_a, u_n, is_cc=True, relative=True
         )
 
         collect_data = ManuSneddonSaveData(error_displacement=e)

--- a/tests/functional/setups/manu_thermoporomech_nofrac_2d.py
+++ b/tests/functional/setups/manu_thermoporomech_nofrac_2d.py
@@ -176,7 +176,6 @@ class ManuThermoPoroMechDataSaving(pp.PorePyModel):
             grid=sd,
             true_array=exact_pressure,
             approx_array=approx_pressure,
-            is_scalar=True,
             is_cc=True,
             relative=True,
         )
@@ -188,7 +187,6 @@ class ManuThermoPoroMechDataSaving(pp.PorePyModel):
             grid=sd,
             true_array=exact_displacement,
             approx_array=approx_displacement,
-            is_scalar=False,
             is_cc=True,
             relative=True,
         )
@@ -200,7 +198,6 @@ class ManuThermoPoroMechDataSaving(pp.PorePyModel):
             grid=sd,
             true_array=exact_temperature,
             approx_array=approx_temperature,
-            is_scalar=True,
             is_cc=True,
             relative=True,
         )
@@ -212,7 +209,6 @@ class ManuThermoPoroMechDataSaving(pp.PorePyModel):
             grid=sd,
             true_array=exact_darcy_flux,
             approx_array=approx_darcy_flux,
-            is_scalar=True,
             is_cc=False,
             relative=True,
         )
@@ -224,7 +220,6 @@ class ManuThermoPoroMechDataSaving(pp.PorePyModel):
             grid=sd,
             true_array=exact_energy_flux,
             approx_array=approx_energy_flux,
-            is_scalar=True,
             is_cc=False,
             relative=True,
         )
@@ -236,7 +231,6 @@ class ManuThermoPoroMechDataSaving(pp.PorePyModel):
             grid=sd,
             true_array=exact_force,
             approx_array=approx_force,
-            is_scalar=False,
             is_cc=False,
             relative=True,
         )


### PR DESCRIPTION
## Proposed changes

Addresses issue #1641. 

Testing: 
* Expanded a test which was already present (test_l2_error()).
* Introduced a new test which ensures errors being raised for different types of "invalid" passed arrays (e.g. 2d arrays, mismatch in size, size not compatible with the grid).

This PR introduces a breaking change: `is_scalar` has been removed from the signature of `lp_error()`. Previously, `is_scalar` was used as a flag to ensure that error computation was performed consistently across all directions. This is now handled automatically by inferring the problem dimension from the provided arrays.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [x] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
