### PR TITLE
Cleanup equation system and introduce indexers

### DIFF
--- a/src/porepy/models/fracture_damage.py
+++ b/src/porepy/models/fracture_damage.py
@@ -293,8 +293,9 @@ class DilationDamageEquation(FractureDamageEquations):
         """Update the dilation damage equation to include new term."""
         super().before_nonlinear_loop()
         fractures = self.mdg.subdomains(dim=self.nd - 1)
-        self.equation_system._equations[self.dilation_damage_equation_name] = (
-            self.dilation_damage_equation(fractures)
+        self.equation_system.update_equation(
+            equation_name=self.dilation_damage_equation_name,
+            new_equation=self.dilation_damage_equation(fractures),
         )
 
     def dilation_damage_equation(self, subdomains: list[pp.Grid]) -> pp.ad.Operator:

--- a/src/porepy/models/metric.py
+++ b/src/porepy/models/metric.py
@@ -183,8 +183,7 @@ class VariableBasedLebesgueMetric(LebesgueMetric):
             dict[str, float]: measure of values for each variable block.
 
         """
-        equation_system = self.model.equation_system
-        variable_indexer = equation_system.variable_indexer
+        variable_indexer = self.variable_indexer
 
         # Sanity check: Ensure that variables are defined on cells.
         for variable in variable_indexer.variable_dofs:
@@ -194,7 +193,7 @@ class VariableBasedLebesgueMetric(LebesgueMetric):
                     """variables defined on cells."""
                 )
 
-        norms = {v.name: 0.0 for v in self.model.equation_system.variables}
+        norms = {v.name: 0.0 for v in variable_indexer.variable_dofs}
 
         for variable, indices in variable_indexer.variable_dofs.items():
             variable_values = pp.ad.DenseArray(values[indices])

--- a/src/porepy/models/metric.py
+++ b/src/porepy/models/metric.py
@@ -96,6 +96,8 @@ class EquationBasedEuclideanMetric(EuclideanMetric):
         equation_indexer: Optional[pp.ad.EquationIndexer] = None,
     ) -> None:
         self.model = model
+        # TODO YZ: Norms should accept equation tags instead of the indexer. This will
+        # be addressed in the PR downstream.
         if equation_indexer is None:
             equation_indexer = model.equation_system.equation_indexer
         self.equation_indexer = equation_indexer
@@ -186,18 +188,18 @@ class VariableBasedLebesgueMetric(LebesgueMetric):
         variable_indexer = self.variable_indexer
 
         # Sanity check: Ensure that variables are defined on cells.
-        for variable in variable_indexer.variable_dofs:
+        for variable in variable_indexer.indices:
             if not variable._faces == 0 and variable._nodes == 0:
                 raise NotImplementedError(
                     """VariableBasedLebesgueMetric currently only supports """
                     """variables defined on cells."""
                 )
 
-        norms = {v.name: 0.0 for v in variable_indexer.variable_dofs}
+        norms = {v.name: 0.0 for v in variable_indexer.indices}
 
-        for variable, indices in variable_indexer.variable_dofs.items():
+        for variable, indices in variable_indexer.indices.items():
             variable_values = pp.ad.DenseArray(values[indices])
-            dim = variable.dof_info["cells"]  # + variable._faces + variable._nodes,
+            dim = variable.dof_info["cells"]
             domains: pp.GridLikeSequence = [variable.domain]  # type: ignore[assignment]
             norms[variable.name] += (
                 self._lebesgue2_norm(variable_values, dim, domains) ** 2
@@ -226,6 +228,8 @@ class EquationBasedLebesgueMetric(LebesgueMetric):
         equation_indexer: Optional[pp.ad.EquationIndexer] = None,
     ) -> None:
         super().__init__(model)
+        # TODO YZ: Norms should accept equation tags instead of the indexer. This will
+        # be addressed in the PR downstream.
         if equation_indexer is None:
             equation_indexer = model.equation_system.equation_indexer
         self.equation_indexer = equation_indexer

--- a/src/porepy/models/metric.py
+++ b/src/porepy/models/metric.py
@@ -5,6 +5,7 @@ From plain Euclidean norms to model-specific L2 norms of states and equations.
 """
 
 from functools import partial
+from typing import cast
 
 import numpy as np
 
@@ -89,8 +90,9 @@ class EquationBasedEuclideanMetric(EuclideanMetric):
 
     """
 
-    def __init__(self, model) -> None:
+    def __init__(self, model, equation_indexer: pp.ad.EquationIndexer) -> None:
         self.model = model
+        self.equation_indexer = equation_indexer
 
     def __call__(self, values: np.ndarray) -> dict[str, float]:  # type: ignore[override]
         """Compute the Euclidean norm of each separate equation.
@@ -103,8 +105,13 @@ class EquationBasedEuclideanMetric(EuclideanMetric):
 
         """
         norms = {}
-        equation_blocks = self.model.equation_system.assembled_equation_indices
-        for name, indices in equation_blocks.items():
+        equation_image_space_composition = (
+            self.equation_indexer.equation_image_space_composition
+        )
+        offset = 0
+        for name, blocks in equation_image_space_composition.items():
+            indices = np.concatenate(list(blocks.values())) + offset
+            offset += len(indices)
             norms[name] = self._euclidean_norm(values[indices])
         return norms
 
@@ -192,6 +199,10 @@ class EquationBasedLebesgueMetric(LebesgueMetric):
 
     """
 
+    def __init__(self, model, equation_indexer: pp.ad.EquationIndexer) -> None:
+        super().__init__(model)
+        self.equation_indexer = equation_indexer
+
     def __call__(self, values: np.ndarray) -> dict[str, float]:
         """Compute the Lebesgue L2 norm of each separate equation.
 
@@ -202,33 +213,24 @@ class EquationBasedLebesgueMetric(LebesgueMetric):
             dict[str, float]: measure of values for each equation block
 
         """
-        norms = {name: 0.0 for name in self.model.equation_system.equations}
-
-        equation_blocks = {}
-        for name in self.model.equation_system.equations:
-            if name not in self.model.equation_system.assembled_equation_indices:
+        equation_system = self.model.equation_system
+        equation_image_space_composition = (
+            self.equation_indexer.equation_image_space_composition
+        )
+        norms = {name: 0.0 for name in equation_image_space_composition}
+        offset = 0
+        for name, blocks in equation_image_space_composition.items():
+            indices = np.concatenate(list(blocks.values())) + offset
+            offset += len(indices)
+            if indices.size == 0:
                 continue
-            indices = self.model.equation_system.assembled_equation_indices[name]
-            if len(indices) == 0:
-                continue
-            equation_blocks[name] = (
-                indices,
-                list(
-                    self.model.equation_system.equation_image_space_composition[
-                        name
-                    ].keys()
-                ),
-                self.model.equation_system.equation_image_size_info[name]["cells"],
+            domains = cast(pp.GridLikeSequence, list(blocks.keys()))
+            equation_dim = equation_system.equation_image_size_info[name]["cells"]
+            equation_values = values[indices].reshape((equation_dim, -1), order="F")
+            cell_weights = np.hstack([domain.cell_volumes for domain in domains])
+            intensive_equation_values = pp.ad.DenseArray(
+                np.linalg.norm(equation_values, ord=2, axis=0) / cell_weights
             )
-        for name, (indices, sd, eq_dim) in equation_blocks.items():
-            if len(sd) == 0:
-                norms[name] = 0.0
-            else:
-                equation_values = values[indices].reshape((eq_dim, -1), order="F")
-                cell_weights = np.hstack([_sd.cell_volumes for _sd in sd])
-                intensive_equation_values = pp.ad.DenseArray(
-                    np.linalg.norm(equation_values, ord=2, axis=0) / cell_weights
-                )
-                norms[name] = self._lebesgue2_norm(intensive_equation_values, 1, sd)
+            norms[name] = self._lebesgue2_norm(intensive_equation_values, 1, domains)
 
         return norms

--- a/src/porepy/models/metric.py
+++ b/src/porepy/models/metric.py
@@ -5,7 +5,7 @@ From plain Euclidean norms to model-specific L2 norms of states and equations.
 """
 
 from functools import partial
-from typing import cast
+from typing import Optional, cast
 
 import numpy as np
 
@@ -42,13 +42,24 @@ class EuclideanMetric:
 
 
 class VariableBasedEuclideanMetric(EuclideanMetric):
-    """Plain Euclidean norm for variables and equations, computed per variable and
-    equation block.
+    """Plain Euclidean norm for variables, computed per variable block.
+
+    Parameters:
+        model: The model used to compute the metric.
+        variable_indexer: Define a subset of variables to evaluate the metric on. If
+            None (default), uses all variables.
 
     """
 
-    def __init__(self, model) -> None:
+    def __init__(
+        self,
+        model: pp.PorePyModel,
+        variable_indexer: Optional[pp.ad.VariableIndexer] = None,
+    ) -> None:
         self.model = model
+        if variable_indexer is None:
+            variable_indexer = model.equation_system.variable_indexer
+        self.variable_indexer = variable_indexer
 
     def __call__(self, values: np.ndarray) -> dict[str, float]:  # type: ignore[override]
         """Compute the Euclidean norm of each separate variable.
@@ -60,38 +71,33 @@ class VariableBasedEuclideanMetric(EuclideanMetric):
             dict[str, float]: measure of values for each variable block
 
         """
-        # Collect variable blocks based on variable names
-        variable_names = [
-            variable.name for variable in self.model.equation_system.variables
-        ]
-        variable_blocks = {
-            (variable.name, variable.domain): (
-                self.model.equation_system.dofs_of([variable])
-            )
-            for variable in self.model.equation_system.variables
-        }
-        concatenated_variable_blocks: dict[str, list[int]] = {
-            name: [] for name in set(variable_names)
-        }
-        for (name, _), indices in variable_blocks.items():
-            concatenated_variable_blocks[name].extend(indices)
-
         # Compute norms for each variable block
-        norms = {name: 0.0 for name in set(variable_names)}
-        for name, indices in concatenated_variable_blocks.items():
+        norms: dict[str, float] = {}
+        for name, domains_dofs in self.variable_indexer.group_by_name().items():
+            indices = np.concatenate(list(domains_dofs.values()))
             norms[name] = self._euclidean_norm(values[indices])
 
         return norms
 
 
 class EquationBasedEuclideanMetric(EuclideanMetric):
-    """Plain Euclidean norm for variables and equations, computed per variable and
-    equation block.
+    """Plain Euclidean norm for equations, computed per equation block.
+
+    Parameters:
+        model: The model used to compute the metric.
+        equation_indexer: Define a subset of equations to evaluate the metric on. If
+            None (default), uses all equations.
 
     """
 
-    def __init__(self, model, equation_indexer: pp.ad.EquationIndexer) -> None:
+    def __init__(
+        self,
+        model: pp.PorePyModel,
+        equation_indexer: Optional[pp.ad.EquationIndexer] = None,
+    ) -> None:
         self.model = model
+        if equation_indexer is None:
+            equation_indexer = model.equation_system.equation_indexer
         self.equation_indexer = equation_indexer
 
     def __call__(self, values: np.ndarray) -> dict[str, float]:  # type: ignore[override]
@@ -105,19 +111,14 @@ class EquationBasedEuclideanMetric(EuclideanMetric):
 
         """
         norms = {}
-        equation_image_space_composition = (
-            self.equation_indexer.equation_image_space_composition
-        )
-        offset = 0
-        for name, blocks in equation_image_space_composition.items():
-            indices = np.concatenate(list(blocks.values())) + offset
-            offset += len(indices)
+        for name, domains_dofs in self.equation_indexer.group_by_name().items():
+            indices = np.concatenate(list(domains_dofs.values()))
             norms[name] = self._euclidean_norm(values[indices])
         return norms
 
 
 class LebesgueMetric:
-    def __init__(self, model) -> None:
+    def __init__(self, model: pp.PorePyModel) -> None:
         self.model = model
 
     def _lebesgue2_norm(
@@ -153,7 +154,24 @@ class LebesgueMetric:
 
 
 class VariableBasedLebesgueMetric(LebesgueMetric):
-    """Lebesgue L2 norm for variables and equations, computed per variable block."""
+    """Lebesgue L2 norm for variables, computed per variable block.
+
+    Parameters:
+        model: The model used to compute the metric.
+        variable_indexer: Define a subset of variables to evaluate the metric on. If
+            None (default), uses all variables.
+
+    """
+
+    def __init__(
+        self,
+        model: pp.PorePyModel,
+        variable_indexer: Optional[pp.ad.VariableIndexer] = None,
+    ) -> None:
+        super().__init__(model)
+        if variable_indexer is None:
+            variable_indexer = model.equation_system.variable_indexer
+        self.variable_indexer = variable_indexer
 
     def __call__(self, values: np.ndarray) -> dict[str, float]:
         """Compute the Lebesgue L2 norm of each separate variable.
@@ -165,8 +183,11 @@ class VariableBasedLebesgueMetric(LebesgueMetric):
             dict[str, float]: measure of values for each variable block.
 
         """
+        equation_system = self.model.equation_system
+        variable_indexer = equation_system.variable_indexer
+
         # Sanity check: Ensure that variables are defined on cells.
-        for variable in self.model.equation_system.variables:
+        for variable in variable_indexer.variable_dofs:
             if not variable._faces == 0 and variable._nodes == 0:
                 raise NotImplementedError(
                     """VariableBasedLebesgueMetric currently only supports """
@@ -174,17 +195,13 @@ class VariableBasedLebesgueMetric(LebesgueMetric):
                 )
 
         norms = {v.name: 0.0 for v in self.model.equation_system.variables}
-        variable_blocks = {
-            (variable.name, variable.domain): (
-                self.model.equation_system.dofs_of([variable]),
-                variable._cells,  # + variable._faces + variable._nodes,
-            )
-            for variable in self.model.equation_system.variables
-        }
-        for (name, sd), (indices, variable_dim) in variable_blocks.items():
+
+        for variable, indices in variable_indexer.variable_dofs.items():
             variable_values = pp.ad.DenseArray(values[indices])
-            norms[name] += (
-                self._lebesgue2_norm(variable_values, variable_dim, [sd]) ** 2
+            dim = variable.dof_info["cells"]  # + variable._faces + variable._nodes,
+            domains: pp.GridLikeSequence = [variable.domain]  # type: ignore[assignment]
+            norms[variable.name] += (
+                self._lebesgue2_norm(variable_values, dim, domains) ** 2
             )
         for name in norms:
             norms[name] = np.sqrt(norms[name])
@@ -197,10 +214,21 @@ class EquationBasedLebesgueMetric(LebesgueMetric):
 
     NOTE: Assumes equations are intensive quantities and defined only on cells.
 
+    Parameters:
+        model: The model used to compute the metric.
+        equation_indexer: Define a subset of equations to evaluate the metric on. If
+            None (default), uses all equations.
+
     """
 
-    def __init__(self, model, equation_indexer: pp.ad.EquationIndexer) -> None:
+    def __init__(
+        self,
+        model: pp.PorePyModel,
+        equation_indexer: Optional[pp.ad.EquationIndexer] = None,
+    ) -> None:
         super().__init__(model)
+        if equation_indexer is None:
+            equation_indexer = model.equation_system.equation_indexer
         self.equation_indexer = equation_indexer
 
     def __call__(self, values: np.ndarray) -> dict[str, float]:
@@ -214,17 +242,10 @@ class EquationBasedLebesgueMetric(LebesgueMetric):
 
         """
         equation_system = self.model.equation_system
-        equation_image_space_composition = (
-            self.equation_indexer.equation_image_space_composition
-        )
-        norms = {name: 0.0 for name in equation_image_space_composition}
-        offset = 0
-        for name, blocks in equation_image_space_composition.items():
-            indices = np.concatenate(list(blocks.values())) + offset
-            offset += len(indices)
-            if indices.size == 0:
-                continue
-            domains = cast(pp.GridLikeSequence, list(blocks.keys()))
+        norms: dict[str, float] = {}
+        for name, grids_dofs in self.equation_indexer.group_by_name().items():
+            indices = np.concatenate(list(grids_dofs.values()))
+            domains = cast(pp.GridLikeSequence, list(grids_dofs.keys()))
             equation_dim = equation_system.equation_image_size_info[name]["cells"]
             equation_values = values[indices].reshape((equation_dim, -1), order="F")
             cell_weights = np.hstack([domain.cell_volumes for domain in domains])

--- a/src/porepy/numerics/ad/__init__.py
+++ b/src/porepy/numerics/ad/__init__.py
@@ -17,6 +17,7 @@ from . import (
     functions,
     get_set_values,
     grid_operators,
+    indexers,
     operator_functions,
     operators,
     surrogate_operator,
@@ -33,6 +34,7 @@ from .operator_functions import *
 from .operators import *
 from .surrogate_operator import *
 from .time_derivatives import *
+from .indexers import *
 
 __all__.extend(ad_utils.__all__)
 __all__.extend(get_set_values.__all__)
@@ -45,3 +47,4 @@ __all__.extend(grid_operators.__all__)
 __all__.extend(equation_system.__all__)
 __all__.extend(time_derivatives.__all__)
 __all__.extend(surrogate_operator.__all__)
+__all__.extend(indexers.__all__)

--- a/src/porepy/numerics/ad/__init__.py
+++ b/src/porepy/numerics/ad/__init__.py
@@ -30,11 +30,11 @@ from .forward_mode import *
 from .functions import *
 from .get_set_values import *
 from .grid_operators import *
+from .indexers import *
 from .operator_functions import *
 from .operators import *
 from .surrogate_operator import *
 from .time_derivatives import *
-from .indexers import *
 
 __all__.extend(ad_utils.__all__)
 __all__.extend(get_set_values.__all__)

--- a/src/porepy/numerics/ad/equation_system.py
+++ b/src/porepy/numerics/ad/equation_system.py
@@ -1268,8 +1268,7 @@ class EquationSystem:
                 defined.
 
         Returns:
-            A dictionary with the index set of the restricted equations (referring to
-            equation rows) as values. If no restriction is given, the value is None.
+            A list of atomic equation-domain identifiers.
 
         """
         equations_on_domains: list[pp.ad.EquationOnDomain] = []
@@ -1562,14 +1561,14 @@ class EquationSystem:
         if variables is not None:
             # Respect the ordering of the input list of variables.
             variable_indexer = self.variable_indexer.construct_restricted_indexer(
-                self._parse_variable_type(variables=variables, ordered=False)
+                self._parse_variable_type(variables=variables, ordered=True)
             )
         else:
             variable_indexer = self.variable_indexer
 
         if equations is not None:
             equation_indexer = self.equation_indexer.construct_restricted_indexer(
-                self._parse_equations(equations=equations, ordered=False)
+                self._parse_equations(equations=equations, ordered=True)
             )
         else:
             equation_indexer = self.equation_indexer

--- a/src/porepy/numerics/ad/equation_system.py
+++ b/src/porepy/numerics/ad/equation_system.py
@@ -327,17 +327,53 @@ class EquationSystem:
             offset += len(dofs)
         return pp.ad.VariableIndexer(variable_dofs=variable_dofs)
 
-    def construct_equation_indexer(self) -> pp.ad.EquationIndexer:
+    def construct_equation_indexer(
+        self, requested_equations: Optional[EquationList | EquationRestriction] = None
+    ) -> pp.ad.EquationIndexer:
         """TODO YZ"""
+        if requested_equations is None:
+            requested_equations_lookup = {
+                pp.ad.EquationOnDomain(name=eq.name, domain=domain)
+                for eq in self._equations.values()
+                for domain in eq.domains
+            }
+        elif isinstance(requested_equations, list):
+            requested_equations_lookup = set()
+            for equation in requested_equations:
+                equation = self._validate_equation_name(equation)
+                for domain in equation.domains:
+                    requested_equations_lookup.add(
+                        pp.ad.EquationOnDomain(name=equation.name, domain=domain)
+                    )
+
+        elif isinstance(requested_equations, dict):
+
+            def sort_grids(grids: list[pp.GridLike]) -> list[pp.GridLike]:
+                indices = self.mdg.argsort_grids(grids)
+                return [grids[i] for i in indices]
+
+            requested_equations_lookup = {
+                pp.ad.EquationOnDomain(
+                    name=self._validate_equation_name(eq).name, domain=domain
+                )
+                for eq, domains in requested_equations.items()
+                for domain in sort_grids(domains)
+            }
+
         equation_dofs: dict[str, dict[pp.GridLike, np.ndarray]] = {}
         # self.equations stores a canonical order of equations.
         for name, equation in self.equations.items():
             dofs_on_domains: dict[pp.GridLike, np.ndarray] = {}
-            equation_dofs[name] = dofs_on_domains
 
             offset = 0
 
             for domain in equation.domains:
+                if (
+                    pp.ad.EquationOnDomain(name=name, domain=domain)
+                    not in requested_equations_lookup
+                ):
+                    continue
+
                 dofs_info = self.equation_image_size_info[name]
                 if isinstance(domain, pp.Grid):
                     dofs_per_grid = (
@@ -356,6 +392,11 @@ class EquationSystem:
                 dofs = np.arange(dofs_per_grid) + offset
                 dofs_on_domains[domain] = dofs
                 offset += len(dofs)
+
+            # Filter equations not defined anywhere.
+            if len(dofs_on_domains) > 0:
+                equation_dofs[name] = dofs_on_domains
+
         return pp.ad.EquationIndexer(equation_dofs_per_equation=equation_dofs)
 
     ### Variable management ------------------------------------------------------------
@@ -892,6 +933,7 @@ class EquationSystem:
         # current number of total dofs
         num_dofs = self.num_dofs()
         if variables:
+            variables = self._parse_variable_type(variables)
             # Array for the indices associated with argument.
             # The ordering is preserved in variable_indexer.
             indices = self.variable_indexer.projection_to(variables=variables)
@@ -1116,14 +1158,6 @@ class EquationSystem:
     def _parse_equation_names(
         self, requested_equations: Optional[EquationList | EquationRestriction]
     ) -> set[str]:
-        def validate_equation_name(name: str) -> str:
-            if name not in self._equations:
-                raise ValueError(
-                    f"Requested equation with name '{name}' is not registered "
-                    "in this equation system."
-                )
-            return name
-
         if requested_equations is None:
             return set(self._equations.keys())
 
@@ -1134,9 +1168,9 @@ class EquationSystem:
         equation_names = set()
         for equation in requested_equations:
             if isinstance(equation, str):
-                equation_names.add(validate_equation_name(name=equation))
+                equation_names.add(self._validate_equation_name(equation).name)
             elif isinstance(equation, pp.ad.Operator):
-                equation_names.add(validate_equation_name(name=equation.name))
+                equation_names.add(self._validate_equation_name(equation.name).name)
             else:
                 raise ValueError(f"Unsupported input type: {equation}")
         return equation_names
@@ -1164,6 +1198,18 @@ class EquationSystem:
 
         return discr
 
+    def _validate_equation_name(self, equation: str | pp.ad.Operator) -> pp.ad.Operator:
+        if isinstance(equation, pp.ad.Operator):
+            equation = equation.name
+
+        equation_or_none = self._equations.get(equation, None)
+        if equation_or_none is None:
+            raise ValueError(
+                f"Requested equation with name '{equation}' is not registered "
+                "in this equation system."
+            )
+        return equation_or_none
+
     def _parse_equations(
         self, equations: Optional[EquationList | EquationRestriction] = None
     ) -> dict[pp.ad.Operator, None | np.ndarray]:
@@ -1184,19 +1230,6 @@ class EquationSystem:
 
         # Store equations together with optional row restrictions, then sort them in
         # the canonical order in which equations were added to this system.
-
-        def validate_equation_name(equation: str | pp.ad.Operator) -> pp.ad.Operator:
-            if isinstance(equation, pp.ad.Operator):
-                equation = equation.name
-
-            equation_or_none = self._equations.get(equation, None)
-            if equation_or_none is None:
-                raise ValueError(
-                    f"Requested equation with name '{equation}' is not registered "
-                    "in this equation system."
-                )
-            return equation_or_none
-
         equation_rows: dict[pp.ad.Operator, np.ndarray | None] = {}
         equation_indexer = self.equation_indexer
 
@@ -1205,11 +1238,11 @@ class EquationSystem:
 
         if isinstance(equations, list):
             for eq in equations:
-                equation_rows[validate_equation_name(eq)] = None
+                equation_rows[self._validate_equation_name(eq)] = None
 
         elif isinstance(equations, dict):
             for eq, domains in equations.items():
-                eq = validate_equation_name(eq)
+                eq = self._validate_equation_name(eq)
                 equation_dofs = equation_indexer.equation_dofs_per_equation[eq.name]
                 domain_indices = self.mdg.argsort_grids(domains)
                 domains = [domains[i] for i in domain_indices]
@@ -1222,7 +1255,7 @@ class EquationSystem:
         equation_rows = {
             eq: dofs
             for eq, dofs in equation_rows.items()
-            if len(equation_indexer.equation_dofs_per_equation[eq.name]) > 0
+            if len(equation_indexer.equation_dofs_per_equation.get(eq.name, [])) > 0
         }
 
         equation_order = {name: i for i, name in enumerate(self.equations)}
@@ -1441,6 +1474,26 @@ class EquationSystem:
             )
             A = A[:, column_projection]
         return A, -rhs_cat
+
+    def construct_assembled_matrix_indexers(
+        self,
+        equations: Optional[EquationList | EquationRestriction] = None,
+        variables: Optional[VariableList] = None,
+    ) -> tuple[pp.ad.EquationIndexer, pp.ad.VariableIndexer]:
+        """TODO YZ"""
+        if variables is not None:
+            variable_indexer = self.variable_indexer.construct_restricted_indexer(
+                self._parse_variable_type(variables=variables)
+            )
+        else:
+            variable_indexer = self.variable_indexer
+
+        if equations is not None:
+            equation_indexer = self.construct_equation_indexer(equations)
+        else:
+            equation_indexer = self.equation_indexer
+
+        return equation_indexer, variable_indexer
 
     def assemble_schur_complement_system(
         self,

--- a/src/porepy/numerics/ad/equation_system.py
+++ b/src/porepy/numerics/ad/equation_system.py
@@ -306,7 +306,7 @@ class EquationSystem:
 
         """
         if self._variable_indexer is None:
-            self._variable_indexer = self.construct_variable_indexer()
+            self._variable_indexer = self._construct_variable_indexer()
         return self._variable_indexer
 
     @property
@@ -327,7 +327,7 @@ class EquationSystem:
             self._equation_indexer = self.construct_equation_indexer()
         return self._equation_indexer
 
-    def construct_variable_indexer(self) -> pp.ad.VariableIndexer:
+    def _construct_variable_indexer(self) -> pp.ad.VariableIndexer:
         """Construct a variable indexer for all the variables registered in this
         equation system.
 
@@ -699,7 +699,6 @@ class EquationSystem:
         # Storage for atomic blocks of the sub vector (identified by name-grid pairs).
         values = []
 
-        # Indexer determines ordering.
         for variable in variables:
             val = pp.get_solution_values(
                 variable.name,
@@ -765,11 +764,9 @@ class EquationSystem:
         for variable in variables:
             # 1. Slice the vector to local size
             num_dofs = variable.size
-            # Extract local vector.
-            # This will raise errors if indexation is out of range.
             dof_end = dof_start + num_dofs
-            # Extract local vector.
-            # This will raise errors if indexation is out of range.
+            # Extract local vector. This will return a smaller-than-requested array if
+            # indexation is out of range.
             local_vec = values[dof_start:dof_end]
 
             # 2. Use the AD utilities to set the values
@@ -1528,7 +1525,6 @@ class EquationSystem:
         # Slice out the columns belonging to the requested subsets of variables and
         # grid-related column blocks by using the transposed projection to respective
         # subspace.
-        # Multiply rhs by -1 to move to the rhs.
         if variables is not None:
             variable_indexer = self.variable_indexer
             # Respect the ordering of the input list of variables.
@@ -1540,6 +1536,7 @@ class EquationSystem:
                 else np.empty(0, dtype=int)
             )
             A = A[:, column_projection]
+        # Multiply rhs by -1 to move to the rhs.
         return A, -rhs_cat
 
     def construct_assembled_matrix_indexers(

--- a/src/porepy/numerics/ad/equation_system.py
+++ b/src/porepy/numerics/ad/equation_system.py
@@ -265,7 +265,7 @@ class EquationSystem:
             "equation_system.equation_image_space_composition is deprecated and will be"
             " removed. See equation_system.equation_indexer, or "
             "equation_system.construct_assembled_matrix_indexers.",
-            category=DeprecationWarning,
+            category=FutureWarning,
             stacklevel=2,
         )
         return self.equation_indexer.equation_image_space_composition

--- a/src/porepy/numerics/ad/equation_system.py
+++ b/src/porepy/numerics/ad/equation_system.py
@@ -317,7 +317,7 @@ class EquationSystem:
         Initialized lazily, upon first request. Changes in equation system may
         invalidate the indexer, leading to its recomputation.
 
-        By default, the row blocks are in the same order as equations were added to this
+        The row blocks are in the same order as equations were added to this
         EquationSystem. If an equation is defined on multiple grids, the respective
         row-block is internally ordered as given by the mixed-dimensional grid
         (for sd in subdomains, for intf in interfaces).
@@ -348,7 +348,7 @@ class EquationSystem:
             dofs = np.arange(dofs_per_grid) + offset
             variable_dofs[var] = dofs
             offset += len(dofs)
-        return pp.ad.VariableIndexer(variable_dofs=variable_dofs)
+        return pp.ad.VariableIndexer(indices=variable_dofs)
 
     def construct_equation_indexer(self) -> pp.ad.EquationIndexer:
         """Construct an equation indexer for all the registered equations.
@@ -877,7 +877,7 @@ class EquationSystem:
 
         """
         if variables is None:
-            return list(self.variable_indexer.variable_dofs.keys())
+            return list(self.variable_indexer.indices.keys())
 
         parsed_variables: list[Variable] = []
         assert isinstance(variables, list)
@@ -913,14 +913,14 @@ class EquationSystem:
 
         # Order variables according to the indexer.
         parsed_variables_ordered: list[Variable] = []
-        for variable in self.variable_indexer.variable_dofs:
+        for variable in self.variable_indexer.indices:
             if variable in parsed_variables_lookup:
                 parsed_variables_ordered.append(variable)
         return parsed_variables_ordered
 
     def num_dofs(self) -> int:
         """Returns the total number of dofs managed by this system."""
-        return self.variable_indexer.num_dofs
+        return self.variable_indexer.size
 
     def projection_to(self, variables: Optional[VariableList] = None) -> sps.csr_matrix:
         """Create a projection matrix from the global vector of unknowns to a specified
@@ -978,15 +978,13 @@ class EquationSystem:
         """
         # Respect the ordering of the input list of variables.
         variables = self._parse_variable_type(variables, ordered=False)
-        unknown_variables = set(variables).difference(
-            self.variable_indexer.variable_dofs
-        )
+        unknown_variables = set(variables).difference(self.variable_indexer.indices)
         if unknown_variables:
             raise ValueError(
                 "Variables not registered by this equation system: "
                 f"{unknown_variables}."
             )
-        dofs = [self.variable_indexer.variable_dofs[var] for var in variables]
+        dofs = [self.variable_indexer.indices[var] for var in variables]
         return np.concatenate(dofs) if len(dofs) > 0 else np.empty(0, dtype=np.int64)
 
     ### Equation management ------------------------------------------------------------
@@ -1163,10 +1161,12 @@ class EquationSystem:
             equations_per_grid_entity=equations_per_grid_entity,
         )
 
-    def update_variable_num_dofs(self) -> None:
-        """Update the count of degrees of freedom related to a MixedDimensionalGrid.
+    def reset_variable_equation_indices(self) -> None:
+        """Inform the equation system that the domain of definition of variables and/or
+        equations has been changed externally, and it needs to recompute the data
+        arrangement in a contiguous vector.
 
-        Used if the domain of definition of variables has been changed externally.
+        Known use case is the dynamic fracture propagation.
 
         """
         # Invalidate indexers to force their recomputation next time they are accessed.
@@ -1301,9 +1301,7 @@ class EquationSystem:
             return equations_on_domains
 
         # Order according to equation_indexer.
-        equation_order = {
-            eq: i for i, eq in enumerate(self.equation_indexer.equation_dofs)
-        }
+        equation_order = {eq: i for i, eq in enumerate(self.equation_indexer.indices)}
         return list(sorted(equations_on_domains, key=lambda eq: equation_order[eq]))
 
     def _gridbased_equation_complement(
@@ -1529,7 +1527,7 @@ class EquationSystem:
             variable_indexer = self.variable_indexer
             # Respect the ordering of the input list of variables.
             variables_ = self._parse_variable_type(variables=variables, ordered=True)
-            col_proj = [variable_indexer.variable_dofs[var] for var in variables_]
+            col_proj = [variable_indexer.indices[var] for var in variables_]
             column_projection = (
                 np.concatenate(col_proj)
                 if len(col_proj) > 0

--- a/src/porepy/numerics/ad/equation_system.py
+++ b/src/porepy/numerics/ad/equation_system.py
@@ -5,9 +5,9 @@ using the AD framework.
 
 from __future__ import annotations
 
+import logging
 from collections import defaultdict
 from typing import Any, Callable, Literal, Optional, Sequence, Union, overload
-import logging
 
 import numpy as np
 import scipy.sparse as sps

--- a/src/porepy/numerics/ad/equation_system.py
+++ b/src/porepy/numerics/ad/equation_system.py
@@ -216,7 +216,7 @@ class EquationSystem:
 
         """
         # Parse and validate input arguments. Will raise if unknown equations or
-        # variables are requested
+        # variables are requested.
         equations = {eq.name for eq in self._parse_equations(equation_names)}
         variables = self._parse_variable_type(variable_names, ordered=True)
 
@@ -1646,9 +1646,9 @@ class EquationSystem:
         # on their full image, and equations specified on a subset of grids.
         # The variable primary_rows will contain the indices in the global system
         # corresponding to the primary block.
-        equations_on_domaisn = self._parse_equations(primary_equations)
+        equations_on_domains = self._parse_equations(primary_equations)
         primary_rows_lists: dict[str, list[np.ndarray]] = {}
-        for eq in equations_on_domaisn:
+        for eq in equations_on_domains:
             primary_rows_lists.setdefault(eq.name, []).append(
                 self.equation_indexer.equation_image_space_composition[eq.name][
                     eq.domain

--- a/src/porepy/numerics/ad/equation_system.py
+++ b/src/porepy/numerics/ad/equation_system.py
@@ -5,9 +5,9 @@ using the AD framework.
 
 from __future__ import annotations
 
-from warnings import warn
 from collections import defaultdict
 from typing import Any, Callable, Literal, Optional, Sequence, Union, overload
+from warnings import warn
 
 import numpy as np
 import scipy.sparse as sps
@@ -273,7 +273,9 @@ class EquationSystem:
         warn(
             "equation_system.equation_image_space_composition is deprecated and will be"
             " removed. See equation_system.equation_indexer, or "
-            "equation_system.construct_assembled_matrix_indexers."
+            "equation_system.construct_assembled_matrix_indexers.",
+            category=DeprecationWarning,
+            stacklevel=2,
         )
         return self.equation_indexer.equation_image_space_composition
 
@@ -771,7 +773,7 @@ class EquationSystem:
 
         # If there are matching blocks, concatenate and return.
         # Else return an empty vector.
-        return np.concatenate(values) if values else np.empty(0)
+        return np.concatenate(values) if values else np.empty(0, dtype=float)
 
     def set_variable_values(
         self,
@@ -931,6 +933,11 @@ class EquationSystem:
             ordered: If False (default), respects the input ordering. Otherwise, orders
                 the returned variables according to the :attr:`variable_indexer`.
 
+        Raises:
+            ValueError: if passed variables are duplicated.
+            ValueError: if any of the passed variables is not registered in this
+                equation system.
+
         Returns:
             List of Variables.
 
@@ -962,11 +969,15 @@ class EquationSystem:
                     f"Variable {variable} is not registered in this equation system."
                 )
 
+        # Validate that variables are unique.
+        parsed_variables_lookup = set(parsed_variables)
+        if len(parsed_variables) != len(parsed_variables_lookup):
+            raise ValueError(f"Passed variables are duplicated: {parsed_variables}.")
+
         if not ordered:
             return parsed_variables
 
         # Order variables according to the indexer.
-        parsed_variables_lookup = set(parsed_variables)
         parsed_variables_ordered: list[Variable] = []
         for variable in self.variable_indexer.variable_dofs:
             if variable in parsed_variables_lookup:
@@ -1378,7 +1389,9 @@ class EquationSystem:
                 domains = [domains[i] for i in domain_indices]
                 rows_list = [equation_dofs[domain] for domain in domains]
                 equation_rows[eq] = (
-                    np.concatenate(rows_list) if len(rows_list) else np.empty(0)
+                    np.concatenate(rows_list)
+                    if len(rows_list)
+                    else np.empty(0, dtype=np.int64)
                 )
 
         # Filter equations defined on empty domains.
@@ -1582,7 +1595,7 @@ class EquationSystem:
         else:
             # Special case if the restriction produced an empty system.
             A = sps.csr_matrix((0, self.num_dofs()))
-            rhs_cat = np.empty(0)
+            rhs_cat = np.empty(0, dtype=float)
 
         if not evaluate_jacobian:
             return -rhs_cat
@@ -1594,10 +1607,10 @@ class EquationSystem:
         if variables is not None:
             variable_indexer = self.variable_indexer
             # Respect the ordering of the input list of variables.
-            variables_ = self._parse_variable_type(variables=variables, ordered=False)
+            variables_ = self._parse_variable_type(variables=variables, ordered=True)
             col_proj = [variable_indexer.variable_dofs[var] for var in variables_]
             column_projection = (
-                np.unique(np.concatenate(col_proj))
+                np.concatenate(col_proj)
                 if len(col_proj) > 0
                 else np.empty(0, dtype=int)
             )

--- a/src/porepy/numerics/ad/equation_system.py
+++ b/src/porepy/numerics/ad/equation_system.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from typing import Any, Callable, Literal, Optional, Sequence, Union, overload
+import logging
 
 import numpy as np
 import scipy.sparse as sps
@@ -19,6 +20,7 @@ from .operators import MixedDimensionalVariable, Operator, Variable
 
 __all__ = ["EquationSystem"]
 
+logger = logging.getLogger(__name__)
 
 # For Python3.8, a direct definition of type aliases with list is apparently not posible
 # (DomainList = Union[list[pp.Grid], list[pp.MortarGrid]]]), the same applies to dict
@@ -100,16 +102,15 @@ class EquationSystem:
     It further provides functions to assemble subsystems and using subsets of equations
     and variables.
 
+    The information about how the equations and variables of a discretized problem are
+    arranged in a single contiguous vector is stored in :attr:`equation_indexer` and
+    :attr:`variable_indexer`.
+
     Note:
         As of now, the system matrix (Jacobian) is assembled with respect to ALL
         variables and then the columns belonging to the requested subset of variables
         and grids are sliced out and returned. This will be optimized with minor changes
         to the AD operator class and its recursive forward AD mode in the future.
-
-        Currently, this class optimizes the block structure of the Jacobian only
-        regarding the subdomains and interfaces. A more localized optimization (e.g.
-        cell-wise for equations without spatial differential operators) is not
-        performed.
 
     """
 
@@ -150,8 +151,7 @@ class EquationSystem:
         by this instance.
 
         Variables contained here are ordered chronologically in terms of
-        instantiation. It does not reflect the order of DOFs, which is to some degree
-        optimized. TODO YZ
+        instantiation. The order in the default :attr:`variable_indexer` is different. 
 
         A Variable is uniquely identified by its name and domain, stored as attributes
         of the Variable object.
@@ -161,10 +161,15 @@ class EquationSystem:
         """
 
         self._equation_indexer: pp.ad.EquationIndexer | None = None
-        """Indexer defining the canonical row ordering of the equation system."""
+        """Indexer defining the ordering of the equations (rows) when multiple equation
+        values are packed in a single vector.
+        
+        """
         self._variable_indexer: pp.ad.VariableIndexer | None = None
-        """Indexer defining the canonical column ordering of the equation system."""
-
+        """Indexer defining the ordering of the variables (columns) when multiple
+        variable values are packed in a single vector.
+        
+        """
         # Schur complement related stuff (to be removed in the next PR).
         self._Schur_complement: Optional[tuple] = None
         """Contains block matrices and the rhs of the last assembled Schur complement.
@@ -265,8 +270,12 @@ class EquationSystem:
         set in this EquationSystem.
 
         """
-        # TODO YZ: Deprecation warning?
-        self.equation_indexer.equation_dofs_per_equation
+        logger.warning(
+            "equation_system.equation_image_space_composition is deprecated and will be"
+            " removed. See equation_system.equation_indexer, or "
+            "equation_system.construct_assembled_matrix_indexers."
+        )
+        return self.equation_indexer.equation_image_space_composition
 
     @property
     def equation_image_size_info(self) -> dict[str, dict["GridEntity", int]]:
@@ -296,31 +305,47 @@ class EquationSystem:
 
     @property
     def variable_indexer(self) -> pp.ad.VariableIndexer:
+        """Indexer defining the ordering of the variables (columns) when multiple
+        variable values are packed in a single vector.
+
+        Initialized lazily, upon first request. Changes in equation system may
+        invalidate the indexer, leading to its recomputation.
+
+        """
         if self._variable_indexer is None:
             self._variable_indexer = self.construct_variable_indexer()
         return self._variable_indexer
 
     @property
     def equation_indexer(self) -> pp.ad.EquationIndexer:
+        """Indexer defining the ordering of the equations (rows) when multiple
+        equation values are packed in a single vector.
+
+        Initialized lazily, upon first request. Changes in equation system may
+        invalidate the indexer, leading to its recomputation.
+
+        """
         if self._equation_indexer is None:
             self._equation_indexer = self.construct_equation_indexer()
         return self._equation_indexer
 
-    def construct_variable_indexer(
-        self, requested_variables: Optional[VariableList] = None
-    ) -> pp.ad.VariableIndexer:
-        """Construct an indexer for a requested variable subspace."""
-        requested_variables = self._parse_variable_type(requested_variables)
-        requested_variables_lookup = set(requested_variables)
+    def construct_variable_indexer(self) -> pp.ad.VariableIndexer:
+        """Construct a variable indexer for all the variables registered in this
+        equation system.
 
+        The ordering of registered variables is determinded by
+        :func:`cluster_dofs_gridwise`.
+
+        Returns:
+            The indexer.
+
+        """
         variable_dofs: dict[pp.ad.Variable, np.ndarray] = {}
         offset = 0
 
-        ordered_variables = cluster_dofs_gridwise(requested_variables)
+        ordered_variables = cluster_dofs_gridwise(self.variables)
 
         for var in ordered_variables:
-            if var not in requested_variables_lookup:
-                continue
             dofs_per_grid = var.size
             dofs = np.arange(dofs_per_grid) + offset
             variable_dofs[var] = dofs
@@ -330,14 +355,34 @@ class EquationSystem:
     def construct_equation_indexer(
         self, requested_equations: Optional[EquationList | EquationRestriction] = None
     ) -> pp.ad.EquationIndexer:
-        """TODO YZ"""
+        """Construct an equation indexer for the requested_equations.
+
+        The ordering of equations is determinded by the order they were registered in
+        this equation system. Equations not defined anywhere are excluded.
+
+        Parameters:
+            requested_equations: Equations to consider in the indexer. Note: ordering is
+            ignored. If None (default), constructs the indexer for all the registered
+            equations.
+
+        Returns:
+            The indexer.
+
+        """
+        # We unfortunately have to parse quite a heterogenuous input. Similar parsing is
+        # done in _parse_equation_names and _parse_equations, but the results are
+        # different enought to prevent unification of the parsing logic. Here, we
+        # construct a lookup set of EquationOnDomain to express the requested
+        # restriction.
         if requested_equations is None:
+            # No restriction, include all equations on all domains.
             requested_equations_lookup = {
                 pp.ad.EquationOnDomain(name=eq.name, domain=domain)
                 for eq in self._equations.values()
                 for domain in eq.domains
             }
         elif isinstance(requested_equations, list):
+            # Restrict equation names, do not restrict domains.
             requested_equations_lookup = set()
             for equation in requested_equations:
                 equation = self._validate_equation_name(equation)
@@ -347,8 +392,9 @@ class EquationSystem:
                     )
 
         elif isinstance(requested_equations, dict):
+            # Restrict equations and domains. Additionally, order domains.
 
-            def sort_grids(grids: list[pp.GridLike]) -> list[pp.GridLike]:
+            def order_grids(grids: list[pp.GridLike]) -> list[pp.GridLike]:
                 indices = self.mdg.argsort_grids(grids)
                 return [grids[i] for i in indices]
 
@@ -357,14 +403,17 @@ class EquationSystem:
                     name=self._validate_equation_name(eq).name, domain=domain
                 )
                 for eq, domains in requested_equations.items()
-                for domain in sort_grids(domains)
+                for domain in order_grids(domains)
             }
 
+        # Result dictionary.
         equation_dofs: dict[str, dict[pp.GridLike, np.ndarray]] = {}
-        # self.equations stores a canonical order of equations.
+
+        # self.equations defines the desired order of equations.
         for name, equation in self.equations.items():
             dofs_on_domains: dict[pp.GridLike, np.ndarray] = {}
 
+            # Offset applies to domains within the same equation.
             offset = 0
 
             for domain in equation.domains:
@@ -372,6 +421,7 @@ class EquationSystem:
                     pp.ad.EquationOnDomain(name=name, domain=domain)
                     not in requested_equations_lookup
                 ):
+                    # The user did not request this equation-domain.
                     continue
 
                 dofs_info = self.equation_image_size_info[name]
@@ -388,16 +438,16 @@ class EquationSystem:
                         + domain.num_nodes * dofs_info.get("nodes", 0)  # nodes
                     )
                 else:
-                    raise ValueError(type(domain))
+                    raise ValueError(f"Unknown domain type: {domain}")
                 dofs = np.arange(dofs_per_grid) + offset
                 dofs_on_domains[domain] = dofs
                 offset += len(dofs)
 
-            # Filter equations not defined anywhere.
+            # Filter out equations not defined anywhere.
             if len(dofs_on_domains) > 0:
                 equation_dofs[name] = dofs_on_domains
 
-        return pp.ad.EquationIndexer(equation_dofs_per_equation=equation_dofs)
+        return pp.ad.EquationIndexer(equation_image_composition=equation_dofs)
 
     ### Variable management ------------------------------------------------------------
 
@@ -556,6 +606,7 @@ class EquationSystem:
         # individual grids.
         merged_variable = MixedDimensionalVariable(variables)
 
+        # Invalidating variable indexer forces to recompute it next time it is accessed.
         self._variable_indexer = None
 
         return merged_variable
@@ -581,7 +632,7 @@ class EquationSystem:
             # Remove the variable from the system.
             del self._variables[var.id]
 
-        # Invalidate variable indexer forces to recompute it next time when accessed.
+        # Invalidating variable indexer forces to recompute it next time it is accessed.
         self._variable_indexer = None
 
     def update_variable_tags(
@@ -696,15 +747,15 @@ class EquationSystem:
         """
         # Normalize the variable input.
         variables = self._parse_variable_type(variables)
-        variable_ids = {variable.id for variable in variables}
+        var_ids = {var.id for var in variables}
 
         # Storage for atomic blocks of the sub vector (identified by name-grid pairs).
         values = []
 
-        # Indexer determines canonical (global) ordering.
+        # Indexer determines ordering.
         indexer = self.variable_indexer
         for variable in indexer.variable_dofs.keys():
-            if variable.id in variable_ids:
+            if variable.id in var_ids:
                 domain = variable.domain
 
                 val = pp.get_solution_values(
@@ -767,7 +818,7 @@ class EquationSystem:
         variables = self._parse_variable_type(variables)
         var_ids = {var.id for var in variables}
 
-        # Indexer determines canonical (global) ordering.
+        # Indexer determines ordering.
         indexer = self.variable_indexer
         for variable, dofs in indexer.variable_dofs.items():
             if variable.id in var_ids:
@@ -936,7 +987,7 @@ class EquationSystem:
             variables = self._parse_variable_type(variables)
             # Array for the indices associated with argument.
             # The ordering is preserved in variable_indexer.
-            indices = self.variable_indexer.projection_to(variables=variables)
+            indices = self.variable_indexer.projection_indices(variables=variables)
             # case where no dofs where found for the VariableType input
             if len(indices) == 0:
                 return sps.csr_matrix((0, num_dofs))
@@ -1019,8 +1070,6 @@ class EquationSystem:
                 number as per evaluation of operator.
 
         """
-        self._equation_indexer = None
-
         # The domain of this equation is the set of grids on which it is defined
         name = equation.name
         if name in self._equations:
@@ -1063,13 +1112,17 @@ class EquationSystem:
             f"Equation defined on unknown domains: {unknown_domains}"
         )
 
-        # TODO: YZ explain
+        # Storing the ordered domains of definition in the equation object. It may
+        # already contain domains, then makings sure they are equal.
         ordered_domain_indices = self.mdg.argsort_grids(grids)
         ordered_domains = [grids[i] for i in ordered_domain_indices]
         if equation.domains is None or len(equation.domains) == 0:
             equation._domains = ordered_domains
-        else:
-            assert equation.domains == ordered_domains
+        elif equation.domains != ordered_domains:
+            raise ValueError(
+                "Attempting to register an equation on domains that do not match "
+                "equation.domains."
+            )
 
         # If all good, we store the information:
         # Information on the size of the equation, in terms of the grids it is defined
@@ -1077,6 +1130,9 @@ class EquationSystem:
         self._equation_image_size_info.update({name: equations_per_grid_entity})
         # Store the equation itself.
         self._equations.update({name: equation})
+
+        # Invalidating equation indexer forces to recompute it next time it is accessed.
+        self._equation_indexer = None
 
     def remove_equation(self, name: str) -> Operator | None:
         """Removes a previously set equation and all related information.
@@ -1096,6 +1152,7 @@ class EquationSystem:
             # Note that there is no need to modify the numbering of the other equations,
             # since this is a local (to the equation) numbering.
             del self._equation_image_size_info[name]
+            # Invalidating equation indexer.
             self._equation_indexer = None
             return equ
         else:
@@ -1129,7 +1186,9 @@ class EquationSystem:
         """
         if grids is None:
             grids = self._equations[equation_name].domains  # type: ignore[assignment]
-            assert grids is not None and len(grids) > 0
+            assert grids is not None and len(grids) > 0, (
+                "Domains must be initialized in equation_system.set_equations."
+            )
 
         if equations_per_grid_entity is None:
             equations_per_grid_entity = self._equation_image_size_info[equation_name]
@@ -1145,19 +1204,31 @@ class EquationSystem:
     def update_variable_num_dofs(self) -> None:
         """Update the count of degrees of freedom related to a MixedDimensionalGrid.
 
-        The method loops through the variables and updates the number of fine-scale
-        degree of freedom. The system size will be updated if the grid has changed or
-        (perhaps less realistically) a variable has had its number of dofs per grid
-        quantity changed.
+        Used if the domain of definition of variables has been changed externally.
 
         """
-        # Invalidate indexers to force their recomputation next time when accessed.
+        # Invalidate indexers to force their recomputation next time they are accessed.
         self._variable_indexer = None
         self._equation_indexer = None
 
     def _parse_equation_names(
         self, requested_equations: Optional[EquationList | EquationRestriction]
     ) -> set[str]:
+        """Parses the user input in a heterogenous format.
+
+        Raises:
+            ValueError: if one of the passed equations is not registered.
+            ValueError: if unsupported input format is passed.
+
+        Parameters:
+            requested_equations: If `None`, returns all registered equation names. If a
+                list of equations, returns their names. If a dictionary, ignores its
+                values.
+
+        Returns:
+             Unordered set of requested equation names.
+
+        """
         if requested_equations is None:
             return set(self._equations.keys())
 
@@ -1199,6 +1270,19 @@ class EquationSystem:
         return discr
 
     def _validate_equation_name(self, equation: str | pp.ad.Operator) -> pp.ad.Operator:
+        """Ensures that the equation is registered.
+
+        Parameters:
+            equation: Either equation name or its operator.
+
+        Raises:
+            ValueError: If the equation is not registered.
+
+        Returns:
+            The corresponding equation operator.
+
+        """
+
         if isinstance(equation, pp.ad.Operator):
             equation = equation.name
 
@@ -1215,12 +1299,14 @@ class EquationSystem:
     ) -> dict[pp.ad.Operator, None | np.ndarray]:
         """Helper method to parse equations into a properly ordered structure.
 
-        The equations will be ordered according to the order in self._equations (which
-        is the order in which they were added to the equation system manager and which
-        also is fixed since iteration of dictionaries is so).
+        The equations will be ordered according to :attr:`equation_indexer`. Equations
+        not defined anywhere are filtered out.
 
         Parameters:
             equations: A list of equations or a dictionary of equation restrictions.
+
+        Raises:
+            ValueError: If the requested equation is not registered.
 
         Returns:
             A dictionary with the index set of the restricted equations (referring to
@@ -1228,22 +1314,26 @@ class EquationSystem:
 
         """
 
-        # Store equations together with optional row restrictions, then sort them in
-        # the canonical order in which equations were added to this system.
         equation_rows: dict[pp.ad.Operator, np.ndarray | None] = {}
         equation_indexer = self.equation_indexer
 
         if equations is None:
+            # Requested are all the registered equations.
             equations = list(self.equations.keys())
 
         if isinstance(equations, list):
+            # Equation names are restricted, domains are not restricted (None).
             for eq in equations:
                 equation_rows[self._validate_equation_name(eq)] = None
 
         elif isinstance(equations, dict):
+            # Equation names and domains are restricted.
+
             for eq, domains in equations.items():
                 eq = self._validate_equation_name(eq)
-                equation_dofs = equation_indexer.equation_dofs_per_equation[eq.name]
+                equation_dofs = equation_indexer.equation_image_space_composition[
+                    eq.name
+                ]
                 domain_indices = self.mdg.argsort_grids(domains)
                 domains = [domains[i] for i in domain_indices]
                 rows_list = [equation_dofs[domain] for domain in domains]
@@ -1255,10 +1345,16 @@ class EquationSystem:
         equation_rows = {
             eq: dofs
             for eq, dofs in equation_rows.items()
-            if len(equation_indexer.equation_dofs_per_equation.get(eq.name, [])) > 0
+            if len(equation_indexer.equation_image_space_composition.get(eq.name, []))
+            > 0
         }
 
-        equation_order = {name: i for i, name in enumerate(self.equations)}
+        # Order according to equation_indexer.
+        equation_order: dict[str, int] = {}
+        for i, name in enumerate(
+            self.equation_indexer.equation_image_space_composition
+        ):
+            equation_order[name] = i
         return dict(
             sorted(equation_rows.items(), key=lambda item: equation_order[item[0].name])
         )
@@ -1289,7 +1385,9 @@ class EquationSystem:
             # If idx is None, this means no filtering was done.
             if idx is not None:
                 # Get the indices associated with this equation.
-                all_idx = equation_indexer.equation_dofs_per_equation[name].values()
+                all_idx = equation_indexer.equation_image_space_composition[
+                    name
+                ].values()
                 all_idx = (
                     np.concatenate(list(all_idx))
                     if len(all_idx) > 0
@@ -1413,8 +1511,7 @@ class EquationSystem:
                 for the specified equations. Scaled with -1 (moved to rhs).
 
         """
-        # Store equations together with optional row restrictions, then sort them in
-        # the canonical order in which equations were added to this system.
+        # Standartized input, it is ordered.
         equations_rows = self._parse_equations(equations=equations)
 
         # Data structures for building matrix and residual vector
@@ -1480,7 +1577,17 @@ class EquationSystem:
         equations: Optional[EquationList | EquationRestriction] = None,
         variables: Optional[VariableList] = None,
     ) -> tuple[pp.ad.EquationIndexer, pp.ad.VariableIndexer]:
-        """TODO YZ"""
+        """Generate indexers for the linear system produced by :meth:`assemble`.
+
+        Parameters:
+            equations: Equations restriction, same as an argument to :meth:`assemble`.
+            variables: Variables restriction, same as an argument to :meth:`assemble`.
+
+        Returns:
+            `equation_indexer` and `variable_indexer`. If no restriction is requested,
+            returns equation system's own indexers.
+
+        """
         if variables is not None:
             variable_indexer = self.variable_indexer.construct_restricted_indexer(
                 self._parse_variable_type(variables=variables)
@@ -1955,15 +2062,13 @@ def cluster_dofs_gridwise(variables: list[pp.ad.Variable]) -> list[pp.ad.Variabl
     2. For each grid in ``mdg.interfaces``
         1. For each variable defined on that mortar grid
 
-    The order of variables per grid is given by the order of passed variables.
+    The order of variables per grid is given by the grid id.
 
     """
     mapping_grid_to_domains = defaultdict(lambda: [])
     for variable in variables:
         mapping_grid_to_domains[variable.domain].append(variable)
 
-    # The ordering is: [Subdomains(3D-2D-1D-0D), Interfaces(2D-1D-0D)]. If equal, sorted
-    # by id.
     known_grids = list(
         sorted(
             mapping_grid_to_domains.keys(),

--- a/src/porepy/numerics/ad/equation_system.py
+++ b/src/porepy/numerics/ad/equation_system.py
@@ -920,9 +920,6 @@ class EquationSystem:
         several exposed methods, allowing the user to specify a single variable or a
         list of variables more flexibly.
 
-        Variables are filtered according to the ordering in the
-        :attr:`variable_indexer`.
-
         Parameters:
             variables: The input argument for the variable type.
                 The following interpretation rules are applied:

--- a/src/porepy/numerics/ad/equation_system.py
+++ b/src/porepy/numerics/ad/equation_system.py
@@ -215,19 +215,10 @@ class EquationSystem:
                 equations.
 
         """
-        # Parsing of input arguments.
-        equations = self._parse_equation_names(equation_names)
+        # Parse and validate input arguments. Will raise if unknown equations or
+        # variables are requested
+        equations = set(self._parse_equation_names(equation_names))
         variables = self._parse_variable_type(variable_names, ordered=True)
-
-        # Check that the requested equations and variables are known to the equation
-        # system.
-        known_equations = set(self._equations.keys())
-        unknown_equations = set(equations).difference(known_equations)
-        if len(unknown_equations) > 0:
-            raise ValueError(f"Unknown variable(s) {unknown_equations}.")
-        unknown_variables = set(variables).difference(self.variables)
-        if len(unknown_variables) > 0:
-            raise ValueError(f"Unknown variable(s) {unknown_variables}.")
 
         # Create the new equation system.
         new_equation_system = EquationSystem(self.mdg)
@@ -1238,7 +1229,7 @@ class EquationSystem:
 
     def _parse_equation_names(
         self, requested_equations: Optional[EquationList | EquationRestriction]
-    ) -> set[str]:
+    ) -> list[str]:
         """Parses the user input in a heterogeneous format.
 
         Raises:
@@ -1255,18 +1246,18 @@ class EquationSystem:
 
         """
         if requested_equations is None:
-            return set(self._equations.keys())
+            return list(self._equations.keys())
 
         if isinstance(requested_equations, dict):
             requested_equations = list(requested_equations.keys())  # type: ignore[assignment]
 
         assert isinstance(requested_equations, list)
-        equation_names = set()
+        equation_names: list[str] = list()
         for equation in requested_equations:
             if isinstance(equation, str):
-                equation_names.add(self._validate_equation_name(equation).name)
+                equation_names.append(self._validate_equation_name(equation).name)
             elif isinstance(equation, pp.ad.Operator):
-                equation_names.add(self._validate_equation_name(equation.name).name)
+                equation_names.append(self._validate_equation_name(equation.name).name)
             else:
                 raise ValueError(f"Unsupported input type: {equation}")
         return equation_names

--- a/src/porepy/numerics/ad/equation_system.py
+++ b/src/porepy/numerics/ad/equation_system.py
@@ -5,7 +5,7 @@ using the AD framework.
 
 from __future__ import annotations
 
-import logging
+from warnings import warn
 from collections import defaultdict
 from typing import Any, Callable, Literal, Optional, Sequence, Union, overload
 
@@ -20,7 +20,6 @@ from .operators import MixedDimensionalVariable, Operator, Variable
 
 __all__ = ["EquationSystem"]
 
-logger = logging.getLogger(__name__)
 
 # For Python3.8, a direct definition of type aliases with list is apparently not posible
 # (DomainList = Union[list[pp.Grid], list[pp.MortarGrid]]]), the same applies to dict
@@ -218,7 +217,7 @@ class EquationSystem:
         """
         # Parsing of input arguments.
         equations = self._parse_equation_names(equation_names)
-        variables = self._parse_variable_type(variable_names)
+        variables = self._parse_variable_type(variable_names, ordered=True)
 
         # Check that the requested equations and variables are known to the equation
         # system.
@@ -237,14 +236,13 @@ class EquationSystem:
         # setting procedures by calling private methods and accessing private
         # attributes. This should be acceptable since this is a factory method.
 
-        # Loop over known variables to preserve DOF order.
-        for variable in self.variables:
-            if variable in variables:
-                # Update variables.
-                new_equation_system._variables[variable.id] = variable
+        # Loop over new system's variables, old DOF ordering is preserved.
+        for variable in variables:
+            # Update variables.
+            new_equation_system._variables[variable.id] = variable
 
         # Loop over known equations to preserve row order.
-        for name in known_equations:
+        for name in self._equations.keys():
             if name in equations:
                 equation = self._equations[name]
                 image_info = self._equation_image_size_info[name]
@@ -269,8 +267,10 @@ class EquationSystem:
         and their block indices in the global system, for every equation
         set in this EquationSystem.
 
+        Note: It does not include equations with empty-domain equations.
+
         """
-        logger.warning(
+        warn(
             "equation_system.equation_image_space_composition is deprecated and will be"
             " removed. See equation_system.equation_indexer, or "
             "equation_system.construct_assembled_matrix_indexers."
@@ -324,6 +324,11 @@ class EquationSystem:
         Initialized lazily, upon first request. Changes in equation system may
         invalidate the indexer, leading to its recomputation.
 
+        By default, the row blocks are in the same order as equations were added to this
+        EquationSystem. If an equation is defined on multiple grids, the respective
+        row-block is internally ordered as given by the mixed-dimensional grid
+        (for sd in subdomains, for intf in interfaces).
+
         """
         if self._equation_indexer is None:
             self._equation_indexer = self.construct_equation_indexer()
@@ -372,7 +377,7 @@ class EquationSystem:
         # We unfortunately have to parse quite a heterogenuous input. Similar parsing is
         # done in _parse_equation_names and _parse_equations, but the results are
         # different enought to prevent unification of the parsing logic. Here, we
-        # construct a lookup set of EquationOnDomain to express the requested
+        # construct a lookup set of EquationOnDomain to filter the requested
         # restriction.
         if requested_equations is None:
             # No restriction, include all equations on all domains.
@@ -398,13 +403,13 @@ class EquationSystem:
                 indices = self.mdg.argsort_grids(grids)
                 return [grids[i] for i in indices]
 
-            requested_equations_lookup = {
-                pp.ad.EquationOnDomain(
-                    name=self._validate_equation_name(eq).name, domain=domain
-                )
-                for eq, domains in requested_equations.items()
-                for domain in order_grids(domains)
-            }
+            requested_equations_lookup = set()
+            for eq, domains in requested_equations.items():
+                equation = self._validate_equation_restriction(eq, domains)
+                for domain in order_grids(domains):  # type: ignore[arg-type]
+                    requested_equations_lookup.add(
+                        pp.ad.EquationOnDomain(name=equation.name, domain=domain)
+                    )
 
         # Result dictionary.
         equation_dofs: dict[str, dict[pp.GridLike, np.ndarray]] = {}
@@ -623,7 +628,7 @@ class EquationSystem:
             ValueError: If a variable is not known to the system.
 
         """
-        variables = self._parse_variable_type(variables)
+        variables = self._parse_variable_type(variables, ordered=False)
         for var in variables:
             if var.id not in self._variables:
                 raise ValueError(
@@ -651,7 +656,7 @@ class EquationSystem:
                 grids).
 
         """
-        variables = self._parse_variable_type(variables)
+        variables = self._parse_variable_type(variables, ordered=False)
         for var in variables:
             var.tags.update(tags)
 
@@ -700,7 +705,8 @@ class EquationSystem:
             grids = self.variable_domains
 
         filtered_variables = []
-        variables = self._parse_variable_type(variables)
+        # Using the ordering of the input list.
+        variables = self._parse_variable_type(variables, ordered=False)
         for var in variables:
             if var.domain in grids:
                 # Add variable if tag_name is not specified or if the variable has the
@@ -745,28 +751,23 @@ class EquationSystem:
             :meth:`num_dofs`.
 
         """
-        # Normalize the variable input.
-        variables = self._parse_variable_type(variables)
-        var_ids = {var.id for var in variables}
+        # Normalize the variable input. Using equation_system's ordering of variables.
+        variables = self._parse_variable_type(variables, ordered=True)
 
         # Storage for atomic blocks of the sub vector (identified by name-grid pairs).
         values = []
 
         # Indexer determines ordering.
-        indexer = self.variable_indexer
-        for variable in indexer.variable_dofs.keys():
-            if variable.id in var_ids:
-                domain = variable.domain
-
-                val = pp.get_solution_values(
-                    variable.name,
-                    self._get_data(domain),
-                    time_step_index=time_step_index,
-                    iterate_index=iterate_index,
-                    reference=reference,
-                )
-                # NOTE get_solution_values already returns a copy
-                values.append(val)
+        for variable in variables:
+            val = pp.get_solution_values(
+                variable.name,
+                self._get_data(variable.domain),
+                time_step_index=time_step_index,
+                iterate_index=iterate_index,
+                reference=reference,
+            )
+            # NOTE get_solution_values already returns a copy
+            values.append(val)
 
         # If there are matching blocks, concatenate and return.
         # Else return an empty vector.
@@ -815,35 +816,33 @@ class EquationSystem:
         # Start of dissection.
         dof_start = 0
         dof_end = 0
-        variables = self._parse_variable_type(variables)
-        var_ids = {var.id for var in variables}
 
-        # Indexer determines ordering.
-        indexer = self.variable_indexer
-        for variable, dofs in indexer.variable_dofs.items():
-            if variable.id in var_ids:
-                # 1. Slice the vector to local size
-                num_dofs = dofs.size
-                # Extract local vector.
-                # This will raise errors if indexation is out of range.
-                dof_end = dof_start + num_dofs
-                # Extract local vector.
-                # This will raise errors if indexation is out of range.
-                local_vec = values[dof_start:dof_end]
+        # Normalize the variable input. Using equation_system's ordering of variables.
+        variables = self._parse_variable_type(variables, ordered=True)
 
-                # 2. Use the AD utilities to set the values
-                pp.set_solution_values(
-                    variable.name,
-                    local_vec,
-                    self._get_data(grid=variable.domain),
-                    time_step_index=time_step_index,
-                    iterate_index=iterate_index,
-                    additive=additive,
-                    reference=reference,
-                )
+        for variable in variables:
+            # 1. Slice the vector to local size
+            num_dofs = variable.size
+            # Extract local vector.
+            # This will raise errors if indexation is out of range.
+            dof_end = dof_start + num_dofs
+            # Extract local vector.
+            # This will raise errors if indexation is out of range.
+            local_vec = values[dof_start:dof_end]
 
-                # 3. Move dissection forward.
-                dof_start = dof_end
+            # 2. Use the AD utilities to set the values
+            pp.set_solution_values(
+                variable.name,
+                local_vec,
+                self._get_data(grid=variable.domain),
+                time_step_index=time_step_index,
+                iterate_index=iterate_index,
+                additive=additive,
+                reference=reference,
+            )
+
+            # 3. Move dissection forward.
+            dof_start = dof_end
 
         # Last sanity check if the vector was properly sized, or if it was too large.
         # This imposes a theoretically unnecessary restriction on the input argument
@@ -872,7 +871,7 @@ class EquationSystem:
                 If called repeatedly with ``None``, the depth in time keeps increasing.
 
         """
-        for var in self._parse_variable_type(variables):
+        for var in self._parse_variable_type(variables, ordered=False):
             pp.shift_solution_values(
                 var.name, self._get_data(var.domain), pp.TIME_STEP_SOLUTIONS, max_index
             )
@@ -884,7 +883,7 @@ class EquationSystem:
     ) -> None:
         """Analogous to :meth:`shift_time_step_values`, but for iterates of the current
         (unknown) time step."""
-        for var in self._parse_variable_type(variables):
+        for var in self._parse_variable_type(variables, ordered=False):
             pp.shift_solution_values(
                 var.name, self._get_data(var.domain), pp.ITERATE_SOLUTIONS, max_index
             )
@@ -910,7 +909,9 @@ class EquationSystem:
 
     ### DOF management -----------------------------------------------------------------
 
-    def _parse_variable_type(self, variables: Optional[VariableList]) -> list[Variable]:
+    def _parse_variable_type(
+        self, variables: Optional[VariableList], ordered: bool = False
+    ) -> list[Variable]:
         """Parse the input argument for the variable type.
 
         This method is used to parse the input argument for the variable type in
@@ -927,6 +928,8 @@ class EquationSystem:
                     - If a list of variables, return same.
                     - If a list of strings, return all variables with those names.
                     - If mixed-dimensional variable, return sub-variables.
+            ordered: If False (default), respects the input ordering. Otherwise, orders
+                the returned variables according to the :attr:`variable_indexer`.
 
         Returns:
             List of Variables.
@@ -935,16 +938,16 @@ class EquationSystem:
         if variables is None:
             return list(self.variable_indexer.variable_dofs.keys())
 
-        parsed_variables_lookup: set[Variable] = set()
+        parsed_variables: list[Variable] = []
         assert isinstance(variables, list)
         for variable in variables:
             if isinstance(variable, MixedDimensionalVariable):
-                parsed_variables_lookup.update(variable.sub_vars)
+                parsed_variables.extend(variable.sub_vars)
             elif isinstance(variable, Variable):
-                parsed_variables_lookup.add(variable)
+                parsed_variables.append(variable)
             elif isinstance(variable, str):
                 vars = [var for var in self._variables.values() if var.name == variable]
-                parsed_variables_lookup.update(vars)
+                parsed_variables.extend(vars)
             else:
                 raise ValueError(
                     "Variable type must be a string or a Variable, not {}".format(
@@ -952,11 +955,22 @@ class EquationSystem:
                     )
                 )
 
+        # Validate that variables are registered.
+        for variable in parsed_variables:
+            if variable.id not in self._variables:
+                raise ValueError(
+                    f"Variable {variable} is not registered in this equation system."
+                )
+
+        if not ordered:
+            return parsed_variables
+
+        # Order variables according to the indexer.
+        parsed_variables_lookup = set(parsed_variables)
         parsed_variables_ordered: list[Variable] = []
         for variable in self.variable_indexer.variable_dofs:
             if variable in parsed_variables_lookup:
                 parsed_variables_ordered.append(variable)
-
         return parsed_variables_ordered
 
     def num_dofs(self) -> int:
@@ -986,7 +1000,7 @@ class EquationSystem:
         # current number of total dofs
         num_dofs = self.num_dofs()
         if variables:
-            variables = self._parse_variable_type(variables)
+            variables = self._parse_variable_type(variables, ordered=True)
             # Array for the indices associated with argument.
             # The ordering is preserved in variable_indexer.
             indices = self.variable_indexer.projection_indices(variables=variables)
@@ -1017,7 +1031,8 @@ class EquationSystem:
             ValueError: If an unknown  variable is passed as argument.
 
         """
-        variables = self._parse_variable_type(variables)
+        # Respect the ordering of the input list of variables.
+        variables = self._parse_variable_type(variables, ordered=False)
         unknown_variables = set(variables).difference(
             self.variable_indexer.variable_dofs
         )
@@ -1188,7 +1203,7 @@ class EquationSystem:
         """
         if grids is None:
             grids = self._equations[equation_name].domains  # type: ignore[assignment]
-            assert grids is not None and len(grids) > 0, (
+            assert grids is not None, (
                 "Domains must be initialized in equation_system.set_equations."
             )
 
@@ -1235,7 +1250,7 @@ class EquationSystem:
             return set(self._equations.keys())
 
         if isinstance(requested_equations, dict):
-            requested_equations = list(requested_equations.keys())
+            requested_equations = list(requested_equations.keys())  # type: ignore[assignment]
 
         assert isinstance(requested_equations, list)
         equation_names = set()
@@ -1296,6 +1311,27 @@ class EquationSystem:
             )
         return equation_or_none
 
+    def _validate_equation_restriction(
+        self, equation: str | pp.ad.Operator, domains: DomainList
+    ) -> pp.ad.Operator:
+        """Validate an equation and the domains to which it is restricted.
+
+        Raises:
+            ValueError: If the equation is not registered or is restricted to a domain
+                on which it is not defined.
+
+        Returns:
+            The registered equation operator.
+
+        """
+        equation = self._validate_equation_name(equation)
+        invalid_domains = set(domains).difference(equation.domains)
+        if invalid_domains:
+            raise ValueError(
+                f"Domains {invalid_domains} are not part of equation '{equation.name}'."
+            )
+        return equation
+
     def _parse_equations(
         self, equations: Optional[EquationList | EquationRestriction] = None
     ) -> dict[pp.ad.Operator, None | np.ndarray]:
@@ -1309,6 +1345,8 @@ class EquationSystem:
 
         Raises:
             ValueError: If the requested equation is not registered.
+            ValueError: If an equation is restricted to a domain on which it is not
+                defined.
 
         Returns:
             A dictionary with the index set of the restricted equations (referring to
@@ -1332,7 +1370,7 @@ class EquationSystem:
             # Equation names and domains are restricted.
 
             for eq, domains in equations.items():
-                eq = self._validate_equation_name(eq)
+                eq = self._validate_equation_restriction(eq, domains)
                 equation_dofs = equation_indexer.equation_image_space_composition[
                     eq.name
                 ]
@@ -1387,12 +1425,10 @@ class EquationSystem:
             # If idx is None, this means no filtering was done.
             if idx is not None:
                 # Get the indices associated with this equation.
-                all_idx = equation_indexer.equation_image_space_composition[
-                    name
-                ].values()
+                all_idx_list = equation_indexer.equation_image_space_composition[name]
                 all_idx = (
-                    np.concatenate(list(all_idx))
-                    if len(all_idx) > 0
+                    np.concatenate(list(all_idx_list.values()))
+                    if len(all_idx_list) > 0
                     else np.empty(0, dtype=int)
                 )
 
@@ -1467,20 +1503,9 @@ class EquationSystem:
         """Assemble Jacobian matrix and residual vector using a specified subset of
         equations, variables and grids.
 
-        The method is intended for use in splitting algorithms. Matrix blocks not
-        included will simply be sliced out.
-
-        Note:
-            The ordering of columns in the returned EquationSystem are defined by the
-            global DOF order. The row blocks are in the same order as equations were
-            added to this EquationSystem. If an equation is defined on multiple grids,
-            the respective row-block is internally ordered as given by the
-            mixed-dimensional grid (for sd in subdomains, for intf in interfaces).
-
-            The columns of the subsystem are assumed to be properly defined by
-            ``variables``, otherwise a matrix of shape ``(M,)`` is returned. This
-            happens if grid variables are passed which are unknown to this
-            :class:`EquationSystem`.
+        The ordering of rows and columns in the returned EquationSystem are defined
+        by the equation system's :attr:`equation_indexer` and
+        :attr:`variable_indexer`, respectively.
 
         Parameters:
             evaluate_jacobian: Whether to evaluate and return the Jacobian matrix.
@@ -1498,6 +1523,10 @@ class EquationSystem:
             state (optional): State vector to assemble from. By default, the
                 ``pp.ITERATE_SOLUTIONS`` or ``pp.TIME_STEP_SOLUTIONS`` are used, in that
                 order.
+
+        Raises:
+            ValueError: if the format of `equations` or `variables` is incorrect, or
+                they are not registered by this equation system.
 
         Returns:
             Tuple with two elements
@@ -1564,7 +1593,8 @@ class EquationSystem:
         # Multiply rhs by -1 to move to the rhs.
         if variables is not None:
             variable_indexer = self.variable_indexer
-            variables_ = self._parse_variable_type(variables=variables)
+            # Respect the ordering of the input list of variables.
+            variables_ = self._parse_variable_type(variables=variables, ordered=False)
             col_proj = [variable_indexer.variable_dofs[var] for var in variables_]
             column_projection = (
                 np.unique(np.concatenate(col_proj))
@@ -1591,8 +1621,9 @@ class EquationSystem:
 
         """
         if variables is not None:
+            # Respect the ordering of the input list of variables.
             variable_indexer = self.variable_indexer.construct_restricted_indexer(
-                self._parse_variable_type(variables=variables)
+                self._parse_variable_type(variables=variables, ordered=False)
             )
         else:
             variable_indexer = self.variable_indexer
@@ -1687,7 +1718,7 @@ class EquationSystem:
         primary_equation_names = list(primary_rows.keys())
 
         # Get the primary variables, represented as Ad variables.
-        active_variables = self._parse_variable_type(primary_variables)
+        active_variables = self._parse_variable_type(primary_variables, ordered=False)
 
         # Projection of variables to the set of primary blocks.
         primary_projection = self.projection_to(active_variables)

--- a/src/porepy/numerics/ad/equation_system.py
+++ b/src/porepy/numerics/ad/equation_system.py
@@ -217,7 +217,7 @@ class EquationSystem:
         """
         # Parse and validate input arguments. Will raise if unknown equations or
         # variables are requested
-        equations = set(self._parse_equation_names(equation_names))
+        equations = {eq.name for eq in self._parse_equations(equation_names)}
         variables = self._parse_variable_type(variable_names, ordered=True)
 
         # Create the new equation system.
@@ -350,60 +350,16 @@ class EquationSystem:
             offset += len(dofs)
         return pp.ad.VariableIndexer(variable_dofs=variable_dofs)
 
-    def construct_equation_indexer(
-        self, requested_equations: Optional[EquationList | EquationRestriction] = None
-    ) -> pp.ad.EquationIndexer:
-        """Construct an equation indexer for the requested_equations.
+    def construct_equation_indexer(self) -> pp.ad.EquationIndexer:
+        """Construct an equation indexer for all the registered equations.
 
         Equation ordering follows registration order. Equations not defined anywhere
         are excluded.
-
-        Parameters:
-            requested_equations: Equations to consider in the indexer. Note: ordering is
-            ignored. If None (default), constructs the indexer for all the registered
-            equations.
 
         Returns:
             The indexer.
 
         """
-        # We unfortunately have to parse quite a heterogeneous input. Similar parsing is
-        # done in _parse_equation_names and _parse_equations, but the results are
-        # different enough to prevent unification of the parsing logic. Here, we
-        # construct a lookup set of EquationOnDomain to filter the requested
-        # restriction.
-        if requested_equations is None:
-            # No restriction, include all equations on all domains.
-            requested_equations_lookup = {
-                pp.ad.EquationOnDomain(name=eq.name, domain=domain)
-                for eq in self._equations.values()
-                for domain in eq.domains
-            }
-        elif isinstance(requested_equations, list):
-            # Restrict equation names, do not restrict domains.
-            requested_equations_lookup = set()
-            for equation in requested_equations:
-                equation = self._validate_equation_name(equation)
-                for domain in equation.domains:
-                    requested_equations_lookup.add(
-                        pp.ad.EquationOnDomain(name=equation.name, domain=domain)
-                    )
-
-        elif isinstance(requested_equations, dict):
-            # Restrict equations and domains. Additionally, order domains.
-
-            def order_grids(grids: list[pp.GridLike]) -> list[pp.GridLike]:
-                indices = self.mdg.argsort_grids(grids)
-                return [grids[i] for i in indices]
-
-            requested_equations_lookup = set()
-            for eq, domains in requested_equations.items():
-                equation = self._validate_equation_restriction(eq, domains)
-                for domain in order_grids(domains):  # type: ignore[arg-type]
-                    requested_equations_lookup.add(
-                        pp.ad.EquationOnDomain(name=equation.name, domain=domain)
-                    )
-
         # Result dictionary.
         equation_dofs: dict[str, dict[pp.GridLike, np.ndarray]] = {}
 
@@ -415,13 +371,6 @@ class EquationSystem:
             offset = 0
 
             for domain in equation.domains:
-                if (
-                    pp.ad.EquationOnDomain(name=name, domain=domain)
-                    not in requested_equations_lookup
-                ):
-                    # The user did not request this equation-domain.
-                    continue
-
                 dofs_info = self.equation_image_size_info[name]
                 if isinstance(domain, pp.Grid):
                     dofs_per_grid = (
@@ -1227,41 +1176,6 @@ class EquationSystem:
         self._variable_indexer = None
         self._equation_indexer = None
 
-    def _parse_equation_names(
-        self, requested_equations: Optional[EquationList | EquationRestriction]
-    ) -> list[str]:
-        """Parses the user input in a heterogeneous format.
-
-        Raises:
-            ValueError: if one of the passed equations is not registered.
-            ValueError: if unsupported input format is passed.
-
-        Parameters:
-            requested_equations: If `None`, returns all registered equation names. If a
-                list of equations, returns their names. If a dictionary, ignores its
-                values.
-
-        Returns:
-            Requested equation names in input order.
-
-        """
-        if requested_equations is None:
-            return list(self._equations.keys())
-
-        if isinstance(requested_equations, dict):
-            requested_equations = list(requested_equations.keys())  # type: ignore[assignment]
-
-        assert isinstance(requested_equations, list)
-        equation_names: list[str] = list()
-        for equation in requested_equations:
-            if isinstance(equation, str):
-                equation_names.append(self._validate_equation_name(equation).name)
-            elif isinstance(equation, pp.ad.Operator):
-                equation_names.append(self._validate_equation_name(equation.name).name)
-            else:
-                raise ValueError(f"Unsupported input type: {equation}")
-        return equation_names
-
     ### System assembly and discretization ---------------------------------------------
 
     @staticmethod
@@ -1332,15 +1246,21 @@ class EquationSystem:
         return equation
 
     def _parse_equations(
-        self, equations: Optional[EquationList | EquationRestriction] = None
-    ) -> dict[pp.ad.Operator, None | np.ndarray]:
+        self,
+        equations: Optional[EquationList | EquationRestriction] = None,
+        ordered: bool = True,
+    ) -> list[pp.ad.EquationOnDomain]:
         """Helper method to parse equations into a properly ordered structure.
 
-        The equations will be ordered according to :attr:`equation_indexer`. Equations
-        not defined anywhere are filtered out.
+        The domains of the resulting equations will be ordered according to the MDG, the
+        input ordering of the domains will be ignored.
+
+        Equations not defined anywhere are filtered out.
 
         Parameters:
             equations: A list of equations or a dictionary of equation restrictions.
+            ordered: If True (default), the equations will be ordered according to
+            :attr:`equation_indexer`. Otherwise, the input ordering will be preserved.
 
         Raises:
             ValueError: If the requested equation is not registered.
@@ -1352,9 +1272,7 @@ class EquationSystem:
             equation rows) as values. If no restriction is given, the value is None.
 
         """
-
-        equation_rows: dict[pp.ad.Operator, np.ndarray | None] = {}
-        equation_indexer = self.equation_indexer
+        equations_on_domains: list[pp.ad.EquationOnDomain] = []
 
         if equations is None:
             # Requested are all the registered equations.
@@ -1363,42 +1281,34 @@ class EquationSystem:
         if isinstance(equations, list):
             # Equation names are restricted, domains are not restricted (None).
             for eq in equations:
-                equation_rows[self._validate_equation_name(eq)] = None
+                eq = self._validate_equation_name(eq)
+                for domain in eq.domains:
+                    # This assumes that eq.domains are already sorted.
+                    equations_on_domains.append(
+                        pp.ad.EquationOnDomain(name=eq.name, domain=domain)
+                    )
 
         elif isinstance(equations, dict):
             # Equation names and domains are restricted.
 
             for eq, domains in equations.items():
                 eq = self._validate_equation_restriction(eq, domains)
-                equation_dofs = equation_indexer.equation_image_space_composition[
-                    eq.name
-                ]
+                # Order domains based on the MDG and append.
                 domain_indices = self.mdg.argsort_grids(domains)
                 domains = [domains[i] for i in domain_indices]
-                rows_list = [equation_dofs[domain] for domain in domains]
-                equation_rows[eq] = (
-                    np.concatenate(rows_list)
-                    if len(rows_list)
-                    else np.empty(0, dtype=np.int64)
-                )
+                for domain in domains:
+                    equations_on_domains.append(
+                        pp.ad.EquationOnDomain(name=eq.name, domain=domain)
+                    )
 
-        # Filter equations defined on empty domains.
-        equation_rows = {
-            eq: dofs
-            for eq, dofs in equation_rows.items()
-            if len(equation_indexer.equation_image_space_composition.get(eq.name, []))
-            > 0
-        }
+        if not ordered:
+            return equations_on_domains
 
         # Order according to equation_indexer.
-        equation_order: dict[str, int] = {}
-        for i, name in enumerate(
-            self.equation_indexer.equation_image_space_composition
-        ):
-            equation_order[name] = i
-        return dict(
-            sorted(equation_rows.items(), key=lambda item: equation_order[item[0].name])
-        )
+        equation_order = {
+            eq: i for i, eq in enumerate(self.equation_indexer.equation_dofs)
+        }
+        return list(sorted(equations_on_domains, key=lambda eq: equation_order[eq]))
 
     def _gridbased_equation_complement(
         self, equations: dict[str, None | np.ndarray]
@@ -1457,7 +1367,11 @@ class EquationSystem:
                 known equations will be discretized.
 
         """
-        equation_names = self._parse_equation_names(equations)
+        equation_names = [
+            eq.name for eq in self._parse_equations(equations, ordered=False)
+        ]
+        # This keeps only unique names and preserves their original (input) order.
+        equation_names = list(dict.fromkeys(equation_names))
 
         # List containing all discretizations
         discr: list = []
@@ -1543,8 +1457,32 @@ class EquationSystem:
                 for the specified equations. Scaled with -1 (moved to rhs).
 
         """
-        # Standardized input, it is ordered.
-        equations_rows = self._parse_equations(equations=equations)
+        # Standardize and validate input, order it according to the equation_indexer.
+        equations_on_domains = self._parse_equations(equations=equations, ordered=True)
+
+        # Distinguish equations where restriction is required by comparing requested
+        # domains with domains of definition of the equation.
+        equation_name_to_domains: dict[str, list[pp.GridLike]] = {}
+        for eq in equations_on_domains:
+            equation_name_to_domains.setdefault(eq.name, []).append(eq.domain)
+
+        # Assembling the list of equations and their requested restriction (np.ndarray),
+        # or no restriction (None).
+        equations_rows: dict[pp.ad.Operator, np.ndarray | None] = {}
+        equation_image_space = self.equation_indexer.equation_image_space_composition
+        for eq_name, domains in equation_name_to_domains.items():
+            # eq_names are validated in _parse_equations, they must be registered.
+            equation = self._equations[eq_name]
+            if domains == equation.domains:
+                # Requested domains match the definition. No restriction is needed.
+                equations_rows[equation] = None
+            else:
+                # Concatenate restriction dofs.
+                domains_to_dofs = equation_image_space[eq_name]
+                dofs = [domains_to_dofs[domain] for domain in domains]
+                equations_rows[equation] = (
+                    np.concatenate(dofs) if len(dofs) else np.empty(0, dtype=int)
+                )
 
         # Data structures for building matrix and residual vector
         mat: list[sps.spmatrix] = []
@@ -1630,7 +1568,9 @@ class EquationSystem:
             variable_indexer = self.variable_indexer
 
         if equations is not None:
-            equation_indexer = self.construct_equation_indexer(equations)
+            equation_indexer = self.equation_indexer.construct_restricted_indexer(
+                self._parse_equations(equations=equations, ordered=False)
+            )
         else:
             equation_indexer = self.equation_indexer
 
@@ -1707,9 +1647,16 @@ class EquationSystem:
         # on their full image, and equations specified on a subset of grids.
         # The variable primary_rows will contain the indices in the global system
         # corresponding to the primary block.
-        primary_rows = {
-            eq.name: dofs
-            for eq, dofs in self._parse_equations(primary_equations).items()
+        equations_on_domaisn = self._parse_equations(primary_equations)
+        primary_rows_lists: dict[str, list[np.ndarray]] = {}
+        for eq in equations_on_domaisn:
+            primary_rows_lists.setdefault(eq.name, []).append(
+                self.equation_indexer.equation_image_space_composition[eq.name][
+                    eq.domain
+                ]
+            )
+        primary_rows: dict[str, None | np.ndarray] = {
+            name: np.concatenate(dofs) for name, dofs in primary_rows_lists.items()
         }
         # Find indices of equations involved in the primary block, but on grids that
         # were filtered out. These will be added to the secondary block.

--- a/src/porepy/numerics/ad/equation_system.py
+++ b/src/porepy/numerics/ad/equation_system.py
@@ -917,12 +917,8 @@ class EquationSystem:
         several exposed methods, allowing the user to specify a single variable or a
         list of variables more flexibly.
 
-        There is no filtering of the variables, for instance:
-
-            - No assumptions should be made on the order of the parsed variables.
-            - The variable list is not uniquified; if the same variable is passed twice
-              (say, as a Variable and by its string), it will duplicated in the list of
-              parsed variables.
+        Variables are filtered according to the ordering in the
+        :attr:`variable_indexer`.
 
         Parameters:
             variables: The input argument for the variable type.
@@ -937,25 +933,31 @@ class EquationSystem:
 
         """
         if variables is None:
-            return self.variables
-        parsed_variables = []
+            return list(self.variable_indexer.variable_dofs.keys())
+
+        parsed_variables_lookup: set[Variable] = set()
         assert isinstance(variables, list)
         for variable in variables:
             if isinstance(variable, MixedDimensionalVariable):
-                parsed_variables += [var for var in variable.sub_vars]
+                parsed_variables_lookup.update(variable.sub_vars)
             elif isinstance(variable, Variable):
-                parsed_variables.append(variable)
+                parsed_variables_lookup.add(variable)
             elif isinstance(variable, str):
-                # Use _variables to avoid recursion (get_variables() calls this method)
                 vars = [var for var in self._variables.values() if var.name == variable]
-                parsed_variables += vars
+                parsed_variables_lookup.update(vars)
             else:
                 raise ValueError(
                     "Variable type must be a string or a Variable, not {}".format(
                         type(variable)
                     )
                 )
-        return parsed_variables
+
+        parsed_variables_ordered: list[Variable] = []
+        for variable in self.variable_indexer.variable_dofs:
+            if variable in parsed_variables_lookup:
+                parsed_variables_ordered.append(variable)
+
+        return parsed_variables_ordered
 
     def num_dofs(self) -> int:
         """Returns the total number of dofs managed by this system."""

--- a/src/porepy/numerics/ad/equation_system.py
+++ b/src/porepy/numerics/ad/equation_system.py
@@ -1242,7 +1242,7 @@ class EquationSystem:
                 values.
 
         Returns:
-             Unordered set of requested equation names.
+            Requested equation names in input order.
 
         """
         if requested_equations is None:

--- a/src/porepy/numerics/ad/equation_system.py
+++ b/src/porepy/numerics/ad/equation_system.py
@@ -150,7 +150,7 @@ class EquationSystem:
         by this instance.
 
         Variables contained here are ordered chronologically in terms of
-        instantiation. The order in the default :attr:`variable_indexer` is different. 
+        instantiation. The order in the default :attr:`variable_indexer` is different.
 
         A Variable is uniquely identified by its name and domain, stored as attributes
         of the Variable object.
@@ -162,12 +162,12 @@ class EquationSystem:
         self._equation_indexer: pp.ad.EquationIndexer | None = None
         """Indexer defining the ordering of the equations (rows) when multiple equation
         values are packed in a single vector.
-        
+
         """
         self._variable_indexer: pp.ad.VariableIndexer | None = None
         """Indexer defining the ordering of the variables (columns) when multiple
         variable values are packed in a single vector.
-        
+
         """
         # Schur complement related stuff (to be removed in the next PR).
         self._Schur_complement: Optional[tuple] = None
@@ -267,7 +267,7 @@ class EquationSystem:
         and their block indices in the global system, for every equation
         set in this EquationSystem.
 
-        Note: It does not include equations with empty-domain equations.
+        Note: It does not include equations with empty domains.
 
         """
         warn(
@@ -340,7 +340,7 @@ class EquationSystem:
         """Construct a variable indexer for all the variables registered in this
         equation system.
 
-        The ordering of registered variables is determinded by
+        The ordering of registered variables is determined by
         :func:`cluster_dofs_gridwise`.
 
         Returns:
@@ -364,8 +364,8 @@ class EquationSystem:
     ) -> pp.ad.EquationIndexer:
         """Construct an equation indexer for the requested_equations.
 
-        The ordering of equations is determinded by the order they were registered in
-        this equation system. Equations not defined anywhere are excluded.
+        Equation ordering follows registration order. Equations not defined anywhere
+        are excluded.
 
         Parameters:
             requested_equations: Equations to consider in the indexer. Note: ordering is
@@ -376,9 +376,9 @@ class EquationSystem:
             The indexer.
 
         """
-        # We unfortunately have to parse quite a heterogenuous input. Similar parsing is
+        # We unfortunately have to parse quite a heterogeneous input. Similar parsing is
         # done in _parse_equation_names and _parse_equations, but the results are
-        # different enought to prevent unification of the parsing logic. Here, we
+        # different enough to prevent unification of the parsing logic. Here, we
         # construct a lookup set of EquationOnDomain to filter the requested
         # restriction.
         if requested_equations is None:
@@ -1140,8 +1140,8 @@ class EquationSystem:
             f"Equation defined on unknown domains: {unknown_domains}"
         )
 
-        # Storing the ordered domains of definition in the equation object. It may
-        # already contain domains, then makings sure they are equal.
+        # Store the ordered equation domains. The equation may
+        # already contain domains, in which case make sure they are equal.
         ordered_domain_indices = self.mdg.argsort_grids(grids)
         ordered_domains = [grids[i] for i in ordered_domain_indices]
         if equation.domains is None or len(equation.domains) == 0:
@@ -1242,7 +1242,7 @@ class EquationSystem:
     def _parse_equation_names(
         self, requested_equations: Optional[EquationList | EquationRestriction]
     ) -> set[str]:
-        """Parses the user input in a heterogenous format.
+        """Parses the user input in a heterogeneous format.
 
         Raises:
             ValueError: if one of the passed equations is not registered.
@@ -1555,7 +1555,7 @@ class EquationSystem:
                 for the specified equations. Scaled with -1 (moved to rhs).
 
         """
-        # Standartized input, it is ordered.
+        # Standardized input, it is ordered.
         equations_rows = self._parse_equations(equations=equations)
 
         # Data structures for building matrix and residual vector
@@ -1625,8 +1625,8 @@ class EquationSystem:
         """Generate indexers for the linear system produced by :meth:`assemble`.
 
         Parameters:
-            equations: Equations restriction, same as an argument to :meth:`assemble`.
-            variables: Variables restriction, same as an argument to :meth:`assemble`.
+            equations: Equation restriction passed to :meth:`assemble`.
+            variables: Variable restriction passed to :meth:`assemble`.
 
         Returns:
             `equation_indexer` and `variable_indexer`. If no restriction is requested,

--- a/src/porepy/numerics/ad/equation_system.py
+++ b/src/porepy/numerics/ad/equation_system.py
@@ -5,8 +5,8 @@ using the AD framework.
 
 from __future__ import annotations
 
-from functools import lru_cache
-from typing import Any, Callable, Literal, Optional, Sequence, Union, cast, overload
+from collections import defaultdict
+from typing import Any, Callable, Literal, Optional, Sequence, Union, overload
 
 import numpy as np
 import scipy.sparse as sps
@@ -129,16 +129,6 @@ class EquationSystem:
         self.mdg: pp.MixedDimensionalGrid = mdg
         """Mixed-dimensional domain passed at instantiation."""
 
-        self.assembled_equation_indices: dict[str, np.ndarray] = dict()
-        """Contains the row indices in the last assembled (sub-) system for a given
-        equation name (key).
-
-        This dictionary changes with every call to any assemble-method, provided the
-        method is invoked to assemble *both* Jacobian matrix *and* the residual vector
-        (argument ``evaluate_jacobian=True``) If only the residual vector is assembled,
-        the indices is not updated.
-        """
-
         ### PRIVATE
 
         self._equations: dict[str, Operator] = dict()
@@ -146,20 +136,6 @@ class EquationSystem:
 
         Private to avoid users setting equations directly and circumventing the current
         set-method which includes information about the image space.
-
-        """
-
-        self._equation_image_space_composition: dict[
-            str, dict[pp.GridLike, np.ndarray]
-        ] = dict()
-        """Definition of image space for all equations.
-
-        Contains for every equation name (key) a dictionary, which provides again for
-        every involved grid (key) the indices of equations expressed through the
-        equation operator. The ordering of the items in the grid-array dictionaries is
-        consistent with the remaining PorePy framework. The ordering is local to the
-        equation, so it can be used to slice an eqution prior to concatenation of
-        equations into a global matrix.
 
         """
 
@@ -175,7 +151,7 @@ class EquationSystem:
 
         Variables contained here are ordered chronologically in terms of
         instantiation. It does not reflect the order of DOFs, which is to some degree
-        optimized.
+        optimized. TODO YZ
 
         A Variable is uniquely identified by its name and domain, stored as attributes
         of the Variable object.
@@ -184,35 +160,16 @@ class EquationSystem:
 
         """
 
+        self._equation_indexer: pp.ad.EquationIndexer | None = None
+        """Indexer defining the canonical row ordering of the equation system."""
+        self._variable_indexer: pp.ad.VariableIndexer | None = None
+        """Indexer defining the canonical column ordering of the equation system."""
+
+        # Schur complement related stuff (to be removed in the next PR).
         self._Schur_complement: Optional[tuple] = None
         """Contains block matrices and the rhs of the last assembled Schur complement.
 
         """
-
-        self._variable_numbers: dict[int, int] = dict()
-        """A Map between a variable's ID and its index in the system vector.
-
-        This is an optimized structure, meaning the order of entries is created in
-        :meth:`_cluster_dofs_gridwise`.
-
-        """
-
-        self._variable_num_dofs: np.ndarray = np.array([], dtype=int)
-        """Array containing the number of DOFS per block number.
-
-        The block number corresponds to this array's indexation, see also
-        attr:`_variable_numbers`.
-
-        """
-
-        self._variable_dof_type: dict[int, dict[GridEntity, int]] = dict()
-        """Dictionary mapping from variable IDs to the type of DOFs per variable.
-
-        The type is given as a dictionary with keys 'cells', 'faces' or 'nodes',
-        and integer values denoting the number of DOFs per grid entity.
-
-        """
-
         self._ad_parser = _ad_parser.AdParser(self.mdg)
 
         self._secondary_block_permutation: dict[
@@ -255,7 +212,7 @@ class EquationSystem:
 
         """
         # Parsing of input arguments.
-        equations = list(self._parse_equations(equation_names).keys())
+        equations = self._parse_equation_names(equation_names)
         variables = self._parse_variable_type(variable_names)
 
         # Check that the requested equations and variables are known to the equation
@@ -281,27 +238,13 @@ class EquationSystem:
                 # Update variables.
                 new_equation_system._variables[variable.id] = variable
 
-                # Update variable numbers.
-                new_equation_system._variable_dof_type[variable.id] = (
-                    self._variable_dof_type[variable.id]
-                )
-
-                # Create DOFs.
-                new_equation_system._append_dofs(variable)
-
-        new_equation_system._cluster_dofs_gridwise()
         # Loop over known equations to preserve row order.
         for name in known_equations:
             if name in equations:
                 equation = self._equations[name]
                 image_info = self._equation_image_size_info[name]
-                image_composition = self._equation_image_space_composition[name]
-                # et the information produced in set_equations directly.
-                new_equation_system._equation_image_space_composition.update(
-                    {name: image_composition}
-                )
-                new_equation_system._equation_image_size_info.update({name: image_info})
-                new_equation_system._equations.update({name: equation})
+                new_equation_system._equation_image_size_info[name] = image_info
+                new_equation_system._equations[name] = equation
 
         return new_equation_system
 
@@ -322,7 +265,8 @@ class EquationSystem:
         set in this EquationSystem.
 
         """
-        return self._equation_image_space_composition
+        # TODO YZ: Deprecation warning?
+        self.equation_indexer.equation_dofs_per_equation
 
     @property
     def equation_image_size_info(self) -> dict[str, dict["GridEntity", int]]:
@@ -347,6 +291,72 @@ class EquationSystem:
         for var in self.variables:
             domains.add(var.domain)
         return list(domains)
+
+    ### Indexers -----------------------------------------------------------------------
+
+    @property
+    def variable_indexer(self) -> pp.ad.VariableIndexer:
+        if self._variable_indexer is None:
+            self._variable_indexer = self.construct_variable_indexer()
+        return self._variable_indexer
+
+    @property
+    def equation_indexer(self) -> pp.ad.EquationIndexer:
+        if self._equation_indexer is None:
+            self._equation_indexer = self.construct_equation_indexer()
+        return self._equation_indexer
+
+    def construct_variable_indexer(
+        self, requested_variables: Optional[VariableList] = None
+    ) -> pp.ad.VariableIndexer:
+        """Construct an indexer for a requested variable subspace."""
+        requested_variables = self._parse_variable_type(requested_variables)
+        requested_variables_lookup = set(requested_variables)
+
+        variable_dofs: dict[pp.ad.Variable, np.ndarray] = {}
+        offset = 0
+
+        ordered_variables = cluster_dofs_gridwise(requested_variables)
+
+        for var in ordered_variables:
+            if var not in requested_variables_lookup:
+                continue
+            dofs_per_grid = var.size
+            dofs = np.arange(dofs_per_grid) + offset
+            variable_dofs[var] = dofs
+            offset += len(dofs)
+        return pp.ad.VariableIndexer(variable_dofs=variable_dofs)
+
+    def construct_equation_indexer(self) -> pp.ad.EquationIndexer:
+        """TODO YZ"""
+        equation_dofs: dict[str, dict[pp.GridLike, np.ndarray]] = {}
+        # self.equations stores a canonical order of equations.
+        for name, equation in self.equations.items():
+            dofs_on_domains: dict[pp.GridLike, np.ndarray] = {}
+            equation_dofs[name] = dofs_on_domains
+
+            offset = 0
+
+            for domain in equation.domains:
+                dofs_info = self.equation_image_size_info[name]
+                if isinstance(domain, pp.Grid):
+                    dofs_per_grid = (
+                        domain.num_cells * dofs_info.get("cells", 0)  # cells
+                        + domain.num_faces * dofs_info.get("faces", 0)  # faces
+                        + domain.num_nodes * dofs_info.get("nodes", 0)  # nodes
+                    )
+                elif isinstance(domain, pp.MortarGrid):
+                    # Mortar grid has no faces.
+                    dofs_per_grid = (
+                        domain.num_cells * dofs_info.get("cells", 0)  # cells
+                        + domain.num_nodes * dofs_info.get("nodes", 0)  # nodes
+                    )
+                else:
+                    raise ValueError(type(domain))
+                dofs = np.arange(dofs_per_grid) + offset
+                dofs_on_domains[domain] = dofs
+                offset += len(dofs)
+        return pp.ad.EquationIndexer(equation_dofs_per_equation=equation_dofs)
 
     ### Variable management ------------------------------------------------------------
 
@@ -501,15 +511,11 @@ class EquationSystem:
             variables.append(new_variable)
             self._variables[new_variable.id] = new_variable
 
-            # Append the new DOFs to the global system.
-            self._variable_dof_type[new_variable.id] = dof_info
-            self._append_dofs(new_variable)
-
-        # New optimized order
-        self._cluster_dofs_gridwise()
         # Create an md variable that wraps all the individual variables created on
         # individual grids.
         merged_variable = MixedDimensionalVariable(variables)
+
+        self._variable_indexer = None
 
         return merged_variable
 
@@ -531,13 +537,11 @@ class EquationSystem:
                 raise ValueError(
                     f"Variable {var.name} (ID: {var.id}) not known to the system."
                 )
-            # Remove the variable from the system. _variables, _variable_dof_type and
-            # _variable_numbers are indexed by variable id.
+            # Remove the variable from the system.
             del self._variables[var.id]
-            self._variable_dof_type.pop(var.id)
-            self._variable_numbers.pop(var.id)
-            # Update the variable clustering. This also updates _variable_num_dofs.
-            self._cluster_dofs_gridwise()
+
+        # Invalidate variable indexer forces to recompute it next time when accessed.
+        self._variable_indexer = None
 
     def update_variable_tags(
         self,
@@ -555,8 +559,6 @@ class EquationSystem:
                 grids).
 
         """
-        assert isinstance(variables, list)
-
         variables = self._parse_variable_type(variables)
         for var in variables:
             var.tags.update(tags)
@@ -653,25 +655,20 @@ class EquationSystem:
         """
         # Normalize the variable input.
         variables = self._parse_variable_type(variables)
-        var_ids = {var.id for var in variables}
+        variable_ids = {variable.id for variable in variables}
 
         # Storage for atomic blocks of the sub vector (identified by name-grid pairs).
         values = []
 
-        # Cache for domain data to avoid recomputing it for the same domain.
-        data_cache = {}
-
-        for id_ in self._variable_numbers:
-            if id_ in var_ids:
-                variable = self._variables[id_]
+        # Indexer determines canonical (global) ordering.
+        indexer = self.variable_indexer
+        for variable in indexer.variable_dofs.keys():
+            if variable.id in variable_ids:
                 domain = variable.domain
-
-                if domain not in data_cache:
-                    data_cache[domain] = self._get_data(domain)
 
                 val = pp.get_solution_values(
                     variable.name,
-                    data_cache[domain],
+                    self._get_data(domain),
                     time_step_index=time_step_index,
                     iterate_index=iterate_index,
                     reference=reference,
@@ -727,13 +724,14 @@ class EquationSystem:
         dof_start = 0
         dof_end = 0
         variables = self._parse_variable_type(variables)
-        var_ids = [var.id for var in variables]
+        var_ids = {var.id for var in variables}
 
-        for id_, variable_number in self._variable_numbers.items():
-            if id_ in var_ids:
+        # Indexer determines canonical (global) ordering.
+        indexer = self.variable_indexer
+        for variable, dofs in indexer.variable_dofs.items():
+            if variable.id in var_ids:
                 # 1. Slice the vector to local size
-                # This will raise errors if indexation is out of range.
-                num_dofs = int(self._variable_num_dofs[variable_number])
+                num_dofs = dofs.size
                 # Extract local vector.
                 # This will raise errors if indexation is out of range.
                 dof_end = dof_start + num_dofs
@@ -741,8 +739,7 @@ class EquationSystem:
                 # This will raise errors if indexation is out of range.
                 local_vec = values[dof_start:dof_end]
 
-                # 2.  Use the AD utilities to set the values
-                variable = self._variables[id_]
+                # 2. Use the AD utilities to set the values
                 pp.set_solution_values(
                     variable.name,
                     local_vec,
@@ -821,91 +818,6 @@ class EquationSystem:
 
     ### DOF management -----------------------------------------------------------------
 
-    def _append_dofs(self, variable: pp.ad.Variable) -> None:
-        """Appends DOFs for a newly created variable at the end of the current order.
-
-        Optimization of variable order is done afterwards.
-
-        Must only be called by :meth:`create_variables`.
-
-        Parameters:
-            variable: The newly created variable
-
-        """
-        # number of totally created dof blocks so far
-        last_variable_number: int = len(self._variable_numbers)
-
-        # Sanity check that no previous data is overwritten. This should not happen,
-        # if class not used in hacky way.
-        assert variable.id not in self._variable_numbers
-
-        # Count number of dofs for this variable on this grid and store it.
-        # The number of dofs for each dof type defaults to zero.
-
-        local_dofs = self._variable_dof_type[variable.id]
-        # Both subdomains and interfaces have cell variables.
-        num_dofs = variable.domain.num_cells * local_dofs.get("cells", 0)
-
-        # For subdomains, but not interfaces, we also need to account for faces and
-        # nodes.
-        if isinstance(variable.domain, pp.Grid):
-            num_dofs += variable.domain.num_faces * local_dofs.get(
-                "faces", 0
-            ) + variable.domain.num_nodes * local_dofs.get("nodes", 0)
-
-        # Update the global dofs and block numbers
-        self._variable_numbers.update({variable.id: last_variable_number})
-        self._variable_num_dofs = np.concatenate(
-            [self._variable_num_dofs, np.array([num_dofs], dtype=int)]
-        )
-        # Clear cache since the global variable dofs have changed.
-        self._global_variable_dofs.cache_clear()
-
-    def _cluster_dofs_gridwise(self) -> None:
-        """Re-arranges the DOFs grid-wise s.t. we obtain grid-blocks in the column sense
-        and reduce the matrix bandwidth.
-
-        The aim is to impose a more block-diagonal-like structure on the Jacobian where
-        blocks in the column sense represent single grids in the following order:
-
-        1. For each grid in ``mdg.subdomains``
-            1. For each variable defined on that grid
-        2. For each grid in ``mdg.interfaces``
-            1. For each variable defined on that mortar grid
-
-        The order of variables per grid is given by the order of variable creation.
-        This method is called after each creation of variables and respective DOFs.
-
-        """
-        # Data stracture for the new order of dofs.
-        new_variable_counter: int = 0
-        new_variable_numbers: dict[int, int] = dict()
-        new_block_dofs: list[int] = list()
-
-        # 1. Per subdomain, order variables
-        for grid in self.mdg.subdomains():
-            for id_, variable in self._variables.items():
-                if variable.domain == grid:
-                    local_dofs = self._variable_num_dofs[self._variable_numbers[id_]]
-                    new_block_dofs.append(local_dofs)
-                    new_variable_numbers.update({id_: new_variable_counter})
-                    new_variable_counter += 1
-
-        # 2. Per interface, order variables
-        for intf in self.mdg.interfaces():
-            for id_, variable in self._variables.items():
-                if variable.domain == intf:
-                    local_dofs = self._variable_num_dofs[self._variable_numbers[id_]]
-                    new_block_dofs.append(local_dofs)
-                    new_variable_numbers.update({id_: new_variable_counter})
-                    new_variable_counter += 1
-
-        # Replace old block order
-        self._variable_num_dofs = np.array(new_block_dofs, dtype=int)
-        self._variable_numbers = new_variable_numbers
-        # Clear cache since the global variable dofs have changed.
-        self._global_variable_dofs.cache_clear()
-
     def _parse_variable_type(self, variables: Optional[VariableList]) -> list[Variable]:
         """Parse the input argument for the variable type.
 
@@ -953,41 +865,9 @@ class EquationSystem:
                 )
         return parsed_variables
 
-    def _gridbased_variable_complement(self, variables: VariableList) -> list[Variable]:
-        """Finds the grid-based complement of a variable-like structure.
-
-        The grid-based complement consists of all variables known to this
-        EquationSystem, but which are not in the passed list ``variables``.
-
-        TODO: Revisit. This method is not used anywhere, and I am not sure it is
-        correct/does what it is supposed to do.
-        """
-
-        # strings and md variables represent always a whole in the variable sense.
-        # Hence, the complement is empty
-        if isinstance(variables, (str, MixedDimensionalVariable)):
-            # TODO: Can we drop this, or is it possible that a single variable has made
-            # it into this subroutine?
-            return list()
-
-        # non sequential var-like structure
-        else:
-            grid_variables = list()
-            for variable in variables:
-                # same processing as above, only grid variables are of interest
-                if isinstance(variable, Variable):
-                    md_variable = self.md_variable(variable.name)
-                    grid_variables += [
-                        var
-                        for var in md_variable.sub_vars
-                        if var.domain != variable.domain
-                    ]
-            # return a unique collection
-            return list(set(grid_variables))
-
     def num_dofs(self) -> int:
         """Returns the total number of dofs managed by this system."""
-        return self._global_variable_dofs()[-1]
+        return self.variable_indexer.num_dofs
 
     def projection_to(self, variables: Optional[VariableList] = None) -> sps.csr_matrix:
         """Create a projection matrix from the global vector of unknowns to a specified
@@ -1013,8 +893,8 @@ class EquationSystem:
         num_dofs = self.num_dofs()
         if variables:
             # Array for the indices associated with argument.
-            # The sort is needed so as not to permute the columns of the projection.
-            indices = np.sort(self.dofs_of(variables))
+            # The ordering is preserved in variable_indexer.
+            indices = self.variable_indexer.projection_to(variables=variables)
             # case where no dofs where found for the VariableType input
             if len(indices) == 0:
                 return sps.csr_matrix((0, num_dofs))
@@ -1027,17 +907,6 @@ class EquationSystem:
         # Case where the subspace is null, i.e. no variables specified
         else:
             return sps.csr_matrix((0, num_dofs))
-
-    @lru_cache
-    def _global_variable_dofs(self) -> np.ndarray:
-        """Compute the global DOF indices for each variable block.
-
-        Returns:
-            An array of indices corresponding to the global DOF indices for each
-            variable block.
-
-        """
-        return np.hstack((0, np.cumsum(self._variable_num_dofs)))
 
     def dofs_of(self, variables: VariableList) -> np.ndarray:
         """Get the indices in the global vector of unknowns belonging to the variables.
@@ -1054,67 +923,16 @@ class EquationSystem:
 
         """
         variables = self._parse_variable_type(variables)
-        global_variable_dofs = self._global_variable_dofs()
-
-        indices: list[np.ndarray] = []
-
-        for var in variables:
-            if var.id in self._variable_numbers:
-                variable_number = self._variable_numbers[var.id]
-                var_indices = np.arange(
-                    global_variable_dofs[variable_number],
-                    global_variable_dofs[variable_number + 1],
-                    dtype=int,
-                )
-                indices.append(var_indices)
-            else:
-                raise ValueError(
-                    f"Variable {var.name} with ID {var.id} not registered among DOFS"
-                    + f" of equation system {self}."
-                )
-
-        # Concatenate indices, if any
-        if len(indices) > 0:
-            all_indices = np.concatenate(indices, dtype=int)
-        else:
-            all_indices = np.array([], dtype=int)
-
-        return all_indices
-
-    def identify_dof(self, dof: int) -> Variable:
-        """Identifies the variable to which a specific DOF index belongs.
-
-        The intended use is to help identify entries in the global vector or the column
-        of the Jacobian.
-
-        Parameters:
-            dof: a single index in the global vector.
-
-        Returns: the identified Variable object.
-
-        Raises:
-            KeyError: if the dof is out of range (larger than ``num_dofs`` or smaller
-                than 0).
-
-        """
-        num_dofs = self.num_dofs()
-        if not (0 <= dof < num_dofs):  # indices go from 0 to num_dofs - 1
-            raise KeyError("Dof index out of range.")
-
-        global_variable_dofs = self._global_variable_dofs()
-        # Find the variable number belonging to this index
-        variable_number = np.argmax(global_variable_dofs > dof) - 1
-        # Get the variable key from _variable_numbers
-        # find the ID belonging to the dof
-        id_ = [
-            id_ for id_, num in self._variable_numbers.items() if num == variable_number
-        ]
-        # sanity check that only 1 ID was found
-        assert len(id_) == 1, "Failed to find unique ID corresponding to `dof`."
-        # find variable with the ID
-        variable = [var for _id, var in self._variables.items() if _id == id_[0]]
-        assert len(variable) == 1, "Failed to find Variable corresponding to `dof`."
-        return variable[0]
+        unknown_variables = set(variables).difference(
+            self.variable_indexer.variable_dofs
+        )
+        if unknown_variables:
+            raise ValueError(
+                "Variables not registered by this equation system: "
+                f"{unknown_variables}."
+            )
+        dofs = [self.variable_indexer.variable_dofs[var] for var in variables]
+        return np.concatenate(dofs) if len(dofs) > 0 else np.empty(0, dtype=np.int64)
 
     ### Equation management ------------------------------------------------------------
 
@@ -1159,13 +977,7 @@ class EquationSystem:
                 number as per evaluation of operator.
 
         """
-        # The grid list is changed in place, so we need to make a copy
-        grids = grids[:]
-        # The function loops over all grids the operator is defined on and calculate the
-        # number of equations per grid quantity (cell, face, node). This information
-        # is then stored together with the equation itself.
-        image_info: dict[pp.GridLike, np.ndarray] = dict()
-        total_num_equ = 0
+        self._equation_indexer = None
 
         # The domain of this equation is the set of grids on which it is defined
         name = equation.name
@@ -1178,7 +990,6 @@ class EquationSystem:
 
         # If no grids are specified, there is nothing to do
         if not grids:
-            self._equation_image_space_composition.update({name: image_info})
             # Information on the size of the equation, in terms of the grids it is
             # defined on.
             self._equation_image_size_info.update({name: equations_per_grid_entity})
@@ -1203,49 +1014,22 @@ class EquationSystem:
                 "An equation should not be defined on both subdomains and interfaces."
             )
 
-        # We loop over the subdomains and interfaces in that order to assert a correct
-        # indexation according to the global order (for grid in subdomains, for grid in
-        # interfaces). The user does not have to care about the order in grids.
-        for sd in self.mdg.subdomains():
-            if sd in grids:
-                # Equations on subdomains can be defined on any grid quantity.
-                num_equ_per_grid = int(
-                    sd.num_cells * equations_per_grid_entity.get("cells", 0)
-                    + sd.num_nodes * equations_per_grid_entity.get("nodes", 0)
-                    + sd.num_faces * equations_per_grid_entity.get("faces", 0)
-                )
-                # Row indices for this grid, cast to integers.
-                block_idx = np.arange(num_equ_per_grid, dtype=int) + total_num_equ
-                # Cumulate total number of equations.
-                total_num_equ += num_equ_per_grid
-                # Store block idx per grid.
-                image_info.update({sd: block_idx})
-                # Remove the subdomain from the domain list.
-                # Ignore mypy error here, since we know that sd is in grids.
-                grids.remove(sd)  # type: ignore
-
-        for intf in self.mdg.interfaces():
-            if intf in grids:
-                # Equations on interfaces can only be defined on cells.
-                num_equ_per_grid = int(
-                    intf.num_cells * equations_per_grid_entity.get("cells", 0)
-                )
-                # Row indices for this grid, cast to integers.
-                block_idx = np.arange(num_equ_per_grid, dtype=int) + total_num_equ
-                # Cumulate total number of equations.
-                total_num_equ += num_equ_per_grid
-                # Store block idx per grid
-                image_info.update({intf: block_idx})
-                # Remove the grid from the domain list
-                # Ignore mypy error here, since we know that intf is in grids.
-                grids.remove(intf)  # type: ignore
-
         # Assert the equation is not defined on an unknown domain.
-        assert len(grids) == 0
+        known_domains = set(self.mdg.subdomains()) | set(self.mdg.interfaces())
+        unknown_domains = set(grids).difference(known_domains)
+        assert not unknown_domains, (
+            f"Equation defined on unknown domains: {unknown_domains}"
+        )
+
+        # TODO: YZ explain
+        ordered_domain_indices = self.mdg.argsort_grids(grids)
+        ordered_domains = [grids[i] for i in ordered_domain_indices]
+        if equation.domains is None or len(equation.domains) == 0:
+            equation._domains = ordered_domains
+        else:
+            assert equation.domains == ordered_domains
 
         # If all good, we store the information:
-        # The rows (referring to a global indexation) that this equation provides.
-        self._equation_image_space_composition.update({name: image_info})
         # Information on the size of the equation, in terms of the grids it is defined
         # on.
         self._equation_image_size_info.update({name: equations_per_grid_entity})
@@ -1266,10 +1050,11 @@ class EquationSystem:
         if name in self._equations:
             # Remove the equation from the storage
             equ = self._equations.pop(name)
-            # Remove the image space information.
+            # Remove the number of dofs per cell / face / node information.
             # Note that there is no need to modify the numbering of the other equations,
             # since this is a local (to the equation) numbering.
-            del self._equation_image_space_composition[name]
+            del self._equation_image_size_info[name]
+            self._equation_indexer = None
             return equ
         else:
             raise ValueError(f"Cannot remove unknown equation {name}")
@@ -1301,10 +1086,8 @@ class EquationSystem:
 
         """
         if grids is None:
-            grids = cast(
-                list[pp.Grid] | list[pp.MortarGrid],
-                list(self._equation_image_space_composition[equation_name].keys()),
-            )
+            grids = self._equations[equation_name].domains  # type: ignore[assignment]
+            assert grids is not None and len(grids) > 0
 
         if equations_per_grid_entity is None:
             equations_per_grid_entity = self._equation_image_size_info[equation_name]
@@ -1325,29 +1108,38 @@ class EquationSystem:
         (perhaps less realistically) a variable has had its number of dofs per grid
         quantity changed.
 
-        NOTE: This method is experimental and should be used with caution. After this
-        method has been called, other attributes of the class that depend on the number
-        of dofs (such as _equation_image_space_composition) will be outdated and should
-        be used with care.
-
         """
-        for id_, var in self._variables.items():
-            # Grid quantity (grid or interface), and variable
-            grid = var.domain
+        # Invalidate indexers to force their recomputation next time when accessed.
+        self._variable_indexer = None
+        self._equation_indexer = None
 
-            dof = self._variable_dof_type[id_]
-            num_dofs: int = grid.num_cells * dof.get("cells", 0)  # type: ignore
+    def _parse_equation_names(
+        self, requested_equations: Optional[EquationList | EquationRestriction]
+    ) -> set[str]:
+        def validate_equation_name(name: str) -> str:
+            if name not in self._equations:
+                raise ValueError(
+                    f"Requested equation with name '{name}' is not registered "
+                    "in this equation system."
+                )
+            return name
 
-            if isinstance(grid, pp.Grid):
-                # Add dofs on faces and nodes, but not on interfaces
-                num_dofs += grid.num_faces * dof.get(
-                    "faces", 0
-                ) + grid.num_nodes * dof.get("nodes", 0)
+        if requested_equations is None:
+            return set(self._equations.keys())
 
-            # Update local counting
-            self._variable_num_dofs[self._variable_numbers[id_]] = num_dofs
-        # Clear cache since the global variable dofs have changed.
-        self._global_variable_dofs.cache_clear()
+        if isinstance(requested_equations, dict):
+            requested_equations = list(requested_equations.keys())
+
+        assert isinstance(requested_equations, list)
+        equation_names = set()
+        for equation in requested_equations:
+            if isinstance(equation, str):
+                equation_names.add(validate_equation_name(name=equation))
+            elif isinstance(equation, pp.ad.Operator):
+                equation_names.add(validate_equation_name(name=equation.name))
+            else:
+                raise ValueError(f"Unsupported input type: {equation}")
+        return equation_names
 
     ### System assembly and discretization ---------------------------------------------
 
@@ -1374,7 +1166,7 @@ class EquationSystem:
 
     def _parse_equations(
         self, equations: Optional[EquationList | EquationRestriction] = None
-    ) -> dict[str, None | np.ndarray]:
+    ) -> dict[pp.ad.Operator, None | np.ndarray]:
         """Helper method to parse equations into a properly ordered structure.
 
         The equations will be ordered according to the order in self._equations (which
@@ -1390,157 +1182,53 @@ class EquationSystem:
 
         """
 
-        # The default return value is all equations defined on non-empty domains
-        # with no grid restriction.
-        if equations is None:
-            # Precompute equations on non-empty domain. This is to avoid
-            # injecting equations with empty-domain into the assembly pipeline.
-            non_empty_equations = [
-                name
-                for name in self._equations
-                if sum(
-                    len(indices)
-                    for indices in self._equation_image_space_composition[name].values()
+        # Store equations together with optional row restrictions, then sort them in
+        # the canonical order in which equations were added to this system.
+
+        def validate_equation_name(equation: str | pp.ad.Operator) -> pp.ad.Operator:
+            if isinstance(equation, pp.ad.Operator):
+                equation = equation.name
+
+            equation_or_none = self._equations.get(equation, None)
+            if equation_or_none is None:
+                raise ValueError(
+                    f"Requested equation with name '{equation}' is not registered "
+                    "in this equation system."
                 )
-                > 0
-            ]
+            return equation_or_none
 
-            return dict((name, None) for name in non_empty_equations)
+        equation_rows: dict[pp.ad.Operator, np.ndarray | None] = {}
+        equation_indexer = self.equation_indexer
 
-        # We need to parse the input.
-        # Storage for requested blocks, unique information per equation name.
-        requested_row_blocks = dict()
-        # Storage for restricted equations.
-        restricted_equations = dict()
+        if equations is None:
+            equations = list(self.equations.keys())
 
-        # Get the row indices (in the global system) associated with this equation.
-        # If the equation is restricted (the user has provided a dictionary with
-        # grids on which the equation should be evaluated), the variable blocks
-        # will contain only the row indices associated with the restricted grids.
+        if isinstance(equations, list):
+            for eq in equations:
+                equation_rows[validate_equation_name(eq)] = None
 
-        for equation in equations:
-            # Store restrictions, using different storage for restricted and
-            # unrestricted equations.
-            if isinstance(equations, dict):
-                block = self._parse_single_equation({equation: equations[equation]})
-                # A dictionary means the equation is restricted to a subset of grids.
-                restricted_equations.update(block)
-            else:
-                # This equation is not restricted to a subset of grids.
-                block = self._parse_single_equation(equation)
-                requested_row_blocks.update(block)
+        elif isinstance(equations, dict):
+            for eq, domains in equations.items():
+                eq = validate_equation_name(eq)
+                equation_dofs = equation_indexer.equation_dofs_per_equation[eq.name]
+                domain_indices = self.mdg.argsort_grids(domains)
+                domains = [domains[i] for i in domain_indices]
+                rows_list = [equation_dofs[domain] for domain in domains]
+                equation_rows[eq] = (
+                    np.concatenate(rows_list) if len(rows_list) else np.empty(0)
+                )
 
-        # Update the requested blocks with the restricted to overwrite the indices if
-        # an equation was passed in both restricted and unrestricted structure.
-        requested_row_blocks.update(restricted_equations)
+        # Filter equations defined on empty domains.
+        equation_rows = {
+            eq: dofs
+            for eq, dofs in equation_rows.items()
+            if len(equation_indexer.equation_dofs_per_equation[eq.name]) > 0
+        }
 
-        # Build the restricted set of equations, using the order in self._equations.
-        # The latter is critical for ensuring determinism of the system.
-        ordered_blocks = dict()
-        for equation in self._equations:
-            # By now, all equations are contained in requested_row_blocks.
-            if equation in requested_row_blocks:
-                ordered_blocks.update({equation: requested_row_blocks[equation]})
-
-        return ordered_blocks
-
-    def _parse_single_equation(
-        self, equation: str | Operator | EquationRestriction
-    ) -> dict[str, None | np.ndarray]:
-        """Helper method to identify possible restrictions of a single equation.
-
-        Parameters:
-            equation: Equation to be parsed.
-
-        Returns:
-            A dictionary with the name of the equation as key and the corresponding
-            restricted indices as values. If no restriction is given, the value is None.
-
-        Raises:
-            ValueError: If an unknown equation name is requested.
-            ValueError: If an unknown operator is requested.
-            ValueError: If an equation is requested restricted to a grid on which it is
-                not defined.
-            TypeError: If the input is not an equation.
-
-        """
-        # If the equation is a dictionary, the dictionary values are grids (subdomains
-        # or interfaces) that defines restrictions of the equation; these must be
-        # identified. If the equation is not a dictionary, there will be restriction.
-
-        # Equation represented by string - return the corresponding equation.
-        if isinstance(equation, str):
-            if equation not in self._equations:
-                raise ValueError(f"Unknown equation name {equation}.")
-            return {equation: None}
-
-        # Equation represented by Operator. Return the
-        elif isinstance(equation, Operator):
-            if equation.name not in self._equations:
-                raise ValueError(f"Unknown equation operator {equation}.")
-            # No restriction.
-            return {equation.name: None}
-
-        # Equations represented by dict with restriction to grids: get target row
-        # indices.
-        elif isinstance(equation, dict):
-            block: dict[str, None | np.ndarray] = dict()
-            for equ, grids in equation.items():
-                # equ is an identifier of the equation (either a string or an operator)
-                # grids is a list of grids (subdomains or interfaces) that defines
-                # a restriction of the equation domain.
-
-                # Translate equ into a name (string).
-                if isinstance(equ, Operator):
-                    name = equ.name
-                    if name not in self._equations:
-                        raise ValueError(f"Unknown equation name {equation}.")
-                elif isinstance(equ, str):
-                    name = equ
-                    if name not in self._equations:
-                        raise ValueError(f"Unknown equation operator {equation}.")
-                else:
-                    raise TypeError(
-                        f"Item ({type(equ)}, {type(grids)}) not parsable as equation."
-                    )
-
-                # Get the indices associated with this equation.
-                img_info = self._equation_image_space_composition[name]
-
-                # Check if the user requests a properly defined subsets of the grids
-                # associated with this equation.
-                unknown_grids = set(grids).difference(set(img_info.keys()))
-                if len(unknown_grids) > 0:
-                    # Getting an error here means the user has requested a grid that is
-                    # not associated with this equation. This is not a meaningful
-                    # operation.
-                    raise ValueError(
-                        f"Equation {name} not defined on grids {unknown_grids}"
-                    )
-
-                # The indices (row indices in the global system) associated with this
-                # equation and the grids requested by the user.
-                block_idx: list[np.ndarray] = list()
-
-                # Loop over image space information to ensure correct order.
-                # Note that looping over the grids risks that the order does not
-                # correspond to the order in the equation was defined. This will surely
-                # lead to trouble down the line.
-                for grid in img_info:
-                    if grid in grids:
-                        block_idx.append(img_info[grid])
-
-                if len(block_idx) > 0:
-                    # If indices not empty, concatenate and return.
-                    block.update({name: np.concatenate(block_idx, dtype=int)})
-                else:
-                    # If indices empty, return empty array.
-                    block.update({name: np.array([], dtype=int)})
-            return block
-        else:
-            # Getting an error here means the user has passed a type that is not
-            # an equation.
-            raise TypeError(f"Type {type(equation)} not parsable as an equation.")
+        equation_order = {name: i for i, name in enumerate(self.equations)}
+        return dict(
+            sorted(equation_rows.items(), key=lambda item: equation_order[item[0].name])
+        )
 
     def _gridbased_equation_complement(
         self, equations: dict[str, None | np.ndarray]
@@ -1559,6 +1247,8 @@ class EquationSystem:
             as values. If the complement is empty, the value is None.
 
         """
+        equation_indexer = self.equation_indexer
+
         complement: dict[str, None | np.ndarray] = dict()
         for name, idx in equations.items():
             # If indices were filtered based on grids, we find the complementing
@@ -1566,11 +1256,12 @@ class EquationSystem:
             # If idx is None, this means no filtering was done.
             if idx is not None:
                 # Get the indices associated with this equation.
-                img_info = self._equation_image_space_composition[name]
-
-                # Ensure ordering and uniqueness of equation indexation.
-                img_values: list[np.ndarray] = list(img_info.values())
-                all_idx = np.unique(np.hstack(img_values))
+                all_idx = equation_indexer.equation_dofs_per_equation[name].values()
+                all_idx = (
+                    np.concatenate(list(all_idx))
+                    if len(all_idx) > 0
+                    else np.empty(0, dtype=int)
+                )
 
                 # Complementing indices are found by deleting the filtered indices.
                 complement_idx = np.delete(all_idx, idx)
@@ -1596,7 +1287,7 @@ class EquationSystem:
                 known equations will be discretized.
 
         """
-        equation_names = list(self._parse_equations(equations).keys())
+        equation_names = self._parse_equation_names(equations)
 
         # List containing all discretizations
         discr: list = []
@@ -1689,37 +1380,23 @@ class EquationSystem:
                 for the specified equations. Scaled with -1 (moved to rhs).
 
         """
-        if variables is None:
-            variables = self.variables
-
-        # equ_blocks is a dictionary with equation names as keys and the corresponding
-        # row indices of the equations. If the user has requested that equations are
-        # restricted to a subset of grids, the row indices are restricted accordingly.
-        # If no such request has been made, the value is None.
-        equ_blocks: dict[str, np.ndarray | None] = self._parse_equations(equations)
+        # Store equations together with optional row restrictions, then sort them in
+        # the canonical order in which equations were added to this system.
+        equations_rows = self._parse_equations(equations=equations)
 
         # Data structures for building matrix and residual vector
         mat: list[sps.spmatrix] = []
         rhs: list[np.ndarray] = []
 
-        # Keep track of DOFs for each equation/block.
-        ind_start = 0
-
-        # Store the indices of the assembled equations.
-        self.assembled_equation_indices = {}
-
-        eqs: list[pp.ad.Operator] = [self._equations[name] for name in equ_blocks]
-        rows = list(equ_blocks.values())
-
         # Ignore impenetrable mypy error here, the overloaded signatures are correctly
         # defined.
         values = self.evaluate(  # type: ignore[call-overload]
-            eqs,
+            list(equations_rows.keys()),
             derivative=evaluate_jacobian,
             state=state,
         )
 
-        for row, equ_name, value in zip(rows, equ_blocks, values):
+        for row, value in zip(equations_rows.values(), values):
             # Extract residual vector and possibly Jacobian matrix.
             rhs_value = value.val if evaluate_jacobian else value
             jac = value.jac if evaluate_jacobian else None
@@ -1727,24 +1404,14 @@ class EquationSystem:
                 # If restriction to grid-related row blocks was made, perform row
                 # slicing based on information we have obtained from parsing.
                 rhs.append(rhs_value[row])
-                block_length = len(rhs[-1])
                 if evaluate_jacobian:
                     assert jac is not None  # mypy
                     mat.append(jac[row])
             else:
                 # If no grid-related row restriction was made, append the whole thing.
                 rhs.append(rhs_value)
-                block_length = len(rhs[-1])
                 if evaluate_jacobian:
                     mat.append(jac)
-
-            # Create indices range and shift to correct position.
-            block_indices = np.arange(block_length) + ind_start
-            self.assembled_equation_indices.update({equ_name: block_indices})
-            # Extract last index and add 1 to get the starting point for next block
-            # of indices.
-            if block_length > 0:
-                ind_start = block_indices[-1] + 1
 
         # Concatenate results equation-wise.
         if len(rhs) > 0:
@@ -1763,8 +1430,17 @@ class EquationSystem:
         # grid-related column blocks by using the transposed projection to respective
         # subspace.
         # Multiply rhs by -1 to move to the rhs.
-        column_projection = self.projection_to(variables).transpose()
-        return A * column_projection, -rhs_cat
+        if variables is not None:
+            variable_indexer = self.variable_indexer
+            variables_ = self._parse_variable_type(variables=variables)
+            col_proj = [variable_indexer.variable_dofs[var] for var in variables_]
+            column_projection = (
+                np.unique(np.concatenate(col_proj))
+                if len(col_proj) > 0
+                else np.empty(0, dtype=int)
+            )
+            A = A[:, column_projection]
+        return A, -rhs_cat
 
     def assemble_schur_complement_system(
         self,
@@ -1792,7 +1468,7 @@ class EquationSystem:
         .. math::
 
             \left( A_{pp} - A_{ps} * A_{ss}^{-1} * A_{sp}\right) * x_p
-            = b_p - A_{ps} * A_{ss} * b_s
+            = b_p - A_{ps} * A_{ss}^{-1} * b_s
 
         The Schur complement is well-defined only if the inverse of :math:`A_{ss}`
         exists, and the efficiency of the approach assumes that an efficient inverter
@@ -1837,7 +1513,10 @@ class EquationSystem:
         # on their full image, and equations specified on a subset of grids.
         # The variable primary_rows will contain the indices in the global system
         # corresponding to the primary block.
-        primary_rows = self._parse_equations(primary_equations)
+        primary_rows = {
+            eq.name: dofs
+            for eq, dofs in self._parse_equations(primary_equations).items()
+        }
         # Find indices of equations involved in the primary block, but on grids that
         # were filtered out. These will be added to the secondary block.
         excluded_primary_rows = self._gridbased_equation_complement(primary_rows)
@@ -1877,7 +1556,6 @@ class EquationSystem:
 
         # Keep track of indices or primary block.
         ind_start = 0
-        self.assembled_equation_indices = dict()
 
         # We loop over stored equations to ensure the correct order but process only
         # primary equations.
@@ -1905,7 +1583,6 @@ class EquationSystem:
                 block_indices = np.arange(block_length) + ind_start
                 # Extract last index and add 1 to get the starting point for next block
                 # of indices.
-                self.assembled_equation_indices.update({name: block_indices})
                 if block_length > 0:
                     ind_start = block_indices[-1] + 1
 
@@ -1921,7 +1598,6 @@ class EquationSystem:
 
                 block_length = b_sec[-1].size
                 block_indices = np.arange(block_length) + ind_start
-                self.assembled_equation_indices.update({name: block_indices})
                 if block_length > 0:
                     ind_start = block_indices[-1] + 1
 
@@ -2212,3 +1888,43 @@ class EquationSystem:
             s += "\n\t".join(eq_names) + "\n"
 
         return s
+
+
+def cluster_dofs_gridwise(variables: list[pp.ad.Variable]) -> list[pp.ad.Variable]:
+    """Re-arranges the DOFs grid-wise s.t. we obtain grid-blocks in the column sense
+    and reduce the matrix bandwidth.
+
+    The aim is to impose a more block-diagonal-like structure on the Jacobian where
+    blocks in the column sense represent single grids in the following order:
+
+    1. For each grid in ``mdg.subdomains``
+        1. For each variable defined on that grid
+    2. For each grid in ``mdg.interfaces``
+        1. For each variable defined on that mortar grid
+
+    The order of variables per grid is given by the order of passed variables.
+
+    """
+    mapping_grid_to_domains = defaultdict(lambda: [])
+    for variable in variables:
+        mapping_grid_to_domains[variable.domain].append(variable)
+
+    # The ordering is: [Subdomains(3D-2D-1D-0D), Interfaces(2D-1D-0D)]. If equal, sorted
+    # by id.
+    known_grids = list(
+        sorted(
+            mapping_grid_to_domains.keys(),
+            key=lambda grid: (
+                isinstance(grid, pp.MortarGrid),
+                -grid.dim,
+                grid.id,
+            ),
+        )
+    )
+
+    ordered_variables = []
+
+    for grid in known_grids:
+        ordered_variables.extend(mapping_grid_to_domains[grid])
+
+    return ordered_variables

--- a/src/porepy/numerics/ad/indexers.py
+++ b/src/porepy/numerics/ad/indexers.py
@@ -30,22 +30,30 @@ class EquationOnDomain:
 
 
 class VariableIndexer:
-    """A variable indexer determines the arrangement of DoFs corresponding to multiple
-    variables on multiple grids in a contiguous array.
+    """A variable indexer determines the arrangement of indices corresponding to
+    multiple variables on multiple grids in a contiguous array.
 
     For a data array with a different arrangement (e.g., produced by taking a subset of
     variables), a new indexer needs to be constructed.
 
+    Parameters:
+        indices: A mapping of atomic variables to their indices. It should be ordered
+            in a sense that if key A goes before key B, indices of key A are located
+            before indices of key B. Ordering is not validated, so passing incorrect
+            ordering may lead to errors.
+
     """
 
-    def __init__(self, variable_dofs: dict[pp.ad.Variable, np.ndarray]) -> None:
-        self.variable_dofs: dict[pp.ad.Variable, np.ndarray] = variable_dofs
-        """An ordered mapping of atomic variables to their DoF indices. The keys are
-        ordered, in the sense that if key A goes before key B, DoFs of key A are located
-        before DoFs of key B.
+    def __init__(self, indices: dict[pp.ad.Variable, np.ndarray]) -> None:
+        self.indices: dict[pp.ad.Variable, np.ndarray] = indices
+        """An ordered mapping of atomic variables to their indices. The keys are
+        ordered, in the sense that if key A goes before key B, indices of key A are
+        located before indices of key B. 
 
         """
-        self.num_dofs: int = sum(x.size for x in self.variable_dofs.values())
+        # TODO YZ: Is it meaningful to enable iterations over this attribute directly
+        # through the class? (addressed in the downstream PR).
+        self.size: int = sum(x.size for x in self.indices.values())
 
     def projection_indices(self, variables: list[pp.ad.Variable]) -> np.ndarray:
         """Create a projection index array from the system vector represented by this
@@ -60,17 +68,17 @@ class VariableIndexer:
             ValueError: If the requested variable is not known to this indexer.
 
         Returns:
-            an index array of `shape=(M,)`, where `0 <= M <= num_dofs`.
+            an index array of `shape=(M,)`, where `0 <= M <= size`.
 
         """
         projections = []
         for variable in variables:
-            dofs = self.variable_dofs.get(variable, None)
-            if dofs is None:
+            indices = self.indices.get(variable, None)
+            if indices is None:
                 raise ValueError(
                     f"Requested variable is not known to this indexer: {variable}."
                 )
-            projections.append(dofs)
+            projections.append(indices)
         return (
             np.concatenate(projections)
             if len(projections) > 0
@@ -94,40 +102,38 @@ class VariableIndexer:
             A new instance of VariableIndexer.
 
         """
-        new_variable_dofs: dict[pp.ad.Variable, np.ndarray] = {}
+        new_variable_indices: dict[pp.ad.Variable, np.ndarray] = {}
         offset = 0
         for variable in variables:
-            dofs = self.variable_dofs.get(variable, None)
-            if dofs is None:
+            indices = self.indices.get(variable, None)
+            if indices is None:
                 raise ValueError(
                     f"Requested variable is not known to this indexer: {variable}."
                 )
-            new_variable_dofs[variable] = np.arange(dofs.size) + offset
-            offset += dofs.size
+            new_variable_indices[variable] = np.arange(indices.size) + offset
+            offset += indices.size
 
-        if len(new_variable_dofs) != len(variables):
+        if len(new_variable_indices) != len(variables):
             raise ValueError(f"Requested variables are duplicated: {variable}.")
 
-        return VariableIndexer(variable_dofs=new_variable_dofs)
+        return VariableIndexer(indices=new_variable_indices)
 
     def group_by_name(self) -> dict[str, dict[pp.GridLike, np.ndarray]]:
-        """Group :attr:`variable_dofs` by variable names.
+        """Group :attr:`indices` by variable names.
 
-        Domains with no dofs are ignored.
-
-        Offset between variables is assumed.
+        Domains with no indices are ignored.
 
         Return:
-            A nested mapping "variable_name" -> "domain" -> "dofs".
+            A nested mapping "variable_name" -> "domain" -> "indices".
 
         """
         variables: dict[str, dict[pp.GridLike, np.ndarray]] = {}
-        for variable, dofs in self.variable_dofs.items():
-            if len(dofs) == 0:
+        for variable, indices in self.indices.items():
+            if len(indices) == 0:
                 continue
             # Get by key variable.name, if not found, initialize it with an empty dict.
-            # Then populate the dict with the domain and dofs.
-            variables.setdefault(variable.name, {})[variable.domain] = dofs
+            # Then populate the dict with the domain and indices.
+            variables.setdefault(variable.name, {})[variable.domain] = indices
         return variables
 
     def identify_dof(self, dof: int) -> pp.ad.Variable:
@@ -149,7 +155,7 @@ class VariableIndexer:
             KeyError: if the dof is out of range.
 
         """
-        for variable, indices in self.variable_dofs.items():
+        for variable, indices in self.indices.items():
             if dof in indices:
                 return variable
 
@@ -157,7 +163,7 @@ class VariableIndexer:
 
 
 class EquationIndexer:
-    """An equation indexer determines the arrangement of DoFs corresponding to multiple
+    """An equation indexer determines the arrangement of indices corresponding to multiple
     equations on multiple grids in a contiguous array.
 
     For a data array with a different arrangement (e.g., produced by taking a subset of
@@ -167,7 +173,7 @@ class EquationIndexer:
     :class:`VariableIndexer` in the way these classes are initialized and what fields
     they expose. This is done to support convenient operations in `EquationSystem`. The
     preferred way to interact with this class outside `EquationSystem` is by using
-    :class:`EquationOnDomain` to query DoFs and not
+    :class:`EquationOnDomain` to query indices and not
     `dict[str, dict[pp.GridLike, np.ndarray]]`. See also the docstring of
     :attr:`equation_image_space_composition`.
 
@@ -176,31 +182,31 @@ class EquationIndexer:
     def __init__(
         self, equation_image_composition: dict[str, dict[pp.GridLike, np.ndarray]]
     ) -> None:
-        equation_dofs: dict[EquationOnDomain, np.ndarray] = {}
+        equation_indices: dict[EquationOnDomain, np.ndarray] = {}
         global_offset = 0
-        for eq_name, dofs_on_domains in equation_image_composition.items():
+        for eq_name, indices_on_domains in equation_image_composition.items():
             offset_per_equation = 0
-            for domain, dofs in dofs_on_domains.items():
-                equation_dofs[EquationOnDomain(name=eq_name, domain=domain)] = (
-                    dofs + global_offset
+            for domain, indices in indices_on_domains.items():
+                equation_indices[EquationOnDomain(name=eq_name, domain=domain)] = (
+                    indices + global_offset
                 )
-                offset_per_equation += dofs.size
+                offset_per_equation += indices.size
             global_offset += offset_per_equation
 
-        self.equation_dofs: dict[EquationOnDomain, np.ndarray] = equation_dofs
+        self.indices: dict[EquationOnDomain, np.ndarray] = equation_indices
         """An ordered mapping of atomic equations to their DoF indices. The keys are
-        ordered, in the sense that if key A goes before key B, DoFs of key A are located
-        before DoFs of key B.
+        ordered, in the sense that if key A goes before key B, indices of key A are located
+        before indices of key B.
 
         """
         self.equation_image_space_composition: dict[
             str, dict[pp.GridLike, np.ndarray]
         ] = equation_image_composition
-        """A mapping `equation_name` -> `domains` -> `dofs`.
+        """A mapping `equation_name` -> `domains` -> `indices`.
 
-        The dofs stored here start from 0 for each equation, i.e. the offset is only
-        relative to domains. The DoFs with the "global" offset can be found in
-        :attr:`equation_dofs`. This is done to respect the implementation of
+        The indices stored here start from 0 for each equation, i.e. the offset is only
+        relative to domains. The indices with the "global" offset can be found in
+        :attr:`indices`. This is done to respect the implementation of
         `EquationSystem`, where both types of offsets are needed.
 
         Note: It does not include equations with empty domains.
@@ -208,9 +214,9 @@ class EquationIndexer:
         """
 
     def group_by_name(self) -> dict[str, dict[pp.GridLike, np.ndarray]]:
-        """Group :attr:`equation_dofs` by equation names.
+        """Group :attr:`indices` by equation names.
 
-        Domains with no dofs are ignored.
+        Domains with no indices are ignored.
 
         Offset between equations is assumed.
 
@@ -218,15 +224,15 @@ class EquationIndexer:
             because the latter does not include offset between equation.
 
         Return:
-            A nested mapping "equation_name" -> "domain" -> "dofs".
+            A nested mapping "equation_name" -> "domain" -> "indices".
 
         """
         equations: dict[str, dict[pp.GridLike, np.ndarray]] = {}
-        for equation, dofs in self.equation_dofs.items():
-            if len(dofs) == 0:
+        for equation, indices in self.indices.items():
+            if len(indices) == 0:
                 continue
             # Get by key equation.name, if not found, initialize it with an empty dict.
-            equations.setdefault(equation.name, {})[equation.domain] = dofs
+            equations.setdefault(equation.name, {})[equation.domain] = indices
         return equations
 
     def construct_restricted_indexer(
@@ -246,18 +252,18 @@ class EquationIndexer:
             A new instance of EquationIndexer.
 
         """
-        new_equation_dofs: dict[pp.ad.EquationOnDomain, np.ndarray] = {}
+        new_equation_indices: dict[pp.ad.EquationOnDomain, np.ndarray] = {}
         offset = 0
         for equation in equations:
-            dofs = self.equation_dofs.get(equation, None)
-            if dofs is None:
+            indices = self.indices.get(equation, None)
+            if indices is None:
                 raise ValueError(
                     f"Requested equation is not known to this indexer: {equation}."
                 )
-            new_equation_dofs[equation] = np.arange(dofs.size) + offset
-            offset += dofs.size
+            new_equation_indices[equation] = np.arange(indices.size) + offset
+            offset += indices.size
 
-        if len(new_equation_dofs) != len(equations):
+        if len(new_equation_indices) != len(equations):
             raise ValueError(f"Requested equations are duplicated: {equations}.")
 
         # YZ: This is a little hack to be removed in the next PR. Now for simplicity,
@@ -265,11 +271,11 @@ class EquationIndexer:
         # equation_image_composition, so we reconstruct it here.
         equation_image_composition: dict[str, dict[pp.GridLike, np.ndarray]] = {}
         offsets_per_equation: dict[str, int] = {}
-        for equation, dofs in new_equation_dofs.items():
+        for equation, indices in new_equation_indices.items():
             equation_offset = offsets_per_equation.get(equation.name, 0)
             equation_image_composition.setdefault(equation.name, {})[
                 equation.domain
-            ] = np.arange(dofs.size) + equation_offset
-            offsets_per_equation[equation.name] = equation_offset + dofs.size
+            ] = np.arange(indices.size) + equation_offset
+            offsets_per_equation[equation.name] = equation_offset + indices.size
 
         return EquationIndexer(equation_image_composition=equation_image_composition)

--- a/src/porepy/numerics/ad/indexers.py
+++ b/src/porepy/numerics/ad/indexers.py
@@ -39,7 +39,7 @@ class VariableIndexer:
         """
         self.num_dofs: int = sum(x.size for x in self.variable_dofs.values())
 
-    def projection_to(self, variables: VariableList) -> np.ndarray:
+    def projection_to(self, variables: list[pp.ad.Variable]) -> np.ndarray:
         """TODO YZ
         Create a projection matrix from the global vector of unknowns to a specified
         subspace.
@@ -60,8 +60,6 @@ class VariableIndexer:
             ``0 <= M <= num_dofs``.
 
         """
-        # TODO YZ: Revisit with indexer
-        # current number of total dofs
         variables_lookup = set(variables)
         projections = []
         for variable in self.variable_dofs:
@@ -73,6 +71,18 @@ class VariableIndexer:
             if len(projections) > 0
             else np.empty(0, dtype=int)
         )
+
+    def construct_restricted_indexer(self, variables: list[pp.ad.Variable]):
+        """TODO YZ"""
+        new_variable_dofs: dict[pp.ad.Variable, np.ndarray] = {}
+        offset = 0
+        for variable in variables:
+            dofs = self.variable_dofs.get(variable, None)
+            if dofs is None:
+                raise ValueError(...)
+            new_variable_dofs[variable] = np.arange(dofs.size) + offset
+            offset += dofs.size
+        return VariableIndexer(variable_dofs=new_variable_dofs)
 
 
 class EquationIndexer:
@@ -88,9 +98,15 @@ class EquationIndexer:
         self, equation_dofs_per_equation: dict[str, dict[pp.GridLike, np.ndarray]]
     ) -> None:
         equation_dofs: dict[EquationOnDomain, np.ndarray] = {}
+        global_offset = 0
         for eq_name, dofs_on_domains in equation_dofs_per_equation.items():
+            offset_per_equation = 0
             for domain, dofs in dofs_on_domains.items():
-                equation_dofs[EquationOnDomain(name=eq_name, domain=domain)] = dofs
+                equation_dofs[EquationOnDomain(name=eq_name, domain=domain)] = (
+                    dofs + global_offset
+                )
+                offset_per_equation += dofs.size
+            global_offset += offset_per_equation
 
         self.equation_dofs: dict[EquationOnDomain, np.ndarray] = equation_dofs
         """An ordered mapping of atomic equations to their DoF indices. The keys are

--- a/src/porepy/numerics/ad/indexers.py
+++ b/src/porepy/numerics/ad/indexers.py
@@ -1,3 +1,10 @@
+"""Indexers for systems of discretized systems of equations and variables, the values of
+which are arranged in a contiguous array.
+
+Used by `EquationSystem` and nonlinear solvers.
+
+"""
+
 from __future__ import annotations
 from dataclasses import dataclass
 
@@ -39,25 +46,18 @@ class VariableIndexer:
         """
         self.num_dofs: int = sum(x.size for x in self.variable_dofs.values())
 
-    def projection_to(self, variables: list[pp.ad.Variable]) -> np.ndarray:
-        """TODO YZ
-        Create a projection matrix from the global vector of unknowns to a specified
-        subspace.
+    def projection_indices(self, variables: list[pp.ad.Variable]) -> np.ndarray:
+        """Create a projection index array from the vector, system vector, represented
+        by this indexer, to the requested subspace.
 
-        The transpose of the returned matrix can be used to slice respective columns out
-        of the global Jacobian.
-
-        The projection preserves the global order defined by the system, i.e. it
-        includes no permutation.
+        The projection preserves the order defined by the this indexer and neglects the
+        order of the input data. In other words, it includes no permutation.
 
         Parameters:
-            variables (optional): VariableType input for which the subspace is
-                requested. If no subspace is specified using ``variables``,
-                a null-space projection is returned.
+            variables (optional): Input for which the subspace is requested.
 
         Returns:
-            a sparse projection matrix of shape ``(M, num_dofs)``, where
-            ``0 <= M <= num_dofs``.
+            an index array of `shape=(M,)`, where `0 <= M <= num_dofs`.
 
         """
         variables_lookup = set(variables)
@@ -73,13 +73,22 @@ class VariableIndexer:
         )
 
     def construct_restricted_indexer(self, variables: list[pp.ad.Variable]):
-        """TODO YZ"""
+        """Constructs a new indexer based on requested subset of variables.
+
+        The order of the new indexer is defined by the input.
+
+        Raises:
+            ValueError: If the requested variable is not known to this indexer.
+
+        """
         new_variable_dofs: dict[pp.ad.Variable, np.ndarray] = {}
         offset = 0
         for variable in variables:
             dofs = self.variable_dofs.get(variable, None)
             if dofs is None:
-                raise ValueError(...)
+                raise ValueError(
+                    f"Requested variable is not known to this indexer: {variable}"
+                )
             new_variable_dofs[variable] = np.arange(dofs.size) + offset
             offset += dofs.size
         return VariableIndexer(variable_dofs=new_variable_dofs)
@@ -92,14 +101,22 @@ class EquationIndexer:
     For a data array with a different arrangement (e.g., produced by taking a subset of
     equations), a new indexer needs to be constructed.
 
+    Implementation note: There is an unfortunate assymetry between this and
+    :class:`VariableIndexer` in the way these classes are initialized and what fields
+    they expose. It is done so for convenient operations in `EquationSystem`. The
+    preferred way to interact with this class outside `EquationSystem` is by using
+    :class:`EquationOnDomain` to query DoFs and not
+    `dict[str, dict[pp.GridLike, np.ndarray]]` See also the docstring of
+    :attr:`equation_image_space_composition`.
+
     """
 
     def __init__(
-        self, equation_dofs_per_equation: dict[str, dict[pp.GridLike, np.ndarray]]
+        self, equation_image_composition: dict[str, dict[pp.GridLike, np.ndarray]]
     ) -> None:
         equation_dofs: dict[EquationOnDomain, np.ndarray] = {}
         global_offset = 0
-        for eq_name, dofs_on_domains in equation_dofs_per_equation.items():
+        for eq_name, dofs_on_domains in equation_image_composition.items():
             offset_per_equation = 0
             for domain, dofs in dofs_on_domains.items():
                 equation_dofs[EquationOnDomain(name=eq_name, domain=domain)] = (
@@ -114,6 +131,14 @@ class EquationIndexer:
         before DoFs of key B.
 
         """
-        self.equation_dofs_per_equation: dict[str, dict[pp.GridLike, np.ndarray]] = (
-            equation_dofs_per_equation
-        )
+        self.equation_image_space_composition: dict[
+            str, dict[pp.GridLike, np.ndarray]
+        ] = equation_image_composition
+        """A mapping `equation_name` -> `domains` -> `dofs`.
+        
+        The dofs stored here start from 0 for each equation, i.e. the offset is only
+        relative to domains. The DoFs with the "global" offset can be found in
+        :attr:`equation_dofs`. This is done to respect the implementation of
+        `EquationSystem`, where both types of offsets are needed. 
+
+        """

--- a/src/porepy/numerics/ad/indexers.py
+++ b/src/porepy/numerics/ad/indexers.py
@@ -1,4 +1,4 @@
-"""Indexers for systems of discretized systems of equations and variables, the values of
+"""Indexers for discretized systems of equations and variables, the values of
 which are arranged in a contiguous array.
 
 Used by `EquationSystem` and nonlinear solvers.
@@ -30,7 +30,7 @@ class EquationOnDomain:
 
 
 class VariableIndexer:
-    """Variable indexer determines the arrangement of DoFs corresponding to multiple
+    """A variable indexer determines the arrangement of DoFs corresponding to multiple
     variables on multiple grids in a contiguous array.
 
     For a data array with a different arrangement (e.g., produced by taking a subset of
@@ -48,8 +48,8 @@ class VariableIndexer:
         self.num_dofs: int = sum(x.size for x in self.variable_dofs.values())
 
     def projection_indices(self, variables: list[pp.ad.Variable]) -> np.ndarray:
-        """Create a projection index array from the vector, system vector, represented
-        by this indexer, to the requested subspace.
+        """Create a projection index array from the system vector represented
+        by this indexer to the requested subspace.
 
         The order of the variables in the projection is defined by the input.
 
@@ -109,18 +109,18 @@ class VariableIndexer:
 
 
 class EquationIndexer:
-    """Equation indexer determines the arrangement of DoFs corresponding to multiple
+    """An equation indexer determines the arrangement of DoFs corresponding to multiple
     equations on multiple grids in a contiguous array.
 
     For a data array with a different arrangement (e.g., produced by taking a subset of
     equations), a new indexer needs to be constructed.
 
-    Implementation note: There is an unfortunate assymetry between this and
+    Implementation note: There is an unfortunate asymmetry between this and
     :class:`VariableIndexer` in the way these classes are initialized and what fields
-    they expose. It is done so for convenient operations in `EquationSystem`. The
+    they expose. This is done to support convenient operations in `EquationSystem`. The
     preferred way to interact with this class outside `EquationSystem` is by using
     :class:`EquationOnDomain` to query DoFs and not
-    `dict[str, dict[pp.GridLike, np.ndarray]]` See also the docstring of
+    `dict[str, dict[pp.GridLike, np.ndarray]]`. See also the docstring of
     :attr:`equation_image_space_composition`.
 
     """
@@ -149,12 +149,12 @@ class EquationIndexer:
             str, dict[pp.GridLike, np.ndarray]
         ] = equation_image_composition
         """A mapping `equation_name` -> `domains` -> `dofs`.
-        
+
         The dofs stored here start from 0 for each equation, i.e. the offset is only
         relative to domains. The DoFs with the "global" offset can be found in
         :attr:`equation_dofs`. This is done to respect the implementation of
-        `EquationSystem`, where both types of offsets are needed. 
+        `EquationSystem`, where both types of offsets are needed.
 
-        Note: It does not include equations with empty-domain equations.
+        Note: It does not include equations with empty domains.
 
         """

--- a/src/porepy/numerics/ad/indexers.py
+++ b/src/porepy/numerics/ad/indexers.py
@@ -56,6 +56,9 @@ class VariableIndexer:
         Parameters:
             variables: Input for which the subspace is requested.
 
+        Raises:
+            ValueError: If the requested variable is not known to this indexer.
+
         Returns:
             an index array of `shape=(M,)`, where `0 <= M <= num_dofs`.
 
@@ -76,7 +79,7 @@ class VariableIndexer:
 
     def construct_restricted_indexer(
         self, variables: list[pp.ad.Variable]
-    ) -> "VariableIndexer":
+    ) -> VariableIndexer:
         """Constructs a new indexer based on requested subset of variables.
 
         The order of the new indexer is defined by the input.
@@ -126,6 +129,31 @@ class VariableIndexer:
             # Then populate the dict with the domain and dofs.
             variables.setdefault(variable.name, {})[variable.domain] = dofs
         return variables
+
+    def identify_dof(self, dof: int) -> pp.ad.Variable:
+        """Identifies the variable to which a specific DOF index belongs.
+
+        The intended use is to help identify entries in the global vector or the column
+        of the Jacobian.
+
+        This operation is O(n) for n elements in the vector in the worst case. This
+        method should not be used in a hot loop.
+
+        Parameters:
+            dof: a single index in the global vector.
+
+        Returns:
+            The identified Variable object.
+
+        Raises:
+            KeyError: if the dof is out of range.
+
+        """
+        for variable, indices in self.variable_dofs.items():
+            if dof in indices:
+                return variable
+
+        raise KeyError("Dof index out of range.")
 
 
 class EquationIndexer:
@@ -203,7 +231,7 @@ class EquationIndexer:
 
     def construct_restricted_indexer(
         self, equations: list[EquationOnDomain]
-    ) -> "EquationIndexer":
+    ) -> EquationIndexer:
         """Constructs a new indexer based on requested subset of equations.
 
         The order of the new indexer is defined by the input.

--- a/src/porepy/numerics/ad/indexers.py
+++ b/src/porepy/numerics/ad/indexers.py
@@ -1,5 +1,5 @@
-"""Indexers for discretized systems of equations and variables, the values of
-which are arranged in a contiguous array.
+"""Indexers for discretized systems of equations and variables, the values of which are
+arranged in a contiguous array.
 
 Used by `EquationSystem` and nonlinear solvers.
 
@@ -41,15 +41,15 @@ class VariableIndexer:
     def __init__(self, variable_dofs: dict[pp.ad.Variable, np.ndarray]) -> None:
         self.variable_dofs: dict[pp.ad.Variable, np.ndarray] = variable_dofs
         """An ordered mapping of atomic variables to their DoF indices. The keys are
-        ordered, in a sense that if key A goes before key B, DoFs of key A are located
+        ordered, in the sense that if key A goes before key B, DoFs of key A are located
         before DoFs of key B.
 
         """
         self.num_dofs: int = sum(x.size for x in self.variable_dofs.values())
 
     def projection_indices(self, variables: list[pp.ad.Variable]) -> np.ndarray:
-        """Create a projection index array from the system vector represented
-        by this indexer to the requested subspace.
+        """Create a projection index array from the system vector represented by this
+        indexer to the requested subspace.
 
         The order of the variables in the projection is defined by the input.
 
@@ -123,6 +123,7 @@ class VariableIndexer:
             if len(dofs) == 0:
                 continue
             # Get by key variable.name, if not found, initialize it with an empty dict.
+            # Then populate the dict with the domain and dofs.
             variables.setdefault(variable.name, {})[variable.domain] = dofs
         return variables
 
@@ -160,7 +161,7 @@ class EquationIndexer:
 
         self.equation_dofs: dict[EquationOnDomain, np.ndarray] = equation_dofs
         """An ordered mapping of atomic equations to their DoF indices. The keys are
-        ordered, in a sense that if key A goes before key B, DoFs of key A are located
+        ordered, in the sense that if key A goes before key B, DoFs of key A are located
         before DoFs of key B.
 
         """

--- a/src/porepy/numerics/ad/indexers.py
+++ b/src/porepy/numerics/ad/indexers.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+from dataclasses import dataclass
+
+import porepy as pp
+
+import numpy as np
+
+__all__ = ["EquationOnDomain", "VariableIndexer", "EquationIndexer"]
+
+
+@dataclass(frozen=True)
+class EquationOnDomain:
+    """An identifier of a single equation defined on a single domain.
+
+    Mirrors the `pp.ad.Variable` design, which is used as an identifier for a single
+    variable defined on a single domain.
+
+    """
+
+    name: str
+    domain: pp.GridLike
+
+
+class VariableIndexer:
+    """Variable indexer determines the arrangement of DoFs corresponding to multiple
+    variables on multiple grids in a contiguous array.
+
+    For a data array with a different arrangement (e.g., produced by taking a subset of
+    variables), a new indexer needs to be constructed.
+
+    """
+
+    def __init__(self, variable_dofs: dict[pp.ad.Variable, np.ndarray]) -> None:
+        self.variable_dofs: dict[pp.ad.Variable, np.ndarray] = variable_dofs
+        """An ordered mapping of atomic variables to their DoF indices. The keys are
+        ordered, in a sense that if key A goes before key B, DoFs of key A are located
+        before DoFs of key B.
+
+        """
+        self.num_dofs: int = sum(x.size for x in self.variable_dofs.values())
+
+    def projection_to(self, variables: VariableList) -> np.ndarray:
+        """TODO YZ
+        Create a projection matrix from the global vector of unknowns to a specified
+        subspace.
+
+        The transpose of the returned matrix can be used to slice respective columns out
+        of the global Jacobian.
+
+        The projection preserves the global order defined by the system, i.e. it
+        includes no permutation.
+
+        Parameters:
+            variables (optional): VariableType input for which the subspace is
+                requested. If no subspace is specified using ``variables``,
+                a null-space projection is returned.
+
+        Returns:
+            a sparse projection matrix of shape ``(M, num_dofs)``, where
+            ``0 <= M <= num_dofs``.
+
+        """
+        # TODO YZ: Revisit with indexer
+        # current number of total dofs
+        variables_lookup = set(variables)
+        projections = []
+        for variable in self.variable_dofs:
+            if variable not in variables_lookup:
+                continue
+            projections.append(self.variable_dofs[variable])
+        return (
+            np.concatenate(projections)
+            if len(projections) > 0
+            else np.empty(0, dtype=int)
+        )
+
+
+class EquationIndexer:
+    """Equation indexer determines the arrangement of DoFs corresponding to multiple
+    equations on multiple grids in a contiguous array.
+
+    For a data array with a different arrangement (e.g., produced by taking a subset of
+    equations), a new indexer needs to be constructed.
+
+    """
+
+    def __init__(
+        self, equation_dofs_per_equation: dict[str, dict[pp.GridLike, np.ndarray]]
+    ) -> None:
+        equation_dofs: dict[EquationOnDomain, np.ndarray] = {}
+        for eq_name, dofs_on_domains in equation_dofs_per_equation.items():
+            for domain, dofs in dofs_on_domains.items():
+                equation_dofs[EquationOnDomain(name=eq_name, domain=domain)] = dofs
+
+        self.equation_dofs: dict[EquationOnDomain, np.ndarray] = equation_dofs
+        """An ordered mapping of atomic equations to their DoF indices. The keys are
+        ordered, in a sense that if key A goes before key B, DoFs of key A are located
+        before DoFs of key B.
+
+        """
+        self.equation_dofs_per_equation: dict[str, dict[pp.GridLike, np.ndarray]] = (
+            equation_dofs_per_equation
+        )

--- a/src/porepy/numerics/ad/indexers.py
+++ b/src/porepy/numerics/ad/indexers.py
@@ -199,3 +199,48 @@ class EquationIndexer:
             # Get by key equation.name, if not found, initialize it with an empty dict.
             equations.setdefault(equation.name, {})[equation.domain] = dofs
         return equations
+
+    def construct_restricted_indexer(
+        self, equations: list[EquationOnDomain]
+    ) -> "EquationIndexer":
+        """Constructs a new indexer based on requested subset of equations.
+
+        The order of the new indexer is defined by the input.
+
+        Parameters:
+            equations: Input for which the subspace is requested.
+
+        Raises:
+            ValueError: If the requested equation is not known to this indexer.
+
+        Returns:
+            A new instance of EquationIndexer.
+
+        """
+        new_equation_dofs: dict[pp.ad.EquationOnDomain, np.ndarray] = {}
+        offset = 0
+        for equation in equations:
+            dofs = self.equation_dofs.get(equation, None)
+            if dofs is None:
+                raise ValueError(
+                    f"Requested equation is not known to this indexer: {equation}."
+                )
+            new_equation_dofs[equation] = np.arange(dofs.size) + offset
+            offset += dofs.size
+
+        if len(new_equation_dofs) != len(equations):
+            raise ValueError(f"Requested equations are duplicated: {equations}.")
+
+        # YZ: This is a little hack to be removed in the next PR. Now for simplicity,
+        # EquationIndexer needs to be initialized with (equation-local)
+        # equation_image_composition, so we reconstruct it here.
+        equation_image_composition: dict[str, dict[pp.GridLike, np.ndarray]] = {}
+        offsets_per_equation: dict[str, int] = {}
+        for equation, dofs in new_equation_dofs.items():
+            equation_offset = offsets_per_equation.get(equation.name, 0)
+            equation_image_composition.setdefault(equation.name, {})[
+                equation.domain
+            ] = np.arange(dofs.size) + equation_offset
+            offsets_per_equation[equation.name] = equation_offset + dofs.size
+
+        return EquationIndexer(equation_image_composition=equation_image_composition)

--- a/src/porepy/numerics/ad/indexers.py
+++ b/src/porepy/numerics/ad/indexers.py
@@ -51,35 +51,44 @@ class VariableIndexer:
         """Create a projection index array from the vector, system vector, represented
         by this indexer, to the requested subspace.
 
-        The projection preserves the order defined by the this indexer and neglects the
-        order of the input data. In other words, it includes no permutation.
+        The order of the variables in the projection is defined by the input.
 
         Parameters:
-            variables (optional): Input for which the subspace is requested.
+            variables: Input for which the subspace is requested.
 
         Returns:
             an index array of `shape=(M,)`, where `0 <= M <= num_dofs`.
 
         """
-        variables_lookup = set(variables)
         projections = []
-        for variable in self.variable_dofs:
-            if variable not in variables_lookup:
-                continue
-            projections.append(self.variable_dofs[variable])
+        for variable in variables:
+            dofs = self.variable_dofs.get(variable, None)
+            if dofs is None:
+                raise ValueError(
+                    f"Requested variable is not known to this indexer: {variable}."
+                )
+            projections.append(dofs)
         return (
             np.concatenate(projections)
             if len(projections) > 0
             else np.empty(0, dtype=int)
         )
 
-    def construct_restricted_indexer(self, variables: list[pp.ad.Variable]):
+    def construct_restricted_indexer(
+        self, variables: list[pp.ad.Variable]
+    ) -> "VariableIndexer":
         """Constructs a new indexer based on requested subset of variables.
 
         The order of the new indexer is defined by the input.
 
+        Parameters:
+            variables: Input for which the subspace is requested.
+
         Raises:
             ValueError: If the requested variable is not known to this indexer.
+
+        Returns:
+            A new instance of VariableIndexer.
 
         """
         new_variable_dofs: dict[pp.ad.Variable, np.ndarray] = {}
@@ -88,10 +97,14 @@ class VariableIndexer:
             dofs = self.variable_dofs.get(variable, None)
             if dofs is None:
                 raise ValueError(
-                    f"Requested variable is not known to this indexer: {variable}"
+                    f"Requested variable is not known to this indexer: {variable}."
                 )
             new_variable_dofs[variable] = np.arange(dofs.size) + offset
             offset += dofs.size
+
+        if len(new_variable_dofs) != len(variables):
+            raise ValueError(f"Requested variables are duplicated: {variable}.")
+
         return VariableIndexer(variable_dofs=new_variable_dofs)
 
 
@@ -141,5 +154,7 @@ class EquationIndexer:
         relative to domains. The DoFs with the "global" offset can be found in
         :attr:`equation_dofs`. This is done to respect the implementation of
         `EquationSystem`, where both types of offsets are needed. 
+
+        Note: It does not include equations with empty-domain equations.
 
         """

--- a/src/porepy/numerics/ad/indexers.py
+++ b/src/porepy/numerics/ad/indexers.py
@@ -163,8 +163,8 @@ class VariableIndexer:
 
 
 class EquationIndexer:
-    """An equation indexer determines the arrangement of indices corresponding to multiple
-    equations on multiple grids in a contiguous array.
+    """An equation indexer determines the arrangement of indices corresponding to
+    multiple equations on multiple grids in a contiguous array.
 
     For a data array with a different arrangement (e.g., produced by taking a subset of
     equations), a new indexer needs to be constructed.
@@ -195,8 +195,8 @@ class EquationIndexer:
 
         self.indices: dict[EquationOnDomain, np.ndarray] = equation_indices
         """An ordered mapping of atomic equations to their DoF indices. The keys are
-        ordered, in the sense that if key A goes before key B, indices of key A are located
-        before indices of key B.
+        ordered, in the sense that if key A goes before key B, indices of key A are
+        located before indices of key B.
 
         """
         self.equation_image_space_composition: dict[

--- a/src/porepy/numerics/ad/indexers.py
+++ b/src/porepy/numerics/ad/indexers.py
@@ -6,11 +6,12 @@ Used by `EquationSystem` and nonlinear solvers.
 """
 
 from __future__ import annotations
+
 from dataclasses import dataclass
 
-import porepy as pp
-
 import numpy as np
+
+import porepy as pp
 
 __all__ = ["EquationOnDomain", "VariableIndexer", "EquationIndexer"]
 

--- a/src/porepy/numerics/ad/indexers.py
+++ b/src/porepy/numerics/ad/indexers.py
@@ -107,6 +107,25 @@ class VariableIndexer:
 
         return VariableIndexer(variable_dofs=new_variable_dofs)
 
+    def group_by_name(self) -> dict[str, dict[pp.GridLike, np.ndarray]]:
+        """Group :attr:`variable_dofs` by variable names.
+
+        Domains with no dofs are ignored.
+
+        Offset between variables is assumed.
+
+        Return:
+            A nested mapping "variable_name" -> "domain" -> "dofs".
+
+        """
+        variables: dict[str, dict[pp.GridLike, np.ndarray]] = {}
+        for variable, dofs in self.variable_dofs.items():
+            if len(dofs) == 0:
+                continue
+            # Get by key variable.name, if not found, initialize it with an empty dict.
+            variables.setdefault(variable.name, {})[variable.domain] = dofs
+        return variables
+
 
 class EquationIndexer:
     """An equation indexer determines the arrangement of DoFs corresponding to multiple
@@ -158,3 +177,25 @@ class EquationIndexer:
         Note: It does not include equations with empty domains.
 
         """
+
+    def group_by_name(self) -> dict[str, dict[pp.GridLike, np.ndarray]]:
+        """Group :attr:`equation_dofs` by equation names.
+
+        Domains with no dofs are ignored.
+
+        Offset between equations is assumed.
+
+        Note: This is not equivalent to :attr:`equation_image_space_composition`,
+            because the latter does not include offset between equation.
+
+        Return:
+            A nested mapping "equation_name" -> "domain" -> "dofs".
+
+        """
+        equations: dict[str, dict[pp.GridLike, np.ndarray]] = {}
+        for equation, dofs in self.equation_dofs.items():
+            if len(dofs) == 0:
+                continue
+            # Get by key equation.name, if not found, initialize it with an empty dict.
+            equations.setdefault(equation.name, {})[equation.domain] = dofs
+        return equations

--- a/src/porepy/numerics/ad/operators.py
+++ b/src/porepy/numerics/ad/operators.py
@@ -1457,6 +1457,15 @@ class Variable(TimeDependentOperator, IterativeOperator, ReferenceOperator, Oper
             )
         raise ValueError()
 
+    @property
+    def dof_info(self) -> dict[Literal["cells", "faces", "nodes"], int]:
+        """Number of degrees of freedom per grid entity."""
+        return {
+            "cells": self._cells,
+            "faces": self._faces,
+            "nodes": self._nodes,
+        }
+
     def set_name(self, name: str) -> None:
         """
         Raises:

--- a/src/porepy/numerics/fracture_deformation/propagation_model.py
+++ b/src/porepy/numerics/fracture_deformation/propagation_model.py
@@ -207,7 +207,7 @@ class FracturePropagation(abc.ABC):
         # Update the equation system's counting of dofs. Note that this update has no
         # proper testing and may not cover all necessary updates of dof management. In
         # particular, the image spaces of the equations are left untouched here.
-        self.equation_system.update_variable_num_dofs()
+        self.equation_system.reset_variable_equation_indices()
 
         x_new = np.zeros(self.equation_system.num_dofs())
         # For each variable, map old solution and initialize for new DOFs.

--- a/src/porepy/numerics/fracture_deformation/propagation_model.py
+++ b/src/porepy/numerics/fracture_deformation/propagation_model.py
@@ -168,7 +168,7 @@ class FracturePropagation(abc.ABC):
             # Only cell-based dofs have been considered so far.
             # It should not be difficult to handle other types of variables,
             # but the need has not been there.
-            dofs = self.equation_system._variable_dof_type[var.id]
+            dofs = var.dof_info
             face_dof: int = dofs.get("faces", 0)
             node_dof: int = dofs.get("nodes", 0)
             if face_dof != 0 or node_dof != 0:
@@ -237,7 +237,7 @@ class FracturePropagation(abc.ABC):
             # grid, second populate newly formed cells.
 
             # Mapping of old variables.
-            dofs = self.equation_system._variable_dof_type[var.id]
+            dofs = var.dof_info
             cell_dof = dofs["cells"]
             mapping = sps.kron(cell_map, sps.eye(cell_dof))
             x_new[self.equation_system.dofs_of([var])] = (

--- a/src/porepy/numerics/solvers/linear_solver.py
+++ b/src/porepy/numerics/solvers/linear_solver.py
@@ -105,6 +105,8 @@ class LinearSystem:
 
     matrix: Optional[csr_matrix]
     rhs: np.ndarray
+    equation_indexer: pp.ad.EquationIndexer
+    variable_indexer: pp.ad.VariableIndexer
 
     def release_matrix_reference(self) -> None:
         """Release this container's reference to the matrix.

--- a/src/porepy/numerics/solvers/linear_solver.py
+++ b/src/porepy/numerics/solvers/linear_solver.py
@@ -105,8 +105,6 @@ class LinearSystem:
 
     matrix: Optional[csr_matrix]
     rhs: np.ndarray
-    equation_indexer: pp.ad.EquationIndexer
-    variable_indexer: pp.ad.VariableIndexer
 
     def release_matrix_reference(self) -> None:
         """Release this container's reference to the matrix.

--- a/src/porepy/viz/data_saving_model_mixin.py
+++ b/src/porepy/viz/data_saving_model_mixin.py
@@ -389,7 +389,7 @@ class ResidualExporting:
             # GridEntity = Literal["cells", "faces", "nodes"]
             image_info = self.equation_system.equation_image_size_info[name]
             dof_start, dof_end = 0, 0
-            for g in self.equation_system.equation_image_space_composition[name].keys():
+            for g in operator.domains:
                 # Add number of dofs for each entity in image_info.
                 for entity, num in image_info.items():
                     dof_end += getattr(g, "num_" + entity) * num

--- a/src/porepy/viz/diagnostics_mixin.py
+++ b/src/porepy/viz/diagnostics_mixin.py
@@ -186,8 +186,8 @@ class DiagnosticsMixin:
             variable_indexer = self.equation_system.variable_indexer
 
         indexed_shape = (
-            sum(dofs.size for dofs in equation_indexer.equation_dofs.values()),
-            variable_indexer.num_dofs,
+            sum(dofs.size for dofs in equation_indexer.indices.values()),
+            variable_indexer.size,
         )
         if full_matrix.shape != indexed_shape:
             raise ValueError(
@@ -352,7 +352,7 @@ class DiagnosticsMixin:
         equations_by_name: dict[str, list[tuple[GridLike, np.ndarray]]] = defaultdict(
             list
         )
-        for equation_on_domain, dofs in equation_indexer.equation_dofs.items():
+        for equation_on_domain, dofs in equation_indexer.indices.items():
             equations_by_name[equation_on_domain.name].append(
                 (equation_on_domain.domain, dofs)
             )
@@ -409,13 +409,13 @@ class DiagnosticsMixin:
         # First, we group variables by names. We assume that variables with the same
         # name are one variable on multiple grids.
         names_to_variables: dict[str, list[Variable]] = defaultdict(list)
-        for variable in variable_indexer.variable_dofs:
+        for variable in variable_indexer.indices:
             names_to_variables[variable.name].append(variable)
 
         for variable_name, variable_on_grids in names_to_variables.items():
             for block_of_grids in grouping:
                 dof_blocks = [
-                    variable_indexer.variable_dofs[variable]
+                    variable_indexer.indices[variable]
                     for variable in variable_on_grids
                     if variable.domain in block_of_grids
                 ]

--- a/src/porepy/viz/diagnostics_mixin.py
+++ b/src/porepy/viz/diagnostics_mixin.py
@@ -6,7 +6,7 @@ import logging
 from collections import defaultdict
 from collections.abc import Iterable
 from itertools import product
-from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, Sequence
+from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, Sequence, cast
 
 import matplotlib
 import numpy as np
@@ -173,7 +173,7 @@ class DiagnosticsMixin:
                 f"{grouping=} instead."
             )
         # The type is checked one line earlier.
-        grouping_: GridGroupingType = grouping  # type: ignore
+        grouping = cast(GridGroupingType, grouping)
 
         full_matrix = linear_system.matrix
         assert full_matrix is not None, (

--- a/src/porepy/viz/diagnostics_mixin.py
+++ b/src/porepy/viz/diagnostics_mixin.py
@@ -19,6 +19,7 @@ from porepy import solvers
 from porepy.grids.md_grid import MixedDimensionalGrid
 from porepy.grids.mortar_grid import MortarGrid
 from porepy.numerics.ad.equation_system import EquationSystem
+from porepy.numerics.ad.indexers import EquationIndexer, VariableIndexer
 from porepy.numerics.ad.operators import Variable
 
 if TYPE_CHECKING:
@@ -83,11 +84,15 @@ class DiagnosticsMixin:
         ) = None,
         default_handlers: Sequence[Literal["cond", "max"]] = ("max",),
         additional_handlers: Optional[dict[str, SubmatrixHandlerType]] = None,
+        equation_indexer: Optional[EquationIndexer] = None,
+        variable_indexer: Optional[VariableIndexer] = None,
     ) -> DiagnosticsData:
         """Collect and plot diagnostics for an assembled Jacobian matrix.
 
-        It is assumed that full information about the matrix indices is stored in
-        `self.equation_system.equation_image_space_composition`.
+        By default, the matrix is assumed to represent the full equation system. For a
+        restricted matrix, pass the indexers returned by
+        :meth:`EquationSystem.construct_assembled_matrix_indexers` with the same
+        restrictions that were used to assemble the matrix.
 
         Note:
             It is assumed that variables with the same name defined on different grids
@@ -111,6 +116,11 @@ class DiagnosticsMixin:
                 equation name and the variable name. The equation and the variable names
                 are passed to allow the user for calculating the handler value only in a
                 subset of equations and variables of interest.
+            equation_indexer: Indexer describing the rows of ``linear_system.matrix``.
+                Defaults to the indexer for all equations in the equation system.
+            variable_indexer: Indexer describing the columns of
+                ``linear_system.matrix``. Defaults to the indexer for all variables in
+                the equation system.
 
         Returns:
             A dictionary with keys corresponding to block index and values of
@@ -170,6 +180,22 @@ class DiagnosticsMixin:
             "Cannot diagnose a linear system whose matrix was freed."
         )
 
+        if equation_indexer is None:
+            equation_indexer = self.equation_system.equation_indexer
+        if variable_indexer is None:
+            variable_indexer = self.equation_system.variable_indexer
+
+        indexed_shape = (
+            sum(dofs.size for dofs in equation_indexer.equation_dofs.values()),
+            variable_indexer.num_dofs,
+        )
+        if full_matrix.shape != indexed_shape:
+            raise ValueError(
+                "The diagnostics indexers do not describe the supplied matrix: "
+                f"matrix shape is {full_matrix.shape}, but indexed shape is "
+                f"{indexed_shape}. Pass the indexers used to assemble this system."
+            )
+
         # Validating default_handlers.
         assert all(x in ("cond", "max") for x in default_handlers)
 
@@ -188,10 +214,14 @@ class DiagnosticsMixin:
 
         # Determining the block indices and collecting the submatrices.
         equation_data = self._equations_data(
-            grouping=grouping_, add_grid_info=add_grid_info
+            equation_indexer=equation_indexer,
+            grouping=grouping_,
+            add_grid_info=add_grid_info,
         )
         variable_data = self._variable_data(
-            grouping=grouping_, add_grid_info=add_grid_info
+            variable_indexer=variable_indexer,
+            grouping=grouping_,
+            add_grid_info=add_grid_info,
         )
 
         submatrices = self._collect_submatrices(
@@ -303,9 +333,14 @@ class DiagnosticsMixin:
             print(np.array_str(block_data, precision=2))
 
     def _equations_data(
-        self, grouping: GridGroupingType, add_grid_info: bool
+        self,
+        equation_indexer: EquationIndexer,
+        grouping: GridGroupingType,
+        add_grid_info: bool,
     ) -> Sequence[dict[str, Any]]:
         """Collects the indices of equations presented in the Jacobian matrix as rows.
+
+        The indexer must describe the row ordering of the matrix being diagnosed.
 
         Returns:
             A tuple with dictionaries -- data of each row in the block matrix. The keys
@@ -314,56 +349,55 @@ class DiagnosticsMixin:
         """
         equation_indices = []
 
-        assembled_equation_indices = self.equation_system.assembled_equation_indices
-
-        # `equation_image_space_composition` has dof indices starting from zero for
-        # each equation. We need to count the offset to get the global dof indices.
-        block_indices = 0
-
-        for eq_name, eq_dof_indices in assembled_equation_indices.items():
-            equation_image_space = (
-                self.equation_system.equation_image_space_composition[eq_name]
+        equations_by_name: dict[str, list[tuple[GridLike, np.ndarray]]] = defaultdict(
+            list
+        )
+        for equation_on_domain, dofs in equation_indexer.equation_dofs.items():
+            equations_by_name[equation_on_domain.name].append(
+                (equation_on_domain.domain, dofs)
             )
+
+        for equation_name, equation_on_domains in equations_by_name.items():
             # Forming a block from required grids.
             for block_of_grids in grouping:
-                block_dofs = []
-                for grid, grid_dof_indices in equation_image_space.items():
-                    if grid not in block_of_grids:
-                        continue
-                    block_dofs.extend(grid_dof_indices.tolist())
-
-                if len(block_dofs) == 0:
+                dof_blocks = [
+                    dofs
+                    for domain, dofs in equation_on_domains
+                    if domain in block_of_grids
+                ]
+                if len(dof_blocks) == 0:
                     # This equation is not present on the grids of interest.
+                    continue
+                block_dofs = np.concatenate(dof_blocks)
+                if block_dofs.size == 0:
                     continue
 
                 printed_name = _format_ticks(
-                    name=eq_name,
+                    name=equation_name,
                     block_of_grids=block_of_grids,
                     add_grid_info=add_grid_info,
                 )
-                # Adding the offset to form the global dofs of this block.
-                block_dofs_array = np.array(block_dofs).flatten() + block_indices
-                # Sanity check - we're still within the dofs of this equation.
-                assert np.all(np.isin(block_dofs_array, eq_dof_indices))
-
                 equation_indices.append(
                     {
-                        "block_dofs": block_dofs_array,
+                        "block_dofs": block_dofs,
                         "printed_name": printed_name,
-                        "equation_name": eq_name,
+                        "equation_name": equation_name,
                         "grids": block_of_grids,
                     }
                 )
 
-            block_indices += eq_dof_indices.size
-
         return tuple(equation_indices)
 
     def _variable_data(
-        self, grouping: GridGroupingType, add_grid_info: bool
+        self,
+        variable_indexer: VariableIndexer,
+        grouping: GridGroupingType,
+        add_grid_info: bool,
     ) -> Sequence[dict[str, Any]]:
         """Collects the indices of variables presented in the Jacobian matrix as
         columns.
+
+        The indexer must describe the column ordering of the matrix being diagnosed.
 
         Returns:
             A tuple with dictionaries -- data of each column in the block matrix. The
@@ -375,35 +409,27 @@ class DiagnosticsMixin:
         # First, we group variables by names. We assume that variables with the same
         # name are one variable on multiple grids.
         names_to_variables: dict[str, list[Variable]] = defaultdict(list)
-        for variable in self.equation_system.variables:
+        for variable in variable_indexer.variable_dofs:
             names_to_variables[variable.name].append(variable)
-        names_to_variables = dict(names_to_variables)
 
         for variable_name, variable_on_grids in names_to_variables.items():
             for block_of_grids in grouping:
-                variables_of_interest = []
-                # We add the variable to the list only on the grids of this block.
-                for variable_on_grid in variable_on_grids:
-                    grids: list[GridLike] = (
-                        variable_on_grid.subdomains + variable_on_grid.interfaces
-                    )
-                    assert len(grids) == 1, (
-                        "Something changed in how we store variables in the equation"
-                        "system."
-                    )
-                    if grids[0] in block_of_grids:
-                        variables_of_interest.append(variable_on_grid)
-
-                dofs = self.equation_system.dofs_of(variables_of_interest)
-                if len(dofs) == 0:
+                dof_blocks = [
+                    variable_indexer.variable_dofs[variable]
+                    for variable in variable_on_grids
+                    if variable.domain in block_of_grids
+                ]
+                if len(dof_blocks) == 0:
                     # This variable is not present on the grids of interest.
+                    continue
+                dofs = np.concatenate(dof_blocks)
+                if dofs.size == 0:
                     continue
                 printed_name = _format_ticks(
                     name=variable_name,
                     block_of_grids=block_of_grids,
                     add_grid_info=add_grid_info,
                 )
-                # variable_indices[printed_name] = dofs
                 variable_indices.append(
                     {
                         "block_dofs": dofs,

--- a/src/porepy/viz/diagnostics_mixin.py
+++ b/src/porepy/viz/diagnostics_mixin.py
@@ -6,7 +6,7 @@ import logging
 from collections import defaultdict
 from collections.abc import Iterable
 from itertools import product
-from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, Sequence, cast
+from typing import Any, Callable, Literal, Optional, Sequence, cast
 
 import matplotlib
 import numpy as np
@@ -15,33 +15,30 @@ from scipy.sparse import spmatrix
 from scipy.sparse.linalg import svds
 from typing_extensions import TypeAlias
 
-from porepy import solvers
+from porepy import GridLike, solvers
 from porepy.grids.md_grid import MixedDimensionalGrid
 from porepy.grids.mortar_grid import MortarGrid
 from porepy.numerics.ad.equation_system import EquationSystem
 from porepy.numerics.ad.indexers import EquationIndexer, VariableIndexer
 from porepy.numerics.ad.operators import Variable
 
-if TYPE_CHECKING:
-    from porepy import GridLike
+# Type aliases. See the docs of `DiagnosticsMixin.show_diagnostics` for the details.
+GridGroupingType: TypeAlias = "list[list[GridLike]]"
+"""A type representing the structuring of grouping the diagnostics among the grids.
 
-    # Type aliases. See the docs of `DiagnosticsMixin.show_diagnostics` for the details.
-    GridGroupingType: TypeAlias = "list[list[GridLike]]"
-    """A type representing the structuring of grouping the diagnostics among the grids.
+"""
+SubmatrixHandlerType: TypeAlias = Callable[[spmatrix, str, str], float]
+"""A type representing the diagnostics handler function to be applied to the
+submatrix.
 
-    """
-    SubmatrixHandlerType: TypeAlias = Callable[[spmatrix, str, str], float]
-    """A type representing the diagnostics handler function to be applied to the
-    submatrix.
+"""
+DiagnosticsData: TypeAlias = "dict[tuple[int, int], dict[str, Any]]"
+"""A type representing the diagnostics data for each submatrix in the Jacobian.
 
-    """
-    DiagnosticsData: TypeAlias = "dict[tuple[int, int], dict[str, Any]]"
-    """A type representing the diagnostics data for each submatrix in the Jacobian.
+The key represents the pair (row, column) of the block. The value is a dictionary of
+all diagnostical values collected for this submatrix -- names and values.
 
-    The key represents the pair (row, column) of the block. The value is a dictionary of
-    all diagnostical values collected for this submatrix -- names and values.
-
-    """
+"""
 
 logger = logging.getLogger(__name__)
 
@@ -215,12 +212,12 @@ class DiagnosticsMixin:
         # Determining the block indices and collecting the submatrices.
         equation_data = self._equations_data(
             equation_indexer=equation_indexer,
-            grouping=grouping_,
+            grouping=grouping,
             add_grid_info=add_grid_info,
         )
         variable_data = self._variable_data(
             variable_indexer=variable_indexer,
-            grouping=grouping_,
+            grouping=grouping,
             add_grid_info=add_grid_info,
         )
 

--- a/tests/functional/test_buoyancy_flow.py
+++ b/tests/functional/test_buoyancy_flow.py
@@ -96,12 +96,17 @@ def _run_buoyancy_model(
     geometry_class = geometry2d if dim == 2 else geometry3d
     model_class = add_mixin(geometry_class, model_class)
     model = model_class(model_params)
+    model.prepare_simulation()
     # Use a Lebesgue metric for the residual convergence criterion, since this will
     # strictly bound the residual error in the mass conservation equations.
     solver_params = {
+        "prepare_simulation": False,
         "nl_convergence_criteria": {
             "res_abs": pp.solvers.ResidualBasedAbsoluteCriterion(
-                tol=residual_tolerance, metric=pp.EquationBasedLebesgueMetric(model)
+                tol=residual_tolerance,
+                metric=pp.EquationBasedLebesgueMetric(
+                    model, model.equation_system.equation_indexer
+                ),
             ),
         },
         "nl_divergence_criteria": {

--- a/tests/functional/test_buoyancy_flow.py
+++ b/tests/functional/test_buoyancy_flow.py
@@ -96,6 +96,7 @@ def _run_buoyancy_model(
     geometry_class = geometry2d if dim == 2 else geometry3d
     model_class = add_mixin(geometry_class, model_class)
     model = model_class(model_params)
+    # TODO YZ: Address in the downstream PR. It should not need to prepare simulation.
     model.prepare_simulation()
     # Use a Lebesgue metric for the residual convergence criterion, since this will
     # strictly bound the residual error in the mass conservation equations.

--- a/tests/models/test_metric.py
+++ b/tests/models/test_metric.py
@@ -409,8 +409,8 @@ def test_variable_based_lebesgue_metric_with_model(random_polynomial_setup):
     """Test integral of a random polynomial expression via variables."""
     # Evaluate the numerical norm using the VariableBasedLebesgueMetric.
     model = DummyModel()
-    m_var = pp.VariableBasedEuclideanMetric(model)
     model.prepare_simulation()
+    m_var = pp.VariableBasedEuclideanMetric(model)
 
     # Use cell centers to define the polynomial expression.
     assert len(model.mdg.subdomains()) == 1

--- a/tests/models/test_metric.py
+++ b/tests/models/test_metric.py
@@ -165,25 +165,28 @@ def test_equation_based_euclidean_metric_on_grids(
 ):
     """Test integration of EquationBasedEuclideanMetric in models with grids."""
     # Generate a dummy residual array filled with ones.
-    # NOTE: Evaluate Jacobian to initialize the equation system properly.
-    _, dummy_residual_array = orthogonal_2d_model.equation_system.assemble()
+    dummy_residual_array = orthogonal_2d_model.equation_system.assemble(
+        evaluate_jacobian=False
+    )
 
-    # Define array and expected norm values.
-    equations = orthogonal_2d_model.equation_system.equations
+    # Define array and expected norm values from the same row arrangement as the
+    # assembled residual.
+    equation_indexer = orthogonal_2d_model.equation_system.equation_indexer
+    equation_blocks: dict[str, list[np.ndarray]] = {}
+    for equation, indices in equation_indexer.equation_dofs.items():
+        equation_blocks.setdefault(equation.name, []).append(indices)
+
     result = {}
-    for name in equations:
-        if name not in orthogonal_2d_model.equation_system.assembled_equation_indices:
-            continue
-        dofs = orthogonal_2d_model.equation_system.assembled_equation_indices[name]
-        if len(dofs) == 0:
-            # Expect zero norm for empty equations
+    for name, index_blocks in equation_blocks.items():
+        indices = np.concatenate(index_blocks)
+        if indices.size == 0:
             result[name] = 0.0
             continue
-        dummy_residual_array[dofs] = assignment(len(dofs))
-        result[name] = expected_value(len(dofs))
+        dummy_residual_array[indices] = assignment(indices.size)
+        result[name] = expected_value(indices.size)
 
     # Compute Lebesgue metric values.
-    m = pp.EquationBasedEuclideanMetric(orthogonal_2d_model)
+    m = pp.EquationBasedEuclideanMetric(orthogonal_2d_model, equation_indexer)
     metric_values = m(dummy_residual_array)
 
     # Make sure that the dictionaries are the same.
@@ -198,40 +201,62 @@ def test_equation_based_euclidean_metric_on_grids(
     assert deepdiff_result == {}
 
 
+def test_equation_based_euclidean_metric_with_restricted_indexer(
+    orthogonal_2d_model,
+):
+    """Compute only equation blocks represented by a restricted indexer."""
+    equation_name = next(iter(orthogonal_2d_model.equation_system.equations))
+    residual = orthogonal_2d_model.equation_system.assemble(
+        evaluate_jacobian=False, equations=[equation_name]
+    )
+    equation_indexer, _ = (
+        orthogonal_2d_model.equation_system.construct_assembled_matrix_indexers(
+            equations=[equation_name]
+        )
+    )
+    metric = pp.EquationBasedEuclideanMetric(orthogonal_2d_model, equation_indexer)
+    norms = metric(residual)
+
+    assert set(norms) == {equation_name}
+    assert np.isclose(norms[equation_name], metric._euclidean_norm(residual))
+
+
 def test_equation_based_lebesgue_metric_on_grid(orthogonal_2d_model):
     """Test whether the integration of 1-s over the domain results in volume."""
 
-    # Fetch the equations.
-    equations = orthogonal_2d_model.equation_system.equations
+    # Fetch the equation blocks from the full-system row indexer.
+    equation_indexer = orthogonal_2d_model.equation_system.equation_indexer
+    equation_blocks: dict[str, list[tuple[pp.GridLike, np.ndarray]]] = {}
+    for equation, indices in equation_indexer.equation_dofs.items():
+        equation_blocks.setdefault(equation.name, []).append((equation.domain, indices))
 
     # Generate a dummy residual array filled with ones scaled with the cell volumes.
-    # NOTE: Evaluate Jacobian to initialize the equation system properly.
-    _, dummy_residual_array = orthogonal_2d_model.equation_system.assemble()
+    dummy_residual_array = orthogonal_2d_model.equation_system.assemble(
+        evaluate_jacobian=False
+    )
     dummy_residual_array.fill(1.0)
 
     # Scale with the right cell volumes.
     # Simultaneously compute the expected L2 norm of the 1 vector (incl dimensionality).
-    result = {name: 0.0 for name in equations}
-    for eqn in equations:
-        domains = orthogonal_2d_model.equation_system.equation_image_space_composition[
-            eqn
-        ].keys()
-        if len(domains) == 0:
+    result = {name: 0.0 for name in equation_blocks}
+    for equation_name, blocks in equation_blocks.items():
+        domains = [domain for domain, _ in blocks]
+        indices = np.concatenate([indices for _, indices in blocks])
+        if indices.size == 0:
             continue
-        indices = orthogonal_2d_model.equation_system.assembled_equation_indices[eqn]
-        cell_volumes = np.hstack([_sd.cell_volumes for _sd in domains])
-        eq_dim = orthogonal_2d_model.equation_system.equation_image_size_info[eqn][
-            "cells"
-        ]
-        dummy_residual_array[indices] *= np.repeat(cell_volumes, repeats=eq_dim)
-        result[eqn] += sum(cell_volumes) * eq_dim
+        cell_volumes = np.hstack([domain.cell_volumes for domain in domains])
+        equation_dim = orthogonal_2d_model.equation_system.equation_image_size_info[
+            equation_name
+        ]["cells"]
+        dummy_residual_array[indices] *= np.repeat(cell_volumes, repeats=equation_dim)
+        result[equation_name] += sum(cell_volumes) * equation_dim
 
     # Take square root to get L2 norm.
     for name in result:
         result[name] = np.sqrt(result[name])
 
     # Compute Lebesgue metric values.
-    m = pp.EquationBasedLebesgueMetric(orthogonal_2d_model)
+    m = pp.EquationBasedLebesgueMetric(orthogonal_2d_model, equation_indexer)
     metric_values = m(dummy_residual_array)
 
     # Make sure that the dictionaries are the same.
@@ -428,8 +453,8 @@ def test_equation_based_lebesgue_metric_with_model(random_polynomial_setup):
             "exp_y": random_polynomial_setup["exponents_y"],
         }
     )
-    m_eq = pp.EquationBasedLebesgueMetric(model)
     model.prepare_simulation()
+    m_eq = pp.EquationBasedLebesgueMetric(model, model.equation_system.equation_indexer)
 
     # Use cell centers and pass as values for the model variables.
     assert len(model.mdg.subdomains()) == 1

--- a/tests/models/test_metric.py
+++ b/tests/models/test_metric.py
@@ -256,7 +256,7 @@ def test_equation_based_lebesgue_metric_on_grid(orthogonal_2d_model):
         result[name] = np.sqrt(result[name])
 
     # Compute Lebesgue metric values.
-    m = pp.EquationBasedLebesgueMetric(orthogonal_2d_model, equation_indexer)
+    m = pp.EquationBasedLebesgueMetric(orthogonal_2d_model)
     metric_values = m(dummy_residual_array)
 
     # Make sure that the dictionaries are the same.
@@ -454,7 +454,7 @@ def test_equation_based_lebesgue_metric_with_model(random_polynomial_setup):
         }
     )
     model.prepare_simulation()
-    m_eq = pp.EquationBasedLebesgueMetric(model, model.equation_system.equation_indexer)
+    m_eq = pp.EquationBasedLebesgueMetric(model)
 
     # Use cell centers and pass as values for the model variables.
     assert len(model.mdg.subdomains()) == 1

--- a/tests/models/test_metric.py
+++ b/tests/models/test_metric.py
@@ -84,7 +84,7 @@ def test_euclidean_metric_on_grids(orthogonal_2d_model, assignment, expected_val
     ],
 )
 def test_variable_based_euclidean_metric_on_grids(
-    orthogonal_2d_model, assignment, expected_value
+    orthogonal_2d_model: pp.PorePyModel, assignment, expected_value
 ):
     """Test integration of VariableBasedEuclideanMetric in models with grids."""
     m = pp.VariableBasedEuclideanMetric(orthogonal_2d_model)
@@ -119,7 +119,7 @@ def test_variable_based_euclidean_metric_on_grids(
         assert np.isclose(value, expected_value(len(dofs)))
 
 
-def test_variable_based_lebesgue_metric_on_grids(orthogonal_2d_model):
+def test_variable_based_lebesgue_metric_on_grids(orthogonal_2d_model: pp.PorePyModel):
     """Test integration of VariableBasedLebesgueMetric in models with grids.
 
     Check that the integration of 1-s over the domain results in the expected L2 norm,
@@ -161,7 +161,7 @@ def test_variable_based_lebesgue_metric_on_grids(orthogonal_2d_model):
     ],
 )
 def test_equation_based_euclidean_metric_on_grids(
-    orthogonal_2d_model, assignment, expected_value
+    orthogonal_2d_model: pp.PorePyModel, assignment, expected_value
 ):
     """Test integration of EquationBasedEuclideanMetric in models with grids."""
     # Generate a dummy residual array filled with ones.
@@ -173,7 +173,7 @@ def test_equation_based_euclidean_metric_on_grids(
     # assembled residual.
     equation_indexer = orthogonal_2d_model.equation_system.equation_indexer
     equation_blocks: dict[str, list[np.ndarray]] = {}
-    for equation, indices in equation_indexer.equation_dofs.items():
+    for equation, indices in equation_indexer.indices.items():
         equation_blocks.setdefault(equation.name, []).append(indices)
 
     result = {}
@@ -202,7 +202,7 @@ def test_equation_based_euclidean_metric_on_grids(
 
 
 def test_equation_based_euclidean_metric_with_restricted_indexer(
-    orthogonal_2d_model,
+    orthogonal_2d_model: pp.PorePyModel,
 ):
     """Compute only equation blocks represented by a restricted indexer."""
     equation_name = next(iter(orthogonal_2d_model.equation_system.equations))
@@ -221,13 +221,13 @@ def test_equation_based_euclidean_metric_with_restricted_indexer(
     assert np.isclose(norms[equation_name], metric._euclidean_norm(residual))
 
 
-def test_equation_based_lebesgue_metric_on_grid(orthogonal_2d_model):
+def test_equation_based_lebesgue_metric_on_grid(orthogonal_2d_model: pp.PorePyModel):
     """Test whether the integration of 1-s over the domain results in volume."""
 
     # Fetch the equation blocks from the full-system row indexer.
     equation_indexer = orthogonal_2d_model.equation_system.equation_indexer
     equation_blocks: dict[str, list[tuple[pp.GridLike, np.ndarray]]] = {}
-    for equation, indices in equation_indexer.equation_dofs.items():
+    for equation, indices in equation_indexer.indices.items():
         equation_blocks.setdefault(equation.name, []).append((equation.domain, indices))
 
     # Generate a dummy residual array filled with ones scaled with the cell volumes.

--- a/tests/models/test_poromechanics.py
+++ b/tests/models/test_poromechanics.py
@@ -660,7 +660,7 @@ def test_poromechanics_empty_equation_filter(model_class):
     # Parsed equations after discarding those whose image space is empty.
     # In poromechanics models without fractures, fracture-related equations are
     # also registered but have empty image spaces, and are therefore removed here.
-    parsed_equations = list(equation_system._parse_equations().keys())
+    parsed_equations = list(eq.name for eq in equation_system._parse_equations().keys())
 
     # Check empty domain equations exist.
     empty_equations = []

--- a/tests/models/test_poromechanics.py
+++ b/tests/models/test_poromechanics.py
@@ -665,14 +665,9 @@ def test_poromechanics_empty_equation_filter(model_class):
     # Check empty domain equations exist.
     empty_equations = []
     for name in equation_system.equations:
-        total = sum(
-            len(indices)
-            for indices in equation_system.equation_image_space_composition[
-                name
-            ].values()
-        )
-        if total == 0:
-            empty_equations.append(name)
+        if name in equation_system.equation_indexer.equation_image_space_composition:
+            continue
+        empty_equations.append(name)
 
     assert len(empty_equations) > 0
 

--- a/tests/models/test_poromechanics.py
+++ b/tests/models/test_poromechanics.py
@@ -657,27 +657,28 @@ def test_poromechanics_empty_equation_filter(model_class):
     # regardless of whether the corresponding domains are present in the model.
     all_equations = list(equation_system.equations.keys())
 
-    # Parsed equations after discarding those whose image space is empty.
-    # In poromechanics models without fractures, fracture-related equations are
-    # also registered but have empty image spaces, and are therefore removed here.
-    parsed_equations = list(eq.name for eq in equation_system._parse_equations().keys())
-
     # Check empty domain equations exist.
     empty_equations = []
+    not_empty_equations = []
     for name in equation_system.equations:
-        if name in equation_system.equation_indexer.equation_image_space_composition:
-            continue
-        empty_equations.append(name)
+        if len(equation_system.equations[name].domains) == 0:
+            empty_equations.append(name)
+        else:
+            not_empty_equations.append(name)
 
     assert len(empty_equations) > 0
+    assert len(not_empty_equations) > 0
 
     # Check empty domain equations are filtered.
     for name in empty_equations:
-        assert name not in parsed_equations
+        assert (
+            name
+            not in equation_system.equation_indexer.equation_image_space_composition
+        )
 
     # Check that the assembled system does not include empty domain equations.
     A_all, b_all = equation_system.assemble(all_equations)
-    A_filtered, b_filtered = equation_system.assemble(parsed_equations)
+    A_filtered, b_filtered = equation_system.assemble(not_empty_equations)
 
     assert A_all.shape == A_filtered.shape
     assert np.allclose(b_all, b_filtered)

--- a/tests/numerics/ad/test_equation_system.py
+++ b/tests/numerics/ad/test_equation_system.py
@@ -1143,7 +1143,14 @@ def test_parse_variable_like(model: EquationSystemMockModel):
 def test_parse_variable_type_rejects_unknown_variable(
     model: EquationSystemMockModel, ordered: bool
 ) -> None:
-    """An unregistered Variable must not be silently discarded in parsing variables."""
+    """An unregistered Variable must not be silently discarded in parsing variables.
+
+    Parameters:
+        model: The mock PorePy model. Needs to provide `mdg` and `equation_system`.
+        ordered: The argument passed to `equation_system._parse_variable_type`. We test
+            with both values, should not affect the test result.
+
+    """
     unknown_variable = pp.ad.Variable(
         "unknown", {"cells": 1}, model.mdg.subdomains()[0]
     )

--- a/tests/numerics/ad/test_equation_system.py
+++ b/tests/numerics/ad/test_equation_system.py
@@ -1284,12 +1284,21 @@ def test_secondary_variable_assembly(model: EquationSystemMockModel, var_names):
     assert pp.test_utils.arrays.compare_matrices(
         A, _eliminate_columns_from_matrix(model.A, dofs, reverse=True)
     )
-    # Check that the size of equation blocks (rows) were correctly recorded
-    # TODO: Revisit after LinearSystem
+    # Check that the equation blocks were correctly recorded.
+    equation_indexer, variable_indexer = (
+        model.equation_system.construct_assembled_matrix_indexers(variables=variables)
+    )
     for name in model.equation_system.equations:
-        assert np.allclose(
-            model.equation_system.assembled_equation_indices[name], model.eq_ind(name)
-        )
+        actual_dofs = [
+            dofs
+            for eq, dofs in equation_indexer.equation_dofs.items()
+            if eq.name == name
+        ]
+        assert np.allclose(np.concatenate(actual_dofs), model.eq_ind(name))
+
+    # Check that the sizes of variable blocks were correctly recorded.
+    for var in variables:
+        assert variable_indexer.variable_dofs[var].size == model.dof_ind(var).size
 
 
 @pytest.mark.parametrize(
@@ -1384,20 +1393,28 @@ def test_assemble(model: EquationSystemMockModel, equation_variables):
     assert np.allclose(b_sub, model.b[rows])
     assert pp.test_utils.arrays.compare_matrices(A_sub, model.A[rows][:, cols])
 
-    # TODO: Revisit after LinearSystem
-    # # Also check that the equation row sizes were correctly recorded.
-    # if eq_names is not None:
-    #     for name in eq_names:
-    #         assert np.allclose(
-    #             model.equation_system.assembled_equation_indices[name].size,
-    #             model.block_size(name),
-    #         )
-    # else:
-    #     for name in model.equation_system.equations:
-    #         assert np.allclose(
-    #             model.equation_system.assembled_equation_indices[name].size,
-    #             model.block_size(name),
-    #         )
+    # Also check that the equation row sizes were correctly recorded.
+    equation_indexer, variable_indexer = (
+        equation_system.construct_assembled_matrix_indexers(
+            equations=eq_names, variables=variables
+        )
+    )
+    equation_dofs = equation_indexer.equation_dofs
+    if eq_names is None:
+        eq_names = list(model.equation_system.equations)
+
+    for name in eq_names:
+        num_dofs = sum(
+            [dofs.size for var, dofs in equation_dofs.items() if var.name == name]
+        )
+        assert num_dofs == model.block_size(name)
+
+    variable_dofs = variable_indexer.variable_dofs
+    for name in var_names:
+        num_dofs = sum(
+            [dofs.size for var, dofs in variable_dofs.items() if var.name == name]
+        )
+        assert num_dofs == model.dof_ind(name).size
 
 
 @pytest.mark.parametrize(
@@ -1618,9 +1635,11 @@ def test_assemble_ignores_empty_equations(model: EquationSystemMockModel):
     assert pp.test_utils.arrays.compare_matrices(A, A_ref)
 
     # Check bookkeeping does not suddenly include the empty equation.
+    equation_indexer, _ = equation_system.construct_assembled_matrix_indexers()
 
-    # TODO: Revisit after LinearSystem
-    assert "empty_equation" not in equation_system.assembled_equation_indices
+    for eq_on_domain in equation_indexer.equation_dofs:
+        assert eq_on_domain.name != "empty_equation"
+    assert "empty_equation" not in equation_indexer.equation_dofs_per_equation
 
 
 def test_schur_complement_empty_equation_filter():

--- a/tests/numerics/ad/test_equation_system.py
+++ b/tests/numerics/ad/test_equation_system.py
@@ -954,7 +954,7 @@ def test_set_remove_equations(model: EquationSystemMockModel):
     # Check that the mapping of equation to subdomain to global dof
     # indices is correctly set.
     equation_subdomain_blocks = (
-        equation_system.equation_indexer.equation_dofs_per_equation
+        equation_system.equation_indexer.equation_image_space_composition
     )
     assert np.allclose(
         equation_subdomain_blocks[model.eq_single_subdomain.name][model.sd_top],
@@ -975,7 +975,7 @@ def test_set_remove_equations(model: EquationSystemMockModel):
         equations_per_grid_entity=dof_info_subdomain,
     )
     equation_subdomain_blocks = (
-        equation_system.equation_indexer.equation_dofs_per_equation
+        equation_system.equation_indexer.equation_image_space_composition
     )
     offset = 0
     for sd in model.subdomains:
@@ -995,7 +995,7 @@ def test_set_remove_equations(model: EquationSystemMockModel):
         equations_per_grid_entity=dof_info_interface,
     )
     equation_subdomain_blocks = (
-        equation_system.equation_indexer.equation_dofs_per_equation
+        equation_system.equation_indexer.equation_image_space_composition
     )
     offset = 0
     for intf in model.interfaces:
@@ -1017,7 +1017,7 @@ def test_set_remove_equations(model: EquationSystemMockModel):
         equations_per_grid_entity=dof_all_interfaces,
     )
     equation_subdomain_blocks = (
-        equation_system.equation_indexer.equation_dofs_per_equation
+        equation_system.equation_indexer.equation_image_space_composition
     )
 
     offset = 0
@@ -1034,7 +1034,7 @@ def test_set_remove_equations(model: EquationSystemMockModel):
         equation_name="eq_all_interfaces",
     )
     equation_subdomain_blocks = (
-        equation_system.equation_indexer.equation_dofs_per_equation
+        equation_system.equation_indexer.equation_image_space_composition
     )
 
     offset = 0
@@ -1542,7 +1542,9 @@ def test_schur_complement(eq_var_to_exclude):
         # For all equations not to be eliminated (e.g., present in eq_names), they are
         # kept on all subdomains.
         equations = {
-            eq: list(equation_system.equation_indexer.equation_dofs_per_equation[eq])
+            eq: list(
+                equation_system.equation_indexer.equation_image_space_composition[eq]
+            )
             for eq in eq_names
         }
         # In addition, we keep 'eq_all_subdomains' on the top subdomain.
@@ -1639,7 +1641,7 @@ def test_assemble_ignores_empty_equations(model: EquationSystemMockModel):
 
     for eq_on_domain in equation_indexer.equation_dofs:
         assert eq_on_domain.name != "empty_equation"
-    assert "empty_equation" not in equation_indexer.equation_dofs_per_equation
+    assert "empty_equation" not in equation_indexer.equation_image_space_composition
 
 
 def test_schur_complement_empty_equation_filter():

--- a/tests/numerics/ad/test_equation_system.py
+++ b/tests/numerics/ad/test_equation_system.py
@@ -1163,6 +1163,15 @@ def test_parse_single_equation(model: EquationSystemMockModel):
 
     """
     equation_system = model.equation_system
+    equation_indexer = equation_system.equation_indexer
+
+    def get_restriction_dofs(equations: list[pp.ad.EquationOnDomain]):
+        return np.concatenate(
+            [
+                equation_indexer.equation_image_space_composition[eq.name][eq.domain]
+                for eq in equations
+            ]
+        )
 
     # Represent the equation both by its string and its operator form.
     # This could have been parametrized to the price of computational higher cost
@@ -1175,10 +1184,9 @@ def test_parse_single_equation(model: EquationSystemMockModel):
         # First parse the equation as it is, without any restriction.
         # This should give back the full equation with no restriction.
         restriction_1 = equation_system._parse_equations([eq_or_name])
-        assert len(restriction_1) == 1
+        assert len(restriction_1) == 4
 
-        assert eq in restriction_1
-        assert restriction_1[eq] is None
+        assert all(eq.name == eq_on_domain.name for eq_on_domain in restriction_1)
 
         # Next, restrict the equation to a single subdomain.
         restriction_2 = equation_system._parse_equations({eq_or_name: [model.sd_top]})
@@ -1186,7 +1194,9 @@ def test_parse_single_equation(model: EquationSystemMockModel):
         # The numbering of the subdomanis in the EquationSystem is the same as that of
         # the MixedDimensionalGrid, thus the indices associated with this subdomain
         # will be 0-offset.
-        assert np.allclose(restriction_2[eq], np.arange(model.sd_top.num_cells))
+        assert np.allclose(
+            get_restriction_dofs(restriction_2), np.arange(model.sd_top.num_cells)
+        )
 
         # Next, permute the subdomains before sending them in. All subdomains are
         # present, thus the indices should cover all cells in the md-grid. Moreover,
@@ -1196,7 +1206,8 @@ def test_parse_single_equation(model: EquationSystemMockModel):
         eq_def = {eq_or_name: model.subdomains[::-1]}
         restriction_3 = equation_system._parse_equations(eq_def)
         assert np.allclose(
-            restriction_3[eq], np.arange(model.mdg.num_subdomain_cells())
+            get_restriction_dofs(restriction_3),
+            np.arange(model.mdg.num_subdomain_cells()),
         )
 
 
@@ -1222,38 +1233,39 @@ def test_parse_equations(model: EquationSystemMockModel):
 
     # First pass None. This should give as all equations on all subdomains.
     received_equations_1 = equation_system._parse_equations(None)
-    received_keys_1 = list(received_equations_1.keys())
 
-    # We expect to receive all equations, thus the length of the dictionary should be
-    # the same as the number of equations.
-    assert len(received_equations_1) == len(all_equation_names)
+    # We expect all equations, thus names must be identical and ordered the same way.
+    # The domains must be the same and also ordered the same way.
+    expected_equations_1 = [
+        pp.ad.EquationOnDomain(name=eq.name, domain=domain)
+        for eq in all_equations
+        for domain in eq.domains
+    ]
+    assert received_equations_1 == expected_equations_1
 
-    for eq, key in zip(all_equations, received_keys_1):
-        # The keys of the received dictionary should be the same as the names of the
-        # equations as they were set in the model, and the order should be preserved.
-        assert eq == key
-        # There should be no restriction on indices.
-        assert received_equations_1[eq] is None
+    # Next, pass the single subdomain and all subdomains, in that order.
 
-    # Next, pass the single subdomain and all subdomains, in that order. We should
-    # receive the same keys, but in reverse order.
+    # Next, pass two equation names in the reversed order. We should receive the same
+    # keys, but in canonical order.
     received_equations_2 = equation_system._parse_equations(
         [all_equation_names[1], all_equation_names[0]]
     )
-    received_keys_2 = list(received_equations_2.keys())
-    assert len(received_keys_2) == 2
-    for i in range(len(received_keys_2)):
-        assert received_keys_2[i] == all_equations[i]
+    expected_equations_2 = [
+        pp.ad.EquationOnDomain(name=name, domain=domain)
+        for name in [all_equation_names[0], all_equation_names[1]]
+        for domain in equation_system.equations[name].domains
+    ]
+    assert received_equations_2 == expected_equations_2
 
     # Send in the all_subdomains equation in both unrestricted and restricted form.
     # The restriction should override the unrestricted form.
     received_equations_3 = equation_system._parse_equations(
         {all_equation_names[0]: None, all_equation_names[0]: [model.sd_top]}
     )
-    assert len(received_equations_3) == 1
-    assert np.allclose(
-        received_equations_3[all_equations[0]], np.arange(model.sd_top.num_cells)
-    )
+    expected_equation_3 = [
+        pp.ad.EquationOnDomain(name=all_equation_names[0], domain=model.sd_top)
+    ]
+    assert received_equations_3 == expected_equation_3
 
     # Add an equation on an empty domain to the equation system.
     model.add_equation_on_empty_domain()
@@ -1262,28 +1274,9 @@ def test_parse_equations(model: EquationSystemMockModel):
     assert "empty_equation" in equation_system.equations
 
     # Check that _parse_equations filters out equations on empty domain.
-    assert (
-        equation_system.equations["empty_equation"]
-        not in equation_system._parse_equations()
-    )
-
-
-def test_invalid_equation_domain_restriction(model: EquationSystemMockModel) -> None:
-    """Equation APIs consistently reject invalid equation restrictions."""
-    equation_system = model.equation_system
-    invalid_domain = next(sd for sd in model.subdomains if sd is not model.sd_top)
-    restrictions = [
-        {"unknown_equation": [model.sd_top]},
-        {model.eq_single_subdomain.name: [invalid_domain]},
-    ]
-
-    for restriction in restrictions:
-        with pytest.raises(ValueError):
-            equation_system.construct_equation_indexer(restriction)
-        with pytest.raises(ValueError):
-            equation_system.construct_assembled_matrix_indexers(equations=restriction)
-        with pytest.raises(ValueError):
-            equation_system.assemble(equations=restriction)
+    assert "empty_equation" not in {
+        eq.name for eq in equation_system._parse_equations()
+    }
 
 
 @pytest.mark.parametrize(

--- a/tests/numerics/ad/test_equation_system.py
+++ b/tests/numerics/ad/test_equation_system.py
@@ -1454,6 +1454,57 @@ def test_assemble(model: EquationSystemMockModel, equation_variables):
 
 
 @pytest.mark.parametrize(
+    "equations",
+    [
+        ["eq_single_interface", "eq_all_subdomains"],
+        ["eq_all_subdomains", "eq_single_interface"],
+    ],
+)
+@pytest.mark.parametrize(
+    "variables",
+    [
+        ["w", "x"],
+        ["x", "w"],
+    ],
+)
+def test_assembled_matrix_indexers_match_assembly_order(
+    model: EquationSystemMockModel,
+    equations: list[str],
+    variables: list[str],
+) -> None:
+    """Restricted indexers must use the canonical matrix assembly order."""
+    equation_system = model.equation_system
+
+    _, _ = equation_system.assemble(equations=equations, variables=variables)
+    equation_indexer, variable_indexer = (
+        equation_system.construct_assembled_matrix_indexers(
+            equations=equations, variables=variables
+        )
+    )
+
+    expected_equations = [
+        equation
+        for equation in equation_system.equation_indexer.equation_dofs
+        if equation.name in equations
+    ]
+    expected_variables = [
+        variable
+        for variable in equation_system.variable_indexer.variable_dofs
+        if variable.name in variables
+    ]
+
+    actual_order = (
+        [equation.name for equation in equation_indexer.equation_dofs],
+        [variable.name for variable in variable_indexer.variable_dofs],
+    )
+    expected_order = (
+        [equation.name for equation in expected_equations],
+        [variable.name for variable in expected_variables],
+    )
+    assert actual_order == expected_order
+
+
+@pytest.mark.parametrize(
     "equation_variables",
     [
         [None, None],  # Two Nones will give the full system

--- a/tests/numerics/ad/test_equation_system.py
+++ b/tests/numerics/ad/test_equation_system.py
@@ -8,8 +8,7 @@ The tests focus on various assembly methods:
     * test_variable_tags: Tagging of variables, used for filtering in an EquationSystem.
     * test_set_get_methods: Get and set methods for variables, including methods for
         shifting between time steps and iterates.
-    * test_projection_matrix: Projection from a global vector to one defined on a subset
-        of variables.
+    * test_variable_indexer_subset: Indexing a subset of variables.
     * test_set_remove_equations: Set and remove equations from an EquationSystem.
     * test_parse_variable_like, test_parse_single_equation, test_parse_equations:
         Parsing of equations, and the methods used to do so. Thorough testing here means
@@ -246,8 +245,14 @@ def test_remove_variables(variable_to_be_removed):
         var_to_remove = equation_system.md_variable(variable_to_be_removed)
         equation_system.remove_variables([var_to_remove])
         # Check that the EquationSystem does not contain the removed variable anymore.
-        for field in ["_variables", "_variable_numbers", "_variable_dof_type"]:
-            assert variable_to_be_removed not in getattr(equation_system, field).keys()
+        assert all(
+            variable.name != variable_to_be_removed
+            for variable in equation_system.variables
+        )
+        assert all(
+            variable.name != variable_to_be_removed
+            for variable in equation_system.variable_indexer.variable_dofs
+        )
         # Check that trying to remove the variable again raises an error.
         with pytest.raises(ValueError):
             equation_system.remove_variables([var_to_remove])
@@ -621,15 +626,6 @@ def model() -> EquationSystemMockModel:
     return EquationSystemMockModel()
 
 
-def _eliminate_rows_from_matrix(A, indices, reverse):
-    # Helper method to extract submatrix by row indices
-    if reverse:
-        inds = np.setdiff1d(np.arange(A.shape[0]), indices)
-    else:
-        inds = indices
-    return A[inds]
-
-
 def _variable_from_model(
     model: EquationSystemMockModel,
     as_str: bool,
@@ -957,7 +953,9 @@ def test_set_remove_equations(model: EquationSystemMockModel):
 
     # Check that the mapping of equation to subdomain to global dof
     # indices is correctly set.
-    equation_subdomain_blocks = equation_system.equation_image_space_composition
+    equation_subdomain_blocks = (
+        equation_system.equation_indexer.equation_dofs_per_equation
+    )
     assert np.allclose(
         equation_subdomain_blocks[model.eq_single_subdomain.name][model.sd_top],
         np.arange(model.sd_top.num_cells * dof_info_subdomain["cells"]),
@@ -976,6 +974,9 @@ def test_set_remove_equations(model: EquationSystemMockModel):
         grids=model.subdomains,
         equations_per_grid_entity=dof_info_subdomain,
     )
+    equation_subdomain_blocks = (
+        equation_system.equation_indexer.equation_dofs_per_equation
+    )
     offset = 0
     for sd in model.subdomains:
         assert np.allclose(
@@ -992,6 +993,9 @@ def test_set_remove_equations(model: EquationSystemMockModel):
         model.eq_all_interfaces,
         grids=model.interfaces[::-1],
         equations_per_grid_entity=dof_info_interface,
+    )
+    equation_subdomain_blocks = (
+        equation_system.equation_indexer.equation_dofs_per_equation
     )
     offset = 0
     for intf in model.interfaces:
@@ -1012,6 +1016,9 @@ def test_set_remove_equations(model: EquationSystemMockModel):
         grids=model.interfaces[::-1],
         equations_per_grid_entity=dof_all_interfaces,
     )
+    equation_subdomain_blocks = (
+        equation_system.equation_indexer.equation_dofs_per_equation
+    )
 
     offset = 0
     for intf in model.interfaces:
@@ -1025,6 +1032,9 @@ def test_set_remove_equations(model: EquationSystemMockModel):
     equation_system.update_equation(
         new_equation=mock_equation,
         equation_name="eq_all_interfaces",
+    )
+    equation_subdomain_blocks = (
+        equation_system.equation_indexer.equation_dofs_per_equation
     )
 
     offset = 0
@@ -1132,35 +1142,36 @@ def test_parse_single_equation(model: EquationSystemMockModel):
     # Represent the equation both by its string and its operator form.
     # This could have been parametrized to the price of computational higher cost
     # (Pytest assembly overhead).
-    for eq in [model.eq_all_subdomains, model.eq_all_subdomains.name]:
+    for eq_or_name in [model.eq_all_subdomains, model.eq_all_subdomains.name]:
         # The equation name.
-        name = eq if isinstance(eq, str) else eq.name
+        name = eq_or_name if isinstance(eq_or_name, str) else eq_or_name.name
+        eq = equation_system.equations[name]
 
         # First parse the equation as it is, without any restriction.
         # This should give back the full equation with no restriction.
-        restriction_1 = equation_system._parse_single_equation(eq)
+        restriction_1 = equation_system._parse_equations([eq_or_name])
         assert len(restriction_1) == 1
 
-        assert name in restriction_1
-        assert restriction_1[name] is None
+        assert eq in restriction_1
+        assert restriction_1[eq] is None
 
         # Next, restrict the equation to a single subdomain.
-        restriction_2 = equation_system._parse_single_equation({eq: [model.sd_top]})
+        restriction_2 = equation_system._parse_equations({eq_or_name: [model.sd_top]})
         assert len(restriction_2) == 1
         # The numbering of the subdomanis in the EquationSystem is the same as that of
         # the MixedDimensionalGrid, thus the indices associated with this subdomain
         # will be 0-offset.
-        assert np.allclose(restriction_2[name], np.arange(model.sd_top.num_cells))
+        assert np.allclose(restriction_2[eq], np.arange(model.sd_top.num_cells))
 
         # Next, permute the subdomains before sending them in. All subdomains are
         # present, thus the indices should cover all cells in the md-grid. Moreover,
         # the EquationSystem will sort the subdomains according in the same order as
         # the MixedDimensionalGrid.subdomains() method, thus the indices should again
         # be linear.
-        eq_def = {eq: model.subdomains[::-1]}
-        restriction_3 = equation_system._parse_single_equation(eq_def)
+        eq_def = {eq_or_name: model.subdomains[::-1]}
+        restriction_3 = equation_system._parse_equations(eq_def)
         assert np.allclose(
-            restriction_3[name], np.arange(model.mdg.num_subdomain_cells())
+            restriction_3[eq], np.arange(model.mdg.num_subdomain_cells())
         )
 
 
@@ -1180,6 +1191,9 @@ def test_parse_equations(model: EquationSystemMockModel):
     # All equations. The order is the same as that in the helper class
     # EquationSystemSetup.
     all_equation_names = model.all_equation_names
+    all_equations = [
+        equation_system.equations[eq_name] for eq_name in all_equation_names
+    ]
 
     # First pass None. This should give as all equations on all subdomains.
     received_equations_1 = equation_system._parse_equations(None)
@@ -1189,7 +1203,7 @@ def test_parse_equations(model: EquationSystemMockModel):
     # the same as the number of equations.
     assert len(received_equations_1) == len(all_equation_names)
 
-    for eq, key in zip(all_equation_names, received_keys_1):
+    for eq, key in zip(all_equations, received_keys_1):
         # The keys of the received dictionary should be the same as the names of the
         # equations as they were set in the model, and the order should be preserved.
         assert eq == key
@@ -1204,7 +1218,7 @@ def test_parse_equations(model: EquationSystemMockModel):
     received_keys_2 = list(received_equations_2.keys())
     assert len(received_keys_2) == 2
     for i in range(len(received_keys_2)):
-        assert received_keys_2[i] == all_equation_names[i]
+        assert received_keys_2[i] == all_equations[i]
 
     # Send in the all_subdomains equation in both unrestricted and restricted form.
     # The restriction should override the unrestricted form.
@@ -1213,7 +1227,7 @@ def test_parse_equations(model: EquationSystemMockModel):
     )
     assert len(received_equations_3) == 1
     assert np.allclose(
-        received_equations_3[all_equation_names[0]], np.arange(model.sd_top.num_cells)
+        received_equations_3[all_equations[0]], np.arange(model.sd_top.num_cells)
     )
 
     # Add an equation on an empty domain to the equation system.
@@ -1223,7 +1237,10 @@ def test_parse_equations(model: EquationSystemMockModel):
     assert "empty_equation" in equation_system.equations
 
     # Check that _parse_equations filters out equations on empty domain.
-    assert "empty_equation" not in equation_system._parse_equations()
+    assert (
+        equation_system.equations["empty_equation"]
+        not in equation_system._parse_equations()
+    )
 
 
 @pytest.mark.parametrize(
@@ -1268,6 +1285,7 @@ def test_secondary_variable_assembly(model: EquationSystemMockModel, var_names):
         A, _eliminate_columns_from_matrix(model.A, dofs, reverse=True)
     )
     # Check that the size of equation blocks (rows) were correctly recorded
+    # TODO: Revisit after LinearSystem
     for name in model.equation_system.equations:
         assert np.allclose(
             model.equation_system.assembled_equation_indices[name], model.eq_ind(name)
@@ -1366,19 +1384,20 @@ def test_assemble(model: EquationSystemMockModel, equation_variables):
     assert np.allclose(b_sub, model.b[rows])
     assert pp.test_utils.arrays.compare_matrices(A_sub, model.A[rows][:, cols])
 
-    # Also check that the equation row sizes were correctly recorded.
-    if eq_names is not None:
-        for name in eq_names:
-            assert np.allclose(
-                model.equation_system.assembled_equation_indices[name].size,
-                model.block_size(name),
-            )
-    else:
-        for name in model.equation_system.equations:
-            assert np.allclose(
-                model.equation_system.assembled_equation_indices[name].size,
-                model.block_size(name),
-            )
+    # TODO: Revisit after LinearSystem
+    # # Also check that the equation row sizes were correctly recorded.
+    # if eq_names is not None:
+    #     for name in eq_names:
+    #         assert np.allclose(
+    #             model.equation_system.assembled_equation_indices[name].size,
+    #             model.block_size(name),
+    #         )
+    # else:
+    #     for name in model.equation_system.equations:
+    #         assert np.allclose(
+    #             model.equation_system.assembled_equation_indices[name].size,
+    #             model.block_size(name),
+    #         )
 
 
 @pytest.mark.parametrize(
@@ -1504,10 +1523,9 @@ def test_schur_complement(eq_var_to_exclude):
     if eq_to_exclude[0] == "eq_all_subdomains":
         # In this case, we use a dictionary to define the equations to keep.
         # For all equations not to be eliminated (e.g., present in eq_names), they are
-        # kept on all subdomains (which we somewhat cumbersomely obtain from a private
-        # variable of EquationSystem).
+        # kept on all subdomains.
         equations = {
-            eq: list(equation_system.equation_image_space_composition[eq].keys())
+            eq: list(equation_system.equation_indexer.equation_dofs_per_equation[eq])
             for eq in eq_names
         }
         # In addition, we keep 'eq_all_subdomains' on the top subdomain.
@@ -1600,6 +1618,8 @@ def test_assemble_ignores_empty_equations(model: EquationSystemMockModel):
     assert pp.test_utils.arrays.compare_matrices(A, A_ref)
 
     # Check bookkeeping does not suddenly include the empty equation.
+
+    # TODO: Revisit after LinearSystem
     assert "empty_equation" not in equation_system.assembled_equation_indices
 
 
@@ -1628,8 +1648,10 @@ def test_schur_complement_empty_equation_filter():
 
     # Check the empty equation exists in system.
     assert "empty_equation" in equation_system.equations
-    # Check whether the parse filter the empty equation out.
-    assert "empty_equation" not in equation_system._parse_equations()
+    # Check whether parsing filters the empty equation out.
+    assert "empty_equation" not in {
+        item.name for item in equation_system._parse_equations(None)
+    }
 
     # Check Schur complement should be unchanged.
     S, bS = equation_system.assemble_schur_complement_system(

--- a/tests/numerics/ad/test_equation_system.py
+++ b/tests/numerics/ad/test_equation_system.py
@@ -951,10 +951,11 @@ def test_set_remove_equations(model: EquationSystemMockModel):
         equations_per_grid_entity=dof_info_subdomain,
     )
 
-    equation_indexer = equation_system.equation_indexer
     # Check that the mapping of equation to subdomain to global dof
     # indices is correctly set.
-    equation_subdomain_blocks = equation_indexer.equation_image_space_composition
+    equation_subdomain_blocks = (
+        equation_system.equation_indexer.equation_image_space_composition
+    )
     assert np.allclose(
         equation_subdomain_blocks[model.eq_single_subdomain.name][model.sd_top],
         np.arange(model.sd_top.num_cells * dof_info_subdomain["cells"]),
@@ -973,7 +974,9 @@ def test_set_remove_equations(model: EquationSystemMockModel):
         grids=model.subdomains,
         equations_per_grid_entity=dof_info_subdomain,
     )
-    equation_subdomain_blocks = equation_indexer.equation_image_space_composition
+    equation_subdomain_blocks = (
+        equation_system.equation_indexer.equation_image_space_composition
+    )
     offset = 0
     for sd in model.subdomains:
         assert np.allclose(
@@ -991,7 +994,9 @@ def test_set_remove_equations(model: EquationSystemMockModel):
         grids=model.interfaces[::-1],
         equations_per_grid_entity=dof_info_interface,
     )
-    equation_subdomain_blocks = equation_indexer.equation_image_space_composition
+    equation_subdomain_blocks = (
+        equation_system.equation_indexer.equation_image_space_composition
+    )
     offset = 0
     for intf in model.interfaces:
         assert np.allclose(
@@ -1011,7 +1016,9 @@ def test_set_remove_equations(model: EquationSystemMockModel):
         grids=model.interfaces[::-1],
         equations_per_grid_entity=dof_all_interfaces,
     )
-    equation_subdomain_blocks = equation_indexer.equation_image_space_composition
+    equation_subdomain_blocks = (
+        equation_system.equation_indexer.equation_image_space_composition
+    )
 
     offset = 0
     for intf in model.interfaces:
@@ -1026,7 +1033,9 @@ def test_set_remove_equations(model: EquationSystemMockModel):
         new_equation=mock_equation,
         equation_name="eq_all_interfaces",
     )
-    equation_subdomain_blocks = equation_indexer.equation_image_space_composition
+    equation_subdomain_blocks = (
+        equation_system.equation_indexer.equation_image_space_composition
+    )
 
     offset = 0
     for intf in model.interfaces:

--- a/tests/numerics/ad/test_equation_system.py
+++ b/tests/numerics/ad/test_equation_system.py
@@ -251,7 +251,7 @@ def test_remove_variables(variable_to_be_removed):
         )
         assert all(
             variable.name != variable_to_be_removed
-            for variable in equation_system.variable_indexer.variable_dofs
+            for variable in equation_system.variable_indexer.indices
         )
         # Check that trying to remove the variable again raises an error.
         with pytest.raises(ValueError):
@@ -951,11 +951,10 @@ def test_set_remove_equations(model: EquationSystemMockModel):
         equations_per_grid_entity=dof_info_subdomain,
     )
 
+    equation_indexer = equation_system.equation_indexer
     # Check that the mapping of equation to subdomain to global dof
     # indices is correctly set.
-    equation_subdomain_blocks = (
-        equation_system.equation_indexer.equation_image_space_composition
-    )
+    equation_subdomain_blocks = equation_indexer.equation_image_space_composition
     assert np.allclose(
         equation_subdomain_blocks[model.eq_single_subdomain.name][model.sd_top],
         np.arange(model.sd_top.num_cells * dof_info_subdomain["cells"]),
@@ -974,9 +973,7 @@ def test_set_remove_equations(model: EquationSystemMockModel):
         grids=model.subdomains,
         equations_per_grid_entity=dof_info_subdomain,
     )
-    equation_subdomain_blocks = (
-        equation_system.equation_indexer.equation_image_space_composition
-    )
+    equation_subdomain_blocks = equation_indexer.equation_image_space_composition
     offset = 0
     for sd in model.subdomains:
         assert np.allclose(
@@ -994,9 +991,7 @@ def test_set_remove_equations(model: EquationSystemMockModel):
         grids=model.interfaces[::-1],
         equations_per_grid_entity=dof_info_interface,
     )
-    equation_subdomain_blocks = (
-        equation_system.equation_indexer.equation_image_space_composition
-    )
+    equation_subdomain_blocks = equation_indexer.equation_image_space_composition
     offset = 0
     for intf in model.interfaces:
         assert np.allclose(
@@ -1016,9 +1011,7 @@ def test_set_remove_equations(model: EquationSystemMockModel):
         grids=model.interfaces[::-1],
         equations_per_grid_entity=dof_all_interfaces,
     )
-    equation_subdomain_blocks = (
-        equation_system.equation_indexer.equation_image_space_composition
-    )
+    equation_subdomain_blocks = equation_indexer.equation_image_space_composition
 
     offset = 0
     for intf in model.interfaces:
@@ -1033,9 +1026,7 @@ def test_set_remove_equations(model: EquationSystemMockModel):
         new_equation=mock_equation,
         equation_name="eq_all_interfaces",
     )
-    equation_subdomain_blocks = (
-        equation_system.equation_indexer.equation_image_space_composition
-    )
+    equation_subdomain_blocks = equation_indexer.equation_image_space_composition
 
     offset = 0
     for intf in model.interfaces:
@@ -1333,15 +1324,13 @@ def test_secondary_variable_assembly(model: EquationSystemMockModel, var_names):
     )
     for name in model.equation_system.equations:
         actual_dofs = [
-            dofs
-            for eq, dofs in equation_indexer.equation_dofs.items()
-            if eq.name == name
+            dofs for eq, dofs in equation_indexer.indices.items() if eq.name == name
         ]
         assert np.allclose(np.concatenate(actual_dofs), model.eq_ind(name))
 
     # Check that the sizes of variable blocks were correctly recorded.
     for var in variables:
-        assert variable_indexer.variable_dofs[var].size == model.dof_ind(var).size
+        assert variable_indexer.indices[var].size == model.dof_ind(var).size
 
 
 @pytest.mark.parametrize(
@@ -1442,7 +1431,7 @@ def test_assemble(model: EquationSystemMockModel, equation_variables):
             equations=eq_names, variables=variables
         )
     )
-    equation_dofs = equation_indexer.equation_dofs
+    equation_dofs = equation_indexer.indices
     if eq_names is None:
         eq_names = list(model.equation_system.equations)
 
@@ -1452,7 +1441,7 @@ def test_assemble(model: EquationSystemMockModel, equation_variables):
         )
         assert num_dofs == model.block_size(name)
 
-    variable_dofs = variable_indexer.variable_dofs
+    variable_dofs = variable_indexer.indices
     for name in var_names:
         num_dofs = sum(
             [dofs.size for var, dofs in variable_dofs.items() if var.name == name]
@@ -1491,18 +1480,18 @@ def test_assembled_matrix_indexers_match_assembly_order(
 
     expected_equations = [
         equation
-        for equation in equation_system.equation_indexer.equation_dofs
+        for equation in equation_system.equation_indexer.indices
         if equation.name in equations
     ]
     expected_variables = [
         variable
-        for variable in equation_system.variable_indexer.variable_dofs
+        for variable in equation_system.variable_indexer.indices
         if variable.name in variables
     ]
 
     actual_order = (
-        [equation.name for equation in equation_indexer.equation_dofs],
-        [variable.name for variable in variable_indexer.variable_dofs],
+        [equation.name for equation in equation_indexer.indices],
+        [variable.name for variable in variable_indexer.indices],
     )
     expected_order = (
         [equation.name for equation in expected_equations],
@@ -1733,7 +1722,7 @@ def test_assemble_ignores_empty_equations(model: EquationSystemMockModel):
     # Check bookkeeping does not suddenly include the empty equation.
     equation_indexer, _ = equation_system.construct_assembled_matrix_indexers()
 
-    for eq_on_domain in equation_indexer.equation_dofs:
+    for eq_on_domain in equation_indexer.indices:
         assert eq_on_domain.name != "empty_equation"
     assert "empty_equation" not in equation_indexer.equation_image_space_composition
 

--- a/tests/numerics/ad/test_equation_system.py
+++ b/tests/numerics/ad/test_equation_system.py
@@ -1050,6 +1050,18 @@ def test_set_remove_equations(model: EquationSystemMockModel):
     )
 
 
+def test_update_equation_on_empty_domain(model: EquationSystemMockModel) -> None:
+    """Updating an empty-domain equation should reuse its empty domain by default."""
+    equation_system = model.equation_system
+    model.add_equation_on_empty_domain()
+    old_equation = equation_system.equations["empty_equation"]
+    new_equation = old_equation * old_equation
+
+    equation_system.update_equation("empty_equation", new_equation)
+
+    assert equation_system.equations["empty_equation"] is new_equation
+
+
 def test_parse_variable_like(model: EquationSystemMockModel):
     """Test the private function _parse_variable_type().
 
@@ -1125,6 +1137,19 @@ def test_parse_variable_like(model: EquationSystemMockModel):
     assert len(received_variables_9) == len(model.sd_variable.sub_vars) + len(
         model.sd_top_variable.sub_vars
     )
+
+
+@pytest.mark.parametrize("ordered", [True, False])
+def test_parse_variable_type_rejects_unknown_variable(
+    model: EquationSystemMockModel, ordered: bool
+) -> None:
+    """An unregistered Variable must not be silently discarded in parsing variables."""
+    unknown_variable = pp.ad.Variable(
+        "unknown", {"cells": 1}, model.mdg.subdomains()[0]
+    )
+
+    with pytest.raises(ValueError, match="not registered"):
+        model.equation_system._parse_variable_type([unknown_variable], ordered=ordered)
 
 
 def test_parse_single_equation(model: EquationSystemMockModel):
@@ -1241,6 +1266,24 @@ def test_parse_equations(model: EquationSystemMockModel):
         equation_system.equations["empty_equation"]
         not in equation_system._parse_equations()
     )
+
+
+def test_invalid_equation_domain_restriction(model: EquationSystemMockModel) -> None:
+    """Equation APIs consistently reject invalid equation restrictions."""
+    equation_system = model.equation_system
+    invalid_domain = next(sd for sd in model.subdomains if sd is not model.sd_top)
+    restrictions = [
+        {"unknown_equation": [model.sd_top]},
+        {model.eq_single_subdomain.name: [invalid_domain]},
+    ]
+
+    for restriction in restrictions:
+        with pytest.raises(ValueError):
+            equation_system.construct_equation_indexer(restriction)
+        with pytest.raises(ValueError):
+            equation_system.construct_assembled_matrix_indexers(equations=restriction)
+        with pytest.raises(ValueError):
+            equation_system.assemble(equations=restriction)
 
 
 @pytest.mark.parametrize(

--- a/tests/numerics/ad/test_indexers.py
+++ b/tests/numerics/ad/test_indexers.py
@@ -1,0 +1,152 @@
+"""Unit tests for indexers used by the AD equation system."""
+
+import numpy as np
+import pytest
+
+import porepy as pp
+from porepy.numerics.ad.indexers import (
+    EquationIndexer,
+    EquationOnDomain,
+    VariableIndexer,
+)
+
+
+@pytest.fixture
+def domains() -> tuple[pp.Grid, pp.Grid, pp.Grid]:
+    """Three distinct domains for indexer tests."""
+    return pp.CartGrid([1]), pp.CartGrid([2]), pp.CartGrid([3])
+
+
+@pytest.fixture
+def variables(
+    domains: tuple[pp.Grid, pp.Grid, pp.Grid],
+) -> tuple[pp.ad.Variable, pp.ad.Variable, pp.ad.Variable]:
+    """Three distinct variables for indexer tests."""
+    return (
+        pp.ad.Variable("x", {"cells": 1}, domains[0]),
+        pp.ad.Variable("y", {"cells": 1}, domains[1]),
+        pp.ad.Variable("z", {"cells": 1}, domains[2]),
+    )
+
+
+def test_equation_on_domain_identity(
+    domains: tuple[pp.Grid, pp.Grid, pp.Grid],
+) -> None:
+    """Equation identifiers compare and hash by equation name and domain."""
+    identifier = EquationOnDomain("equation", domains[0])
+
+    assert identifier == EquationOnDomain("equation", domains[0])
+    assert identifier != EquationOnDomain("other_equation", domains[0])
+    assert identifier != EquationOnDomain("equation", domains[1])
+    assert {identifier: 1}[EquationOnDomain("equation", domains[0])] == 1
+
+
+def test_variable_indexer_projection(
+    variables: tuple[pp.ad.Variable, pp.ad.Variable, pp.ad.Variable],
+) -> None:
+    """Projection indices respect requested variable order."""
+    x, y, _ = variables
+    indexer = VariableIndexer(
+        variable_dofs={x: np.array([0, 1]), y: np.array([2, 3, 4])}
+    )
+
+    assert indexer.num_dofs == 5
+    np.testing.assert_array_equal(
+        indexer.projection_indices([y, x]), np.array([2, 3, 4, 0, 1])
+    )
+    empty_projection = indexer.projection_indices([])
+    assert empty_projection.dtype == int
+    assert empty_projection.size == 0
+
+
+def test_variable_indexer_unknown_variable(
+    variables: tuple[pp.ad.Variable, pp.ad.Variable, pp.ad.Variable],
+) -> None:
+    """Variable indexer operations reject variables outside the indexer."""
+    x, _, unknown = variables
+    indexer = VariableIndexer(variable_dofs={x: np.array([0])})
+
+    with pytest.raises(ValueError, match="not known"):
+        indexer.projection_indices([unknown])
+    with pytest.raises(ValueError, match="not known"):
+        indexer.construct_restricted_indexer([unknown])
+
+
+def test_variable_indexer_restriction(
+    variables: tuple[pp.ad.Variable, pp.ad.Variable, pp.ad.Variable],
+) -> None:
+    """Restricted indexers are contiguous and follow requested variable order."""
+    x, y, _ = variables
+    indexer = VariableIndexer(
+        variable_dofs={x: np.array([4, 7]), y: np.array([10, 12, 13])}
+    )
+
+    restricted = indexer.construct_restricted_indexer([y, x])
+
+    assert list(restricted.variable_dofs) == [y, x]
+    np.testing.assert_array_equal(restricted.variable_dofs[y], np.arange(3))
+    np.testing.assert_array_equal(restricted.variable_dofs[x], np.arange(3, 5))
+    assert restricted.num_dofs == 5
+
+
+def test_variable_indexer_duplicate_restriction(
+    variables: tuple[pp.ad.Variable, pp.ad.Variable, pp.ad.Variable],
+) -> None:
+    """A restricted indexer cannot represent the same variable more than once."""
+    x, _, _ = variables
+    indexer = VariableIndexer(variable_dofs={x: np.array([0, 1])})
+
+    with pytest.raises(ValueError, match="duplicate"):
+        indexer.construct_restricted_indexer([x, x])
+
+
+def test_equation_indexer_offsets(
+    domains: tuple[pp.Grid, pp.Grid, pp.Grid],
+) -> None:
+    """Equation indexers expose local and globally offset equation indices."""
+    first, second, third = domains
+    composition = {
+        "equation_a": {
+            first: np.array([0, 1]),
+            second: np.array([2, 3, 4]),
+        },
+        "equation_b": {
+            second: np.array([0]),
+            third: np.array([1, 2]),
+        },
+    }
+
+    indexer = EquationIndexer(equation_image_composition=composition)
+
+    np.testing.assert_array_equal(
+        indexer.equation_image_space_composition["equation_a"][first], [0, 1]
+    )
+    np.testing.assert_array_equal(
+        indexer.equation_image_space_composition["equation_b"][third], [1, 2]
+    )
+    expected_keys = [
+        EquationOnDomain("equation_a", first),
+        EquationOnDomain("equation_a", second),
+        EquationOnDomain("equation_b", second),
+        EquationOnDomain("equation_b", third),
+    ]
+    assert list(indexer.equation_dofs) == expected_keys
+    np.testing.assert_array_equal(indexer.equation_dofs[expected_keys[0]], [0, 1])
+    np.testing.assert_array_equal(indexer.equation_dofs[expected_keys[1]], [2, 3, 4])
+    np.testing.assert_array_equal(indexer.equation_dofs[expected_keys[2]], [5])
+    np.testing.assert_array_equal(indexer.equation_dofs[expected_keys[3]], [6, 7])
+
+
+def test_empty_indexers() -> None:
+    """Indexers support empty systems and restrictions."""
+    variable_indexer = VariableIndexer(variable_dofs={})
+    restricted_indexer = variable_indexer.construct_restricted_indexer([])
+    equation_indexer = EquationIndexer(equation_image_composition={})
+
+    assert variable_indexer.num_dofs == 0
+    assert variable_indexer.variable_dofs == {}
+    assert variable_indexer.projection_indices([]).size == 0
+    assert restricted_indexer.num_dofs == 0
+    assert restricted_indexer.variable_dofs == {}
+    assert equation_indexer.equation_dofs == {}
+    assert equation_indexer.equation_image_space_composition == {}

--- a/tests/numerics/ad/test_indexers.py
+++ b/tests/numerics/ad/test_indexers.py
@@ -137,6 +137,49 @@ def test_equation_indexer_offsets(
     np.testing.assert_array_equal(indexer.equation_dofs[expected_keys[3]], [6, 7])
 
 
+def test_equation_indexer_restriction(
+    domains: tuple[pp.Grid, pp.Grid, pp.Grid],
+) -> None:
+    """Restricted equation indices are local and follow the requested order."""
+    first, second, third = domains
+    equation_a_second = EquationOnDomain("equation_a", second)
+    equation_b_second = EquationOnDomain("equation_b", second)
+    equation_b_third = EquationOnDomain("equation_b", third)
+    indexer = EquationIndexer(
+        equation_image_composition={
+            "equation_a": {first: np.arange(2), second: np.arange(2, 5)},
+            "equation_b": {second: np.arange(1), third: np.arange(1, 3)},
+        }
+    )
+
+    restricted = indexer.construct_restricted_indexer(
+        [equation_b_second, equation_b_third, equation_a_second]
+    )
+
+    assert list(restricted.equation_dofs) == [
+        equation_b_second,
+        equation_b_third,
+        equation_a_second,
+    ]
+    np.testing.assert_array_equal(
+        restricted.equation_dofs[equation_b_second], np.arange(1)
+    )
+    np.testing.assert_array_equal(
+        restricted.equation_dofs[equation_b_third], np.arange(1, 3)
+    )
+    np.testing.assert_array_equal(
+        restricted.equation_dofs[equation_a_second], np.arange(3, 6)
+    )
+    np.testing.assert_array_equal(
+        restricted.equation_image_space_composition["equation_b"][third],
+        np.arange(1, 3),
+    )
+    np.testing.assert_array_equal(
+        restricted.equation_image_space_composition["equation_a"][second],
+        np.arange(3),
+    )
+
+
 def test_empty_indexers() -> None:
     """Indexers support empty systems and restrictions."""
     variable_indexer = VariableIndexer(variable_dofs={})

--- a/tests/numerics/ad/test_indexers.py
+++ b/tests/numerics/ad/test_indexers.py
@@ -46,11 +46,9 @@ def test_variable_indexer_projection(
 ) -> None:
     """Projection indices respect requested variable order."""
     x, y, _ = variables
-    indexer = VariableIndexer(
-        variable_dofs={x: np.array([0, 1]), y: np.array([2, 3, 4])}
-    )
+    indexer = VariableIndexer(indices={x: np.array([0, 1]), y: np.array([2, 3, 4])})
 
-    assert indexer.num_dofs == 5
+    assert indexer.size == 5
     np.testing.assert_array_equal(
         indexer.projection_indices([y, x]), np.array([2, 3, 4, 0, 1])
     )
@@ -64,7 +62,7 @@ def test_variable_indexer_unknown_variable(
 ) -> None:
     """Variable indexer operations reject variables outside the indexer."""
     x, _, unknown = variables
-    indexer = VariableIndexer(variable_dofs={x: np.array([0])})
+    indexer = VariableIndexer(indices={x: np.array([0])})
 
     with pytest.raises(ValueError, match="not known"):
         indexer.projection_indices([unknown])
@@ -77,16 +75,14 @@ def test_variable_indexer_restriction(
 ) -> None:
     """Restricted indexers are contiguous and follow requested variable order."""
     x, y, _ = variables
-    indexer = VariableIndexer(
-        variable_dofs={x: np.array([4, 7]), y: np.array([10, 12, 13])}
-    )
+    indexer = VariableIndexer(indices={x: np.array([4, 7]), y: np.array([10, 12, 13])})
 
     restricted = indexer.construct_restricted_indexer([y, x])
 
-    assert list(restricted.variable_dofs) == [y, x]
-    np.testing.assert_array_equal(restricted.variable_dofs[y], np.arange(3))
-    np.testing.assert_array_equal(restricted.variable_dofs[x], np.arange(3, 5))
-    assert restricted.num_dofs == 5
+    assert list(restricted.indices) == [y, x]
+    np.testing.assert_array_equal(restricted.indices[y], np.arange(3))
+    np.testing.assert_array_equal(restricted.indices[x], np.arange(3, 5))
+    assert restricted.size == 5
 
 
 def test_variable_indexer_duplicate_restriction(
@@ -94,7 +90,7 @@ def test_variable_indexer_duplicate_restriction(
 ) -> None:
     """A restricted indexer cannot represent the same variable more than once."""
     x, _, _ = variables
-    indexer = VariableIndexer(variable_dofs={x: np.array([0, 1])})
+    indexer = VariableIndexer(indices={x: np.array([0, 1])})
 
     with pytest.raises(ValueError, match="duplicate"):
         indexer.construct_restricted_indexer([x, x])
@@ -130,11 +126,11 @@ def test_equation_indexer_offsets(
         EquationOnDomain("equation_b", second),
         EquationOnDomain("equation_b", third),
     ]
-    assert list(indexer.equation_dofs) == expected_keys
-    np.testing.assert_array_equal(indexer.equation_dofs[expected_keys[0]], [0, 1])
-    np.testing.assert_array_equal(indexer.equation_dofs[expected_keys[1]], [2, 3, 4])
-    np.testing.assert_array_equal(indexer.equation_dofs[expected_keys[2]], [5])
-    np.testing.assert_array_equal(indexer.equation_dofs[expected_keys[3]], [6, 7])
+    assert list(indexer.indices) == expected_keys
+    np.testing.assert_array_equal(indexer.indices[expected_keys[0]], [0, 1])
+    np.testing.assert_array_equal(indexer.indices[expected_keys[1]], [2, 3, 4])
+    np.testing.assert_array_equal(indexer.indices[expected_keys[2]], [5])
+    np.testing.assert_array_equal(indexer.indices[expected_keys[3]], [6, 7])
 
 
 def test_equation_indexer_restriction(
@@ -156,19 +152,15 @@ def test_equation_indexer_restriction(
         [equation_b_second, equation_b_third, equation_a_second]
     )
 
-    assert list(restricted.equation_dofs) == [
+    assert list(restricted.indices) == [
         equation_b_second,
         equation_b_third,
         equation_a_second,
     ]
+    np.testing.assert_array_equal(restricted.indices[equation_b_second], np.arange(1))
+    np.testing.assert_array_equal(restricted.indices[equation_b_third], np.arange(1, 3))
     np.testing.assert_array_equal(
-        restricted.equation_dofs[equation_b_second], np.arange(1)
-    )
-    np.testing.assert_array_equal(
-        restricted.equation_dofs[equation_b_third], np.arange(1, 3)
-    )
-    np.testing.assert_array_equal(
-        restricted.equation_dofs[equation_a_second], np.arange(3, 6)
+        restricted.indices[equation_a_second], np.arange(3, 6)
     )
     np.testing.assert_array_equal(
         restricted.equation_image_space_composition["equation_b"][third],
@@ -182,14 +174,14 @@ def test_equation_indexer_restriction(
 
 def test_empty_indexers() -> None:
     """Indexers support empty systems and restrictions."""
-    variable_indexer = VariableIndexer(variable_dofs={})
+    variable_indexer = VariableIndexer(indices={})
     restricted_indexer = variable_indexer.construct_restricted_indexer([])
     equation_indexer = EquationIndexer(equation_image_composition={})
 
-    assert variable_indexer.num_dofs == 0
-    assert variable_indexer.variable_dofs == {}
+    assert variable_indexer.size == 0
+    assert variable_indexer.indices == {}
     assert variable_indexer.projection_indices([]).size == 0
-    assert restricted_indexer.num_dofs == 0
-    assert restricted_indexer.variable_dofs == {}
-    assert equation_indexer.equation_dofs == {}
+    assert restricted_indexer.size == 0
+    assert restricted_indexer.indices == {}
+    assert equation_indexer.indices == {}
     assert equation_indexer.equation_image_space_composition == {}

--- a/tests/numerics/ad/test_indexers.py
+++ b/tests/numerics/ad/test_indexers.py
@@ -148,6 +148,7 @@ def test_equation_indexer_restriction(
         }
     )
 
+    # Only equation b on sd 2, equation b on sd 3, equation a on sd 2.
     restricted = indexer.construct_restricted_indexer(
         [equation_b_second, equation_b_third, equation_a_second]
     )
@@ -157,8 +158,11 @@ def test_equation_indexer_restriction(
         equation_b_third,
         equation_a_second,
     ]
+    # Equation b on sd 2 should have a single dof.
     np.testing.assert_array_equal(restricted.indices[equation_b_second], np.arange(1))
+    # Equation b on sd 3 should have two dofs: [1, 2].
     np.testing.assert_array_equal(restricted.indices[equation_b_third], np.arange(1, 3))
+    # Equation a on sd 2 should have 3 dofs: [3, 4, 5].
     np.testing.assert_array_equal(
         restricted.indices[equation_a_second], np.arange(3, 6)
     )

--- a/tests/viz/test_diagnostics_mixin.py
+++ b/tests/viz/test_diagnostics_mixin.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
+import porepy as pp
 from porepy.applications.test_utils.models import Poromechanics
 from porepy.viz.diagnostics_mixin import DiagnosticsMixin
 
@@ -122,3 +123,40 @@ def test_diagnostics_mixin_grouping(_, model: PoromechanicsWithDiagnostics) -> N
                 subdomain_data["is_interface_block"]
                 == subdomain_data_new["is_interface_block"]
             )
+
+
+def test_diagnostics_mixin_restricted_system(
+    model: PoromechanicsWithDiagnostics,
+) -> None:
+    """Use matrix indexers when diagnosing a restricted system."""
+    equation_name = next(iter(model.equation_system.equations))
+    variable = model.equation_system.variables[0]
+    equations = [equation_name]
+    variables = [variable]
+
+    matrix, rhs = model.equation_system.assemble(
+        equations=equations, variables=variables
+    )
+    linear_system = pp.solvers.LinearSystem(matrix=matrix, rhs=rhs)
+    equation_indexer, variable_indexer = (
+        model.equation_system.construct_assembled_matrix_indexers(
+            equations=equations, variables=variables
+        )
+    )
+
+    with pytest.raises(ValueError, match="indexers do not describe"):
+        model.run_diagnostics(linear_system, grouping="dense")
+
+    diagnostics_data = model.run_diagnostics(
+        linear_system,
+        grouping="dense",
+        equation_indexer=equation_indexer,
+        variable_indexer=variable_indexer,
+    )
+
+    assert len(diagnostics_data) == 1
+    block_data = diagnostics_data[0, 0]
+    assert block_data["equation_name"] == equation_name
+    assert block_data["variable_name"] == variable.name
+    assert block_data["block_dofs_row"].tolist() == list(range(matrix.shape[0]))
+    assert block_data["block_dofs_col"].tolist() == list(range(matrix.shape[1]))

--- a/tutorials/convergence_criteria.ipynb
+++ b/tutorials/convergence_criteria.ipynb
@@ -158,7 +158,8 @@
             "outputs": [],
             "source": [
                 "model = Model({\"solver_statistics_file_name\": \"solver_statistics.json\"})\n",
-                "multi_norm_model = Model({\"solver_statistics_file_name\": \"multiphysics_norm_solver_statistics.json\"})"
+                "multi_norm_model = Model({\"solver_statistics_file_name\": \"multiphysics_norm_solver_statistics.json\"})\n",
+                "multi_norm_model.prepare_simulation()"
             ]
         },
         {
@@ -236,7 +237,10 @@
                 "            tol=1e-2, metric=pp.VariableBasedEuclideanMetric(multi_norm_model)\n",
                 "        ),\n",
                 "        \"res_abs\": pp.solvers.ResidualBasedAbsoluteCriterion(\n",
-                "            tol=1e-2, metric=pp.EquationBasedEuclideanMetric(multi_norm_model)\n",
+                "            tol=1e-2,\n",
+                "            metric=pp.EquationBasedEuclideanMetric(\n",
+                "                multi_norm_model, multi_norm_model.equation_system.equation_indexer\n",
+                "            ),\n",
                 "        ),\n",
                 "    },\n",
                 "    \"nl_divergence_criteria\": {\n",
@@ -271,7 +275,10 @@
             ],
             "source": [
                 "pp.run_time_dependent_model(model, solver_params_with_euclidean_norms)\n",
-                "pp.run_time_dependent_model(multi_norm_model, solver_params_with_multiphysics_norm)"
+                "pp.run_time_dependent_model(\n",
+                "    multi_norm_model,\n",
+                "    solver_params_with_multiphysics_norm | {\"prepare_simulation\": False},\n",
+                ")"
             ]
         },
         {
@@ -523,13 +530,17 @@
             ],
             "source": [
                 "multi_lebesgue_model = Model()\n",
+                "multi_lebesgue_model.prepare_simulation()\n",
                 "solver_params_with_lebesgue_norm = {\n",
                 "    \"nl_convergence_criteria\": {\n",
                 "        \"inc_abs\": pp.solvers.IncrementBasedAbsoluteCriterion(\n",
                 "            tol=1e-2, metric=pp.VariableBasedLebesgueMetric(multi_lebesgue_model)\n",
                 "        ),\n",
                 "        \"res_abs\": pp.solvers.ResidualBasedAbsoluteCriterion(\n",
-                "            tol=1e-2, metric=pp.EquationBasedLebesgueMetric(multi_lebesgue_model)\n",
+                "            tol=1e-2,\n",
+                "            metric=pp.EquationBasedLebesgueMetric(\n",
+                "                multi_lebesgue_model, multi_lebesgue_model.equation_system.equation_indexer\n",
+                "            ),\n",
                 "        ),\n",
                 "    },\n",
                 "    \"nl_divergence_criteria\": {\n",
@@ -538,7 +549,10 @@
                 "        \"res_nan\": pp.solvers.ResidualBasedNanCriterion(),\n",
                 "    },\n",
                 "}\n",
-                "pp.run_time_dependent_model(multi_lebesgue_model, solver_params_with_lebesgue_norm)\n",
+                "pp.run_time_dependent_model(\n",
+                "    multi_lebesgue_model,\n",
+                "    solver_params_with_lebesgue_norm | {\"prepare_simulation\": False},\n",
+                ")\n",
                 "print(f\"Number of iterations (multi-physics Lebesgue criteria): {multi_lebesgue_model.nonlinear_solver_statistics.num_iterations}\")"
             ]
         },
@@ -575,7 +589,8 @@
             "outputs": [],
             "source": [
                 "multi_norm_model_with_skewed_units = Model(params)\n",
-                "multi_norm_model_with_skewed_units_and_relative_criteria = Model(params)"
+                "multi_norm_model_with_skewed_units_and_relative_criteria = Model(params)\n",
+                "multi_norm_model_with_skewed_units_and_relative_criteria.prepare_simulation()"
             ]
         },
         {
@@ -606,7 +621,10 @@
                 "            tol=1e-2, metric=pp.VariableBasedEuclideanMetric(multi_norm_model_with_skewed_units_and_relative_criteria)\n",
                 "        ),\n",
                 "        \"res_rel\": pp.solvers.ResidualBasedRelativeCriterion(\n",
-                "            tol=1e-2, metric=pp.EquationBasedEuclideanMetric(multi_norm_model_with_skewed_units_and_relative_criteria)\n",
+                "            tol=1e-2,\n",
+                "            metric=pp.EquationBasedEuclideanMetric(\n",
+                "                multi_norm_model_with_skewed_units_and_relative_criteria, multi_norm_model_with_skewed_units_and_relative_criteria.equation_system.equation_indexer\n",
+                "            ),\n",
                 "        ),\n",
                 "    },\n",
                 "    \"nl_divergence_criteria\": {\n",
@@ -623,7 +641,10 @@
                 "}\n",
                 "\n",
                 "pp.run_time_dependent_model(multi_norm_model_with_skewed_units, solver_params_with_multiphysics_norm)\n",
-                "pp.run_time_dependent_model(multi_norm_model_with_skewed_units_and_relative_criteria, solver_params_with_relative_criteria)\n",
+                "pp.run_time_dependent_model(\n",
+                "    multi_norm_model_with_skewed_units_and_relative_criteria,\n",
+                "    solver_params_with_relative_criteria | {\"prepare_simulation\": False},\n",
+                ")\n",
                 "\n",
                 "print(f\"Number of iterations (restarted model with skewed units and absolute criteria): {multi_norm_model_with_skewed_units.nonlinear_solver_statistics.num_iterations}\")\n",
                 "print(f\"Number of iterations (restarted model with skewed units and relative criteria): {multi_norm_model_with_skewed_units_and_relative_criteria.nonlinear_solver_statistics.num_iterations}\")"


### PR DESCRIPTION
The goal of this PR is to move all DoF management away from the equation system and introduce `EquationIndexer` and `VariableIndexer` objects, which now control it. This is done as a preparation step for introducing nonlinear solvers that work on a subset of equations and variables, and need their own indexers.

Breaking API changes:
- removed `equation_system.assembled_equation_indices`. Introduced a method `equation_system.construct_assembled_matrix_indexers(equations, variables)`, which constructs indices of a subsystem produced by `assemble(equations, variables)`. 
- `equation_system.equation_image_space_composition` prints a deprecation warning but it still available. The only difference - it does not store equations defined on none domains. This might be a breaking change for a user code like ```for eq in equation_system.equations: ... = equation_image_space_composition[eq]```. 

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [x] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [x] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
