### PR TITLE
Restored old behavior of reference state expected by some tests

### DIFF
--- a/src/porepy/models/solution_strategy.py
+++ b/src/porepy/models/solution_strategy.py
@@ -237,7 +237,9 @@ class SolutionStrategy(pp.PorePyModel):
                 variables=variables, iterate_index=0
             )
             self.equation_system.set_variable_values(
-                values, variables=variables, reference=True
+                np.full_like(values, reference_value),
+                variables=variables,
+                reference=True,
             )
 
     def set_equation_system_manager(self) -> None:


### PR DESCRIPTION
## Proposed changes

I did a small investigation on why `pp_solvers/test_preconditioner_performance.py` regressed and found 3 things. Thanks to @IvarStefansson for help!

1. `solver_opts = {"nl_convergence_tol_res": 1e-8, "nl_convergence_tol": 1e-8}`. The keys accepted by porepy have changed. Now it's `nl_convergence_res_atol` and `nl_convergence_inc_atol`. It does not see the right keys and sets the default tolerance of 1e-10. 
2. Due to the default tolerance, the nonlinear solver fails. This failure previously happened silently as `pp.run_time_dependent_simulation` did not return anything. This is (probably) why we had to use `min_length` in 
```
np.testing.assert_equal(
        linear_iterations[:min_length],
        expected_iterations[:min_length],
        err_msg="Number of linear iterations does not match expected value.",
    )
```
Models with iterative and direct linear solver failed after different number of nonlinear iterations.
3. New reference state. See the change in this PR. As @IvarStefansson explained to me, this method was introduced for backwards compatability. The fix in this PR does what was originally intended (as I understood) - initialize the reference state with the old reference value.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [x] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
