### PR TITLE
Update typing to be compatible with numpy 2.5

### DIFF
--- a/src/porepy/fracs/fracture_network_2d.py
+++ b/src/porepy/fracs/fracture_network_2d.py
@@ -469,7 +469,7 @@ class FractureNetwork2d(FractureNetwork):
             # occur more than once will be intersections.
             all_intersection_points = np.where(
                 np.bincount(unique_boundary_points[:, 0]) > 1
-            )[0]
+            )[0].astype(int)
 
         else:
             # No intersections, simply create an empty list.

--- a/src/porepy/fracs/fracture_network_3d.py
+++ b/src/porepy/fracs/fracture_network_3d.py
@@ -690,7 +690,7 @@ class FractureNetwork3d(FractureNetwork):
 
         num_point_occ = np.bincount(points_of_intersection_lines)
         # Identify all points that occur more than once.
-        all_intersection_points = np.where(num_point_occ > 1)[0]
+        all_intersection_points = np.where(num_point_occ > 1)[0].astype(int)
         # Filter away those points that lie on the domain boundary.
         intersection_points = [
             pt

--- a/src/porepy/fracs/split_grid.py
+++ b/src/porepy/fracs/split_grid.py
@@ -899,7 +899,7 @@ def duplicate_nodes(sd: pp.Grid, nodes: np.ndarray, node_offset: float) -> int:
         if hasattr(sd, "tags") and key in sd.tags:
             sd.tags[key] = sd.tags[key][new_2_old_nodes].astype(bool)
 
-    return num_added
+    return int(num_added)
 
 
 def _avg_normal(sd: pp.Grid, faces: np.ndarray) -> np.ndarray:

--- a/src/porepy/geometry/intersections.py
+++ b/src/porepy/geometry/intersections.py
@@ -2354,9 +2354,9 @@ def split_intersecting_segments_2d(
             loc_start = pt(unique_all_pt, ib[e[0, ei]])
             # Measure the distance of the points from the start. This can be used to
             # sort the points along the line
-            dist = np.sum((loc_pts - loc_start) ** 2, axis=0)
-            assert isinstance(dist, np.ndarray)  # Needed to appease mypy
-            order = np.argsort(dist)
+            loc_dist = np.sum((loc_pts - loc_start) ** 2, axis=0)
+            assert isinstance(loc_dist, np.ndarray)  # Needed to appease mypy
+            order = np.argsort(loc_dist)
             new_inds = inds[order]
             # All new segments share the tags of the old one.
             loc_tags = e[2:, ei].reshape((-1, 1)) * np.ones(num_branches, dtype=int)

--- a/src/porepy/geometry/map_geometry.py
+++ b/src/porepy/geometry/map_geometry.py
@@ -209,7 +209,7 @@ def project_points_to_line(
     sort_ind = np.argsort(coord_1d)[0]
     sorted_coord = coord_1d[0, sort_ind]
 
-    return sorted_coord, rot, active_dimension, sort_ind
+    return sorted_coord, rot, active_dimension[0], sort_ind
 
 
 def project_plane_matrix(

--- a/src/porepy/numerics/linalg/matrix_operations.py
+++ b/src/porepy/numerics/linalg/matrix_operations.py
@@ -332,24 +332,23 @@ def slice_sparse_matrix(A: sps.spmatrix, ind: np.ndarray | int) -> sps.spmatrix:
     # The slicing will be done based on a numpy array of indices (row and column for csr
     # and csc, respectively). The provided index can be an array of booleans, or a
     # single integer. Convert these to numpy arrays of indices.
-    if np.asarray(ind).dtype == "bool":
-        ind = np.where(ind)[0]
-    if isinstance(ind, int):
-        ind = np.array([ind])
+    ind_arr = np.asarray(ind)
+    if ind_arr.dtype == "bool":
+        ind_arr = np.where(ind_arr)[0]
 
     # Dimension of the sliced matrix along the axis of the slicing.
-    N = ind.size
+    N = ind_arr.size
     # Expand the indices along the compressed axis. To understand this command, it is
     # necessary to be familiar with the compressed storage format.
     ind_slice = pp.array_operations.expand_index_pointers(
-        A.indptr[ind], A.indptr[ind + 1]
+        A.indptr[ind_arr], A.indptr[ind_arr + 1]
     )
     # Pick out the subset of the indices from A that are also in the slice.
     indices = A.indices[ind_slice]
     # Make a new indptr array and fill it with the relevant parts of the original indptr
     # array.
-    indptr = np.zeros(ind.size + 1)
-    indptr[1:] = np.cumsum(A.indptr[ind + 1] - A.indptr[ind])
+    indptr = np.zeros(ind_arr.size + 1)
+    indptr[1:] = np.cumsum(A.indptr[ind_arr + 1] - A.indptr[ind_arr])
     # Data can be extracted directly from the data array of A.
     data = A.data[ind_slice]
 

--- a/src/porepy/utils/adtree.py
+++ b/src/porepy/utils/adtree.py
@@ -157,9 +157,9 @@ class ADTree:
 
         self.nodes: List[ADTNode] = []
         """The list of nodes as ADTNode."""
-        self.region_min: float = 0.0
+        self.region_min: np.ndarray = np.zeros(phys_dim, dtype=float)
         """To scale the bounding box of all the elements in [0, 1]^phys_dim."""
-        self.delta: float = 1.0
+        self.delta: np.ndarray = np.ones(phys_dim, dtype=float)
         """float: a parameter to scale and get all the bounding box of the elements in
         [0, 1]^phys_dim."""
 


### PR DESCRIPTION
## Proposed changes
This PR fixes typing-related issues that arise with the update to numpy 2.5. There are no functional changes to the code.

NB: Numba is not yet ready for numpy v2.5, so full installations of the code must run on 2.4. However, the GH action with static tests, which do not require numba, are currently run with 2.5 - hence this PR is needed to make those tests pass.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
