### PR TITLE
MAINT/TST: Make mechanics Neumann BC dimension-aware and consolidate BC tests

### DIFF
--- a/src/porepy/applications/boundary_conditions/model_boundary_conditions.py
+++ b/src/porepy/applications/boundary_conditions/model_boundary_conditions.py
@@ -298,11 +298,14 @@ class BoundaryConditionsMechanicsNeumann:
     boundaries.
 
     The only exception is that internal boundaries are converted to Dirichlet and three
-    points are partly fixed to avoid rigid body motions. We pick maximum z coordinate
-    for all three points. The points have
-            1) min x and max y coordinate, (fixed in y and z directions)
-            2) max x and max y coordinate,  (fixed in y and z directions)
-            3) mean x and min y coordinate. (fixed in x and z directions)
+    points are partly fixed to avoid rigid body motions.
+
+    In both 2D and 3D, the anchor points are ordered west, south, east.
+
+    In 3D, the points are selected at maximum z coordinate:
+        1) min x and high y coordinate, (fixed in y and z directions)
+        2) mean x and min y coordinate, (fixed in x and z directions)
+        3) max x and high y coordinate. (fixed in y and z directions)
     Seen from above, this looks like:
 
                 -------
@@ -311,6 +314,12 @@ class BoundaryConditionsMechanicsNeumann:
                 |     |             |
                 -------             +---> x
                    3 (no x)
+
+    In 2D, the points are selected at mean y on west/east and mean x on south, with
+    the same ordering and constraints:
+        1) west boundary: fix y
+        2) south boundary: fix x
+        3) east boundary: fix y
     """
 
     domain: pp.domain.Domain
@@ -339,16 +348,44 @@ class BoundaryConditionsMechanicsNeumann:
             return bc
         bc.internal_to_dirichlet(sd)
         faces_to_fix = self.faces_to_fix(sd)
-        # Fix y and z displacements on face 1 and 2, x and z displacements on face 3.
-        dir = [
-            np.array([False, True, True]),  # Fix y and z on face 1 (west)
-            np.array([False, True, True]),  # Fix y and z on face 2 (east)
-            np.array([True, False, True]),  # Fix x and z on face 3 (south)
-        ]
-        for i, face in enumerate(faces_to_fix):
-            bc.is_dir[:, face] = dir[i]
-            bc.is_neu[:, face] = ~dir[i]  # Negate for Neumann
+        dir_masks = self.anchor_dirichlet_component_masks()
+        if len(faces_to_fix) != len(dir_masks):
+            raise ValueError("Number of anchor faces and component masks must match.")
+        for face, mask in zip(faces_to_fix, dir_masks):
+            if mask.shape != (self.nd,):
+                raise ValueError(
+                    f"Anchor mask shape {mask.shape} incompatible with nd={self.nd}."
+                )
+            bc.is_dir[:, face] = mask
+            bc.is_neu[:, face] = ~mask  # Negate for Neumann
         return bc
+
+    def anchor_dirichlet_component_masks(self) -> list[np.ndarray]:
+        """Return Dirichlet component masks for anchor faces.
+
+        Returns:
+            A list of boolean arrays, one for each anchor face. `True` indicates the
+            component is fixed with Dirichlet data.
+
+        """
+        if self.nd == 2:
+            # Fix y on face 1 (west), x on face 2 (south), y on face 3 (east).
+            return [
+                np.array([False, True]),
+                np.array([True, False]),
+                np.array([False, True]),
+            ]
+        if self.nd == 3:
+            # In 3D, use the same west-south-east ordering as in 2D, with
+            # additional z-fixing to remove out-of-plane rigid-body motion.
+            return [
+                np.array([False, True, True]),
+                np.array([True, False, True]),
+                np.array([False, True, True]),
+            ]
+        raise NotImplementedError(
+            f"BoundaryConditionsMechanicsNeumann is only implemented for nd=2 or nd=3, got nd={self.nd}."
+        )
 
     def faces_to_fix(self, sd: pp.Grid) -> list[np.int64]:
         """Return list of faces to fix to avoid rigid body motions.
@@ -365,34 +402,63 @@ class BoundaryConditionsMechanicsNeumann:
         domain_sides = self.domain_boundary_sides(sd)
         box = self.domain.bounding_box
 
