### PR TITLE
Radial return formulation for contact mechanics

### DIFF
--- a/src/porepy/models/contact_mechanics.py
+++ b/src/porepy/models/contact_mechanics.py
@@ -589,9 +589,19 @@ class ContactMechanics(
 # ! ---- VARIANT BASED ON RADIAL RETURN ---- ! #
 
 
-class RadialReturnFormulation:
-    """Alternative formulation for tangential fracture deformation based on classical
-    radial return projection.
+class RadialReturnTangentialContactMechanicsEquation:
+    """Alternative formulation for tangential fracture deformation based on the
+    classical radial return projection.
+
+    . math::
+
+        \\mathbf{t}_t^{trial} &= \\mathbf{t}_t + c_{num} \\Delta \\mathbf{u}_t \\\\
+        \\mathbf{t}_t &= \\min\\left(
+            1,
+            -\\frac{b_p}{\\|\\mathbf{t}_t^{trial}\\|}
+        \\right) \cdot \\mathbf{t}_t^{trial}
+
+    where :math:`b_p = \\max(\\text{friction\\_bound}, 0)` is the friction bound.
 
     """
 
@@ -694,12 +704,11 @@ class RadialReturnFormulation:
         # Define the traction to be the linear radial return projection of the augmented
         # traction. The use of the mask function allows for ignoring cases when the
         # denominator degenerates.
-        ones_frac = pp.ad.DenseArray(np.ones(num_cells))
         min_term = scalar_to_tangential @ (
             f_mask_by_threshold(
                 norm_t_t_trial,
                 -f_max(
-                    pp.ad.Scalar(-1.0) * ones_frac,
+                    pp.ad.Scalar(-1.0),
                     pp.ad.Scalar(-1.0) * b_p / norm_t_t_trial,
                 ),
             )
@@ -710,5 +719,7 @@ class RadialReturnFormulation:
         return equation
 
 
-class RadialReturnContactMechanics(RadialReturnFormulation, ContactMechanics):
+class RadialReturnContactMechanics(
+    RadialReturnTangentialContactMechanicsEquation, ContactMechanics
+):
     """Full contact mechanics model with (linear instead of rescaled) radial return."""

--- a/src/porepy/models/contact_mechanics.py
+++ b/src/porepy/models/contact_mechanics.py
@@ -593,16 +593,6 @@ class RadialReturnTangentialContactMechanicsEquation:
     """Alternative formulation for tangential fracture deformation based on the
     classical radial return projection.
 
-    . math::
-
-        \\mathbf{t}_t^{trial} &= \\mathbf{t}_t + c_{num} \\Delta \\mathbf{u}_t \\\\
-        \\mathbf{t}_t &= \\min\\left(
-            1,
-            -\\frac{b_p}{\\|\\mathbf{t}_t^{trial}\\|}
-        \\right) \cdot \\mathbf{t}_t^{trial}
-
-    where :math:`b_p = \\max(\\text{friction\\_bound}, 0)` is the friction bound.
-
     """
 
     tangential_component: Callable[[list[pp.Grid]], pp.ad.Operator]
@@ -652,7 +642,23 @@ class RadialReturnTangentialContactMechanicsEquation:
         self,
         subdomains: list[pp.Grid],
     ) -> pp.ad.Operator:
-        """Contact mechanics equation for the tangential constraints."""
+        """Contact mechanics equation for the tangential constraints.
+
+        .. math::
+
+            \\mathbf{t}_t^{trial} &= \\mathbf{t}_t + c_{num} \\Delta \\mathbf{u}_t \\\\
+            \\mathbf{t}_t &= \\min\\left(
+                1,
+                -\\frac{b_p}{\\|\\mathbf{t}_t^{trial}\\|}
+            \\right) \\cdot \\mathbf{t}_t^{trial}
+
+        where :math:`b_p = \\max(\\text{friction\\_bound}, 0)` is the friction bound.
+
+        See e.g.: Eq. (48c) in Alart and Curnier, "A mixed formulation for frictional
+        contact problems prone to Newton like solution methods", CMAME, 1991,
+        DOI: 10.1016/0045-7825(91)90022-X.
+
+        """
 
         # Basis vector combinations.
         num_cells = sum([sd.num_cells for sd in subdomains])

--- a/src/porepy/models/contact_mechanics.py
+++ b/src/porepy/models/contact_mechanics.py
@@ -598,9 +598,19 @@ class ContactMechanics(
 # ! ---- VARIANT BASED ON RADIAL RETURN ---- ! #
 
 
-class RadialReturnFormulation:
-    """Alternative formulation for tangential fracture deformation based on classical
-    radial return projection.
+class RadialReturnTangentialContactMechanicsEquation:
+    """Alternative formulation for tangential fracture deformation based on the
+    classical radial return projection.
+
+    . math::
+
+        \\mathbf{t}_t^{trial} &= \\mathbf{t}_t + c_{num} \\Delta \\mathbf{u}_t \\\\
+        \\mathbf{t}_t &= \\min\\left(
+            1,
+            -\\frac{b_p}{\\|\\mathbf{t}_t^{trial}\\|}
+        \\right) \cdot \\mathbf{t}_t^{trial}
+
+    where :math:`b_p = \\max(\\text{friction\\_bound}, 0)` is the friction bound.
 
     """
 
@@ -703,12 +713,11 @@ class RadialReturnFormulation:
         # Define the traction to be the linear radial return projection of the augmented
         # traction. The use of the mask function allows for ignoring cases when the
         # denominator degenerates.
-        ones_frac = pp.ad.DenseArray(np.ones(num_cells))
         min_term = scalar_to_tangential @ (
             f_mask_by_threshold(
                 norm_t_t_trial,
                 -f_max(
-                    pp.ad.Scalar(-1.0) * ones_frac,
+                    pp.ad.Scalar(-1.0),
                     pp.ad.Scalar(-1.0) * b_p / norm_t_t_trial,
                 ),
             )
@@ -719,5 +728,7 @@ class RadialReturnFormulation:
         return equation
 
 
-class RadialReturnContactMechanics(RadialReturnFormulation, ContactMechanics):
+class RadialReturnContactMechanics(
+    RadialReturnTangentialContactMechanicsEquation, ContactMechanics
+):
     """Full contact mechanics model with (linear instead of rescaled) radial return."""

--- a/src/porepy/models/contact_mechanics.py
+++ b/src/porepy/models/contact_mechanics.py
@@ -457,10 +457,10 @@ class SolutionStrategyContactMechanics(pp.SolutionStrategy):
     """
 
     characteristic_displacement: Callable[[list[pp.Grid]], pp.ad.Operator]
-    """Characteristic displacement of the problem. Normally defined in a mixin 
-    instance of either 
+    """Characteristic displacement of the problem. Normally defined in a mixin
+    instance of either
     :class:`~porepy.models.constitutive_laws.CharacteristicTractionFromDisplacement`
-    or 
+    or
     :class:`~porepy.models.constitutive_laws.CharacteristicDisplacementFromTraction`.
 
     """
@@ -653,10 +653,10 @@ class RadialReturnFormulation:
     ) -> pp.ad.Operator:
         """Contact mechanics equation for the tangential constraints."""
 
-        # Basis vector combinations
+        # Basis vector combinations.
         num_cells = sum([sd.num_cells for sd in subdomains])
 
-        # Mapping from a full vector to the tangential component
+        # Mapping from a full vector to the tangential component.
         nd_vec_to_tangential = self.tangential_component(subdomains)
 
         # Basis vectors for the tangential components.
@@ -700,9 +700,9 @@ class RadialReturnFormulation:
         zeros_frac = pp.ad.DenseArray(np.zeros(num_cells))
         b_p = f_max(self.friction_bound(subdomains), zeros_frac)
 
-        # Define the traction to be the linear radial return projection of the
-        # augmented traction. The use of the mask function allows for ignoring
-        # cases when the denominator degenerates.
+        # Define the traction to be the linear radial return projection of the augmented
+        # traction. The use of the mask function allows for ignoring cases when the
+        # denominator degenerates.
         ones_frac = pp.ad.DenseArray(np.ones(num_cells))
         min_term = scalar_to_tangential @ (
             f_mask_by_threshold(

--- a/src/porepy/models/contact_mechanics.py
+++ b/src/porepy/models/contact_mechanics.py
@@ -8,7 +8,7 @@ combination with the momentum balance model, but can be used as a standalone mod
 """
 
 from functools import partial
-from typing import Callable, Optional, cast
+from typing import Callable, Optional, Sequence, cast
 
 import numpy as np
 
@@ -593,3 +593,131 @@ class ContactMechanics(
     pp.DataSavingMixin,
 ):
     pass
+
+
+# ! ---- VARIANT BASED ON RADIAL RETURN ---- ! #
+
+
+class RadialReturnFormulation:
+    """Alternative formulation for tangential fracture deformation based on classical
+    radial return projection.
+
+    """
+
+    tangential_component: Callable[[list[pp.Grid]], pp.ad.Operator]
+    """Mapping from a full vector to the tangential component."""
+
+    basis: Callable[[Sequence[pp.GridLike], int], list[pp.ad.Projection]]
+    """Basis vectors for the tangential components."""
+
+    nd: int
+    """Ambient dimension of the problem."""
+
+    contact_traction: Callable[[list[pp.Grid]], pp.ad.Operator]
+    """Contact traction variable. Normally defined in a mixin instance of
+    :class:`~porepy.models.contact_mechanics.ContactTractionVariable`.
+
+    """
+    plastic_displacement_jump: Callable[[list[pp.Grid]], pp.ad.Operator]
+    """The plastic component of the displacement jump. Normally defined in a mixin
+    instance of
+    :class:`~porepy.models.constitutive_laws.DisplacementJump`.
+    """
+
+    numerical: pp.NumericalConstants
+    """Numerical parameters of the model, used for the open state tolerance."""
+
+    friction_bound: Callable[[list[pp.Grid]], pp.ad.Operator]
+    """Friction bound of a fracture. Normally provided by a mixin instance of
+    :class:`~porepy.models.constitutive_laws.CoulombFrictionBound`.
+
+    """
+    contact_mechanics_numerical_constant: Callable[[list[pp.Grid]], pp.ad.Scalar]
+    """Numerical constant for contact mechanics. Normally provided by a mixin instance
+    of :class:`~porepy.models.momuntum_balance.SolutionStrategyMomentumBalance`.
+
+    """
+    contact_mechanics_open_state_characteristic: Callable[
+        [list[pp.Grid]], pp.ad.Operator
+    ]
+    """Characteristic function used in the tangential contact mechanics relation.
+    Can be interpreted as an indicator of the fracture cells in the open state.
+    Normally provided by a mixin instance of
+    :class:`~porepy.models.contact_mechanics.SolutionStrategyMomentumBalance`.
+
+    """
+
+    def tangential_fracture_deformation_equation(
+        self,
+        subdomains: list[pp.Grid],
+    ) -> pp.ad.Operator:
+        """Contact mechanics equation for the tangential constraints."""
+
+        # Basis vector combinations
+        num_cells = sum([sd.num_cells for sd in subdomains])
+
+        # Mapping from a full vector to the tangential component
+        nd_vec_to_tangential = self.tangential_component(subdomains)
+
+        # Basis vectors for the tangential components.
+        tangential_basis = self.basis(subdomains, self.nd - 1)
+
+        # To map a scalar to the tangential plane, we need to sum the basis vectors.
+        scalar_to_tangential = pp.ad.sum_projection_list(tangential_basis)
+
+        # Variables: The tangential component of the contact traction and the plastic
+        # displacement jump, and its time increment.
+        t_t: pp.ad.Operator = nd_vec_to_tangential @ self.contact_traction(subdomains)
+        u_t: pp.ad.Operator = nd_vec_to_tangential @ self.plastic_displacement_jump(
+            subdomains
+        )
+
+        # The time increment of the tangential displacement jump.
+        u_t_increment: pp.ad.Operator = pp.ad.time_increment(u_t)
+
+        # Auxiliary functions.
+        f_max = pp.ad.Function(pp.ad.maximum, "max_function")
+        f_norm = pp.ad.Function(partial(pp.ad.l2_norm, self.nd - 1), "norm_function")
+        f_mask_by_threshold = pp.ad.Function(
+            partial(
+                pp.ad.mask_by_threshold,
+                self.numerical.open_state_tolerance,
+            ),
+            "mask_by_threshold_function",
+        )
+
+        # Augment the traction.
+        c_num = scalar_to_tangential @ self.contact_mechanics_numerical_constant(
+            subdomains
+        )
+        t_t_trial = t_t + c_num * u_t_increment
+        t_t_trial.set_name("t_t_trial")
+
+        norm_t_t_trial = f_norm(t_t_trial)
+        norm_t_t_trial.set_name("norm_t_t_trial")
+
+        # Friction bound - cut off negative values to avoid open state.
+        zeros_frac = pp.ad.DenseArray(np.zeros(num_cells))
+        b_p = f_max(self.friction_bound(subdomains), zeros_frac)
+
+        # Define the traction to be the linear radial return projection of the
+        # augmented traction. The use of the mask function allows for ignoring
+        # cases when the denominator degenerates.
+        ones_frac = pp.ad.DenseArray(np.ones(num_cells))
+        min_term = scalar_to_tangential @ (
+            f_mask_by_threshold(
+                norm_t_t_trial,
+                -f_max(
+                    pp.ad.Scalar(-1.0) * ones_frac,
+                    pp.ad.Scalar(-1.0) * b_p / norm_t_t_trial,
+                ),
+            )
+        )
+        equation: pp.ad.Operator = t_t - min_term * t_t_trial
+        equation.set_name("tangential_fracture_deformation_equation")
+
+        return equation
+
+
+class RadialReturnContactMechanics(RadialReturnFormulation, ContactMechanics):
+    """Full contact mechanics model with (linear instead of rescaled) radial return."""

--- a/src/porepy/models/contact_mechanics.py
+++ b/src/porepy/models/contact_mechanics.py
@@ -8,7 +8,7 @@ combination with the momentum balance model, but can be used as a standalone mod
 """
 
 from functools import partial
-from typing import Callable, Optional, cast
+from typing import Callable, Optional, Sequence, cast
 
 import numpy as np
 
@@ -584,3 +584,131 @@ class ContactMechanics(
     pp.DataSavingMixin,
 ):
     pass
+
+
+# ! ---- VARIANT BASED ON RADIAL RETURN ---- ! #
+
+
+class RadialReturnFormulation:
+    """Alternative formulation for tangential fracture deformation based on classical
+    radial return projection.
+
+    """
+
+    tangential_component: Callable[[list[pp.Grid]], pp.ad.Operator]
+    """Mapping from a full vector to the tangential component."""
+
+    basis: Callable[[Sequence[pp.GridLike], int], list[pp.ad.Projection]]
+    """Basis vectors for the tangential components."""
+
+    nd: int
+    """Ambient dimension of the problem."""
+
+    contact_traction: Callable[[list[pp.Grid]], pp.ad.Operator]
+    """Contact traction variable. Normally defined in a mixin instance of
+    :class:`~porepy.models.contact_mechanics.ContactTractionVariable`.
+
+    """
+    plastic_displacement_jump: Callable[[list[pp.Grid]], pp.ad.Operator]
+    """The plastic component of the displacement jump. Normally defined in a mixin
+    instance of
+    :class:`~porepy.models.constitutive_laws.DisplacementJump`.
+    """
+
+    numerical: pp.NumericalConstants
+    """Numerical parameters of the model, used for the open state tolerance."""
+
+    friction_bound: Callable[[list[pp.Grid]], pp.ad.Operator]
+    """Friction bound of a fracture. Normally provided by a mixin instance of
+    :class:`~porepy.models.constitutive_laws.CoulombFrictionBound`.
+
+    """
+    contact_mechanics_numerical_constant: Callable[[list[pp.Grid]], pp.ad.Scalar]
+    """Numerical constant for contact mechanics. Normally provided by a mixin instance
+    of :class:`~porepy.models.momuntum_balance.SolutionStrategyMomentumBalance`.
+
+    """
+    contact_mechanics_open_state_characteristic: Callable[
+        [list[pp.Grid]], pp.ad.Operator
+    ]
+    """Characteristic function used in the tangential contact mechanics relation.
+    Can be interpreted as an indicator of the fracture cells in the open state.
+    Normally provided by a mixin instance of
+    :class:`~porepy.models.contact_mechanics.SolutionStrategyMomentumBalance`.
+
+    """
+
+    def tangential_fracture_deformation_equation(
+        self,
+        subdomains: list[pp.Grid],
+    ) -> pp.ad.Operator:
+        """Contact mechanics equation for the tangential constraints."""
+
+        # Basis vector combinations
+        num_cells = sum([sd.num_cells for sd in subdomains])
+
+        # Mapping from a full vector to the tangential component
+        nd_vec_to_tangential = self.tangential_component(subdomains)
+
+        # Basis vectors for the tangential components.
+        tangential_basis = self.basis(subdomains, self.nd - 1)
+
+        # To map a scalar to the tangential plane, we need to sum the basis vectors.
+        scalar_to_tangential = pp.ad.sum_projection_list(tangential_basis)
+
+        # Variables: The tangential component of the contact traction and the plastic
+        # displacement jump, and its time increment.
+        t_t: pp.ad.Operator = nd_vec_to_tangential @ self.contact_traction(subdomains)
+        u_t: pp.ad.Operator = nd_vec_to_tangential @ self.plastic_displacement_jump(
+            subdomains
+        )
+
+        # The time increment of the tangential displacement jump.
+        u_t_increment: pp.ad.Operator = pp.ad.time_increment(u_t)
+
+        # Auxiliary functions.
+        f_max = pp.ad.Function(pp.ad.maximum, "max_function")
+        f_norm = pp.ad.Function(partial(pp.ad.l2_norm, self.nd - 1), "norm_function")
+        f_mask_by_threshold = pp.ad.Function(
+            partial(
+                pp.ad.mask_by_threshold,
+                self.numerical.open_state_tolerance,
+            ),
+            "mask_by_threshold_function",
+        )
+
+        # Augment the traction.
+        c_num = scalar_to_tangential @ self.contact_mechanics_numerical_constant(
+            subdomains
+        )
+        t_t_trial = t_t + c_num * u_t_increment
+        t_t_trial.set_name("t_t_trial")
+
+        norm_t_t_trial = f_norm(t_t_trial)
+        norm_t_t_trial.set_name("norm_t_t_trial")
+
+        # Friction bound - cut off negative values to avoid open state.
+        zeros_frac = pp.ad.DenseArray(np.zeros(num_cells))
+        b_p = f_max(self.friction_bound(subdomains), zeros_frac)
+
+        # Define the traction to be the linear radial return projection of the
+        # augmented traction. The use of the mask function allows for ignoring
+        # cases when the denominator degenerates.
+        ones_frac = pp.ad.DenseArray(np.ones(num_cells))
+        min_term = scalar_to_tangential @ (
+            f_mask_by_threshold(
+                norm_t_t_trial,
+                -f_max(
+                    pp.ad.Scalar(-1.0) * ones_frac,
+                    pp.ad.Scalar(-1.0) * b_p / norm_t_t_trial,
+                ),
+            )
+        )
+        equation: pp.ad.Operator = t_t - min_term * t_t_trial
+        equation.set_name("tangential_fracture_deformation_equation")
+
+        return equation
+
+
+class RadialReturnContactMechanics(RadialReturnFormulation, ContactMechanics):
+    """Full contact mechanics model with (linear instead of rescaled) radial return."""

--- a/src/porepy/models/contact_mechanics.py
+++ b/src/porepy/models/contact_mechanics.py
@@ -644,10 +644,10 @@ class RadialReturnFormulation:
     ) -> pp.ad.Operator:
         """Contact mechanics equation for the tangential constraints."""
 
-        # Basis vector combinations
+        # Basis vector combinations.
         num_cells = sum([sd.num_cells for sd in subdomains])
 
-        # Mapping from a full vector to the tangential component
+        # Mapping from a full vector to the tangential component.
         nd_vec_to_tangential = self.tangential_component(subdomains)
 
         # Basis vectors for the tangential components.
@@ -691,9 +691,9 @@ class RadialReturnFormulation:
         zeros_frac = pp.ad.DenseArray(np.zeros(num_cells))
         b_p = f_max(self.friction_bound(subdomains), zeros_frac)
 
-        # Define the traction to be the linear radial return projection of the
-        # augmented traction. The use of the mask function allows for ignoring
-        # cases when the denominator degenerates.
+        # Define the traction to be the linear radial return projection of the augmented
+        # traction. The use of the mask function allows for ignoring cases when the
+        # denominator degenerates.
         ones_frac = pp.ad.DenseArray(np.ones(num_cells))
         min_term = scalar_to_tangential @ (
             f_mask_by_threshold(

--- a/src/porepy/numerics/ad/functions.py
+++ b/src/porepy/numerics/ad/functions.py
@@ -519,7 +519,7 @@ def mask_by_threshold(tol: float, char_var: FloatType, var: FloatType) -> FloatT
     if not isinstance(var, AdArray):
         if isinstance(var, np.ndarray):
             vals = var.copy()
-            vals[~char_inds] = 0.0
+            vals[np.logical_not(char_inds)] = 0.0
             return vals
         else:
             if isinstance(char_inds, np.ndarray):
@@ -527,7 +527,7 @@ def mask_by_threshold(tol: float, char_var: FloatType, var: FloatType) -> FloatT
             else:
                 return float(char_inds) * var
     vals = var.val.copy()
-    vals[~char_inds] = 0.0
+    vals[np.logical_not(char_inds)] = 0.0
     jac = var.jac.copy()
     pp.matrix_operations.zero_rows(jac, np.where(~char_inds)[0])
     return AdArray(vals, jac)

--- a/src/porepy/numerics/ad/functions.py
+++ b/src/porepy/numerics/ad/functions.py
@@ -53,6 +53,7 @@ __all__ = [
     "RegularizedHeaviside",
     "maximum",
     "characteristic_function",
+    "mask_by_threshold",
 ]
 
 
@@ -484,4 +485,49 @@ def characteristic_function(tol: float, var: FloatType) -> FloatType:
     zero_inds = np.isclose(var.val, 0, atol=tol)
     vals[zero_inds] = 1.0
     jac = sps.csr_matrix(var.jac.shape)
+    return AdArray(vals, jac)
+
+
+def mask_by_threshold(tol: float, char_var: FloatType, var: FloatType) -> FloatType:
+    """Mask a variable by a characteristic function (greater than tolerance).
+
+    Returns the variable `var` where `char_var` exceeds the tolerance `tol`,
+    and zeros it out elsewhere. This implements element-wise masking:
+    ``result = var * (char_var > tol)``, without evaluating the var if not needed
+    (i.e. may also be NaN).
+
+    The Jacobian is zeroed for rows corresponding to masked-out elements.
+
+    Note:
+        See module level documentation on how to wrap functions like this in
+        ``ad.Function``.
+
+    Parameters:
+        tol: Absolute tolerance threshold for the characteristic variable.
+        char_var: Characteristic variable (Ad operator, array, or scalar).
+            Used to determine which elements of `var` are kept.
+        var: Variable to be masked (Ad operator, array, or scalar).
+            Kept where ``char_var > tol``, zeroed elsewhere.
+
+    Returns:
+        Masked version of `var` as an AdArray (if `var` is AdArray) or ndarray.
+
+    """
+    # Determine characteristic indices, i.e. where char_var is greater than tol.
+    char_inds = (char_var.val if isinstance(char_var, AdArray) else char_var) > tol
+    # Return var(.val) at characteristic indices, and zero otherwise.
+    if not isinstance(var, AdArray):
+        if isinstance(var, np.ndarray):
+            vals = var.copy()
+            vals[~char_inds] = 0.0
+            return vals
+        else:
+            if isinstance(char_inds, np.ndarray):
+                return char_inds.astype(float) * var
+            else:
+                return float(char_inds) * var
+    vals = var.val.copy()
+    vals[~char_inds] = 0.0
+    jac = var.jac.copy()
+    pp.matrix_operations.zero_rows(jac, np.where(~char_inds)[0])
     return AdArray(vals, jac)

--- a/src/porepy/numerics/ad/functions.py
+++ b/src/porepy/numerics/ad/functions.py
@@ -550,7 +550,7 @@ def mask_by_threshold(tol: float, char_var: FloatType, var: FloatType) -> FloatT
     if not isinstance(var, AdArray):
         if isinstance(var, np.ndarray):
             vals = var.copy()
-            vals[~char_inds] = 0.0
+            vals[np.logical_not(char_inds)] = 0.0
             return vals
         else:
             if isinstance(char_inds, np.ndarray):
@@ -558,7 +558,7 @@ def mask_by_threshold(tol: float, char_var: FloatType, var: FloatType) -> FloatT
             else:
                 return float(char_inds) * var
     vals = var.val.copy()
-    vals[~char_inds] = 0.0
+    vals[np.logical_not(char_inds)] = 0.0
     jac = var.jac.copy()
     pp.matrix_operations.zero_rows(jac, np.where(~char_inds)[0])
     return AdArray(vals, jac)

--- a/src/porepy/numerics/ad/functions.py
+++ b/src/porepy/numerics/ad/functions.py
@@ -54,6 +54,7 @@ __all__ = [
     "maximum",
     "characteristic_function",
     "clip",
+    "mask_by_threshold",
 ]
 
 
@@ -515,4 +516,49 @@ def characteristic_function(tol: float, var: FloatType) -> FloatType:
     zero_inds = np.isclose(var.val, 0, atol=tol)
     vals[zero_inds] = 1.0
     jac = sps.csr_matrix(var.jac.shape)
+    return AdArray(vals, jac)
+
+
+def mask_by_threshold(tol: float, char_var: FloatType, var: FloatType) -> FloatType:
+    """Mask a variable by a characteristic function (greater than tolerance).
+
+    Returns the variable `var` where `char_var` exceeds the tolerance `tol`,
+    and zeros it out elsewhere. This implements element-wise masking:
+    ``result = var * (char_var > tol)``, without evaluating the var if not needed
+    (i.e. may also be NaN).
+
+    The Jacobian is zeroed for rows corresponding to masked-out elements.
+
+    Note:
+        See module level documentation on how to wrap functions like this in
+        ``ad.Function``.
+
+    Parameters:
+        tol: Absolute tolerance threshold for the characteristic variable.
+        char_var: Characteristic variable (Ad operator, array, or scalar).
+            Used to determine which elements of `var` are kept.
+        var: Variable to be masked (Ad operator, array, or scalar).
+            Kept where ``char_var > tol``, zeroed elsewhere.
+
+    Returns:
+        Masked version of `var` as an AdArray (if `var` is AdArray) or ndarray.
+
+    """
+    # Determine characteristic indices, i.e. where char_var is greater than tol.
+    char_inds = (char_var.val if isinstance(char_var, AdArray) else char_var) > tol
+    # Return var(.val) at characteristic indices, and zero otherwise.
+    if not isinstance(var, AdArray):
+        if isinstance(var, np.ndarray):
+            vals = var.copy()
+            vals[~char_inds] = 0.0
+            return vals
+        else:
+            if isinstance(char_inds, np.ndarray):
+                return char_inds.astype(float) * var
+            else:
+                return float(char_inds) * var
+    vals = var.val.copy()
+    vals[~char_inds] = 0.0
+    jac = var.jac.copy()
+    pp.matrix_operations.zero_rows(jac, np.where(~char_inds)[0])
     return AdArray(vals, jac)

--- a/tests/models/test_contact_mechanics.py
+++ b/tests/models/test_contact_mechanics.py
@@ -6,11 +6,11 @@ import numpy as np
 import pytest
 
 import porepy as pp
+from porepy.applications.md_grids.domains import nd_cube_domain
 from porepy.applications.md_grids.model_geometries import (
     CubeDomainOrthogonalFractures,
     SquareDomainOrthogonalFractures,
 )
-from porepy.applications.md_grids.domains import nd_cube_domain
 from porepy.applications.test_utils.models import ContactMechanicsTester, add_mixin
 from porepy.models.contact_mechanics import (
     RadialReturnTangentialContactMechanicsEquation,

--- a/tests/models/test_contact_mechanics.py
+++ b/tests/models/test_contact_mechanics.py
@@ -105,7 +105,6 @@ def test_contact_mechanics(nd, formulation):
 def test_friction_constraint(nd, formulation, friction_coefficient):
     """Test whether friction constraint ||t_t|| <= b_p (friction bound) is respected."""
 
-    solid = pp.SolidConstants(**pp.solid_values.extended_granite_values_for_testing)
     solid_vals = {
         "fracture_tangential_stiffness": 0.5e0,
         "fracture_normal_stiffness": 1.0e0,
@@ -175,8 +174,7 @@ def test_contact_mechanics_convergence(nd, formulation):
     model = model_class(params)
 
     # Run and capture solver info.
-    runner = pp.ModelRunner(model)
-    runner.run()
+    pp.ModelRunner(model).run()
 
     # Fetch convergence status from statistics.
     status = model.nonlinear_solver_statistics.simulation_status

--- a/tests/models/test_contact_mechanics.py
+++ b/tests/models/test_contact_mechanics.py
@@ -142,7 +142,8 @@ def test_friction_constraint(nd, formulation):
     # Radial return should enforce ||t_t|| <= b_p (with small tolerance)
     tol = 1e-10
     assert np.all(norm_t_t <= friction_bound + tol), (
-        f"Friction constraint violated: ||t_t|| = {norm_t_t.max()}, b_p = {friction_bound.max()}"
+        f"Friction constraint violated: ||t_t|| = {norm_t_t.max()}, "
+        f"b_p = {friction_bound.max()}"
     )
 
 

--- a/tests/models/test_contact_mechanics.py
+++ b/tests/models/test_contact_mechanics.py
@@ -11,12 +11,20 @@ from porepy.applications.md_grids.model_geometries import (
     SquareDomainOrthogonalFractures,
 )
 from porepy.applications.test_utils.models import ContactMechanicsTester, add_mixin
+from porepy.models.contact_mechanics import RadialReturnFormulation
 
 grid_classes = {2: SquareDomainOrthogonalFractures, 3: CubeDomainOrthogonalFractures}
 
+# Define the two formulation variants
+tester_classes = {
+    "standard": ContactMechanicsTester,
+    "radial_return": add_mixin(RadialReturnFormulation, ContactMechanicsTester),
+}
+
 
 @pytest.mark.parametrize("nd", list(grid_classes.keys()))
-def test_contact_mechanics(nd):
+@pytest.mark.parametrize("formulation", list(tester_classes.keys()))
+def test_contact_mechanics(nd, formulation):
     solid = pp.SolidConstants(**pp.solid_values.extended_granite_values_for_testing)
     solid_vals = {
         "fracture_tangential_stiffness": 1.0e0,  # [Pa m^-1]
@@ -34,7 +42,7 @@ def test_contact_mechanics(nd):
         "material_constants": {"solid": solid},
         "interface_displacement_parameter_values": displacement_vals,
     }
-    model_class = add_mixin(grid_classes[nd], ContactMechanicsTester)
+    model_class = add_mixin(grid_classes[nd], tester_classes[formulation])
     model: pp.PorePyModel = model_class(params)
     pp.ModelRunner(model).run()
     fractures = model.mdg.subdomains(dim=nd - 1)

--- a/tests/models/test_contact_mechanics.py
+++ b/tests/models/test_contact_mechanics.py
@@ -92,3 +92,130 @@ def test_contact_mechanics(nd, formulation):
     inds_t = np.arange(nd - 1)
     sigma_t = solid.fracture_tangential_stiffness * displacement_jump_local[inds_t]
     np.testing.assert_allclose(traction[inds_t] - sigma_t, 0, atol=1e-15)
+
+
+@pytest.mark.parametrize("nd", list(grid_classes.keys()))
+@pytest.mark.parametrize("formulation", list(tester_classes.keys()))
+def test_friction_constraint(nd, formulation):
+    """Test that radial return formulation respects friction constraints.
+
+    This test verifies that the radial return projection correctly enforces
+    ||t_t|| <= b_p (friction bound).
+    """
+    solid = pp.SolidConstants(**pp.solid_values.extended_granite_values_for_testing)
+    solid_vals = {
+        "fracture_tangential_stiffness": 0.5e0,  # Reduce to test friction more
+        "fracture_normal_stiffness": 1.0e0,
+        "maximum_elastic_fracture_opening": 2.0,
+        "friction_coefficient": 0.5,  # Important for friction bound
+    }
+    solid = pp.SolidConstants(**solid_vals)
+
+    # Large displacement to trigger sliding
+    displacement_vals = np.array([[0.0, 0.0, 0.0], [5.0, 5.0, 0.0]]).T[:nd]
+    params = {
+        "times_to_export": [],
+        "fracture_indices": [1],
+        "cartesian": True,
+        "material_constants": {"solid": solid},
+        "interface_displacement_parameter_values": displacement_vals,
+    }
+
+    model_class = add_mixin(grid_classes[nd], tester_classes[formulation])
+    model: pp.PorePyModel = model_class(params)
+    pp.ModelRunner(model).run()
+
+    fractures = model.mdg.subdomains(dim=nd - 1)
+
+    # Evaluate tangential traction and friction bound
+    nd_vec_to_tangential = model.tangential_component(fractures)
+    t_t = nd_vec_to_tangential @ model.contact_traction(fractures)
+
+    t_t_vals = model.equation_system.evaluate(t_t).reshape((nd - 1, -1), order="F")
+    norm_t_t = np.linalg.norm(t_t_vals, axis=0)
+
+    # Evaluate friction bound
+    friction_bound = model.equation_system.evaluate(
+        model.friction_bound(fractures)
+    ).ravel()
+
+    # Radial return should enforce ||t_t|| <= b_p (with small tolerance)
+    tol = 1e-10
+    assert np.all(norm_t_t <= friction_bound + tol), (
+        f"Friction constraint violated: ||t_t|| = {norm_t_t.max()}, b_p = {friction_bound.max()}"
+    )
+
+
+@pytest.mark.parametrize("nd", list(grid_classes.keys()))
+@pytest.mark.parametrize("formulation", list(tester_classes.keys()))
+def test_zero_friction_bound_handling(nd, formulation):
+    """Test behavior when friction bound is zero (open state).
+
+    Both formulations should handle the case where b_p = 0 correctly.
+    In the open state, tangential traction should be zero.
+    """
+    solid_vals = {
+        "fracture_tangential_stiffness": 1.0e0,
+        "fracture_normal_stiffness": 1.0e0,
+        "maximum_elastic_fracture_opening": 2.0,
+        "friction_coefficient": 0.0,  # Zero friction - open state
+    }
+    solid = pp.SolidConstants(**solid_vals)
+
+    displacement_vals = np.array([[0.0, 0.0, 0.0], [0.5, 0.5, 0.0]]).T[:nd]
+    params = {
+        "times_to_export": [],
+        "fracture_indices": [1],
+        "cartesian": True,
+        "material_constants": {"solid": solid},
+        "interface_displacement_parameter_values": displacement_vals,
+    }
+
+    model_class = add_mixin(grid_classes[nd], tester_classes[formulation])
+    model: pp.PorePyModel = model_class(params)
+    pp.ModelRunner(model).run()
+
+    fractures = model.mdg.subdomains(dim=nd - 1)
+
+    # Evaluate tangential traction
+    nd_vec_to_tangential = model.tangential_component(fractures)
+    t_t = nd_vec_to_tangential @ model.contact_traction(fractures)
+    t_t_vals = model.equation_system.evaluate(t_t).ravel()
+
+    # In open state with zero friction, tangential traction should be near zero
+    assert np.allclose(t_t_vals, 0.0, atol=1e-10), (
+        f"Tangential traction should be zero in open state, got {t_t_vals}"
+    )
+
+
+@pytest.mark.parametrize("nd", list(grid_classes.keys()))
+@pytest.mark.parametrize("formulation", list(tester_classes.keys()))
+def test_contact_mechanics_convergence(nd, formulation):
+    """Check successful convergence behavior."""
+    solid_vals = {
+        "fracture_tangential_stiffness": 1.0e0,
+        "fracture_normal_stiffness": 1.0e0,
+        "maximum_elastic_fracture_opening": 2.0,
+    }
+    solid = pp.SolidConstants(**solid_vals)
+
+    displacement_vals = np.array([[0.0, 0.0, 0.0], [1.0, 1.0, 0.0]]).T[:nd]
+
+    params = {
+        "times_to_export": [],
+        "fracture_indices": [1],
+        "cartesian": True,
+        "material_constants": {"solid": solid},
+        "interface_displacement_parameter_values": displacement_vals,
+    }
+
+    model_class = add_mixin(grid_classes[nd], tester_classes[formulation])
+    model: pp.PorePyModel = model_class(params)
+
+    # Run and capture solver info
+    runner = pp.ModelRunner(model)
+    runner.run()
+
+    # Fetch convergence status from statistics.
+    status = model.nonlinear_solver_statistics.simulation_status
+    assert status.is_successful()

--- a/tests/models/test_contact_mechanics.py
+++ b/tests/models/test_contact_mechanics.py
@@ -10,15 +10,20 @@ from porepy.applications.md_grids.model_geometries import (
     CubeDomainOrthogonalFractures,
     SquareDomainOrthogonalFractures,
 )
+from porepy.applications.md_grids.domains import nd_cube_domain
 from porepy.applications.test_utils.models import ContactMechanicsTester, add_mixin
-from porepy.models.contact_mechanics import RadialReturnFormulation
+from porepy.models.contact_mechanics import (
+    RadialReturnTangentialContactMechanicsEquation,
+)
 
 grid_classes = {2: SquareDomainOrthogonalFractures, 3: CubeDomainOrthogonalFractures}
 
 # Define the two formulation variants
 tester_classes = {
     "standard": ContactMechanicsTester,
-    "radial_return": add_mixin(RadialReturnFormulation, ContactMechanicsTester),
+    "radial_return": add_mixin(
+        RadialReturnTangentialContactMechanicsEquation, ContactMechanicsTester
+    ),
 }
 
 
@@ -96,22 +101,20 @@ def test_contact_mechanics(nd, formulation):
 
 @pytest.mark.parametrize("nd", list(grid_classes.keys()))
 @pytest.mark.parametrize("formulation", list(tester_classes.keys()))
-def test_friction_constraint(nd, formulation):
-    """Test that radial return formulation respects friction constraints.
+@pytest.mark.parametrize("friction_coefficient", [0.0, 0.5])
+def test_friction_constraint(nd, formulation, friction_coefficient):
+    """Test whether friction constraint ||t_t|| <= b_p (friction bound) is respected."""
 
-    This test verifies that the radial return projection correctly enforces
-    ||t_t|| <= b_p (friction bound).
-    """
     solid = pp.SolidConstants(**pp.solid_values.extended_granite_values_for_testing)
     solid_vals = {
-        "fracture_tangential_stiffness": 0.5e0,  # Reduce to test friction more
+        "fracture_tangential_stiffness": 0.5e0,
         "fracture_normal_stiffness": 1.0e0,
         "maximum_elastic_fracture_opening": 2.0,
-        "friction_coefficient": 0.5,  # Important for friction bound
+        "friction_coefficient": friction_coefficient,
     }
     solid = pp.SolidConstants(**solid_vals)
 
-    # Large displacement to trigger sliding
+    # Large displacement to trigger sliding.
     displacement_vals = np.array([[0.0, 0.0, 0.0], [5.0, 5.0, 0.0]]).T[:nd]
     params = {
         "times_to_export": [],
@@ -127,65 +130,23 @@ def test_friction_constraint(nd, formulation):
 
     fractures = model.mdg.subdomains(dim=nd - 1)
 
-    # Evaluate tangential traction and friction bound
+    # Evaluate tangential traction and friction bound.
     nd_vec_to_tangential = model.tangential_component(fractures)
     t_t = nd_vec_to_tangential @ model.contact_traction(fractures)
 
     t_t_vals = model.equation_system.evaluate(t_t).reshape((nd - 1, -1), order="F")
     norm_t_t = np.linalg.norm(t_t_vals, axis=0)
 
-    # Evaluate friction bound
+    # Evaluate friction bound.
     friction_bound = model.equation_system.evaluate(
         model.friction_bound(fractures)
     ).ravel()
 
-    # Radial return should enforce ||t_t|| <= b_p (with small tolerance)
+    # Should enfore ||t_t|| <= b_p (with small tolerance).
     tol = 1e-10
     assert np.all(norm_t_t <= friction_bound + tol), (
         f"Friction constraint violated: ||t_t|| = {norm_t_t.max()}, "
         f"b_p = {friction_bound.max()}"
-    )
-
-
-@pytest.mark.parametrize("nd", list(grid_classes.keys()))
-@pytest.mark.parametrize("formulation", list(tester_classes.keys()))
-def test_zero_friction_bound_handling(nd, formulation):
-    """Test behavior when friction bound is zero (open state).
-
-    Both formulations should handle the case where b_p = 0 correctly.
-    In the open state, tangential traction should be zero.
-    """
-    solid_vals = {
-        "fracture_tangential_stiffness": 1.0e0,
-        "fracture_normal_stiffness": 1.0e0,
-        "maximum_elastic_fracture_opening": 2.0,
-        "friction_coefficient": 0.0,  # Zero friction - open state
-    }
-    solid = pp.SolidConstants(**solid_vals)
-
-    displacement_vals = np.array([[0.0, 0.0, 0.0], [0.5, 0.5, 0.0]]).T[:nd]
-    params = {
-        "times_to_export": [],
-        "fracture_indices": [1],
-        "cartesian": True,
-        "material_constants": {"solid": solid},
-        "interface_displacement_parameter_values": displacement_vals,
-    }
-
-    model_class = add_mixin(grid_classes[nd], tester_classes[formulation])
-    model: pp.PorePyModel = model_class(params)
-    pp.ModelRunner(model).run()
-
-    fractures = model.mdg.subdomains(dim=nd - 1)
-
-    # Evaluate tangential traction
-    nd_vec_to_tangential = model.tangential_component(fractures)
-    t_t = nd_vec_to_tangential @ model.contact_traction(fractures)
-    t_t_vals = model.equation_system.evaluate(t_t).ravel()
-
-    # In open state with zero friction, tangential traction should be near zero
-    assert np.allclose(t_t_vals, 0.0, atol=1e-10), (
-        f"Tangential traction should be zero in open state, got {t_t_vals}"
     )
 
 
@@ -211,9 +172,9 @@ def test_contact_mechanics_convergence(nd, formulation):
     }
 
     model_class = add_mixin(grid_classes[nd], tester_classes[formulation])
-    model: pp.PorePyModel = model_class(params)
+    model = model_class(params)
 
-    # Run and capture solver info
+    # Run and capture solver info.
     runner = pp.ModelRunner(model)
     runner.run()
 

--- a/tests/numerics/ad/test_functions.py
+++ b/tests/numerics/ad/test_functions.py
@@ -8,6 +8,7 @@ scalar times a variable.
 """
 
 import warnings
+import pytest
 
 import numpy as np
 import scipy.sparse as sps
@@ -801,3 +802,76 @@ def test_heaviside_smooth_times_ad_var():
         b.jac.toarray(), true_jac.toarray()
     )
     assert np.all(a.val == [1, -2, -3]) and np.all(a.jac.toarray() == J.toarray())
+
+
+# Function: mask_by_threshold
+@pytest.mark.parametrize(
+    "char_var,var,tol,expected_val,expected_jac",
+    [
+        # Test case 1: scalar, no AdArray
+        pytest.param(
+            np.array([0.5, -0.1, 2.0]),
+            10.0,
+            0.0,
+            np.array([10.0, 0.0, 10.0]),
+            None,
+            id="scalar_no_advar",
+        ),
+        # Test case 2: ndarray, no AdArray
+        pytest.param(
+            np.array([0.5, -0.1, 2.0]),
+            np.array([10, 20, 30]),
+            0.0,
+            np.array([10, 0, 30]),
+            None,
+            id="array_no_advar",
+        ),
+        # Test case 3: NaN * 0 = 0
+        pytest.param(
+            np.array([0.5, -0.1, 2.0]),
+            np.array([10.0, np.nan, 30.0]),
+            0.0,
+            np.array([10.0, 0.0, 30.0]),
+            None,
+            id="nan_times_zero",
+        ),
+        # Test case 4: AdArray with tolerance
+        pytest.param(
+            AdArray(np.array([0.05, 0.1, 1.0]), sps.csr_matrix((3, 3))),
+            AdArray(np.array([10, 20, 30]), sps.csr_matrix(np.diag([1, 1, 1]))),
+            0.08,
+            np.array([0, 20, 30]),
+            np.array([[0, 0, 0], [0, 1, 0], [0, 0, 1]]),
+            id="adarray_with_tolerance",
+        ),
+        # Test case 5: all masked
+        pytest.param(
+            AdArray(np.array([0.1, 0.2, 0.3]), sps.csr_matrix((3, 3))),
+            AdArray(np.array([10, 20, 30]), sps.csr_matrix(np.diag([1, 1, 1]))),
+            0.5,
+            np.array([0, 0, 0]),
+            np.zeros((3, 3)),
+            id="all_masked",
+        ),
+        # Test case 6: all kept
+        pytest.param(
+            AdArray(np.array([0.5, 1.0, 2.0]), sps.csr_matrix((3, 3))),
+            AdArray(np.array([10, 20, 30]), sps.csr_matrix(np.diag([1, 1, 1]))),
+            0.0,
+            np.array([10, 20, 30]),
+            np.diag([1, 1, 1]),
+            id="all_kept",
+        ),
+    ],
+)
+def test_mask_by_threshold(char_var, var, tol, expected_val, expected_jac):
+    """Parametrized test for mask_by_threshold covering multiple cases."""
+    result = af.mask_by_threshold(tol, char_var, var)
+
+    # Check values
+    assert np.allclose(result.val if hasattr(result, "val") else result, expected_val)
+
+    # Check Jacobian if expected
+    if expected_jac is not None:
+        assert hasattr(result, "jac"), "Expected AdArray with Jacobian"
+        assert np.allclose(result.jac.toarray(), expected_jac)

--- a/tests/numerics/ad/test_functions.py
+++ b/tests/numerics/ad/test_functions.py
@@ -8,6 +8,7 @@ scalar times a variable.
 """
 
 import warnings
+import pytest
 
 import numpy as np
 import scipy.sparse as sps
@@ -893,3 +894,76 @@ def test_clip_does_not_mutate_input():
     _ = af.clip(a, 0.0, 3.0)
     assert np.allclose(a.val, np.array([-1.0, 2.0, 5.0]))
     assert np.allclose(a.jac.toarray(), sps.eye(3).toarray())
+
+
+# Function: mask_by_threshold
+@pytest.mark.parametrize(
+    "char_var,var,tol,expected_val,expected_jac",
+    [
+        # Test case 1: scalar, no AdArray
+        pytest.param(
+            np.array([0.5, -0.1, 2.0]),
+            10.0,
+            0.0,
+            np.array([10.0, 0.0, 10.0]),
+            None,
+            id="scalar_no_advar",
+        ),
+        # Test case 2: ndarray, no AdArray
+        pytest.param(
+            np.array([0.5, -0.1, 2.0]),
+            np.array([10, 20, 30]),
+            0.0,
+            np.array([10, 0, 30]),
+            None,
+            id="array_no_advar",
+        ),
+        # Test case 3: NaN * 0 = 0
+        pytest.param(
+            np.array([0.5, -0.1, 2.0]),
+            np.array([10.0, np.nan, 30.0]),
+            0.0,
+            np.array([10.0, 0.0, 30.0]),
+            None,
+            id="nan_times_zero",
+        ),
+        # Test case 4: AdArray with tolerance
+        pytest.param(
+            AdArray(np.array([0.05, 0.1, 1.0]), sps.csr_matrix((3, 3))),
+            AdArray(np.array([10, 20, 30]), sps.csr_matrix(np.diag([1, 1, 1]))),
+            0.08,
+            np.array([0, 20, 30]),
+            np.array([[0, 0, 0], [0, 1, 0], [0, 0, 1]]),
+            id="adarray_with_tolerance",
+        ),
+        # Test case 5: all masked
+        pytest.param(
+            AdArray(np.array([0.1, 0.2, 0.3]), sps.csr_matrix((3, 3))),
+            AdArray(np.array([10, 20, 30]), sps.csr_matrix(np.diag([1, 1, 1]))),
+            0.5,
+            np.array([0, 0, 0]),
+            np.zeros((3, 3)),
+            id="all_masked",
+        ),
+        # Test case 6: all kept
+        pytest.param(
+            AdArray(np.array([0.5, 1.0, 2.0]), sps.csr_matrix((3, 3))),
+            AdArray(np.array([10, 20, 30]), sps.csr_matrix(np.diag([1, 1, 1]))),
+            0.0,
+            np.array([10, 20, 30]),
+            np.diag([1, 1, 1]),
+            id="all_kept",
+        ),
+    ],
+)
+def test_mask_by_threshold(char_var, var, tol, expected_val, expected_jac):
+    """Parametrized test for mask_by_threshold covering multiple cases."""
+    result = af.mask_by_threshold(tol, char_var, var)
+
+    # Check values
+    assert np.allclose(result.val if hasattr(result, "val") else result, expected_val)
+
+    # Check Jacobian if expected
+    if expected_jac is not None:
+        assert hasattr(result, "jac"), "Expected AdArray with Jacobian"
+        assert np.allclose(result.jac.toarray(), expected_jac)

--- a/tests/numerics/ad/test_functions.py
+++ b/tests/numerics/ad/test_functions.py
@@ -8,9 +8,9 @@ scalar times a variable.
 """
 
 import warnings
-import pytest
 
 import numpy as np
+import pytest
 import scipy.sparse as sps
 
 from porepy.numerics.ad import AdArray

--- a/tests/numerics/ad/test_functions.py
+++ b/tests/numerics/ad/test_functions.py
@@ -875,6 +875,8 @@ def test_mask_by_threshold(char_var, var, tol, expected_val, expected_jac):
     if expected_jac is not None:
         assert hasattr(result, "jac"), "Expected AdArray with Jacobian"
         assert np.allclose(result.jac.toarray(), expected_jac)
+
+
 # Function: clip
 
 


### PR DESCRIPTION
This PR implements an alternative formulation for the tangential fracture deformation based on the classical radial return formulation. In order to allow multiplication with inf or nan of the form 0/0 in the ad framework, an additional AD function has been added tailored to the use within the particular formulation. Only minimal tests are added following a similar style as for existing functionality (AD and contact mechanics).

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
