### PR TITLE
Fix slow tests

### DIFF
--- a/.github/workflows/run-pytest-all.yml
+++ b/.github/workflows/run-pytest-all.yml
@@ -76,10 +76,6 @@ jobs:
         pip install .[testing]
         pip freeze
 
-    - name: Install pypardiso
-      run: |
-        pip install pypardiso
-
     - name: all tests
       if: ${{always()}}
       run: pytest --run-skipped -m "not tutorials"

--- a/tests/functional/test_benchmark_2d_case_3.py
+++ b/tests/functional/test_benchmark_2d_case_3.py
@@ -77,7 +77,12 @@ def model(
         model = Model3bWithEffectivePermeability(model_params)
     else:
         ValueError("Parameter combination not admissible.")
-    pp.ModelRunner(model).run()
+    solver_params = {
+        "nl_max_iterations": 100,
+        "nl_convergence_res_atol": 1e-6,
+        "nl_convergence_inc_atol": 1e-6,
+    }
+    pp.ModelRunner(model, solver_params).run()
     return model
 
 

--- a/tests/functional/test_benchmark_3d_case_2.py
+++ b/tests/functional/test_benchmark_3d_case_2.py
@@ -63,7 +63,11 @@ def model_conductive(
         "flux_discretization": flux_discretization,
         "times_to_export": [],  # Suppress output for tests
     }
-    solver_params = {"nl_convergence_res_atol": 1e-9}
+    solver_params = {
+        "nl_max_iterations": 100,
+        "nl_convergence_res_atol": 1e-4,
+        "nl_convergence_inc_atol": 1e-4,
+    }
     model = ModelWithEffectivePermeability(model_params)
     pp.ModelRunner(model, solver_params).run()
     return model
@@ -88,7 +92,12 @@ def model_blocking(
         "times_to_export": [],  # Suppress output for tests
     }
     model = ModelWithEffectivePermeability(model_params)
-    pp.ModelRunner(model).run()
+    solver_params = {
+        "nl_max_iterations": 100,
+        "nl_convergence_res_atol": 1e-6,
+        "nl_convergence_inc_atol": 1e-6,
+    }
+    pp.ModelRunner(model, solver_params).run()
     return model
 
 

--- a/tests/models/test_boundary_condition.py
+++ b/tests/models/test_boundary_condition.py
@@ -514,9 +514,14 @@ def _run_and_recover_in_si(spec: _BCUnitInvarianceSpec, units: pp.Units) -> np.n
         "times_to_export": [],
         "grid_type": "cartesian",
     }
+    solver_params = {
+        "nl_max_iterations": 100,
+        "nl_convergence_res_atol": 1e-6,
+        "nl_convergence_inc_atol": 1e-6,
+    }
 
     model = spec.probe_model_class(params)
-    pp.ModelRunner(model).run()
+    pp.ModelRunner(model, solver_params).run()
 
     sd = model.mdg.subdomains(dim=spec.extraction_subdomain_dim)[0]
     var_internal = spec.observable_accessor(model, sd)


### PR DESCRIPTION
## Proposed changes
1. Tweak parameters for non-linear solvers to make some slow tests pass again after #1684 introduced stricter criteria.
2. Make the slow tests run with superlu rather than pypardiso as linear solver, as the latter seems to be less robust with respect to rounding errors for our kind of problems.

When running the slow tests on this branch, one test in geothermal_reservoir example is still failing, but the remaining tests now pass.


## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
