### PR TITLE
Issue #1693

### DIFF
--- a/src/porepy/numerics/linalg/matrix_operations.py
+++ b/src/porepy/numerics/linalg/matrix_operations.py
@@ -5,12 +5,12 @@ module for operations on sparse matrices
 from __future__ import annotations
 
 import warnings
+from functools import lru_cache
 from typing import Literal, Optional, Union, cast, overload
 
 import networkx as nx
 import numpy as np
 import scipy.sparse as sps
-from functools import lru_cache
 
 import porepy as pp
 
@@ -27,8 +27,8 @@ if numba_available:
     def _get_inv_compiled_function():
         """Build and cache the Numba-compiled block-inverse function.
 
-        The function is compiled on first use and reused on subsequent calls, 
-        which keeps importing PorePy fast and avoids recompiling the function 
+        The function is compiled on first use and reused on subsequent calls,
+        which keeps importing PorePy fast and avoids recompiling the function
         on every inversion.
 
         Returns:

--- a/src/porepy/numerics/linalg/matrix_operations.py
+++ b/src/porepy/numerics/linalg/matrix_operations.py
@@ -20,6 +20,69 @@ try:
 except ImportError:
     numba_available = False
 
+if numba_available:
+    @njit(
+        cache=True,
+        parallel=True,
+    )
+    def inv_compiled_function(is_csr_q, data, indices, indptr, sz):
+        # Construction of simple data structures (low complexity). Indices for block
+        # positions, flattened inverse block positions and nonzeros. Expanded block
+        # positions.
+        idx_blocks = np.cumsum(sz).astype(np.int32)
+        # Expanded nonzero positions for flattened inverse blocks
+        idx_inv_blocks = np.cumsum(np.square(sz)).astype(np.int32)
+        # Nonzero positions for the given matrix data (i.e. a.data)
+        idx_nnz = np.searchsorted(indices, idx_blocks).astype(np.int32)
+
+        # Retrieve global indices (low complexity)
+        if is_csr_q:
+            cols = indices
+            row_reps = indptr[1 : indptr.size] - indptr[0 : indptr.size - 1]
+        else:
+            rows = indices
+            col_reps = indptr[1 : indptr.size] - indptr[0 : indptr.size - 1]
+
+        # flattened nonzero values of the dense inverse (low complexity)
+        # Numba np.zeros support ensures v is a contiguous array (C-contiguous)
+        v = np.zeros(idx_inv_blocks[-1])
+
+        for ib in prange(sz.size - 1):
+            v_range = np.arange(idx_inv_blocks[ib], idx_inv_blocks[ib + 1])
+            flat_block = v[v_range]
+            # Retrieve global block position
+            idx_shift = idx_blocks[ib]
+            idx_block = idx_blocks[np.array([ib, ib + 1])]
+
+            # Transform from global to local rows and cols positions
+            if is_csr_q:
+                l_row = (
+                    np.repeat(
+                        np.arange(idx_block[0], idx_block[1]),
+                        row_reps[idx_block[0] : idx_block[1]],
+                    ).astype(np.int32)
+                    - idx_shift
+                )
+                l_col = cols[idx_nnz[ib] : idx_nnz[ib + 1]] - idx_shift
+            else:
+                l_row = rows[idx_nnz[ib] : idx_nnz[ib + 1]] - idx_shift
+                l_col = (
+                    np.repeat(
+                        np.arange(idx_block[0], idx_block[1]),
+                        col_reps[idx_block[0] : idx_block[1]],
+                    ).astype(np.int32)
+                    - idx_shift
+                )
+            # Construct flattened local positions (major order of non-zeros)
+            sequence_ij = l_row * sz[ib + 1] + l_col
+            # Assigning flattened positions directly from the matrix data (a.data)
+            flat_block[sequence_ij] = data[idx_nnz[ib] : idx_nnz[ib + 1]]
+            # Reshape flattened block to squared dense block of size[ib]
+            dense_block = np.reshape(flat_block, (sz[ib + 1], sz[ib + 1]))
+            # Perform inversion and assigning values from a 1-D ravelled array
+            v[v_range] = np.ravel(np.linalg.inv(dense_block))
+        return v
+
 
 def zero_columns(A: sps.csc_matrix, cols: np.ndarray) -> None:
     """
