### PR TITLE
FEAT: Add offset to hydrostatic and lithostatics BCs

### DIFF
--- a/src/porepy/applications/boundary_conditions/model_boundary_conditions.py
+++ b/src/porepy/applications/boundary_conditions/model_boundary_conditions.py
@@ -466,6 +466,19 @@ class LithostaticBoundaryStressValues(GravityMagnitude):
     """Time manager associated with the model."""
 
     @property
+    def lithostatic_stress_offset(self) -> np.ndarray:
+        """Return surface lithostatic stress.
+
+        Returns:
+            Surface lithostatic stress in Pa. Default is 0 Pa.
+
+        """
+        surface_lithostatic_stress = self.params.get(
+            "surface_lithostatic_stress", np.zeros(3)
+        )
+        return self.units.convert_units(surface_lithostatic_stress, units="Pa")
+
+    @property
     def lithostatic_stress_multipliers(self) -> np.ndarray:
         """Return multipliers for lithostatic stress.
 
@@ -497,6 +510,9 @@ class LithostaticBoundaryStressValues(GravityMagnitude):
         # Multiply with lithostatic stress multipliers, which can be used to set
         # different stresses in different directions.
         gradient = self.lithostatic_stress_multipliers * gravity
+        # Allow for explicit offset (typically lithostatic stress multiplier times
+        # effective overburden stress at surface of the domain).
+        offset = self.lithostatic_stress_offset
         # Get domain sides and depth at boundary cell centers.
         domain_sides = self.domain_boundary_sides(boundary_grid)
         depth = self.depth(boundary_grid.cell_centers)
@@ -513,8 +529,7 @@ class LithostaticBoundaryStressValues(GravityMagnitude):
                 if np.any(ind):
                     # Set ith component of stress on these faces.
                     values[i, ind] = (
-                        gradient[i]
-                        * depth[ind]
+                        (offset + gradient[i] * depth[ind])
                         * sign
                         * boundary_grid.cell_volumes[ind]
                     )
@@ -529,6 +544,25 @@ class HydrostaticPressureValues(GravityMagnitude):
 
     """
 
+    params: dict
+    """Model parameters."""
+
+    @property
+    def hydrostatic_pressure_offset(self) -> float:
+        """Return hydrostatic pressure at surface.
+
+        Default is atmospheric pressure, assuming the top of the domain
+        corresponds to the surface of the Earth. To control the effective
+        hydrostatic pressure at the surface, set the parameter "surface_pressure"
+        in the model parameters.
+
+        Returns:
+            Surface pressure in Pa.
+
+        """
+        surface_pressure = self.params.get("surface_pressure", pp.ATMOSPHERIC_PRESSURE)
+        return self.units.convert_units(surface_pressure, units="Pa")
+
     def hydrostatic_pressure(self, depth: np.ndarray) -> np.ndarray:
         r"""Compute hydrostatic pressure at given depths.
 
@@ -536,7 +570,7 @@ class HydrostaticPressureValues(GravityMagnitude):
         .. math::
             p(z) = \rho g z + p_{atm}
         where :math:`\rho` is the fluid density, :math:`g` is the gravity acceleration,
-        and :math:`p_{atm}` is the atmospheric pressure.
+        and :math:`p_{atm}` is the atmospheric pressure / or surface pressure.
 
         Parameters:
             depth: Array of depths at which to compute hydrostatic pressure.
@@ -547,7 +581,7 @@ class HydrostaticPressureValues(GravityMagnitude):
         """
         gravity = self.gravity_force_magnitude("fluid")
         pressure = gravity * depth + self.units.convert_units(
-            pp.ATMOSPHERIC_PRESSURE, units="Pa"
+            self.hydrostatic_pressure_offset, units="Pa"
         )
         return pressure
 

--- a/src/porepy/applications/boundary_conditions/model_boundary_conditions.py
+++ b/src/porepy/applications/boundary_conditions/model_boundary_conditions.py
@@ -467,20 +467,20 @@ class LithostaticBoundaryStressValues(GravityMagnitude):
 
     @property
     def lithostatic_stress_offset(self) -> np.ndarray:
-        """Return surface lithostatic stress.
+        """Return datum lithostatic stress.
 
-        Defaults to 0. For geometries below the surface, typical values
+        Defaults to 0. For geometries below the datum, typical values
         are lithostatic stress multiplier times effective overburden stress
