### PR TITLE
Revert trial time step

### DIFF
--- a/src/porepy/models/solution_strategy.py
+++ b/src/porepy/models/solution_strategy.py
@@ -411,9 +411,10 @@ class SolutionStrategy(pp.PorePyModel):
     def after_time_step_failure(self) -> None:
         """Called after a time step has failed to converge.
 
-        The base method does nothing.
+        The base method reverts the trial time step being executed.
 
         """
+        self.revert_trial_time_step_solution()
 
     def reset_state_from_file(self) -> None:
         """Reset states but through a restart from file.
@@ -678,6 +679,19 @@ class SolutionStrategy(pp.PorePyModel):
         self.equation_system.set_variable_values(
             values=solution, time_step_index=0, additive=False
         )
+
+    def revert_trial_time_step_solution(self) -> None:
+        """Revert the solution to the previous time step solution.
+
+        This method is intended to be used in the case of a failed time step, where the
+        trial solution should be reverted to the last known good solution. All iterate
+        indices are updated to the previous time step solution, which is stored at time
+        step index 0. I.e., we assume time step solution has *not* been shifted yet.
+
+        """
+        prev_solution = self.equation_system.get_variable_values(time_step_index=0)
+        for ind in self.iterate_indices:
+            self.equation_system.set_variable_values(prev_solution, iterate_index=ind)
 
     def after_simulation(self) -> None:
         """Run at the end of simulation. Can be used for cleanup etc."""

--- a/tests/models/test_model_runner.py
+++ b/tests/models/test_model_runner.py
@@ -16,6 +16,7 @@ def test_failed_nonlinear_solve_dynamic_time_step():
     do not propagate into the residual vector of the next.
     """
     STATE_VALUE = 1.0  # The value for the primary variables.
+    num_times_visited_assemble_linear_system = 0
     num_times_visited_solve_linear_system = 0
 
     class FailingModel(pp.SinglePhaseFlow):
@@ -28,6 +29,9 @@ def test_failed_nonlinear_solve_dynamic_time_step():
         def assemble_linear_system(self) -> None:
             # The iterate array should be equal to the state array, since we never
             # proceed further than the 0-th Newton iteration.
+            nonlocal num_times_visited_assemble_linear_system
+            num_times_visited_assemble_linear_system += 1
+
             state = self.equation_system.get_variable_values(time_step_index=0)
             iterate = self.equation_system.get_variable_values(iterate_index=0)
             assert np.all(state == STATE_VALUE)
@@ -59,3 +63,6 @@ def test_failed_nonlinear_solve_dynamic_time_step():
     model_runner.run()
 
     assert num_times_visited_solve_linear_system == 2, "Should do exactly 2 attempts."
+    assert num_times_visited_assemble_linear_system == 2, (
+        "Should do exactly 2 attempts."
+    )

--- a/tests/models/test_model_runner.py
+++ b/tests/models/test_model_runner.py
@@ -1,0 +1,61 @@
+import numpy as np
+
+import porepy as pp
+
+
+def test_failed_nonlinear_solve_dynamic_time_step():
+    """Test that a failed nonlinear solve resets iterates to the last known state.
+
+    When the linear solver returns NaN (simulating a failure), the time step
+    manager should retry with a smaller time step. Before each retry, the
+    iterate array must be reset to the last accepted time state, and not left at
+    the NaN values from the failed attempt.
+
+    The test also checks that the solver makes exactly as many attempts as
+    allowed by `nl_max_iterations`, and that NaN values from one iteration
+    do not propagate into the residual vector of the next.
+    """
+    STATE_VALUE = 1.0  # The value for the primary variables.
+    num_times_visited_solve_linear_system = 0
+
+    class FailingModel(pp.SinglePhaseFlow):
+        def initial_condition(self):
+            super().initial_condition()
+            # Setting some non-trivial initial condition.
+            values = np.full(self.equation_system.num_dofs(), STATE_VALUE)
+            self.equation_system.set_variable_values(values, iterate_index=0)
+
+        def assemble_linear_system(self) -> None:
+            # The iterate array should be equal to the state array, since we never
+            # proceed further than the 0-th Newton iteration.
+            state = self.equation_system.get_variable_values(time_step_index=0)
+            iterate = self.equation_system.get_variable_values(iterate_index=0)
+            assert np.all(state == STATE_VALUE)
+            assert np.all(iterate == STATE_VALUE)
+            return super().assemble_linear_system()
+
+        def solve_linear_system(self) -> np.ndarray:
+            nonlocal num_times_visited_solve_linear_system
+            num_times_visited_solve_linear_system += 1
+
+            _, b = self.linear_system
+            # Nans from the previous iteration must not propagate here.
+            assert not np.any(np.isnan(b))
+            # The linear solver failed and returned an array of nans.
+            return np.full_like(b, np.nan)
+
+    model_params = {
+        "time_manager": pp.TimeManager(
+            schedule=[0, 1],
+            dt_init=0.1,
+            dt_min_max=(0.05, 0.1),
+        )
+    }
+    model = FailingModel(params=model_params)
+    runner_params = {
+        "nl_max_iterations": 2,  # Only 2 Newton iterations
+    }
+    model_runner = pp.ModelRunner(model, params=runner_params)
+    model_runner.run()
+
+    assert num_times_visited_solve_linear_system == 2, "Should do exactly 2 attempts."


### PR DESCRIPTION
## Proposed changes

Fixes bug causing corrupted solutions during failed nonlinear solve to survive in iterate and propagate to recomputation of the failed time step.

Also adds test...

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
