### PR TITLE
STY: Typing related to numba 0.66

### DIFF
--- a/src/porepy/compositional/utils.py
+++ b/src/porepy/compositional/utils.py
@@ -101,7 +101,7 @@ def _chainrule_fractional_derivatives_parallel(
     """Parallelized version of :func:`_chainrule_fractional_derivatives` to take
     vectorized input."""
     df_dx = np.empty(df_dxn.shape)
-    for i in nb.prange(df_dxn.shape[1]):
+    for i in nb.prange(df_dxn.shape[1]):  # type:ignore[attr-defined]
         df_dx[:, i] = _chainrule_fractional_derivatives(df_dxn[:, i], x[:, i])
     return df_dx
 
@@ -220,7 +220,7 @@ def _compute_saturations_parallel(
 ) -> np.ndarray:
     """Parallelized version of :func:`_compute_saturations` to take vectorized input."""
     s = np.empty(y.shape)
-    for i in nb.prange(y.shape[1]):
+    for i in nb.prange(y.shape[1]):  # type:ignore[attr-defined]
         s[:, i] = _compute_saturations(y[:, i], rho[:, i], eps)
     return s
 

--- a/src/porepy/utils/array_operations.py
+++ b/src/porepy/utils/array_operations.py
@@ -642,7 +642,7 @@ def uniquify_point_set(points: np.ndarray, tol: float):
             points=points,
             sorted_idx=sorted_idx,
             cluster_start=cluster_start,
-            cluster_size=cluster_size,
+            cluster_size=int(cluster_size),
             tol=tol,
         )
         # Number of unique points in the cluster.


### PR DESCRIPTION
## Proposed changes
Minor typing fixes related to numba v0.66.  No functional changes.


## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