-        at surface of the domain due to gravity.
+        at datum of the domain due to gravity.
 
         Returns:
-            Surface lithostatic stress in Pa. Default is 0 Pa.
+            Datum lithostatic stress in Pa. Default is 0 Pa.
 
         """
-        surface_lithostatic_stress = self.params.get(
-            "surface_lithostatic_stress", np.zeros(3)
+        datum_lithostatic_stress = self.params.get(
+            "datum_lithostatic_stress", np.zeros(3)
         )
-        return self.units.convert_units(surface_lithostatic_stress, units="Pa")
+        return self.units.convert_units(datum_lithostatic_stress, units="Pa")
 
     @property
     def lithostatic_stress_multipliers(self) -> np.ndarray:
@@ -552,28 +552,28 @@ class HydrostaticPressureValues(GravityMagnitude):
 
     @property
     def hydrostatic_pressure_offset(self) -> float:
-        """Return hydrostatic pressure at surface.
+        """Return hydrostatic pressure at datum.
 
         Default is atmospheric pressure, assuming the top of the domain
         corresponds to the surface of the Earth. To control the effective
-        hydrostatic pressure at the surface, set the parameter "surface_pressure"
+        hydrostatic pressure at the datum, set the parameter "datum_pressure"
         in the model parameters.
 
         Returns:
-            Surface pressure in Pa.
+            Datum pressure in Pa.
 
         """
-        surface_pressure = self.params.get("surface_pressure", pp.ATMOSPHERIC_PRESSURE)
-        return self.units.convert_units(surface_pressure, units="Pa")
+        datum_pressure = self.params.get("datum_pressure", pp.ATMOSPHERIC_PRESSURE)
+        return self.units.convert_units(datum_pressure, units="Pa")
 
     def hydrostatic_pressure(self, depth: np.ndarray) -> np.ndarray:
         r"""Compute hydrostatic pressure at given depths.
 
         The hydrostatic pressure at depth z is given by
         .. math::
-            p(z) = \rho g z + p_{atm}
+            p(z) = \rho g z + p_{offset}
         where :math:`\rho` is the fluid density, :math:`g` is the gravity acceleration,
-        and :math:`p_{atm}` is the atmospheric pressure / or surface pressure.
+        and :math:`p_{offset}` is the offset pressure.
 
         Parameters:
             depth: Array of depths at which to compute hydrostatic pressure.

--- a/src/porepy/applications/boundary_conditions/model_boundary_conditions.py
+++ b/src/porepy/applications/boundary_conditions/model_boundary_conditions.py
@@ -532,7 +532,7 @@ class LithostaticBoundaryStressValues(GravityMagnitude):
                 if np.any(ind):
                     # Set ith component of stress on these faces.
                     values[i, ind] = (
-                        (offset + gradient[i] * depth[ind])
+                        (offset[i] + gradient[i] * depth[ind])
                         * sign
                         * boundary_grid.cell_volumes[ind]
                     )

--- a/src/porepy/applications/boundary_conditions/model_boundary_conditions.py
+++ b/src/porepy/applications/boundary_conditions/model_boundary_conditions.py
@@ -469,6 +469,10 @@ class LithostaticBoundaryStressValues(GravityMagnitude):
     def lithostatic_stress_offset(self) -> np.ndarray:
         """Return surface lithostatic stress.
 
+        Defaults to 0. For geometries below the surface, typical values
+        are lithostatic stress multiplier times effective overburden stress
+        at surface of the domain due to gravity.
+
         Returns:
             Surface lithostatic stress in Pa. Default is 0 Pa.
 
@@ -510,8 +514,7 @@ class LithostaticBoundaryStressValues(GravityMagnitude):
         # Multiply with lithostatic stress multipliers, which can be used to set
         # different stresses in different directions.
         gradient = self.lithostatic_stress_multipliers * gravity
-        # Allow for explicit offset (typically lithostatic stress multiplier times
-        # effective overburden stress at surface of the domain).
+        # Allow for explicit offset.
         offset = self.lithostatic_stress_offset
         # Get domain sides and depth at boundary cell centers.
         domain_sides = self.domain_boundary_sides(boundary_grid)


### PR DESCRIPTION
## Proposed changes

Addresses #1698. Introduces the possibility to add offset to hydrostatic pressure and lithostatic stress BCs. When using lithostatic multipliers unequal 1, the offset is typically different for each dimension such that the lithostatic stress offset needs to be a vector.


## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [x] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