@@ -1351,68 +1414,68 @@ def invert_diagonal_blocks(
         # Extended block sizes structure
         sz = np.insert(size, 0, 0).astype(np.int32)
 
-        @njit(
-            "f8[::1](b1,f8[::1],i4[::1],i4[::1],i4[::1])",
-            cache=True,
-            parallel=True,
-        )
-        def inv_compiled_function(is_csr_q, data, indices, indptr, sz):
-            # Construction of simple data structures (low complexity). Indices for block
-            # positions, flattened inverse block positions and nonzeros. Expanded block
-            # positions.
-            idx_blocks = np.cumsum(sz).astype(np.int32)
-            # Expanded nonzero positions for flattened inverse blocks
-            idx_inv_blocks = np.cumsum(np.square(sz)).astype(np.int32)
-            # Nonzero positions for the given matrix data (i.e. a.data)
-            idx_nnz = np.searchsorted(indices, idx_blocks).astype(np.int32)
+        # @njit(
+        #     "f8[::1](b1,f8[::1],i4[::1],i4[::1],i4[::1])",
+        #     cache=True,
+        #     parallel=True,
+        # )
+        # def inv_compiled_function_porepy(is_csr_q, data, indices, indptr, sz):
+        #     # Construction of simple data structures (low complexity). Indices for block
+        #     # positions, flattened inverse block positions and nonzeros. Expanded block
+        #     # positions.
+        #     idx_blocks = np.cumsum(sz).astype(np.int32)
+        #     # Expanded nonzero positions for flattened inverse blocks
+        #     idx_inv_blocks = np.cumsum(np.square(sz)).astype(np.int32)
+        #     # Nonzero positions for the given matrix data (i.e. a.data)
+        #     idx_nnz = np.searchsorted(indices, idx_blocks).astype(np.int32)
 
-            # Retrieve global indices (low complexity)
-            if is_csr_q:
-                cols = indices
-                row_reps = indptr[1 : indptr.size] - indptr[0 : indptr.size - 1]
-            else:
-                rows = indices
-                col_reps = indptr[1 : indptr.size] - indptr[0 : indptr.size - 1]
+        #     # Retrieve global indices (low complexity)
+        #     if is_csr_q:
+        #         cols = indices
+        #         row_reps = indptr[1 : indptr.size] - indptr[0 : indptr.size - 1]
+        #     else:
+        #         rows = indices
+        #         col_reps = indptr[1 : indptr.size] - indptr[0 : indptr.size - 1]
 
-            # flattened nonzero values of the dense inverse (low complexity)
-            # Numba np.zeros support ensures v is a contiguous array (C-contiguous)
-            v = np.zeros(idx_inv_blocks[-1])
+        #     # flattened nonzero values of the dense inverse (low complexity)
+        #     # Numba np.zeros support ensures v is a contiguous array (C-contiguous)
+        #     v = np.zeros(idx_inv_blocks[-1])
 
-            for ib in prange(sz.size - 1):
-                v_range = np.arange(idx_inv_blocks[ib], idx_inv_blocks[ib + 1])
-                flat_block = v[v_range]
-                # Retrieve global block position
-                idx_shift = idx_blocks[ib]
-                idx_block = idx_blocks[np.array([ib, ib + 1])]
+        #     for ib in prange(sz.size - 1):
+        #         v_range = np.arange(idx_inv_blocks[ib], idx_inv_blocks[ib + 1])
+        #         flat_block = v[v_range]
+        #         # Retrieve global block position
+        #         idx_shift = idx_blocks[ib]
+        #         idx_block = idx_blocks[np.array([ib, ib + 1])]
 
-                # Transform from global to local rows and cols positions
-                if is_csr_q:
-                    l_row = (
-                        np.repeat(
-                            np.arange(idx_block[0], idx_block[1]),
-                            row_reps[idx_block[0] : idx_block[1]],
-                        ).astype(np.int32)
-                        - idx_shift
-                    )
-                    l_col = cols[idx_nnz[ib] : idx_nnz[ib + 1]] - idx_shift
-                else:
-                    l_row = rows[idx_nnz[ib] : idx_nnz[ib + 1]] - idx_shift
-                    l_col = (
-                        np.repeat(
-                            np.arange(idx_block[0], idx_block[1]),
-                            col_reps[idx_block[0] : idx_block[1]],
-                        ).astype(np.int32)
-                        - idx_shift
-                    )
-                # Construct flattened local positions (major order of non-zeros)
-                sequence_ij = l_row * sz[ib + 1] + l_col
-                # Assigning flattened positions directly from the matrix data (a.data)
-                flat_block[sequence_ij] = data[idx_nnz[ib] : idx_nnz[ib + 1]]
-                # Reshape flattened block to squared dense block of size[ib]
-                dense_block = np.reshape(flat_block, (sz[ib + 1], sz[ib + 1]))
-                # Perform inversion and assigning values from a 1-D ravelled array
-                v[v_range] = np.ravel(np.linalg.inv(dense_block))
-            return v
+        #         # Transform from global to local rows and cols positions
+        #         if is_csr_q:
+        #             l_row = (
+        #                 np.repeat(
+        #                     np.arange(idx_block[0], idx_block[1]),
+        #                     row_reps[idx_block[0] : idx_block[1]],
+        #                 ).astype(np.int32)
+        #                 - idx_shift
+        #             )
+        #             l_col = cols[idx_nnz[ib] : idx_nnz[ib + 1]] - idx_shift
+        #         else:
+        #             l_row = rows[idx_nnz[ib] : idx_nnz[ib + 1]] - idx_shift
+        #             l_col = (
+        #                 np.repeat(
+        #                     np.arange(idx_block[0], idx_block[1]),
+        #                     col_reps[idx_block[0] : idx_block[1]],
+        #                 ).astype(np.int32)
+        #                 - idx_shift
+        #             )
+        #         # Construct flattened local positions (major order of non-zeros)
+        #         sequence_ij = l_row * sz[ib + 1] + l_col
+        #         # Assigning flattened positions directly from the matrix data (a.data)
+        #         flat_block[sequence_ij] = data[idx_nnz[ib] : idx_nnz[ib + 1]]
+        #         # Reshape flattened block to squared dense block of size[ib]
+        #         dense_block = np.reshape(flat_block, (sz[ib + 1], sz[ib + 1]))
+        #         # Perform inversion and assigning values from a 1-D ravelled array
+        #         v[v_range] = np.ravel(np.linalg.inv(dense_block))
+        #     return v
 
         inv_a = inv_compiled_function(is_csr_q, data, indices, indptr, sz)
         return inv_a

--- a/src/porepy/numerics/linalg/matrix_operations.py
+++ b/src/porepy/numerics/linalg/matrix_operations.py
@@ -10,6 +10,7 @@ from typing import Literal, Optional, Union, cast, overload
 import networkx as nx
 import numpy as np
 import scipy.sparse as sps
+from functools import lru_cache
 
 import porepy as pp
 
@@ -21,67 +22,81 @@ except ImportError:
     numba_available = False
 
 if numba_available:
-    @njit(
-        cache=True,
-        parallel=True,
-    )
-    def inv_compiled_function(is_csr_q, data, indices, indptr, sz):
-        # Construction of simple data structures (low complexity). Indices for block
-        # positions, flattened inverse block positions and nonzeros. Expanded block
-        # positions.
-        idx_blocks = np.cumsum(sz).astype(np.int32)
-        # Expanded nonzero positions for flattened inverse blocks
-        idx_inv_blocks = np.cumsum(np.square(sz)).astype(np.int32)
-        # Nonzero positions for the given matrix data (i.e. a.data)
-        idx_nnz = np.searchsorted(indices, idx_blocks).astype(np.int32)
 
-        # Retrieve global indices (low complexity)
-        if is_csr_q:
-            cols = indices
-            row_reps = indptr[1 : indptr.size] - indptr[0 : indptr.size - 1]
-        else:
-            rows = indices
-            col_reps = indptr[1 : indptr.size] - indptr[0 : indptr.size - 1]
+    @lru_cache(maxsize=None)
+    def _get_inv_compiled_function():
+        """Build and cache the Numba-compiled block-inverse function.
 
-        # flattened nonzero values of the dense inverse (low complexity)
-        # Numba np.zeros support ensures v is a contiguous array (C-contiguous)
-        v = np.zeros(idx_inv_blocks[-1])
+        The function is compiled on first use and reused on subsequent calls, 
+        which keeps importing PorePy fast and avoids recompiling the function 
+        on every inversion.
 
-        for ib in prange(sz.size - 1):
-            v_range = np.arange(idx_inv_blocks[ib], idx_inv_blocks[ib + 1])
-            flat_block = v[v_range]
-            # Retrieve global block position
-            idx_shift = idx_blocks[ib]
-            idx_block = idx_blocks[np.array([ib, ib + 1])]
+        Returns:
+            The compiled block-inverse function.
 
-            # Transform from global to local rows and cols positions
+        """
+
+        @njit("f8[::1](b1,f8[::1],i4[::1],i4[::1],i4[::1])", cache=True, parallel=True)
+        def inv_compiled_function(is_csr_q, data, indices, indptr, sz):
+
+            # Construction of simple data structures (low complexity). Indices for block
+            # positions, flattened inverse block positions and nonzeros. Expanded block
+            # positions.
+            idx_blocks = np.cumsum(sz).astype(np.int32)
+            # Expanded nonzero positions for flattened inverse blocks
+            idx_inv_blocks = np.cumsum(np.square(sz)).astype(np.int32)
+            # Nonzero positions for the given matrix data (i.e. a.data)
+            idx_nnz = np.searchsorted(indices, idx_blocks).astype(np.int32)
+
+            # Retrieve global indices (low complexity)
             if is_csr_q:
-                l_row = (
-                    np.repeat(
-                        np.arange(idx_block[0], idx_block[1]),
-                        row_reps[idx_block[0] : idx_block[1]],
-                    ).astype(np.int32)
-                    - idx_shift
-                )
-                l_col = cols[idx_nnz[ib] : idx_nnz[ib + 1]] - idx_shift
+                cols = indices
+                row_reps = indptr[1 : indptr.size] - indptr[0 : indptr.size - 1]
             else:
-                l_row = rows[idx_nnz[ib] : idx_nnz[ib + 1]] - idx_shift
-                l_col = (
-                    np.repeat(
-                        np.arange(idx_block[0], idx_block[1]),
-                        col_reps[idx_block[0] : idx_block[1]],
-                    ).astype(np.int32)
-                    - idx_shift
-                )
-            # Construct flattened local positions (major order of non-zeros)
-            sequence_ij = l_row * sz[ib + 1] + l_col
-            # Assigning flattened positions directly from the matrix data (a.data)
-            flat_block[sequence_ij] = data[idx_nnz[ib] : idx_nnz[ib + 1]]
-            # Reshape flattened block to squared dense block of size[ib]
-            dense_block = np.reshape(flat_block, (sz[ib + 1], sz[ib + 1]))
-            # Perform inversion and assigning values from a 1-D ravelled array
-            v[v_range] = np.ravel(np.linalg.inv(dense_block))
-        return v
+                rows = indices
+                col_reps = indptr[1 : indptr.size] - indptr[0 : indptr.size - 1]
+
+            # flattened nonzero values of the dense inverse (low complexity)
+            # Numba np.zeros support ensures v is a contiguous array (C-contiguous)
+            v = np.zeros(idx_inv_blocks[-1])
+
+            for ib in prange(sz.size - 1):
+                v_range = np.arange(idx_inv_blocks[ib], idx_inv_blocks[ib + 1])
+                flat_block = v[v_range]
+                # Retrieve global block position
+                idx_shift = idx_blocks[ib]
+                idx_block = idx_blocks[np.array([ib, ib + 1])]
+
+                # Transform from global to local rows and cols positions
+                if is_csr_q:
+                    l_row = (
+                        np.repeat(
+                            np.arange(idx_block[0], idx_block[1]),
+                            row_reps[idx_block[0] : idx_block[1]],
+                        ).astype(np.int32)
+                        - idx_shift
+                    )
+                    l_col = cols[idx_nnz[ib] : idx_nnz[ib + 1]] - idx_shift
+                else:
+                    l_row = rows[idx_nnz[ib] : idx_nnz[ib + 1]] - idx_shift
+                    l_col = (
+                        np.repeat(
+                            np.arange(idx_block[0], idx_block[1]),
+                            col_reps[idx_block[0] : idx_block[1]],
+                        ).astype(np.int32)
+                        - idx_shift
+                    )
+                # Construct flattened local positions (major order of non-zeros)
+                sequence_ij = l_row * sz[ib + 1] + l_col
+                # Assigning flattened positions directly from the matrix data (a.data)
+                flat_block[sequence_ij] = data[idx_nnz[ib] : idx_nnz[ib + 1]]
+                # Reshape flattened block to squared dense block of size[ib]
+                dense_block = np.reshape(flat_block, (sz[ib + 1], sz[ib + 1]))
+                # Perform inversion and assigning values from a 1-D ravelled array
+                v[v_range] = np.ravel(np.linalg.inv(dense_block))
+            return v
+
+        return inv_compiled_function
 
 
 def zero_columns(A: sps.csc_matrix, cols: np.ndarray) -> None:
@@ -1414,177 +1429,8 @@ def invert_diagonal_blocks(
         # Extended block sizes structure
         sz = np.insert(size, 0, 0).astype(np.int32)
 
-        # @njit(
-        #     "f8[::1](b1,f8[::1],i4[::1],i4[::1],i4[::1])",
-        #     cache=True,
-        #     parallel=True,
-        # )
-        # def inv_compiled_function_porepy(is_csr_q, data, indices, indptr, sz):
-        #     # Construction of simple data structures (low complexity). Indices for block
-        #     # positions, flattened inverse block positions and nonzeros. Expanded block
-        #     # positions.
-        #     idx_blocks = np.cumsum(sz).astype(np.int32)
-        #     # Expanded nonzero positions for flattened inverse blocks
-        #     idx_inv_blocks = np.cumsum(np.square(sz)).astype(np.int32)
-        #     # Nonzero positions for the given matrix data (i.e. a.data)
-        #     idx_nnz = np.searchsorted(indices, idx_blocks).astype(np.int32)
-
-        #     # Retrieve global indices (low complexity)
-        #     if is_csr_q:
-        #         cols = indices
-        #         row_reps = indptr[1 : indptr.size] - indptr[0 : indptr.size - 1]
-        #     else:
-        #         rows = indices
-        #         col_reps = indptr[1 : indptr.size] - indptr[0 : indptr.size - 1]
-
-        #     # flattened nonzero values of the dense inverse (low complexity)
-        #     # Numba np.zeros support ensures v is a contiguous array (C-contiguous)
-        #     v = np.zeros(idx_inv_blocks[-1])
-
-        #     for ib in prange(sz.size - 1):
-        #         v_range = np.arange(idx_inv_blocks[ib], idx_inv_blocks[ib + 1])
-        #         flat_block = v[v_range]
-        #         # Retrieve global block position
-        #         idx_shift = idx_blocks[ib]
-        #         idx_block = idx_blocks[np.array([ib, ib + 1])]
-
-        #         # Transform from global to local rows and cols positions
-        #         if is_csr_q:
-        #             l_row = (
-        #                 np.repeat(
-        #                     np.arange(idx_block[0], idx_block[1]),
-        #                     row_reps[idx_block[0] : idx_block[1]],
-        #                 ).astype(np.int32)
-        #                 - idx_shift
-        #             )
-        #             l_col = cols[idx_nnz[ib] : idx_nnz[ib + 1]] - idx_shift
-        #         else:
-        #             l_row = rows[idx_nnz[ib] : idx_nnz[ib + 1]] - idx_shift
-        #             l_col = (
-        #                 np.repeat(
-        #                     np.arange(idx_block[0], idx_block[1]),
-        #                     col_reps[idx_block[0] : idx_block[1]],
-        #                 ).astype(np.int32)
-        #                 - idx_shift
-        #             )
-        #         # Construct flattened local positions (major order of non-zeros)
-        #         sequence_ij = l_row * sz[ib + 1] + l_col
-        #         # Assigning flattened positions directly from the matrix data (a.data)
-        #         flat_block[sequence_ij] = data[idx_nnz[ib] : idx_nnz[ib + 1]]
-        #         # Reshape flattened block to squared dense block of size[ib]
-        #         dense_block = np.reshape(flat_block, (sz[ib + 1], sz[ib + 1]))
-        #         # Perform inversion and assigning values from a 1-D ravelled array
-        #         v[v_range] = np.ravel(np.linalg.inv(dense_block))
-        #     return v
-
+        inv_compiled_function = _get_inv_compiled_function()
         inv_a = inv_compiled_function(is_csr_q, data, indices, indptr, sz)
-        return inv_a
-
-    def invert_diagonal_blocks_numba_old(
-        a: sps.csr_matrix, size: np.ndarray
-    ) -> np.ndarray:
-        """Invert block diagonal matrix by invoking numba acceleration of a simple
-        for-loop based algorithm.
-
-        Currently not used, but may be resurrected if the new implementation fails.
-        Parameters:
-            a : sps.csr matrix
-            size : Size of individual blocks
-
-        Returns:
-            inv_a: Flattened nonzero values of the inverse matrix.
-
-        """
-
-        # This function only supports CSR format.
-        if not sps.isspmatrix_csr(a):
-            raise TypeError("Sparse array type not implemented: ", type(a))
-
-        ptr = a.indptr
-        indices = a.indices
-        dat = a.data
-
-        # Just in time compilation
-        @njit("f8[:](i4[:],i4[:],f8[:],i8[:])", cache=True, parallel=True)
-        def inv_python(indptr, ind, data, sz):
-            """
-            Invert block matrices by explicitly forming local matrices. The code
-            in itself is not efficient, but it is hopefully well suited for
-            speeding up with numba.
-
-            IMPLEMENTATION NOTES BELOW
-
-            The code consists of a loop over the blocks. For each block, a local square
-            matrix is formed, the inverse is computed using numpy (which again will
-            invoke LAPACK), and the inverse is stored in an (raveled) array. The most
-            complex part of the code is the formation of the local matrix: Since the
-            original matrix is sparse, there may be zero elements in the blocks
-            which may not be explicitly represented in the data, and the order of the
-            columns in the sparse format may not be linear. To deal with this, we do a
-            double loop to fill in the local matrix.
-
-            Profiling (June 2022) showed that the overhead in filling in the local
-            matrix by for-loops was minimal; specifically, attempts at speeding up the
-            computations by forcing a full block structure of the matrices (with
-            explicit zeros and linear ordering of columns), so that the local matrix
-            could be formed by a reshape, failed.
-
-            """
-
-            # Index of where the rows start for each block.
-            block_row_starts_ind = np.zeros(sz.size, dtype=np.int32)
-            block_row_starts_ind[1:] = np.cumsum(sz[:-1])
-
-            # Number of columns per row. Will change from one column to the
-            # next
-            num_cols_per_row = indptr[1:] - indptr[0:-1]
-            # Index to where the columns start for each row (NOT blocks)
-            row_cols_start_ind = np.zeros(num_cols_per_row.size + 1, dtype=np.int32)
-            row_cols_start_ind[1:] = np.cumsum(num_cols_per_row)
-
-            # Index to where the (full) data starts. Needed, since the
-            # inverse matrix will generally be full
-            full_block_starts_ind = np.zeros(sz.size + 1, dtype=np.int32)
-            full_block_starts_ind[1:] = np.cumsum(np.square(sz))
-            # Structure to store the solution
-            inv_vals = np.zeros(np.sum(np.square(sz)))
-
-            # Loop over all blocks. Do this in parallel, this has shown significant
-            # speedups by numba.
-            for iter1 in prange(sz.size):
-                n = sz[iter1]
-
-                loc_mat = np.zeros((n, n))
-                # Fill in non-zero elements in local matrix
-                # This requires some work, since not all elements in the local matrix
-                # are represented in the data array (elements may be zero). Also, the
-                # ordering of the data may not correspond to a linear ordering of the
-                # columns.
-                for iter2 in range(n):  # Local rows
-                    global_row = block_row_starts_ind[iter1] + iter2
-                    data_counter = row_cols_start_ind[global_row]
-
-                    # Loop over local columns. Getting the number of columns
-                    #  for each row is a bit involved
-                    for _ in range(
-                        num_cols_per_row[iter2 + block_row_starts_ind[iter1]]
-                    ):
-                        loc_col = ind[data_counter] - block_row_starts_ind[iter1]
-                        loc_mat[iter2, loc_col] = data[data_counter]
-                        data_counter += 1
-                # Compute inverse using np.linalg.inv, which will again invoke an
-                # appropriate lapack function.
-                inv_mat = np.ravel(np.linalg.inv(loc_mat))
-
-                # Store data in the output
-                loc_ind = np.arange(
-                    full_block_starts_ind[iter1], full_block_starts_ind[iter1 + 1]
-                )
-                inv_vals[loc_ind] = inv_mat
-
-            return inv_vals
-
-        inv_a = inv_python(ptr, indices, dat, size)
         return inv_a
 
     # Remove blocks of size 0


### PR DESCRIPTION
## Proposed changes

This PR fixes a memory leak in `invert_diagonal_blocks`, which defined its Numba kernel, `inv_compiled_function`, inside the per-call function. Every call re-registered a compiled kernel that Numba never releases, so resident memory grew linearly with the number of inversions.  

This PR moves the kernel into a cached factory (functools.lru_cache), so it is built once on first use and reused on every subsequent call. Compilation stays lazy, so import porepy is unaffected.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [x] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [x] Documentation (contribution related to adding, improving, or fixing documentation).
- [x] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