-        # Point 1 is on the center top of the west boundary, having min x coordinate and
-        # y coordinate slightly smaller than the max y coordinate. This is intended to
-        # avoid picking a face along the z-aligned edge.
         x_mean = 0.5 * (box["xmax"] + box["xmin"])
-        # Compute a cell size h to place the point slightly inside the domain along the
-        # y direction instead of at the very corner.
-        h = np.mean(np.sqrt(sd.face_areas[domain_sides.west]))
-        y_high = box["ymax"] - 0.5 * h
-        z_max = box["zmax"]
-        point_1 = np.array([box["xmin"], y_high, z_max])
-        pts = sd.face_centers[:, domain_sides.west]
-        ind_1 = domain_sides.west.nonzero()[0][
-            np.argmin(pp.distances.point_pointset(point_1, pts))
-        ]
-        # Point 2 is on the center top of the east boundary.
-        point_2 = np.array([box["xmax"], y_high, z_max])
-        pts = sd.face_centers[:, domain_sides.east]
-        ind_2 = domain_sides.east.nonzero()[0][
-            np.argmin(pp.distances.point_pointset(point_2, pts))
-        ]
-        # Point 3 is on the center top of the south boundary, having min y coordinate
-        # and mean x coordinate.
-        point_3 = np.array([x_mean, box["ymin"], z_max])
-        pts = sd.face_centers[:, domain_sides.south]
-        ind_3 = domain_sides.south.nonzero()[0][
-            np.argmin(pp.distances.point_pointset(point_3, pts))
-        ]
-        return [ind_1, ind_2, ind_3]
+
+        if self.nd == 2:
+            y_mean = 0.5 * (box["ymax"] + box["ymin"])
+            # Point 1: center on west boundary.
+            point_1 = np.array([box["xmin"], y_mean])
+            pts = sd.face_centers[:2, domain_sides.west]
+            ind_1 = domain_sides.west.nonzero()[0][
+                np.argmin(pp.distances.point_pointset(point_1, pts))
+            ]
+
+            # Point 2: center of south boundary.
+            point_2 = np.array([x_mean, box["ymin"]])
+            pts = sd.face_centers[:2, domain_sides.south]
+            ind_2 = domain_sides.south.nonzero()[0][
+                np.argmin(pp.distances.point_pointset(point_2, pts))
+            ]
+
+            # Point 3: center on east boundary.
+            point_3 = np.array([box["xmax"], y_mean])
+            pts = sd.face_centers[:2, domain_sides.east]
+            ind_3 = domain_sides.east.nonzero()[0][
+                np.argmin(pp.distances.point_pointset(point_3, pts))
+            ]
+            return [ind_1, ind_2, ind_3]
+
+        if self.nd == 3:
+            # Point 1 is on the center top of the west boundary, having min x
+            # coordinate and y coordinate slightly smaller than the max y coordinate.
+            # This avoids picking a face along the z-aligned edge.
+            h = np.mean(np.sqrt(sd.face_areas[domain_sides.west]))
+            y_high = box["ymax"] - 0.5 * h
+            z_max = box["zmax"]
+            point_1 = np.array([box["xmin"], y_high, z_max])
+            pts = sd.face_centers[:, domain_sides.west]
+            ind_1 = domain_sides.west.nonzero()[0][
+                np.argmin(pp.distances.point_pointset(point_1, pts))
+            ]
+
+            # Point 2 is on the center top of the south boundary.
+            point_2 = np.array([x_mean, box["ymin"], z_max])
+            pts = sd.face_centers[:, domain_sides.south]
+            ind_2 = domain_sides.south.nonzero()[0][
+                np.argmin(pp.distances.point_pointset(point_2, pts))
+            ]
+
+            # Point 3 is on the center top of the east boundary.
+            point_3 = np.array([box["xmax"], y_high, z_max])
+            pts = sd.face_centers[:, domain_sides.east]
+            ind_3 = domain_sides.east.nonzero()[0][
+                np.argmin(pp.distances.point_pointset(point_3, pts))
+            ]
+            return [ind_1, ind_2, ind_3]
+
+        raise NotImplementedError(
+            f"BoundaryConditionsMechanicsNeumann is only implemented for nd=2 or nd=3, got nd={self.nd}."
+        )
 
 
 class GravityMagnitude:

--- a/src/porepy/applications/boundary_conditions/model_boundary_conditions.py
+++ b/src/porepy/applications/boundary_conditions/model_boundary_conditions.py
@@ -348,7 +348,7 @@ class BoundaryConditionsMechanicsNeumann:
             return bc
         bc.internal_to_dirichlet(sd)
         faces_to_fix = self.faces_to_fix(sd)
-        dir_masks = self.anchor_dirichlet_component_masks()
+        dir_masks = self._anchor_dirichlet_component_masks()
         if len(faces_to_fix) != len(dir_masks):
             raise ValueError("Number of anchor faces and component masks must match.")
         for face, mask in zip(faces_to_fix, dir_masks):
@@ -360,7 +360,7 @@ class BoundaryConditionsMechanicsNeumann:
             bc.is_neu[:, face] = ~mask  # Negate for Neumann
         return bc
 
-    def anchor_dirichlet_component_masks(self) -> list[np.ndarray]:
+    def _anchor_dirichlet_component_masks(self) -> list[np.ndarray]:
         """Return Dirichlet component masks for anchor faces.
 
         Returns:
@@ -405,28 +405,25 @@ class BoundaryConditionsMechanicsNeumann:
 
         x_mean = 0.5 * (box["xmax"] + box["xmin"])
 
+        def face_index(side, point):
+            """For a given side of a domain and a target point, find the index of the
+            face closest to the point."""
+            side_mask = domain_sides.__getattribute__(side)
+            points_on_side = sd.face_centers[: self.nd, side_mask]
+            return side_mask.nonzero()[0][
+                np.argmin(pp.distances.point_pointset(point, points_on_side))
+            ]
+
         if self.nd == 2:
             y_mean = 0.5 * (box["ymax"] + box["ymin"])
             # Point 1: center on west boundary.
-            point_1 = np.array([box["xmin"], y_mean])
-            pts = sd.face_centers[:2, domain_sides.west]
-            ind_1 = domain_sides.west.nonzero()[0][
-                np.argmin(pp.distances.point_pointset(point_1, pts))
-            ]
+            ind_1 = face_index("west", np.array([box["xmin"], y_mean]))
 
             # Point 2: center of south boundary.
-            point_2 = np.array([x_mean, box["ymin"]])
-            pts = sd.face_centers[:2, domain_sides.south]
-            ind_2 = domain_sides.south.nonzero()[0][
-                np.argmin(pp.distances.point_pointset(point_2, pts))
-            ]
+            ind_2 = face_index("south", np.array([x_mean, box["ymin"]]))
 
             # Point 3: center on east boundary.
-            point_3 = np.array([box["xmax"], y_mean])
-            pts = sd.face_centers[:2, domain_sides.east]
-            ind_3 = domain_sides.east.nonzero()[0][
-                np.argmin(pp.distances.point_pointset(point_3, pts))
-            ]
+            ind_3 = face_index("east", np.array([box["xmax"], y_mean]))
             return [ind_1, ind_2, ind_3]
 
         if self.nd == 3:
@@ -436,25 +433,13 @@ class BoundaryConditionsMechanicsNeumann:
             h = np.mean(np.sqrt(sd.face_areas[domain_sides.west]))
             y_high = box["ymax"] - 0.5 * h
             z_max = box["zmax"]
-            point_1 = np.array([box["xmin"], y_high, z_max])
-            pts = sd.face_centers[:, domain_sides.west]
-            ind_1 = domain_sides.west.nonzero()[0][
-                np.argmin(pp.distances.point_pointset(point_1, pts))
-            ]
+            ind_1 = face_index("west", np.array([box["xmin"], y_high, z_max]))
 
             # Point 2 is on the center top of the south boundary.
-            point_2 = np.array([x_mean, box["ymin"], z_max])
-            pts = sd.face_centers[:, domain_sides.south]
-            ind_2 = domain_sides.south.nonzero()[0][
-                np.argmin(pp.distances.point_pointset(point_2, pts))
-            ]
+            ind_2 = face_index("south", np.array([x_mean, box["ymin"], z_max]))
 
             # Point 3 is on the center top of the east boundary.
-            point_3 = np.array([box["xmax"], y_high, z_max])
-            pts = sd.face_centers[:, domain_sides.east]
-            ind_3 = domain_sides.east.nonzero()[0][
-                np.argmin(pp.distances.point_pointset(point_3, pts))
-            ]
+            ind_3 = face_index("east", np.array([box["xmax"], y_high, z_max]))
             return [ind_1, ind_2, ind_3]
 
         raise NotImplementedError(

--- a/src/porepy/applications/boundary_conditions/model_boundary_conditions.py
+++ b/src/porepy/applications/boundary_conditions/model_boundary_conditions.py
@@ -384,7 +384,8 @@ class BoundaryConditionsMechanicsNeumann:
                 np.array([False, True, True]),
             ]
         raise NotImplementedError(
-            f"BoundaryConditionsMechanicsNeumann is only implemented for nd=2 or nd=3, got nd={self.nd}."
+            "BoundaryConditionsMechanicsNeumann is only implemented for nd=2 or nd=3, "
+            + f" got nd={self.nd}."
         )
 
     def faces_to_fix(self, sd: pp.Grid) -> list[np.int64]:
@@ -457,7 +458,8 @@ class BoundaryConditionsMechanicsNeumann:
             return [ind_1, ind_2, ind_3]
 
         raise NotImplementedError(
-            f"BoundaryConditionsMechanicsNeumann is only implemented for nd=2 or nd=3, got nd={self.nd}."
+            "BoundaryConditionsMechanicsNeumann is only implemented for nd=2 or nd=3, "
+            + f" got nd={self.nd}."
         )
 
 

--- a/tests/applications/boundary_conditions/test_model_boundary_conditions.py
+++ b/tests/applications/boundary_conditions/test_model_boundary_conditions.py
@@ -238,15 +238,14 @@ def test_lithostatic_boundary_stress_values(momentum_boundary_model):
             np.testing.assert_allclose(values[south][1::3], expected_south)
 
         # For this geometry, some sides contain no cells for the fracture boundary.
-        east_value = values[east].mean() if np.any(east) else 0
-        west_value = values[west].mean() if np.any(west) else 0
-        if model.nd == 3:
-            north_value = values[north].mean()
-            south_value = values[south].mean()
+        east_value = values[east].mean() if np.any(east) else 0.0
+        west_value = values[west].mean() if np.any(west) else 0.0
 
         # Forces on opposite sides should equilibrate each other, the domain is static.
         np.testing.assert_almost_equal(east_value + west_value, 0)
-        if model_dim == 3:
+        if model.nd == 3:
+            north_value = float(values[north].mean())
+            south_value = float(values[south].mean())
             np.testing.assert_almost_equal(north_value + south_value, 0)
 
 
@@ -283,7 +282,7 @@ def test_mechanics_bcs_neumann(
     np.testing.assert_array_equal(south_mask[:2], np.array([True, False]))
     np.testing.assert_array_equal(east_mask[:2], np.array([False, True]))
 
-    if momentum_boundary_model.model_dim == 3:
+    if momentum_boundary_model.nd == 3:
         assert west_mask[2]
         assert south_mask[2]
         assert east_mask[2]

--- a/tests/applications/boundary_conditions/test_model_boundary_conditions.py
+++ b/tests/applications/boundary_conditions/test_model_boundary_conditions.py
@@ -13,6 +13,7 @@ from pytest import param
 
 import porepy as pp
 from porepy.applications.boundary_conditions.model_boundary_conditions import (
+    BoundaryConditionsMechanicsNeumann,
     HydrostaticBoundaryPressureValues,
     LithostaticBoundaryStressValues,
     ThermalGradientBoundaryTemperatureValues,
@@ -21,6 +22,42 @@ from porepy.applications.md_grids.model_geometries import (
     CubeDomainOrthogonalFractures,
     SquareDomainOrthogonalFractures,
 )
+
+
+def _geometry_mixin(model_dim: int):
+    if model_dim == 3:
+        return CubeDomainOrthogonalFractures
+    elif model_dim == 2:
+        return SquareDomainOrthogonalFractures
+    else:
+        raise ValueError(model_dim)
+
+
+@pytest.fixture(params=[2, 3], ids=["2d", "3d"])
+def momentum_boundary_model(request):
+    model_dim = request.param
+    geometry_mixin_type = _geometry_mixin(model_dim)
+
+    class TestedModel(
+        BoundaryConditionsMechanicsNeumann,
+        LithostaticBoundaryStressValues,
+        geometry_mixin_type,
+        pp.MomentumBalance,
+    ):
+        pass
+
+    model = TestedModel()
+    model.prepare_simulation()
+    return model
+
+
+@pytest.fixture
+def momentum_boundary_matrix_grid(momentum_boundary_model):
+    matrix_grids = [
+        sd for sd in momentum_boundary_model.mdg.subdomains() if sd.dim == momentum_boundary_model.nd
+    ]
+    assert len(matrix_grids) == 1
+    return matrix_grids[0]
 
 
 @pytest.mark.parametrize("model_dim", [2, 3])
@@ -141,34 +178,18 @@ def test_gradient_scalar_boundary_values(params, model_dim: int):
         )
 
 
-@pytest.mark.parametrize("model_dim", [2, 3])
-def test_lithostatic_boundary_stress_values(model_dim: int):
-    if model_dim == 3:
-        geometry_mixin_type = CubeDomainOrthogonalFractures
-    elif model_dim == 2:
-        geometry_mixin_type = SquareDomainOrthogonalFractures
-    else:
-        raise ValueError(model_dim)
-
-    class TestedModel(
-        LithostaticBoundaryStressValues,
-        geometry_mixin_type,
-        pp.MomentumBalance,
-    ):
-        pass
-
+def test_lithostatic_boundary_stress_values(momentum_boundary_model):
     # Scaling of the lithostatic stress.
     stress_multipliers = np.array([1, 2, 0.1])
-    tested_model = TestedModel()
-    tested_model.params.update({"lithostatic_stress_multipliers": stress_multipliers})
-    tested_model.prepare_simulation()
+    model = momentum_boundary_model
+    model.params.update({"lithostatic_stress_multipliers": stress_multipliers})
 
     # Lithostatic boundary condition requires non-zero time.
-    tested_model.time_manager.time = 1
+    model.time_manager.time = 1
 
-    for boundary_grid in tested_model.mdg.boundaries():
-        values = tested_model.bc_values_stress(boundary_grid)
-        sides = tested_model.domain_boundary_sides(boundary_grid)
+    for boundary_grid in model.mdg.boundaries():
+        values = model.bc_values_stress(boundary_grid)
+        sides = model.domain_boundary_sides(boundary_grid)
 
         # Expanding the indices to reflect vector data, 3 DoFs per cell.
         bottom = np.repeat(sides.bottom, 3)
@@ -186,17 +207,17 @@ def test_lithostatic_boundary_stress_values(model_dim: int):
         np.testing.assert_array_equal(values[north | south][0::3], 0)
         np.testing.assert_array_equal(values[north | south][2::3], 0)
 
-        vertical_index = 2 if model_dim == 3 else 1
+        vertical_index = 2 if model.nd == 3 else 1
 
         # Explicitly compute expected normal stresses in each direction.
-        domain_key = "zmax" if model_dim == 3 else "ymax"
+        domain_key = "zmax" if model.nd == 3 else "ymax"
         depth_bc = (
-            tested_model.domain.bounding_box[domain_key]
+            model.domain.bounding_box[domain_key]
             - boundary_grid.cell_centers[vertical_index]
         )
-        rho_f = tested_model.fluid.reference_component.density
-        rho_s = tested_model.solid.density
-        phi = tested_model.solid.porosity
+        rho_f = model.fluid.reference_component.density
+        rho_s = model.solid.density
+        phi = model.solid.porosity
         rho_eff = rho_s * (1 - phi) + rho_f * phi
         gravity = rho_eff * pp.GRAVITY_ACCELERATION
 
@@ -210,7 +231,7 @@ def test_lithostatic_boundary_stress_values(model_dim: int):
         expected_west = +expected_stress[0][sides.east]
         np.testing.assert_allclose(values[east][0::3], expected_east)
         np.testing.assert_allclose(values[west][0::3], expected_west)
-        if model_dim == 3:
+        if model.nd == 3:
             expected_north = -expected_stress[1][sides.north]
             expected_south = +expected_stress[1][sides.south]
             np.testing.assert_allclose(values[north][1::3], expected_north)
@@ -219,7 +240,7 @@ def test_lithostatic_boundary_stress_values(model_dim: int):
         # For this geometry, some sides contain no cells for the fracture boundary.
         east_value = values[east].mean() if np.any(east) else 0
         west_value = values[west].mean() if np.any(west) else 0
-        if model_dim == 3:
+        if model.nd == 3:
             north_value = values[north].mean()
             south_value = values[south].mean()
 
@@ -227,3 +248,45 @@ def test_lithostatic_boundary_stress_values(model_dim: int):
         np.testing.assert_almost_equal(east_value + west_value, 0)
         if model_dim == 3:
             np.testing.assert_almost_equal(north_value + south_value, 0)
+
+
+def test_mechanics_bcs_neumann(
+    momentum_boundary_model,
+    momentum_boundary_matrix_grid,
+):
+    """Test anchor ordering and component constraints for Neumann mechanics BCs.
+
+    The anchor faces are ordered west-south-east in 2D and 3D. The in-plane
+    constraints are identical across dimensions, and 3D additionally fixes z.
+
+    """
+    sd = momentum_boundary_matrix_grid
+    sides = momentum_boundary_model.domain_boundary_sides(sd)
+    bc = momentum_boundary_model.bc_type_mechanics(sd)
+    faces = momentum_boundary_model.faces_to_fix(sd)
+
+    assert len(faces) == 3
+    assert np.any(bc.is_dir)
+    assert not np.all(bc.is_dir)
+
+    # Anchors are ordered west, south, east.
+    assert sides.west[faces[0]]
+    assert sides.south[faces[1]]
+    assert sides.east[faces[2]]
+
+    west_mask = bc.is_dir[:, faces[0]]
+    south_mask = bc.is_dir[:, faces[1]]
+    east_mask = bc.is_dir[:, faces[2]]
+
+    # In-plane constraints are shared in 2D and 3D.
+    np.testing.assert_array_equal(west_mask[:2], np.array([False, True]))
+    np.testing.assert_array_equal(south_mask[:2], np.array([True, False]))
+    np.testing.assert_array_equal(east_mask[:2], np.array([False, True]))
+
+    if momentum_boundary_model.model_dim == 3:
+        assert west_mask[2]
+        assert south_mask[2]
+        assert east_mask[2]
+
+    for face in faces:
+        assert np.array_equal(bc.is_neu[:, face], ~bc.is_dir[:, face])

--- a/tests/applications/boundary_conditions/test_model_boundary_conditions.py
+++ b/tests/applications/boundary_conditions/test_model_boundary_conditions.py
@@ -34,7 +34,7 @@ def _geometry_mixin(model_dim: int):
 
 
 @pytest.fixture(params=[2, 3], ids=["2d", "3d"])
-def momentum_boundary_model(request):
+def momentum_model(request):
     model_dim = request.param
     geometry_mixin_type = _geometry_mixin(model_dim)
 
@@ -52,9 +52,9 @@ def momentum_boundary_model(request):
 
 
 @pytest.fixture
-def momentum_boundary_matrix_grid(momentum_boundary_model):
+def momentum_boundary_matrix_grid(momentum_model):
     matrix_grids = [
-        sd for sd in momentum_boundary_model.mdg.subdomains() if sd.dim == momentum_boundary_model.nd
+        sd for sd in momentum_model.mdg.subdomains() if sd.dim == momentum_model.nd
     ]
     assert len(matrix_grids) == 1
     return matrix_grids[0]
@@ -178,10 +178,10 @@ def test_gradient_scalar_boundary_values(params, model_dim: int):
         )
 
 
-def test_lithostatic_boundary_stress_values(momentum_boundary_model):
+def test_lithostatic_boundary_stress_values(momentum_model):
     # Scaling of the lithostatic stress.
     stress_multipliers = np.array([1, 2, 0.1])
-    model = momentum_boundary_model
+    model = momentum_model
     model.params.update({"lithostatic_stress_multipliers": stress_multipliers})
 
     # Lithostatic boundary condition requires non-zero time.
@@ -250,7 +250,7 @@ def test_lithostatic_boundary_stress_values(momentum_boundary_model):
 
 
 def test_mechanics_bcs_neumann(
-    momentum_boundary_model,
+    momentum_model,
     momentum_boundary_matrix_grid,
 ):
     """Test anchor ordering and component constraints for Neumann mechanics BCs.
@@ -260,9 +260,9 @@ def test_mechanics_bcs_neumann(
 
     """
     sd = momentum_boundary_matrix_grid
-    sides = momentum_boundary_model.domain_boundary_sides(sd)
-    bc = momentum_boundary_model.bc_type_mechanics(sd)
-    faces = momentum_boundary_model.faces_to_fix(sd)
+    sides = momentum_model.domain_boundary_sides(sd)
+    bc = momentum_model.bc_type_mechanics(sd)
+    faces = momentum_model.faces_to_fix(sd)
 
     assert len(faces) == 3
     assert np.any(bc.is_dir)
@@ -282,7 +282,7 @@ def test_mechanics_bcs_neumann(
     np.testing.assert_array_equal(south_mask[:2], np.array([True, False]))
     np.testing.assert_array_equal(east_mask[:2], np.array([False, True]))
 
-    if momentum_boundary_model.nd == 3:
+    if momentum_model.nd == 3:
         assert west_mask[2]
         assert south_mask[2]
         assert east_mask[2]

--- a/tests/examples/test_geothermal_reservoir.py
+++ b/tests/examples/test_geothermal_reservoir.py
@@ -13,7 +13,6 @@ import porepy.applications.md_grids.model_geometries
 from porepy.applications.discretizations.flux_discretization import FluxDiscretization
 from porepy.applications.test_utils import well_models
 from porepy.examples.geothermal_reservoir import (
-    BoundaryConditionsMechanicsNeumann,
     GeothermalReservoirWellBCs,
     NeumannWellBCsFirstTimeInterval,
     WellBoundaryConditions,
@@ -132,51 +131,6 @@ def test_well_bcs_temperature(well_bc_model):
     values = model.bc_values_temperature(bg)
 
     assert np.any(np.isclose(values, expected_value))
-
-
-class GeothermalModelMechanics(
-    FastMeshingMixin,
-    well_models.OneVerticalWell,
-    porepy.applications.md_grids.model_geometries.CubeDomainOrthogonalFractures,
-    BoundaryConditionsMechanicsNeumann,
-    pp.Poromechanics,
-):
-    pass
-
-
-@pytest.fixture
-def mechanics_bc_model():
-    model = GeothermalModelMechanics()
-    model.prepare_simulation()
-    return model
-
-
-def test_mechanics_bcs_neumann(mechanics_bc_model):
-    """
-    Test the boundary conditions of mechanics.
-    """
-    model = mechanics_bc_model
-    matrix_grids = [sd for sd in model.mdg.subdomains() if sd.dim == model.nd]
-    assert len(matrix_grids) == 1
-
-    sd = matrix_grids[0]
-    bc = model.bc_type_mechanics(sd)
-
-    faces = model.faces_to_fix(sd)
-
-    expected_dir = [
-        np.array([False, True, True]),
-        np.array([False, True, True]),
-        np.array([True, False, True]),
-    ]
-
-    assert len(faces) == 3
-    assert np.any(bc.is_dir)
-    assert not np.all(bc.is_dir)
-
-    for i, value in zip(faces, expected_dir):
-        assert np.array_equal(bc.is_dir[:, i], value)
-        assert np.array_equal(bc.is_neu[:, i], ~value)
 
 
 # MARK: Integration


### PR DESCRIPTION
## Proposed changes
This PR updates BoundaryConditionsMechanicsNeumann to behave consistently in both 2D and 3D, with aligned anchor-face semantics across dimensions.

### Main changes:

Refactors mechanics Neumann BC logic to be dimension-aware in the core boundary-condition implementation.
Keeps anchor ordering consistent as west, south, east in both 2D and 3D.
Preserves shared in-plane constraints across dimensions, with the expected additional z-fix in 3D.
Moves mechanics BC tests to the boundary-conditions test module.
Removes duplicated mechanics BC coverage from the geothermal example test module.
Cleans and consolidates BC test fixtures/assertions for readability and maintainability.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag. TODO.
