### PR TITLE
Schur complement reduction

### DIFF
--- a/src/porepy/examples/example_params.py
+++ b/src/porepy/examples/example_params.py
@@ -82,8 +82,6 @@ model_params = {
     # Compositional model (multiphase multicomponent flow)
     "fractional_flow": True,
     "enable_buoyancy_effects": False,
-    "apply_schur_complement_reduction": False,
-    "schur_complement_inverter": None,
     "eliminate_reference_phase": True,
     "eliminate_reference_component": True,
     "phase_property_params": None,  # See Phase.compute_properties for details.

--- a/src/porepy/examples/solvers/README.md
+++ b/src/porepy/examples/solvers/README.md
@@ -1,0 +1,5 @@
+# Examples of applying more advanced nonlinear and linear solvers
+
+Contents:
+
+1. Schur complement reduction: [`schur_complement_reduction_linear_tracer_3p.py`](schur_complement_reduction_linear_tracer_3p.py)

--- a/src/porepy/examples/solvers/schur_complement_reduction_linear_tracer_3p.py
+++ b/src/porepy/examples/solvers/schur_complement_reduction_linear_tracer_3p.py
@@ -1,7 +1,7 @@
 """This example shows how to apply the Schur complement reduction-based linear solver.
 
-The considered model a simplified model of 3-phase 2-component flow, which do not
-represent any real physics and should not be used in modeling.
+The considered model is a simplified model of three-phase, two-component flow. It does
+not represent any real physics and should not be used in modeling.
 
 The setup is heavily inspired by `tests/functional/test_linear_tracer.py`.
 
@@ -30,7 +30,7 @@ def run_example():
 
     model = TracerFlowModel_3p(model_params)
 
-    # Setting dt and end time schedule according to cfl condition and approximate
+    # Setting dt and end time schedule according to the CFL condition and approximate
     # flow velocity.
     model.prepare_simulation()
     sd = model.mdg.subdomains()[0]
@@ -47,8 +47,8 @@ def run_example():
     # Initializing a nonlinear solver with a custom linear solver that applies a Schur
     # complement reduction. It requires us to list the primary variables and equations.
     # The default tags are available for the standard equations and variables in PorePy.
-    # This model uses a non-standard equation and variable "z_tracer". Creating custom
-    # tags for them.
+    # This model uses a non-standard equation and variable, "z_tracer", so we create
+    # custom tags for them.
     nonlinear_solver = pp.solvers.NewtonSolver(
         linear_solver=pp.solvers.SchurComplementReductionLinearSolver(
             primary_equation_tags=[

--- a/src/porepy/examples/solvers/schur_complement_reduction_linear_tracer_3p.py
+++ b/src/porepy/examples/solvers/schur_complement_reduction_linear_tracer_3p.py
@@ -19,7 +19,7 @@ def run_example():
     model_params = {
         "material_constants": {
             "solid": pp.SolidConstants(
-                porosity=1.0, permeability=1.0, residual_aperture=1
+                porosity=1.0, residual_aperture=1
             ),
         },
         "meshing_arguments": {"cell_size": SimplePipe2D.pipe_length / 10},

--- a/src/porepy/examples/solvers/schur_complement_reduction_linear_tracer_3p.py
+++ b/src/porepy/examples/solvers/schur_complement_reduction_linear_tracer_3p.py
@@ -1,49 +1,58 @@
 """This example shows how to apply the Schur complement reduction-based linear solver.
 
-The considered model is a simplified model of three-phase, two-component flow. It does
+The considered model is a simplified model of single-phase, two-component flow. It does
 not represent any real physics and should not be used in modeling.
 
-The setup is heavily inspired by `tests/functional/test_linear_tracer.py`.
+The setup is heavily inspired by `examples/tracer_flow.py`.
 
 """
 
 import logging
 
 import porepy as pp
-from tests.functional.setups.linear_tracer import SimplePipe2D, TracerFlowModel_3p
+from porepy.examples.tracer_flow import TracerFlowModel
 
 
 def run_example():
-    logging.basicConfig(level=logging.INFO)
+    # The same initialization as in examples/tracer_flow.py.
 
-    model_params = {
-        "material_constants": {
-            "solid": pp.SolidConstants(
-                porosity=1.0, residual_aperture=1
-            ),
-        },
-        "meshing_arguments": {"cell_size": SimplePipe2D.pipe_length / 10},
-        "prepare_simulation": False,  # Need to do it manually to determine CFL.
-        "times_to_export": [],
-        "equilibrium_condition": "dummy",
-    }
-
-    model = TracerFlowModel_3p(model_params)
-
-    # Setting dt and end time schedule according to the CFL condition and approximate
-    # flow velocity.
-    model.prepare_simulation()
-    sd = model.mdg.subdomains()[0]
-    dt = model.exact_sol.dt_from_cfl(sd)
+    # Initial time step 60 seconds.
+    dt_init = pp.MINUTE
+    # Simulation time 20 minutes.
+    T_end = 20 * pp.MINUTE
+    # min max time step size is 6 seconds and 10 minutes respectively
+    dt_min_max = (0.1 * dt_init, 10 * pp.MINUTE)
+    # parameters for Newton solver
+    max_iterations = 80
+    newton_tol = 1e-6
+    newton_tol_increment = newton_tol
 
     time_manager = pp.TimeManager(
-        schedule=[0, 3 * dt, 6 * dt, 9 * dt, 10 * dt],
-        dt_init=dt,
-        constant_dt=True,
+        schedule=[0, T_end],
+        dt_init=dt_init,
+        dt_min_max=dt_min_max,
+        iter_max=max_iterations,
+        iter_optimal_range=(2, 10),
+        iter_relax_factors=(0.8, 1.2),
+        recomp_factor=0.8,
+        recomp_max=5,
     )
-    model.ad_time_step.set_value(dt)
-    model.time_manager = time_manager
 
+    params = {
+        "material_constants": {
+            # Solid with impermeable fractures.
+            "solid": pp.SolidConstants(
+                porosity=0.1, permeability=1e-7, normal_permeability=1e-19
+            ),
+        },
+        "fracture_indices": [0, 1],
+        "time_manager": time_manager,
+        "meshing_arguments": {"cell_size": 0.05},
+        "grid_type": "simplex",
+    }
+    model = TracerFlowModel(params)  # type: ignore[abstract]
+
+    # This part is different from examples/tracer_flow.py:
     # Initializing a nonlinear solver with a custom linear solver that applies a Schur
     # complement reduction. It requires us to list the primary variables and equations.
     # The default tags are available for the standard equations and variables in PorePy.
@@ -53,21 +62,31 @@ def run_example():
         linear_solver=pp.solvers.SchurComplementReductionLinearSolver(
             primary_equation_tags=[
                 pp.solvers.DefaultEquationTags.mass_balance,
-                pp.solvers.DefaultEquationTags.energy_balance,
+                pp.solvers.DefaultEquationTags.interface_darcy_flux,
+                pp.solvers.DefaultEquationTags.well_flux,
                 pp.solvers.EquationTag(name="component_mass_balance_equation_tracer"),
             ],
             primary_variable_tags=[
                 pp.solvers.DefaultVariableTags.pressure,
-                pp.solvers.DefaultVariableTags.enthalpy,
+                pp.solvers.DefaultVariableTags.interface_darcy_flux,
+                pp.solvers.DefaultVariableTags.well_flux,
                 pp.solvers.VariableTag(name="z_tracer"),
             ],
             # Using a direct linear solver as the inner algorithm. It can be replaced
             # with an iterative solver.
             primary_linear_solver=pp.solvers.LinearSolverDirect(),
-        )
+        ),
+        params={
+            "nl_max_iterations": max_iterations,
+            "nl_convergence_inc_atol": newton_tol_increment,
+            "nl_convergence_res_atol": newton_tol,
+        },
     )
-    pp.ModelRunner(model, model_params, nonlinear_solver=nonlinear_solver).run()
+    runner = pp.ModelRunner(model, nonlinear_solver=nonlinear_solver)
+    runner.run()
+    return [model]
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
     run_example()

--- a/src/porepy/examples/solvers/schur_complement_reduction_linear_tracer_3p.py
+++ b/src/porepy/examples/solvers/schur_complement_reduction_linear_tracer_3p.py
@@ -1,0 +1,73 @@
+"""This example shows how to apply the Schur complement reduction-based linear solver.
+
+The considered model a simplified model of 3-phase 2-component flow, which do not
+represent any real physics and should not be used in modeling.
+
+The setup is heavily inspired by `tests/functional/test_linear_tracer.py`.
+
+"""
+
+import logging
+
+import porepy as pp
+from tests.functional.setups.linear_tracer import SimplePipe2D, TracerFlowModel_3p
+
+
+def run_example():
+    logging.basicConfig(level=logging.INFO)
+
+    model_params = {
+        "material_constants": {
+            "solid": pp.SolidConstants(
+                porosity=1.0, permeability=1.0, residual_aperture=1
+            ),
+        },
+        "meshing_arguments": {"cell_size": SimplePipe2D.pipe_length / 10},
+        "prepare_simulation": False,  # Need to do it manually to determine CFL.
+        "times_to_export": [],
+        "equilibrium_condition": "dummy",
+    }
+
+    model = TracerFlowModel_3p(model_params)
+
+    # Setting dt and end time schedule according to cfl condition and approximate
+    # flow velocity.
+    model.prepare_simulation()
+    sd = model.mdg.subdomains()[0]
+    dt = model.exact_sol.dt_from_cfl(sd)
+
+    time_manager = pp.TimeManager(
+        schedule=[0, 3 * dt, 6 * dt, 9 * dt, 10 * dt],
+        dt_init=dt,
+        constant_dt=True,
+    )
+    model.ad_time_step.set_value(dt)
+    model.time_manager = time_manager
+
+    # Initializing a nonlinear solver with a custom linear solver that applies a Schur
+    # complement reduction. It requires us to list the primary variables and equations.
+    # The default tags are available for the standard equations and variables in PorePy.
+    # This model uses a non-standard equation and variable "z_tracer". Creating custom
+    # tags for them.
+    nonlinear_solver = pp.solvers.NewtonSolver(
+        linear_solver=pp.solvers.SchurComplementReductionLinearSolver(
+            primary_equation_tags=[
+                pp.solvers.DefaultEquationTags.mass_balance,
+                pp.solvers.DefaultEquationTags.energy_balance,
+                pp.solvers.EquationTag(name="component_mass_balance_equation_tracer"),
+            ],
+            primary_variable_tags=[
+                pp.solvers.DefaultVariableTags.pressure,
+                pp.solvers.DefaultVariableTags.enthalpy,
+                pp.solvers.VariableTag(name="z_tracer"),
+            ],
+            # Using a direct linear solver as the inner algorithm. It can be replaced
+            # with an iterative solver.
+            primary_linear_solver=pp.solvers.LinearSolverDirect(),
+        )
+    )
+    pp.ModelRunner(model, model_params, nonlinear_solver=nonlinear_solver).run()
+
+
+if __name__ == "__main__":
+    run_example()

--- a/src/porepy/models/compositional_flow.py
+++ b/src/porepy/models/compositional_flow.py
@@ -213,7 +213,6 @@ def log_cf_model_configuration(model: pp.PorePyModel) -> None:
     c_elim = model._is_reference_component_eliminated()
     is_ff = is_fractional_flow(model)
     et = compositional.get_local_equilibrium_condition(model)
-    schur = model.params.get("apply_schur_complement_reduction", False)
     var_names = set([v.name for v in model.equation_system.variables])
     dofs = model.equation_system.num_dofs()
     dofs_loc = dofs / len(var_names)
@@ -223,7 +222,6 @@ def log_cf_model_configuration(model: pp.PorePyModel) -> None:
         f"Configuration of model {model}:\n"
         + f"\tEquilibrium condition: {et}\n"
         + f"\tFractional flow: {is_ff}"
-        + f"\tEliminating secondary block via Schur complement: {schur}"
         + f"\tNumber of phases: {model.fluid.num_phases}\n"
         + f"\tNumber of components: {model.fluid.num_components}\n"
         + f"\tReference phase eliminated: {p_elim}\n"

--- a/src/porepy/models/protocol.py
+++ b/src/porepy/models/protocol.py
@@ -692,19 +692,8 @@ else:
 
             """
 
-        def after_nonlinear_iteration(
-            self,
-            nonlinear_increment: np.ndarray,
-        ) -> None:
-            """Method to be called after every non-linear iteration.
-
-            Parameters:
-                nonlinear_increment: The new solution, as computed by the non-linear
-                    solver.
-                updated_variables: Variables to update with `nonlinear_increment`. If
-                    `None`, all variables are updated.
-
-            """
+        def after_nonlinear_iteration(self, nonlinear_increment: np.ndarray) -> None:
+            """Method to be called after every non-linear iteration."""
 
         def after_nonlinear_convergence(self) -> None:
             """Called after a nonlinear solver loop converges.

--- a/src/porepy/models/protocol.py
+++ b/src/porepy/models/protocol.py
@@ -695,7 +695,6 @@ else:
         def after_nonlinear_iteration(
             self,
             nonlinear_increment: np.ndarray,
-            updated_variables: Optional[list[pp.ad.Variable]] = None,
         ) -> None:
             """Method to be called after every non-linear iteration.
 

--- a/src/porepy/models/protocol.py
+++ b/src/porepy/models/protocol.py
@@ -692,8 +692,20 @@ else:
 
             """
 
-        def after_nonlinear_iteration(self, nonlinear_increment: np.ndarray) -> None:
-            """Method to be called after every non-linear iteration."""
+        def after_nonlinear_iteration(
+            self,
+            nonlinear_increment: np.ndarray,
+            updated_variables: Optional[list[pp.ad.Variable]] = None,
+        ) -> None:
+            """Method to be called after every non-linear iteration.
+
+            Parameters:
+                nonlinear_increment: The new solution, as computed by the non-linear
+                    solver.
+                updated_variables: Variables to update with `nonlinear_increment`. If
+                    `None`, all variables are updated.
+
+            """
 
         def after_nonlinear_convergence(self) -> None:
             """Called after a nonlinear solver loop converges.
@@ -707,9 +719,6 @@ else:
             Use this method for loop-specific post-processing.
 
             """
-
-        def assemble_linear_system(self) -> pp.solvers.LinearSystem:
-            """Assemble and return the linearized system."""
 
         def after_nonlinear_failure(self) -> None:
             """Called after a nonlinear solver loop fails to converge.

--- a/src/porepy/models/solution_strategy.py
+++ b/src/porepy/models/solution_strategy.py
@@ -42,12 +42,14 @@ class SolutionStrategy(pp.PorePyModel):
 
         # Print deprecation warning for an old parameter.
         if "linear_solver" in params:
-            logger.warning(
+            warn(
                 "Linear solver was moved outside the PorePy model. If you previously "
                 "passed 'linear_solver' backend string (e.g. 'pypardiso') in model "
                 "params, replace it with "
                 "pp.solvers.NewtonSolver(linear_solver=pp.LinearSolverDirect(backend="
-                "'pypardiso')). The current passed value is ignored."
+                "'pypardiso')). The current passed value is ignored.",
+                category=DeprecationWarning,
+                stacklevel=2,
             )
 
         # Set default parameters, these will be overwritten by any parameters passed.
@@ -139,12 +141,6 @@ class SolutionStrategy(pp.PorePyModel):
         the cache sparingly, and only for operators that have been shown to be expensive
         to construct.
         """
-
-        self._schur_complement_primary_variables: list[str] = []
-        """See :meth:`schur_complement_primary_variables`."""
-
-        self._schur_complement_primary_equations: list[str] = []
-        """See :meth:`schur_complement_primary_equations`."""
 
     def prepare_simulation(self) -> None:
         """Run at the start of simulation. Used for initialization etc."""
@@ -313,84 +309,6 @@ class SolutionStrategy(pp.PorePyModel):
         """
         return np.array([0])
 
-    @property
-    def schur_complement_primary_equations(self) -> list[str]:
-        """Names of the primary equations for the Schur complement reduction of the
-        linear system.
-
-        They define the row-block which does not contain the sub-matrix which is to be
-        inverted for the Schur complement.
-
-        See also:
-
-            - :meth:`assemble_linear_system`
-            - :meth:`~porepy.numerics.ad.equation_system.EquationSystem.
-              assemble_schur_complement_system`
-
-        Parameters:
-            names: List of equation names to be set as primary equations.
-
-        Raises:
-            ValueError: If any name is not known to the model's equation system or the
-                given names are not unique.
-
-        Returns:
-            The names of the equations (currently) defined as primary equations.
-
-        """
-        return self._schur_complement_primary_equations
-
-    @schur_complement_primary_equations.setter
-    def schur_complement_primary_equations(self, names: list[str]) -> None:
-        known_equations = list(self.equation_system.equations.keys())
-        for n in names:
-            if n not in known_equations:
-                raise ValueError(f"Equation {n} unknown to the equation system.")
-        if len(set(names)) != len(names):
-            raise ValueError("Primary equation names must be unique.")
-        # Shallow copy for safety, and keep order of equation system.
-        self._schur_complement_primary_equations = [
-            n for n in known_equations if n in names
-        ]
-
-    @property
-    def schur_complement_primary_variables(self) -> list[str]:
-        """Names of the primary variables for the Schur complement reduction of the
-        linear system.
-
-        They define the column-block which does not contain the sub-matrix which is to
-        be inverted for the Schur complement.
-
-        See also:
-
-            - :meth:`assemble_linear_system`
-            - :meth:`~porepy.numerics.ad.equation_system.EquationSystem.
-              assemble_schur_complement_system`
-
-        Parameters:
-            names: List of variable names to be set as primary variables.
-
-        Raises:
-            ValueError: If any name is not known to the model's equation system or the
-                given names are not unique.
-
-        Returns:
-            The names of the variables (currently) defined as primary variables.
-
-        """
-        return self._schur_complement_primary_variables
-
-    @schur_complement_primary_variables.setter
-    def schur_complement_primary_variables(self, names: list[str]) -> None:
-        known_variables = list(set(v.name for v in self.equation_system.variables))
-        for n in names:
-            if n not in known_variables:
-                raise ValueError(f"Variable {n} unknown to the equation system.")
-        if len(set(names)) != len(names):
-            raise ValueError("Primary variables names must be unique.")
-        # Shallow copy for safety
-        self._schur_complement_primary_variables = [n for n in names]
-
     def before_time_step(self) -> None:
         """Called from the outside of the model at the start of each time step.
 
@@ -436,7 +354,11 @@ class SolutionStrategy(pp.PorePyModel):
 
         """
 
-    def after_nonlinear_iteration(self, nonlinear_increment: np.ndarray) -> None:
+    def after_nonlinear_iteration(
+        self,
+        nonlinear_increment: np.ndarray,
+        updated_variables: Optional[list[pp.ad.Variable]] = None,
+    ) -> None:
         """Method to be called after every non-linear iteration.
 
         The base method does the following:
@@ -447,11 +369,16 @@ class SolutionStrategy(pp.PorePyModel):
 
         Parameters:
             nonlinear_increment: The new solution, as computed by the non-linear solver.
+            updated_variables: Variables to update with `nonlinear_increment`. If
+                `None`, all variables are updated.
 
         """
         self.equation_system.shift_iterate_values(max_index=len(self.iterate_indices))
         self.equation_system.set_variable_values(
-            values=nonlinear_increment, additive=True, iterate_index=0
+            values=nonlinear_increment,
+            variables=updated_variables,
+            additive=True,
+            iterate_index=0,
         )
         self.update_derived_quantities()
 
@@ -784,56 +711,30 @@ class SolutionStrategy(pp.PorePyModel):
         self.save_statistics()
 
     def assemble_linear_system(self) -> solvers.LinearSystem:
-        """Assemble and return the linearized system.
+        """Assemble the linearized system.
 
         The linear system is defined by the current state of the model.
 
-        If ``params['apply_schur_complement_reduction']`` is True, the
-        :meth:`schur_complement_primary_variables` and
-        :meth:`schur_complement_primary_equations` are used to perform a Schur
-        complement technique.
-
-        To invert the secondary block, :meth:`~porepy.numerics.ad.equation_system.
-        EquationSystem.default_schur_complement_inverter` is used by default.
-        This inverter assumes the secondary equations to consist of non-overlapping
-        blocks (local equations, block-diagonal matrix).
-        The user can provide a custom inverter
-        ``model.params['schur_complement_inverter']``, which is a callable taking a
-        sparse matrix and returning the inverse (sparse) matrix.
-
         See Also:
-
-            - :meth:`~porepy.numerics.ad.equation_system.EquationSystem.
-              assemble_schur_complement_system`
             - :meth:`~porepy.numerics.ad.equation_system.EquationSystem.assemble`
 
         Returns:
             The assembled matrix and right-hand side vector.
 
         """
+        warn(
+            "The method model.assemble_linear_system is deprecated and will be removed."
+            " Use model.equation_system.assemble instead.",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
         t_0 = time.time()
 
-        if self._apply_schur_complement_reduction():
-            assert self.schur_complement_primary_variables, (
-                "Primary column block for Schur technique not found."
-            )
-            assert self.schur_complement_primary_equations, (
-                "Primary row block for Schur technique not defined."
-            )
-            mat, rhs = self.equation_system.assemble_schur_complement_system(
-                self.schur_complement_primary_equations,
-                self.schur_complement_primary_variables,
-                inverter=cast(
-                    Callable[[sps.spmatrix], sps.spmatrix],
-                    self.params.get("schur_complement_inverter", None),
-                ),
-            )
-        else:
-            mat, rhs = self.equation_system.assemble()
+        linear_system = self.equation_system.assemble()
 
         t_1 = time.time()
         logger.debug(f"Assembled linear system in {t_1 - t_0:.2e} seconds.")
-        return solvers.LinearSystem(matrix=mat, rhs=rhs)
+        return linear_system
 
     def solve_linear_system(self) -> Never:
         raise AttributeError(
@@ -841,17 +742,6 @@ class SolutionStrategy(pp.PorePyModel):
             "function, provide a custom linear solver to the nonlinear solver, e.g.: "
             "pp.NewtonSolver(linear_solver=CustomLinearSolver())"
         )
-
-    def _apply_schur_complement_reduction(self) -> bool:
-        """Returns the model parameter on whether the linear system should be reduced
-        via Schur complement using the defined primary and secondary equations and
-        variables.
-
-        Can be set via ``model.params['apply_schur_complement_reduction'].
-        Returns False by default.
-
-        """
-        return bool(self.params.get("apply_schur_complement_reduction", False))
 
     def _is_nonlinear_problem(self) -> bool:
         """Specifies whether the Model problem is nonlinear.

--- a/src/porepy/models/solution_strategy.py
+++ b/src/porepy/models/solution_strategy.py
@@ -354,11 +354,7 @@ class SolutionStrategy(pp.PorePyModel):
 
         """
 
-    def after_nonlinear_iteration(
-        self,
-        nonlinear_increment: np.ndarray,
-        updated_variables: Optional[list[pp.ad.Variable]] = None,
-    ) -> None:
+    def after_nonlinear_iteration(self, nonlinear_increment: np.ndarray) -> None:
         """Method to be called after every non-linear iteration.
 
         The base method does the following:
@@ -369,16 +365,11 @@ class SolutionStrategy(pp.PorePyModel):
 
         Parameters:
             nonlinear_increment: The new solution, as computed by the non-linear solver.
-            updated_variables: Variables to update with `nonlinear_increment`. If
-                `None`, all variables are updated.
 
         """
         self.equation_system.shift_iterate_values(max_index=len(self.iterate_indices))
         self.equation_system.set_variable_values(
-            values=nonlinear_increment,
-            variables=updated_variables,
-            additive=True,
-            iterate_index=0,
+            values=nonlinear_increment, additive=True, iterate_index=0
         )
         self.update_derived_quantities()
 

--- a/src/porepy/numerics/ad/equation_system.py
+++ b/src/porepy/numerics/ad/equation_system.py
@@ -321,7 +321,7 @@ class EquationSystem:
             The indexer.
 
         """
-        variable_dofs: dict[pp.ad.Variable, np.ndarray] = {}
+        indices: dict[pp.ad.Variable, np.ndarray] = {}
         offset = 0
 
         ordered_variables = cluster_dofs_gridwise(self.variables)
@@ -329,9 +329,9 @@ class EquationSystem:
         for var in ordered_variables:
             dofs_per_grid = var.size
             dofs = np.arange(dofs_per_grid) + offset
-            variable_dofs[var] = dofs
+            indices[var] = dofs
             offset += len(dofs)
-        return pp.ad.VariableIndexer(indices=variable_dofs)
+        return pp.ad.VariableIndexer(indices=indices)
 
     def construct_equation_indexer(self) -> pp.ad.EquationSystemIndexer:
         """Construct an equation indexer for all the registered equations.
@@ -344,7 +344,7 @@ class EquationSystem:
 
         """
         # Result dictionary.
-        equation_dofs: dict[str, dict[pp.GridLike, np.ndarray]] = {}
+        indices: dict[str, dict[pp.GridLike, np.ndarray]] = {}
 
         # self.equations defines the desired order of equations.
         for name, equation in self.equations.items():
@@ -376,11 +376,9 @@ class EquationSystem:
 
             # Filter out equations not defined anywhere.
             if len(dofs_on_domains) > 0:
-                equation_dofs[name] = dofs_on_domains
+                indices[name] = dofs_on_domains
 
-        return pp.ad.EquationSystemIndexer(
-            equation_image_space_composition=equation_dofs
-        )
+        return pp.ad.EquationSystemIndexer(equation_image_space_composition=indices)
 
     ### Variable management ------------------------------------------------------------
 

--- a/src/porepy/numerics/ad/equation_system.py
+++ b/src/porepy/numerics/ad/equation_system.py
@@ -1459,7 +1459,7 @@ class EquationSystem:
         if not evaluate_jacobian:
             return -rhs_cat
 
-        equation_indexer, variable_indexer = self.construct_assembled_matrix_indexers(
+        equation_indexer, variable_indexer = self._construct_assembled_matrix_indexers(
             equations=equations, variables=variables
         )
 
@@ -1485,7 +1485,7 @@ class EquationSystem:
             variable_indexer=variable_indexer,
         )
 
-    def construct_assembled_matrix_indexers(
+    def _construct_assembled_matrix_indexers(
         self,
         equations: Optional[EquationList | EquationRestriction] = None,
         variables: Optional[VariableList] = None,

--- a/src/porepy/numerics/ad/equation_system.py
+++ b/src/porepy/numerics/ad/equation_system.py
@@ -1263,11 +1263,6 @@ class EquationSystem:
         if isinstance(equations, list):
             # Equation names are restricted, domains are not restricted (None).
             for eq in equations:
-                if isinstance(eq, pp.ad.EquationOnDomain):
-                    # This assumes that eq.domains are already sorted.
-                    self._validate_equation_name(eq.name)
-                    equations_on_domains.append(eq)
-
                 eq = self._validate_equation_name(eq)
                 for domain in eq.domains:
                     # This assumes that eq.domains are already sorted.
@@ -1496,7 +1491,7 @@ class EquationSystem:
         self,
         equations: Optional[EquationList | EquationRestriction] = None,
         variables: Optional[VariableList] = None,
-    ) -> tuple[pp.ad.EquationSystemIndexer, pp.ad.VariableIndexer]:
+    ) -> tuple[pp.ad.EquationIndexer, pp.ad.VariableIndexer]:
         """Generate indexers for the linear system produced by :meth:`assemble`.
 
         Parameters:

--- a/src/porepy/numerics/ad/equation_system.py
+++ b/src/porepy/numerics/ad/equation_system.py
@@ -1356,7 +1356,7 @@ class EquationSystem:
         """Assemble Jacobian matrix and residual vector using a specified subset of
         equations, variables and grids.
 
-        The ordering of rows and columns in the returned EquationSystem are defined
+        The ordering of rows and columns in the returned LinearSystem are defined
         by the equation system's :attr:`equation_indexer` and
         :attr:`variable_indexer`, respectively.
 

--- a/src/porepy/numerics/ad/equation_system.py
+++ b/src/porepy/numerics/ad/equation_system.py
@@ -6,7 +6,7 @@ using the AD framework.
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import Any, Callable, Literal, Optional, Sequence, Union, overload
+from typing import Any, Literal, Optional, Sequence, Union, overload
 from warnings import warn
 
 import numpy as np
@@ -159,7 +159,7 @@ class EquationSystem:
 
         """
 
-        self._equation_indexer: pp.ad.EquationIndexer | None = None
+        self._equation_indexer: pp.ad.EquationSystemIndexer | None = None
         """Indexer defining the ordering of the equations (rows) when multiple equation
         values are packed in a single vector.
 
@@ -169,24 +169,7 @@ class EquationSystem:
         variable values are packed in a single vector.
 
         """
-        # Schur complement related stuff (to be removed in the next PR).
-        self._Schur_complement: Optional[tuple] = None
-        """Contains block matrices and the rhs of the last assembled Schur complement.
-
-        """
         self._ad_parser = _ad_parser.AdParser(self.mdg)
-
-        self._secondary_block_permutation: dict[
-            Literal["row_perm_indices", "col_perm_indices", "block_sizes"], np.ndarray
-        ] = {}
-        """Stores the information on the permutations in the secondary block of the
-        linear system, which is to be eliminated when
-        ``model.params['apply_schur_complement_reduction'] == True``.
-
-        Permutations generated and stored using :func:`~porepy.numerics.linalg.
-        matrix_operations.generate_permutation_to_block_diag_matrix`.
-
-        """
 
     def SubSystem(
         self,
@@ -310,7 +293,7 @@ class EquationSystem:
         return self._variable_indexer
 
     @property
-    def equation_indexer(self) -> pp.ad.EquationIndexer:
+    def equation_indexer(self) -> pp.ad.EquationSystemIndexer:
         """Indexer defining the ordering of the equations (rows) when multiple
         equation values are packed in a single vector.
 
@@ -350,7 +333,7 @@ class EquationSystem:
             offset += len(dofs)
         return pp.ad.VariableIndexer(indices=variable_dofs)
 
-    def construct_equation_indexer(self) -> pp.ad.EquationIndexer:
+    def construct_equation_indexer(self) -> pp.ad.EquationSystemIndexer:
         """Construct an equation indexer for all the registered equations.
 
         Equation ordering follows registration order. Equations not defined anywhere
@@ -386,15 +369,18 @@ class EquationSystem:
                     )
                 else:
                     raise ValueError(f"Unknown domain type: {domain}")
+
                 dofs = np.arange(dofs_per_grid) + offset
                 dofs_on_domains[domain] = dofs
-                offset += len(dofs)
+                offset += dofs_per_grid
 
             # Filter out equations not defined anywhere.
             if len(dofs_on_domains) > 0:
                 equation_dofs[name] = dofs_on_domains
 
-        return pp.ad.EquationIndexer(equation_image_composition=equation_dofs)
+        return pp.ad.EquationSystemIndexer(
+            equation_image_space_composition=equation_dofs
+        )
 
     ### Variable management ------------------------------------------------------------
 
@@ -1277,6 +1263,11 @@ class EquationSystem:
         if isinstance(equations, list):
             # Equation names are restricted, domains are not restricted (None).
             for eq in equations:
+                if isinstance(eq, pp.ad.EquationOnDomain):
+                    # This assumes that eq.domains are already sorted.
+                    self._validate_equation_name(eq.name)
+                    equations_on_domains.append(eq)
+
                 eq = self._validate_equation_name(eq)
                 for domain in eq.domains:
                     # This assumes that eq.domains are already sorted.
@@ -1303,48 +1294,6 @@ class EquationSystem:
         # Order according to equation_indexer.
         equation_order = {eq: i for i, eq in enumerate(self.equation_indexer.indices)}
         return list(sorted(equations_on_domains, key=lambda eq: equation_order[eq]))
-
-    def _gridbased_equation_complement(
-        self, equations: dict[str, None | np.ndarray]
-    ) -> dict[str, None | np.ndarray]:
-        """Takes the information from equation parsing and finds for each equation
-        (identified by its name string) the indices which were excluded in the
-        grid-sense.
-
-        Parameters:
-            equations: Dictionary with equation names as keys and indices as values.
-                The indices are the indices of the rows in the global system that
-                were included in the last parsing of the equations.
-
-        Returns:
-            A dictionary with the name of the equation as key and the grid-complement
-            as values. If the complement is empty, the value is None.
-
-        """
-        equation_indexer = self.equation_indexer
-
-        complement: dict[str, None | np.ndarray] = dict()
-        for name, idx in equations.items():
-            # If indices were filtered based on grids, we find the complementing
-            # indices.
-            # If idx is None, this means no filtering was done.
-            if idx is not None:
-                # Get the indices associated with this equation.
-                all_idx_list = equation_indexer.equation_image_space_composition[name]
-                all_idx = (
-                    np.concatenate(list(all_idx_list.values()))
-                    if len(all_idx_list) > 0
-                    else np.empty(0, dtype=int)
-                )
-
-                # Complementing indices are found by deleting the filtered indices.
-                complement_idx = np.delete(all_idx, idx)
-                complement.update({name: complement_idx})
-
-            # If there was no grid-based row filtering, the complement is empty.
-            else:
-                complement.update({name: None})
-        return complement
 
     def discretize(
         self, equations: Optional[EquationList | EquationRestriction] = None
@@ -1391,7 +1340,7 @@ class EquationSystem:
         equations: Optional[EquationList | EquationRestriction] = None,
         variables: Optional[VariableList] = None,
         state: Optional[np.ndarray] = None,
-    ) -> tuple[sps.spmatrix, np.ndarray]: ...
+    ) -> pp.solvers.LinearSystem: ...
 
     @overload
     def assemble(
@@ -1408,7 +1357,7 @@ class EquationSystem:
         equations: Optional[EquationList | EquationRestriction] = None,
         variables: Optional[VariableList] = None,
         state: Optional[np.ndarray] = None,
-    ) -> tuple[sps.spmatrix, np.ndarray] | np.ndarray:
+    ) -> pp.solvers.LinearSystem | np.ndarray:
         """Assemble Jacobian matrix and residual vector using a specified subset of
         equations, variables and grids.
 
@@ -1438,16 +1387,13 @@ class EquationSystem:
                 they are not registered by this equation system.
 
         Returns:
-            Tuple with two elements
-
-                spmatrix: (Part of the) Jacobian matrix corresponding to the targeted
-                variable state, for the specified equations and variables.
-                ndarray: Residual vector corresponding to the targeted variable state,
-                for the specified equations. Scaled with -1 (moved to rhs).
+            A linear system containing (requested part of) the Jacobian matrix and
+                residual vector. The residual is scaled with -1 (moved to the right-hand
+                side).
 
             or, if ``evaluate_jacobian`` is False,
 
-                ndarray: Residual vector corresponding to the targeted variable state,
+            ndarray: Residual vector corresponding to the targeted variable state,
                 for the specified equations. Scaled with -1 (moved to rhs).
 
         """
@@ -1520,28 +1466,37 @@ class EquationSystem:
         if not evaluate_jacobian:
             return -rhs_cat
 
+        equation_indexer, variable_indexer = self.construct_assembled_matrix_indexers(
+            equations=equations, variables=variables
+        )
+
         # Slice out the columns belonging to the requested subsets of variables and
         # grid-related column blocks by using the transposed projection to respective
         # subspace.
         if variables is not None:
-            variable_indexer = self.variable_indexer
             # Respect the ordering of the input list of variables.
             variables_ = self._parse_variable_type(variables=variables, ordered=True)
-            col_proj = [variable_indexer.indices[var] for var in variables_]
+            col_proj = [self.variable_indexer.indices[var] for var in variables_]
             column_projection = (
                 np.concatenate(col_proj)
                 if len(col_proj) > 0
                 else np.empty(0, dtype=int)
             )
             A = A[:, column_projection]
+
         # Multiply rhs by -1 to move to the rhs.
-        return A, -rhs_cat
+        return pp.solvers.LinearSystem(
+            matrix=A,
+            rhs=-rhs_cat,
+            equation_indexer=equation_indexer,
+            variable_indexer=variable_indexer,
+        )
 
     def construct_assembled_matrix_indexers(
         self,
         equations: Optional[EquationList | EquationRestriction] = None,
         variables: Optional[VariableList] = None,
-    ) -> tuple[pp.ad.EquationIndexer, pp.ad.VariableIndexer]:
+    ) -> tuple[pp.ad.EquationSystemIndexer, pp.ad.VariableIndexer]:
         """Generate indexers for the linear system produced by :meth:`assemble`.
 
         Parameters:
@@ -1569,293 +1524,6 @@ class EquationSystem:
             equation_indexer = self.equation_indexer
 
         return equation_indexer, variable_indexer
-
-    def assemble_schur_complement_system(
-        self,
-        primary_equations: EquationList | EquationRestriction,
-        primary_variables: VariableList,
-        inverter: Optional[Callable[[sps.spmatrix], sps.spmatrix]] = None,
-        state: Optional[np.ndarray] = None,
-    ) -> tuple[sps.spmatrix, np.ndarray]:
-        r"""Assemble Jacobian matrix and residual vector using a Schur complement
-        elimination of the variables and equations not to be included.
-
-        The specified equations and variables will define blocks of the linearized
-        system as
-
-        .. math::
-            \left [ \begin{matrix} A_{pp} & A_{ps} \\ A_{sp} & A_{ss} \end{matrix}
-            \right]
-            \left [ \begin{matrix} x_p \\ x_s \end{matrix}\right]
-            = \left [ \begin{matrix} b_p \\ b_s \end{matrix}\right]
-
-
-        where subscripts p and s define primary and secondary blocks.
-        The Schur complement system is then given by
-
-        .. math::
-
-            \left( A_{pp} - A_{ps} * A_{ss}^{-1} * A_{sp}\right) * x_p
-            = b_p - A_{ps} * A_{ss}^{-1} * b_s
-
-        The Schur complement is well-defined only if the inverse of :math:`A_{ss}`
-        exists, and the efficiency of the approach assumes that an efficient inverter
-        for :math:`A_{ss}` can be found.
-        **The user must ensure both requirements are fulfilled.**
-
-        Parameters:
-            primary_equations: A subset of equations specifying the primary subspace in
-                row-sense.
-            primary_variables: A subset of variables specifying the primary subspace in
-                column-sense.
-            inverter: ``default=None``
-
-                Callable to compute the inverse of the matrix :math:`A_{ss}`.
-                :meth:`default_schur_complement_inverter` is used if not provided.
-            state: ``default=None``
-
-                See :meth:`assemble`. Defaults to None.
-
-        Returns:
-            Tuple containing
-
-                sps.spmatrix: Jacobian matrix representing the Schur complement with
-                respect to the targeted state.
-                np.ndarray: Residual vector for the Schur complement with respect to the
-                targeted state. Scaled with -1 (moved to rhs).
-
-        Raises:
-            AssertionError:
-
-                - If the primary block would have 0 rows or columns.
-                - If the secondary block would have 0 rows or columns.
-                - If the secondary block is not square.
-
-            ValueError: If primary and secondary columns overlap.
-
-        """
-        if inverter is None:
-            inverter = self.default_schur_complement_inverter
-
-        # Find the rows of the primary block. This can include both equations defined
-        # on their full image, and equations specified on a subset of grids.
-        # The variable primary_rows will contain the indices in the global system
-        # corresponding to the primary block.
-        equations_on_domains = self._parse_equations(primary_equations)
-        primary_rows_lists: dict[str, list[np.ndarray]] = {}
-        for eq in equations_on_domains:
-            primary_rows_lists.setdefault(eq.name, []).append(
-                self.equation_indexer.equation_image_space_composition[eq.name][
-                    eq.domain
-                ]
-            )
-        primary_rows: dict[str, None | np.ndarray] = {
-            name: np.concatenate(dofs) for name, dofs in primary_rows_lists.items()
-        }
-        # Find indices of equations involved in the primary block, but on grids that
-        # were filtered out. These will be added to the secondary block.
-        excluded_primary_rows = self._gridbased_equation_complement(primary_rows)
-
-        # Names of equations that form the primary block.
-        primary_equation_names = list(primary_rows.keys())
-
-        # Get the primary variables, represented as Ad variables.
-        active_variables = self._parse_variable_type(primary_variables, ordered=False)
-
-        # Projection of variables to the set of primary blocks.
-        primary_projection = self.projection_to(active_variables)
-
-        # Assert non-emptiness of primary block.
-        assert len(primary_rows) > 0
-        assert primary_projection.shape[0] > 0
-
-        # Equations that are not part of the primary block. These will form parts of the
-        # secondary block, as will the equations that are defined on grids that were
-        # excluded.
-        secondary_equation_names: list[str] = list(
-            set(self._equations.keys()).difference(set(primary_rows.keys()))
-        )
-        secondary_variables = list(set(self.variables).difference(active_variables))
-        secondary_projection = self.projection_to(secondary_variables)
-
-        # Assert non-emptiness of secondary block. We do not check the length of
-        # sequandary_equation_names, since this can empty if the secondary block is
-        # defined by a subset of grids.
-        assert secondary_projection.shape[0] > 0
-
-        # Storage of primary and secondary row blocks.
-        A_sec: list[sps.csr_matrix] = list()
-        b_sec: list[np.ndarray] = list()
-        A_prim: list[sps.csr_matrix] = list()
-        b_prim: list[np.ndarray] = list()
-
-        # Keep track of indices or primary block.
-        ind_start = 0
-
-        # We loop over stored equations to ensure the correct order but process only
-        # primary equations.
-        # Excluded local primary blocks are stored as top rows in the secondary block.
-        for name in self._equations:
-            if name in primary_equation_names:
-                A_temp, b_temp = self.assemble(equations=[name], state=state)
-                idx_p = primary_rows[name]
-                # Check if a grid filter was applied for that equation
-                if idx_p is not None:
-                    # Append the respective rows.
-                    A_prim.append(A_temp[idx_p])
-                    b_prim.append(b_temp[idx_p])
-                    # If requested, the excluded primary rows are appended as secondary.
-                    idx_excl_p = excluded_primary_rows[name]
-                    A_sec.append(A_temp[idx_excl_p])
-                    b_sec.append(b_temp[idx_excl_p])
-                else:
-                    # If no filter was applied, the whole row block is appended.
-                    A_prim.append(A_temp)
-                    b_prim.append(b_temp)
-
-                block_length = b_prim[-1].size
-                # Create indices range and shift to correct position.
-                block_indices = np.arange(block_length) + ind_start
-                # Extract last index and add 1 to get the starting point for next block
-                # of indices.
-                if block_length > 0:
-                    ind_start = block_indices[-1] + 1
-
-        # We loop again over stored equation to ensure a correct order
-        # but process only secondary equations.
-        for name in self._equations:
-            # Secondary equations (those not explicitly given as being primary) are
-            # assembled wholesale to the secondary block.
-            if name in secondary_equation_names:
-                A_temp, b_temp = self.assemble(equations=[name], state=state)
-                A_sec.append(A_temp)
-                b_sec.append(b_temp)
-
-                block_length = b_sec[-1].size
-                block_indices = np.arange(block_length) + ind_start
-                if block_length > 0:
-                    ind_start = block_indices[-1] + 1
-
-        # stack the results
-        A_p = sps.vstack(A_prim, format="csr")
-        b_p = np.concatenate(b_prim)
-        A_s = sps.vstack(A_sec, format="csr")
-        b_s = np.concatenate(b_sec)
-
-        # turn the projections into prolongations
-        primary_projection = primary_projection.transpose()
-        secondary_projection = secondary_projection.transpose()
-
-        # Matrices involved in the Schur complements
-        A_pp = A_p * primary_projection
-        A_ps = A_p * secondary_projection
-        A_sp = A_s * primary_projection
-        A_ss = A_s * secondary_projection
-
-        # Last sanity check, if A_ss is square.
-        assert A_ss.shape[0] == A_ss.shape[1]
-
-        # Compute the inverse of A_ss using the passed inverter.
-        inv_A_ss = inverter(A_ss)
-
-        S = A_pp - A_ps * inv_A_ss * A_sp
-        rhs_S = b_p - A_ps * inv_A_ss * b_s
-
-        # Store information necessary for expanding the Schur complement later.
-        self._Schur_complement = (
-            inv_A_ss,
-            b_s,
-            A_sp,
-            primary_projection,
-            secondary_projection,
-        )
-
-        return S, rhs_S
-
-    def expand_schur_complement_solution(
-        self, reduced_solution: np.ndarray
-    ) -> np.ndarray:
-        r"""Expands the solution of the *last assembled* Schur complement system to the
-        whole solution.
-
-        With ``reduced_solution`` as :math:`x_p` from
-
-        .. math::
-            \left [ \begin{matrix} A_{pp} & A_{ps} \\ A_{sp} & A_{ss} \end{matrix}
-            \right]
-            \left [ \begin{matrix} x_p \\ x_s \end{matrix}\right]
-            = \left [ \begin{matrix} b_p \\ b_s \end{matrix}\right],
-
-        the method returns the whole vector :math:`[x_p, x_s]`, where
-
-        .. math::
-            x_s = A_{ss}^{-1} * (b_s - A_{sp} * x_p).
-
-        Note:
-            Independent of how the primary and secondary blocks were chosen, this method
-            always returns a vector of size ``num_dofs``.
-            Especially when the primary and secondary variables did not constitute the
-            whole vector of unknowns, the result is still of size ``num_dofs``.
-            The entries corresponding to the excluded grid variables are zero.
-
-        Parameters:
-            reduced_solution: Solution to the linear system returned by
-                :meth:`assemble_schur_complement_system`.
-
-        Returns:
-            The expanded Schur solution in global size.
-
-        Raises:
-            ValueError: If the Schur complement system was not assembled before.
-
-        """
-        if self._Schur_complement is None:
-            raise ValueError("Schur complement system was not assembled before.")
-
-        # Get data stored from last constructed Schur complement.
-        inv_A_ss, b_s, A_sp, prolong_p, prolong_s = self._Schur_complement
-
-        # Calculate the complement solution.
-        x_s = inv_A_ss * (b_s - A_sp * reduced_solution)
-
-        # Prolong primary and secondary block to global-sized arrays
-        X = prolong_p * reduced_solution + prolong_s * x_s
-        return X
-
-    def default_schur_complement_inverter(self, A: sps.spmatrix) -> sps.spmatrix:
-        """The inverter for the secondary block in the Schur complement
-        reduction.
-
-        The default implementation assumes the secondary block to be a permuted, block
-        diagonal matrix (local equations), and computes and stores the permutation
-        only *once*. It then proceeds to call an efficient, parallelized block-diagonal
-        matrix inverter.
-
-        See also:
-
-            - :func:`~porepy.numerics.linalg.matrix_operations.
-              generate_permutation_to_block_diag_matrix`
-            - :func:`~porepy.numerics.linalg.matrix_operations.
-              invert_permuted_block_diag_matrix`
-
-        """
-
-        # Generate permutations only once, if not already present.
-        if not self._secondary_block_permutation:
-            row_perm, col_perm, block_sizes = (
-                pp.matrix_operations.generate_permutation_to_block_diag_matrix(A)
-            )
-            self._secondary_block_permutation["row_perm_indices"] = row_perm
-            self._secondary_block_permutation["col_perm_indices"] = col_perm
-            self._secondary_block_permutation["block_sizes"] = block_sizes
-        else:
-            row_perm = self._secondary_block_permutation["row_perm_indices"]
-            col_perm = self._secondary_block_permutation["col_perm_indices"]
-            block_sizes = self._secondary_block_permutation["block_sizes"]
-
-        return pp.matrix_operations.invert_permuted_block_diag_matrix(
-            A, row_perm, col_perm, block_sizes
-        )
 
     ### Evaluate Ad operators ----------------------------------------------------------
 

--- a/src/porepy/numerics/ad/indexers.py
+++ b/src/porepy/numerics/ad/indexers.py
@@ -8,12 +8,18 @@ Used by `EquationSystem` and nonlinear solvers.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Final
 
 import numpy as np
 
 import porepy as pp
 
-__all__ = ["EquationOnDomain", "VariableIndexer", "EquationIndexer"]
+__all__ = [
+    "EquationOnDomain",
+    "VariableIndexer",
+    "EquationIndexer",
+    "EquationSystemIndexer",
+]
 
 
 @dataclass(frozen=True)
@@ -114,7 +120,7 @@ class VariableIndexer:
             offset += indices.size
 
         if len(new_variable_indices) != len(variables):
-            raise ValueError(f"Requested variables are duplicated: {variable}.")
+            raise ValueError(f"Requested variables are duplicated: {variables}.")
 
         return VariableIndexer(indices=new_variable_indices)
 
@@ -163,55 +169,18 @@ class VariableIndexer:
 
 
 class EquationIndexer:
-    """An equation indexer determines the arrangement of indices corresponding to
-    multiple equations on multiple grids in a contiguous array.
+    """Map atomic equations to their DoF indices in an algebraic system.
 
-    For a data array with a different arrangement (e.g., produced by taking a subset of
-    equations), a new indexer needs to be constructed.
-
-    Implementation note: There is an unfortunate asymmetry between this and
-    :class:`VariableIndexer` in the way these classes are initialized and what fields
-    they expose. This is done to support convenient operations in `EquationSystem`. The
-    preferred way to interact with this class outside `EquationSystem` is by using
-    :class:`EquationOnDomain` to query indices and not
-    `dict[str, dict[pp.GridLike, np.ndarray]]`. See also the docstring of
-    :attr:`equation_image_space_composition`.
+    The DoFs may have an arbitrary arrangement. In particular, the indices belonging to
+    an equation need not be contiguous, and equations need not occur in registration
+    order. A new indexer must be constructed for a data array with a different
+    arrangement.
 
     """
 
-    def __init__(
-        self, equation_image_composition: dict[str, dict[pp.GridLike, np.ndarray]]
-    ) -> None:
-        equation_indices: dict[EquationOnDomain, np.ndarray] = {}
-        global_offset = 0
-        for eq_name, indices_on_domains in equation_image_composition.items():
-            offset_per_equation = 0
-            for domain, indices in indices_on_domains.items():
-                equation_indices[EquationOnDomain(name=eq_name, domain=domain)] = (
-                    indices + global_offset
-                )
-                offset_per_equation += indices.size
-            global_offset += offset_per_equation
-
-        self.indices: dict[EquationOnDomain, np.ndarray] = equation_indices
-        """An ordered mapping of atomic equations to their DoF indices. The keys are
-        ordered, in the sense that if key A goes before key B, indices of key A are
-        located before indices of key B.
-
-        """
-        self.equation_image_space_composition: dict[
-            str, dict[pp.GridLike, np.ndarray]
-        ] = equation_image_composition
-        """A mapping `equation_name` -> `domains` -> `indices`.
-
-        The indices stored here start from 0 for each equation, i.e. the offset is only
-        relative to domains. The indices with the "global" offset can be found in
-        :attr:`indices`. This is done to respect the implementation of
-        `EquationSystem`, where both types of offsets are needed.
-
-        Note: It does not include equations with empty domains.
-
-        """
+    def __init__(self, indices: dict[EquationOnDomain, np.ndarray]) -> None:
+        self.indices: Final[dict[EquationOnDomain, np.ndarray]] = indices
+        """Mapping of atomic equations to their DoF indices."""
 
     def group_by_name(self) -> dict[str, dict[pp.GridLike, np.ndarray]]:
         """Group :attr:`indices` by equation names.
@@ -266,16 +235,81 @@ class EquationIndexer:
         if len(new_equation_indices) != len(equations):
             raise ValueError(f"Requested equations are duplicated: {equations}.")
 
-        # YZ: This is a little hack to be removed in the next PR. Now for simplicity,
-        # EquationIndexer needs to be initialized with (equation-local)
-        # equation_image_composition, so we reconstruct it here.
-        equation_image_composition: dict[str, dict[pp.GridLike, np.ndarray]] = {}
-        offsets_per_equation: dict[str, int] = {}
-        for equation, indices in new_equation_indices.items():
-            equation_offset = offsets_per_equation.get(equation.name, 0)
-            equation_image_composition.setdefault(equation.name, {})[
-                equation.domain
-            ] = np.arange(indices.size) + equation_offset
-            offsets_per_equation[equation.name] = equation_offset + indices.size
+        return EquationIndexer(indices=new_equation_indices)
 
-        return EquationIndexer(equation_image_composition=equation_image_composition)
+    def projection_indices(self, equations: list[EquationOnDomain]) -> np.ndarray:
+        """Create a projection index array from the system vector represented
+        by this indexer to the requested subspace.
+
+        The order of the equations in the projection is defined by the input.
+
+        Parameters:
+            equation: Input for which the subspace is requested.
+
+        Returns:
+            an index array of `shape=(M,)`, where `0 <= M <= num_dofs`.
+
+        """
+        projections = []
+        for equation in equations:
+            dofs = self.indices.get(equation, None)
+            if dofs is None:
+                raise ValueError(
+                    f"Requested equation is not known to this indexer: {equation}."
+                )
+            projections.append(dofs)
+        return (
+            np.concatenate(projections)
+            if len(projections) > 0
+            else np.empty(0, dtype=int)
+        )
+
+
+class EquationSystemIndexer(EquationIndexer):
+    """Equation indexer for the block arrangement used by :class:`EquationSystem`.
+
+    The AD framework evaluates each equation separately. Before these per-equation
+    results are concatenated into a global matrix and residual vector,
+    :class:`EquationSystem` may need to select rows belonging to requested domains.
+    :attr:`equation_image_space_composition` provides the per-equation indices needed
+    for this selection.
+
+    In the global algebraic system, equations form consecutive blocks. Within each
+    equation, the image-space composition maps every requested domain to indices in
+    that equation's unreduced result. These local indices need not be consecutive: A
+    restricted system can select only part of an equation's result.
+
+    """
+
+    def __init__(
+        self,
+        equation_image_space_composition: dict[str, dict[pp.GridLike, np.ndarray]],
+    ) -> None:
+        equation_indices: dict[EquationOnDomain, np.ndarray] = {}
+        global_offset = 0
+        for eq_name, dofs_on_domains in equation_image_space_composition.items():
+            offset_within_equation = 0
+            for domain, dofs in dofs_on_domains.items():
+                equation_indices[EquationOnDomain(name=eq_name, domain=domain)] = (
+                    np.arange(dofs.size) + (global_offset + offset_within_equation)
+                )
+                offset_within_equation += dofs.size
+            global_offset += offset_within_equation
+
+        super().__init__(indices=equation_indices)
+        self.equation_image_space_composition: Final[
+            dict[str, dict[pp.GridLike, np.ndarray]]
+        ] = equation_image_space_composition
+        """A mapping `equation_name` -> `domains` -> `dofs`.
+
+        The DoFs stored here refer to rows in each equation's separate AD result. The
+        consecutive indices of the selected rows after global concatenation can be
+        found in :attr:`equation_dofs`. The equation-local indices allow
+        :class:`EquationSystem` to select rows before concatenating the per-equation
+        results into the global matrix and residual vector.
+
+        Callers must not mutate the dictionary or its arrays.
+
+        Note: It does not include equations with empty domains.
+
+        """

--- a/src/porepy/numerics/ad/indexers.py
+++ b/src/porepy/numerics/ad/indexers.py
@@ -181,6 +181,7 @@ class EquationIndexer:
     def __init__(self, indices: dict[EquationOnDomain, np.ndarray]) -> None:
         self.indices: Final[dict[EquationOnDomain, np.ndarray]] = indices
         """Mapping of atomic equations to their DoF indices."""
+        self.size: int = sum(x.size for x in self.indices.values())
 
     def group_by_name(self) -> dict[str, dict[pp.GridLike, np.ndarray]]:
         """Group :attr:`indices` by equation names.

--- a/src/porepy/numerics/ad/indexers.py
+++ b/src/porepy/numerics/ad/indexers.py
@@ -304,7 +304,7 @@ class EquationSystemIndexer(EquationIndexer):
 
         The DoFs stored here refer to rows in each equation's separate AD result. The
         consecutive indices of the selected rows after global concatenation can be
-        found in :attr:`equation_dofs`. The equation-local indices allow
+        found in :attr:`indices`. The equation-local indices allow
         :class:`EquationSystem` to select rows before concatenating the per-equation
         results into the global matrix and residual vector.
 

--- a/src/porepy/numerics/linalg/matrix_operations.py
+++ b/src/porepy/numerics/linalg/matrix_operations.py
@@ -1733,6 +1733,10 @@ def generate_permutation_to_block_diag_matrix(
     matrix entry is non-zero. The connected components of this graph then define the
     blocks in the permuted matrix.
 
+    This function is not used in PorePy, because it was replaced by a more targeted
+    :func:`rearrange_matrix_as_array_of_structures`. It remains here because it covers
+    the general case, and therefore might be useful at some point.
+
     Notes:
 
         - The function assumes that the matrix is square or rectangular with consistent

--- a/src/porepy/numerics/solvers/__init__.py
+++ b/src/porepy/numerics/solvers/__init__.py
@@ -16,6 +16,7 @@ from .convergence_check import *
 from .equation_variable_tags import *
 from .line_search import *
 from .linear_solvers import *
+from .linear_solvers.linear_solver import LinearSolverStatus, LinearSystem
 from .nonlinear_solver_status import *
 from .nonlinear_solvers import *
 

--- a/src/porepy/numerics/solvers/__init__.py
+++ b/src/porepy/numerics/solvers/__init__.py
@@ -5,15 +5,17 @@ __all__ = []
 from . import (
     anderson_acceleration,
     convergence_check,
+    equation_variable_tags,
     line_search,
-    linear_solver,
+    linear_solvers,
     nonlinear_solver_status,
     nonlinear_solvers,
 )
 from .anderson_acceleration import *
 from .convergence_check import *
+from .equation_variable_tags import *
 from .line_search import *
-from .linear_solver import *
+from .linear_solvers import *
 from .nonlinear_solver_status import *
 from .nonlinear_solvers import *
 
@@ -22,4 +24,5 @@ __all__.extend(convergence_check.__all__)
 __all__.extend(line_search.__all__)
 __all__.extend(nonlinear_solver_status.__all__)
 __all__.extend(nonlinear_solvers.__all__)
-__all__.extend(linear_solver.__all__)
+__all__.extend(linear_solvers.__all__)
+__all__.extend(equation_variable_tags.__all__)

--- a/src/porepy/numerics/solvers/equation_variable_tags.py
+++ b/src/porepy/numerics/solvers/equation_variable_tags.py
@@ -1,0 +1,138 @@
+"""This module defines `EquationTag` and `VariableTag`, which identify equations
+and variables in a model, optionally restricted to specific grids.
+
+These tags are intended for defining nonlinear and linear solution strategies. Unlike
+`pp.ad.Variable`, `pp.ad.MixedDimensionalVariable`, and `pp.ad.Operator`, they can be
+created without initializing a PorePy model, which requires constructing and meshing its
+grids. This makes them less expensive to use and easier to incorporate into modular
+code, particularly in tests.
+
+"""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from dataclasses import dataclass
+
+import porepy as pp
+
+__all__ = [
+    "EquationTag",
+    "VariableTag",
+    "DefaultEquationTags",
+    "DefaultVariableTags",
+]
+
+
+@dataclass(frozen=True)
+class DomainFilter:
+    """A filter to restrict domains of a variable or an equation.
+
+    Used in :class:`EquationTag` and :class:`VariableTag`."""
+
+    @abstractmethod
+    def filter(self, domain: pp.GridLike) -> bool:
+        """Whether this `domain` is included in the domains where the equation /
+        variable tag operates.
+
+        """
+
+
+@dataclass(frozen=True)
+class Anywhere(DomainFilter):
+    """A default filter that includes all domains."""
+
+    def filter(self, domain: pp.GridLike) -> bool:
+        return True
+
+
+@dataclass(frozen=True)
+class EquationTag:
+    """An identifier of a single equation defined on multiple domains. Used to define
+    nonlinear and linear solvers outside PorePy models, where identification by
+    `pp.ad.Operator` or a list of `pp.GridLike` is unavailable.
+
+    """
+
+    name: str
+    """Equation name."""
+    defined_on: DomainFilter = Anywhere()
+    """Operational domains of the equation identified by this tag. Possibly a subset of
+    all domains where this equation is defined by a PorePy model.
+
+    """
+
+
+@dataclass(frozen=True)
+class VariableTag:
+    """An identifier of a single variable defined on multiple domains. Used to define
+    nonlinear and linear solvers outside PorePy models, where identification by
+    `pp.ad.Variable`, `pp.ad.MixedDimensionalVariable` or a list of `pp.GridLike` is
+    unavailable.
+
+    """
+
+    name: str
+    """Variable name."""
+    defined_on: DomainFilter = Anywhere()
+    """Operational domains of the variable identified by this tag. Possibly a subset of
+    all domains where this variable is defined by a PorePy model.
+
+    """
+
+
+class DefaultEquationTags:
+    """A namespace for all known equations defined by standard PorePy models."""
+
+    # Mass balance
+    mass_balance = EquationTag(name="mass_balance_equation")
+    interface_darcy_flux = EquationTag(name="interface_darcy_flux_equation")
+    well_flux = EquationTag(name="well_flux_equation")
+    # Energy balance
+    energy_balance = EquationTag(name="energy_balance_equation")
+    interface_fourier_flux = EquationTag(name="interface_fourier_flux_equation")
+    interface_enthalpy_flux = EquationTag(name="interface_enthalpy_flux_equation")
+    well_enthalpy_flux = EquationTag(name="well_enthalpy_flux_equation")
+    # Momentum balance MPSA
+    momentum_balance = EquationTag(name="momentum_balance_equation")
+    # Momentum balance TPSA
+    angular_momentum_balance = EquationTag(name="angular_momentum_balance_equation")
+    solid_mass = EquationTag(name="solid_mass_equation")
+    poromechanics_solid_mass = EquationTag(name="Solid_mass_equation_poromechanics")
+    # Contact mechanics
+    normal_fracture_deformation = EquationTag(
+        name="normal_fracture_deformation_equation"
+    )
+    tangential_fracture_deformation = EquationTag(
+        name="tangential_fracture_deformation_equation"
+    )
+    interface_force_balance = EquationTag(name="interface_force_balance_equation")
+    # Fracture damage (?)
+    dilation_damage = EquationTag(name="dilation_damage_equation")
+    friction_damage = EquationTag(name="friction_damage_equation")
+
+
+class DefaultVariableTags:
+    """A namespace for all known variables defined by standard PorePy models."""
+
+    # Mass balance
+    pressure = VariableTag(name="pressure")
+    interface_darcy_flux = VariableTag(name="interface_darcy_flux")
+    well_flux = VariableTag(name="well_flux")
+    # Energy balance
+    temperature = VariableTag(name="temperature")
+    enthalpy = VariableTag(name="enthalpy")
+    interface_fourier_flux = VariableTag(name="interface_fourier_flux")
+    interface_enthalpy_flux = VariableTag(name="interface_enthalpy_flux")
+    well_enthalpy_flux = VariableTag(name="well_enthalpy_flux")
+    # Momentum balance MPSA and TPSA
+    displacement = VariableTag(name="u")
+    # Momentum balance TPSA
+    rotation_stress = VariableTag(name="rotation_stress")
+    total_pressure = VariableTag(name="total_pressure")
+    # Contact mechanics
+    interface_displacement = VariableTag(name="u_interface")
+    contact_traction = VariableTag(name="contact_traction")
+    # Fracture damage (?)
+    dilation_damage_history = VariableTag(name="dilation_damage_history")
+    friction_damage_history = VariableTag(name="friction_damage_history")

--- a/src/porepy/numerics/solvers/equation_variable_tags.py
+++ b/src/porepy/numerics/solvers/equation_variable_tags.py
@@ -83,6 +83,12 @@ class VariableTag:
     """
 
 
+# Below are namespaces of default tags for equations and variables, default to PorePy.
+# Compositional model equations and variables are omitted, since their names depend on
+# the composition. See how to construct custom tags for them in
+# schur_complement_reduction_linear_tracer_3p.py example.
+
+
 class DefaultEquationTags:
     """A namespace for all known equations defined by standard PorePy models."""
 

--- a/src/porepy/numerics/solvers/equation_variable_tags.py
+++ b/src/porepy/numerics/solvers/equation_variable_tags.py
@@ -11,7 +11,7 @@ code, particularly in tests.
 
 from __future__ import annotations
 
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 
 import porepy as pp
@@ -21,11 +21,13 @@ __all__ = [
     "VariableTag",
     "DefaultEquationTags",
     "DefaultVariableTags",
+    "DomainFilter",
+    "Anywhere",
 ]
 
 
 @dataclass(frozen=True)
-class DomainFilter:
+class DomainFilter(ABC):
     """A filter to restrict domains of a variable or an equation.
 
     Used in :class:`EquationTag` and :class:`VariableTag`."""

--- a/src/porepy/numerics/solvers/linear_solvers/__init__.py
+++ b/src/porepy/numerics/solvers/linear_solvers/__init__.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+__all__ = []
+
+
+from . import linear_solver, schur_complement_reduction
+from .linear_solver import *
+from .schur_complement_reduction import *
+
+__all__.extend(linear_solver.__all__)
+__all__.extend(schur_complement_reduction.__all__)

--- a/src/porepy/numerics/solvers/linear_solvers/linear_solver.py
+++ b/src/porepy/numerics/solvers/linear_solvers/linear_solver.py
@@ -108,12 +108,12 @@ class LinearSystem:
     equation_indexer: pp.ad.EquationIndexer
     """Indexer to map equations and their definition domains to the DoFs of the `matrix`
     and the `rhs`.
-    
+
     """
     variable_indexer: pp.ad.VariableIndexer
     """Indexer to map variables and their definition domains to the DoFs of the
     `matrix`.
-    
+
     """
 
     def release_matrix_reference(self) -> None:

--- a/src/porepy/numerics/solvers/linear_solvers/linear_solver.py
+++ b/src/porepy/numerics/solvers/linear_solvers/linear_solver.py
@@ -105,6 +105,16 @@ class LinearSystem:
 
     matrix: Optional[csr_matrix]
     rhs: np.ndarray
+    equation_indexer: pp.ad.EquationIndexer
+    """Indexer to map equations and their definition domains to the DoFs of the `matrix`
+    and the `rhs`.
+    
+    """
+    variable_indexer: pp.ad.VariableIndexer
+    """Indexer to map variables and their definition domains to the DoFs of the
+    `matrix`.
+    
+    """
 
     def release_matrix_reference(self) -> None:
         """Release this container's reference to the matrix.

--- a/src/porepy/numerics/solvers/linear_solvers/schur_complement_reduction.py
+++ b/src/porepy/numerics/solvers/linear_solvers/schur_complement_reduction.py
@@ -62,8 +62,8 @@ class SchurComplementReductionLinearSolver(LinearSolverBase):
     x_s = (A_ss)^-1 * (b_s - A_sp * x_p)
     ```
 
-    The implementation assumes that the shape of the block matrix won't change between
-    subsequent linear systems.
+    The implementation assumes that the shape and arrangement of the block matrix won't
+    change between subsequent linear systems.
 
     Parameters:
         primary_equation_tags: Tags that define primary equations (rows).
@@ -91,6 +91,9 @@ class SchurComplementReductionLinearSolver(LinearSolverBase):
         self._data: _SchurComplementReductionData | None = None
         """The indices arrays needed for the algorithm to operate. Initialized lazily in
         :meth:`_initialize_data` the first time :meth:`solve_linear_system` is invoked.
+
+        It assumes that the arrangement in the linear system does not change between
+        iterations.
 
         """
 
@@ -391,5 +394,15 @@ def _filter_by_tags[T: (pp.ad.EquationOnDomain, pp.ad.Variable)](
             else:
                 not_filtered_operators.append(operator)
 
+    # Bad tags can lead to duplicated operators.
+    if len(filtered_operators) + len(not_filtered_operators) != len(all_operators):
+        count: dict[T, int] = {op: 0 for op in all_operators}
+
+        for operator in filtered_operators + not_filtered_operators:
+            count[operator] += 1
+
+        raise ValueError(
+            f"Duplicated operators: {[op for op, i in count.items() if i > 1]}"
+        )
     assert len(filtered_operators) + len(not_filtered_operators) == len(all_operators)
     return filtered_operators, not_filtered_operators

--- a/src/porepy/numerics/solvers/linear_solvers/schur_complement_reduction.py
+++ b/src/porepy/numerics/solvers/linear_solvers/schur_complement_reduction.py
@@ -102,11 +102,11 @@ class SchurComplementReductionLinearSolver(LinearSolverBase):
     ) -> _SchurComplementReductionData:
         """Construct index arrays based on the linear system indexers."""
         primary_eqs, secondary_eqs = _filter_by_tags(
-            all_operators=linear_system.equation_indexer.equation_dofs,
+            all_operators=linear_system.equation_indexer.indices,
             tags=self.primary_equation_tags,
         )
         primary_vars, secondary_vars = _filter_by_tags(
-            all_operators=linear_system.variable_indexer.variable_dofs,
+            all_operators=linear_system.variable_indexer.indices,
             tags=self.primary_variable_tags,
         )
 
@@ -248,21 +248,21 @@ def rearrange_matrix_as_array_of_structures(
             permuted matrix.
 
     """
-    unique_grids_equations = {eq.domain for eq in eq_indexer.equation_dofs}
-    unique_grids_variables = {var.domain for var in var_indexer.variable_dofs}
-    assert len(eq_indexer.equation_dofs) == len(var_indexer.variable_dofs)
+    unique_grids_equations = {eq.domain for eq in eq_indexer.indices}
+    unique_grids_variables = {var.domain for var in var_indexer.indices}
+    assert len(eq_indexer.indices) == len(var_indexer.indices)
     assert unique_grids_equations == unique_grids_variables
 
     eq_dofs_by_grid: dict[pp.GridLike, list[np.ndarray]] = {
         grid: [] for grid in unique_grids_equations
     }
-    for eq, dofs in eq_indexer.equation_dofs.items():
+    for eq, dofs in eq_indexer.indices.items():
         eq_dofs_by_grid[eq.domain].append(dofs)
 
     var_dofs_by_grid: dict[pp.GridLike, list[np.ndarray]] = {
         grid: [] for grid in unique_grids_variables
     }
-    for var, dofs in var_indexer.variable_dofs.items():
+    for var, dofs in var_indexer.indices.items():
         var_dofs_by_grid[var.domain].append(dofs)
 
     # Sanity check that assumes that the number of equations and variables is the same
@@ -285,8 +285,8 @@ def rearrange_matrix_as_array_of_structures(
     if bs == 0:
         return np.empty(0, dtype=int), np.empty(0, dtype=int), np.empty(0, dtype=int)
 
-    assert var_indexer.num_dofs % bs == 0
-    block_sizes = np.full(var_indexer.num_dofs // bs, bs, dtype=np.int64)
+    assert var_indexer.size % bs == 0
+    block_sizes = np.full(var_indexer.size // bs, bs, dtype=np.int64)
 
     eq_dofs_by_grid_rearranged = [
         np.stack(dofs).ravel(order="F") for dofs in eq_dofs_by_grid.values()
@@ -384,9 +384,7 @@ def _filter_by_tags[T: (pp.ad.EquationOnDomain, pp.ad.Variable)](
     for operator in all_operators:
         tags_for_this_name = tags_by_name[operator.name]
         matching_tags = [
-            tag
-            for tag in tags_for_this_name
-            if tag.defined_on.filter(operator.domain)
+            tag for tag in tags_for_this_name if tag.defined_on.filter(operator.domain)
         ]
         if len(matching_tags) > 1:
             # Overlapping tags would place the operator in the filtered group more than

--- a/src/porepy/numerics/solvers/linear_solvers/schur_complement_reduction.py
+++ b/src/porepy/numerics/solvers/linear_solvers/schur_complement_reduction.py
@@ -97,7 +97,7 @@ class SchurComplementReductionLinearSolver(LinearSolverBase):
     def _initialize_data(
         self, linear_system: LinearSystem
     ) -> _SchurComplementReductionData:
-        """Lazy initialization of arrays. Applied when"""
+        """Construct indices arrays based on the linear system indexers."""
         primary_eqs, secondary_eqs = _filter_by_tags(
             all_operators=linear_system.equation_indexer.equation_dofs,
             tags=self.primary_equation_tags,
@@ -300,17 +300,36 @@ def rearrange_matrix_as_array_of_structures(
 
 @dataclass
 class _SchurComplementReductionData:
+    """Data structures needed for the Schur complement reduction algorithm."""
+
     primary_eq_indexer: pp.ad.EquationIndexer
+    """Equation indexer of the primary submatrix."""
     primary_var_indexer: pp.ad.VariableIndexer
+    """Variable indexer of the primary submatrix."""
 
     primary_eq_dofs: np.ndarray
+    """Indices that map the full equations vector to the primary equations vector."""
     primary_var_dofs: np.ndarray
+    """Indices that map the full variables vector to the primary variables vector."""
     secondary_eq_dofs: np.ndarray
+    """Indices that map the full equations vector to the secondary equations vector."""
     secondary_var_dofs: np.ndarray
+    """Indices that map the full variables vector to the secondary variables vector."""
 
     secondary_eq_perm: np.ndarray
+    """Equations (rows) permutation of the secondary block to the block-diagonal form.
+
+    """
     secondary_var_perm: np.ndarray
+    """Variables (columns) permutation of the secondary block to the block-diagonal
+    form.
+
+    """
     secondary_block_sizes: np.ndarray
+    """Array with block sizes of each small dense square block on the permuted secondary
+    matrix diagonal.
+
+    """
 
 
 def _concatenate_safe(arrays: list[np.ndarray]) -> np.ndarray:

--- a/src/porepy/numerics/solvers/linear_solvers/schur_complement_reduction.py
+++ b/src/porepy/numerics/solvers/linear_solvers/schur_complement_reduction.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections import defaultdict
 from dataclasses import dataclass
 from time import time
-from typing import Iterable, Optional, Sequence
+from typing import Collection, Optional, Sequence
 
 import numpy as np
 
@@ -321,8 +321,8 @@ def _concatenate_safe(arrays: list[np.ndarray]) -> np.ndarray:
 
 
 def _wrap_primary_solver_status(
-    primary_solver_status: pp.solvers.LinearSolverStatus, solve_time: float
-) -> pp.solvers.LinearSolverStatus:
+    primary_solver_status: LinearSolverStatus, solve_time: float
+) -> LinearSolverStatus:
     """Wrap a primary linear solver status with a Schur complement solver status."""
     if primary_solver_status.is_success():
         return SchurComplementReductionStatusSuccess(
@@ -337,7 +337,7 @@ def _wrap_primary_solver_status(
 
 
 def _filter_by_tags[T: (pp.ad.EquationOnDomain, pp.ad.Variable)](
-    all_operators: Iterable[T], tags: Sequence[EquationTag | VariableTag]
+    all_operators: Collection[T], tags: Sequence[EquationTag | VariableTag]
 ) -> tuple[list[T], list[T]]:
     """Split atomic equations or variables into two groups: the one covered by `tags`
     and its complement.

--- a/src/porepy/numerics/solvers/linear_solvers/schur_complement_reduction.py
+++ b/src/porepy/numerics/solvers/linear_solvers/schur_complement_reduction.py
@@ -1,3 +1,16 @@
+"""This module provides the Schur complement reduction-based linear solver.
+
+Its intended usage is the compositional flow model, but it can be used for any model
+that generates linear systems of the following structure:
+```
+A_pp A_ps
+A_sp A_ss
+```
+where p and s subscripts denote "prmimary" and "secondary" equations / variables. It
+should be possible to permute `A_ss` in a block-diagonal form.
+
+"""
+
 from __future__ import annotations
 
 from collections import defaultdict

--- a/src/porepy/numerics/solvers/linear_solvers/schur_complement_reduction.py
+++ b/src/porepy/numerics/solvers/linear_solvers/schur_complement_reduction.py
@@ -133,8 +133,8 @@ class SchurComplementReductionLinearSolver(LinearSolverBase):
         )
 
     def initialize_with_model(self, model: pp.PorePyModel) -> None:
-        """It does not need initialization by itself, but the inner linear solver might
-        need it. TODO YZ: Test it."""
+        """SchurComplementReductionLinearSolver does not need initialization by itself,
+        but the inner linear solver might need it."""
         return self.primary_linear_solver.initialize_with_model(model)
 
     def solve_linear_system(
@@ -383,26 +383,18 @@ def _filter_by_tags[T: (pp.ad.EquationOnDomain, pp.ad.Variable)](
 
     for operator in all_operators:
         tags_for_this_name = tags_by_name[operator.name]
-
-        if len(tags_for_this_name) == 0:
-            # No tags for this eq/var name. It goes to the second group.
+        matching_tags = [
+            tag
+            for tag in tags_for_this_name
+            if tag.defined_on.filter(operator.domain)
+        ]
+        if len(matching_tags) > 1:
+            # Overlapping tags would place the operator in the filtered group more than
+            # once.
+            raise ValueError(f"Duplicated operators: [{operator}]")
+        if len(matching_tags) == 1:
+            filtered_operators.append(operator)
+        else:
             not_filtered_operators.append(operator)
 
-        for tag in tags_by_name[operator.name]:
-            if tag.defined_on.filter(operator.domain):
-                filtered_operators.append(operator)
-            else:
-                not_filtered_operators.append(operator)
-
-    # Bad tags can lead to duplicated operators.
-    if len(filtered_operators) + len(not_filtered_operators) != len(all_operators):
-        count: dict[T, int] = {op: 0 for op in all_operators}
-
-        for operator in filtered_operators + not_filtered_operators:
-            count[operator] += 1
-
-        raise ValueError(
-            f"Duplicated operators: {[op for op, i in count.items() if i > 1]}"
-        )
-    assert len(filtered_operators) + len(not_filtered_operators) == len(all_operators)
     return filtered_operators, not_filtered_operators

--- a/src/porepy/numerics/solvers/linear_solvers/schur_complement_reduction.py
+++ b/src/porepy/numerics/solvers/linear_solvers/schur_complement_reduction.py
@@ -100,7 +100,13 @@ class SchurComplementReductionLinearSolver(LinearSolverBase):
     def _initialize_data(
         self, linear_system: LinearSystem
     ) -> _SchurComplementReductionData:
-        """Construct index arrays based on the linear system indexers."""
+        """Construct index arrays based on the linear system indexers.
+
+        Raises:
+            ValueError: If A_pp and A_ss are not square matrices according to the tags
+                passed to the solver.
+
+        """
         eq_indexer = linear_system.equation_indexer
         var_indexer = linear_system.variable_indexer
         primary_eqs, secondary_eqs = _filter_by_tags(
@@ -110,6 +116,22 @@ class SchurComplementReductionLinearSolver(LinearSolverBase):
             all_operators=var_indexer.indices, tags=self.primary_variable_tags
         )
 
+        # Validate that A_pp and A_ss are square matrices.
+        primary_eq_indexer = eq_indexer.construct_restricted_indexer(primary_eqs)
+        primary_var_indexer = var_indexer.construct_restricted_indexer(primary_vars)
+        secondary_eq_indexer = eq_indexer.construct_restricted_indexer(secondary_eqs)
+        secondary_var_indexer = var_indexer.construct_restricted_indexer(secondary_vars)
+        if primary_eq_indexer.size != primary_var_indexer.size:
+            raise ValueError(
+                "Primary submatrix is not square with shape: "
+                f"({primary_eq_indexer.size}, {primary_var_indexer.size})"
+            )
+        if secondary_eq_indexer.size != secondary_var_indexer.size:
+            raise ValueError(
+                "Secondary submatrix is not square with shape: "
+                f"({secondary_eq_indexer.size}, {secondary_var_indexer.size})"
+            )
+
         # The function below requires that the secondary equations and variables are
         # defined on all subdomains (and does not care about where primary equations and
         # variables are defined). It will validate it and raise otherwise. If this ever
@@ -117,14 +139,13 @@ class SchurComplementReductionLinearSolver(LinearSolverBase):
         # case: generate_permutation_to_block_diag_matrix.
         secondary_eq_perm, secondary_var_perm, block_sizes = (
             rearrange_matrix_as_array_of_structures(
-                eq_indexer=eq_indexer.construct_restricted_indexer(secondary_eqs),
-                var_indexer=var_indexer.construct_restricted_indexer(secondary_vars),
+                eq_indexer=secondary_eq_indexer, var_indexer=secondary_var_indexer
             )
         )
 
         return _SchurComplementReductionData(
-            primary_eq_indexer=eq_indexer.construct_restricted_indexer(primary_eqs),
-            primary_var_indexer=var_indexer.construct_restricted_indexer(primary_vars),
+            primary_eq_indexer=primary_eq_indexer,
+            primary_var_indexer=primary_var_indexer,
             primary_eq_dofs=eq_indexer.projection_indices(primary_eqs),
             primary_var_dofs=var_indexer.projection_indices(primary_vars),
             secondary_eq_dofs=eq_indexer.projection_indices(secondary_eqs),

--- a/src/porepy/numerics/solvers/linear_solvers/schur_complement_reduction.py
+++ b/src/porepy/numerics/solvers/linear_solvers/schur_complement_reduction.py
@@ -46,9 +46,9 @@ class SchurComplementReductionLinearSolver(LinearSolverBase):
     primary block is defined by parameters `primary_equation_tags` and
     `primary_variable_tags`. The secondary block is a complement to it.
 
-    The submatrix `A_ss` must be invertible, and computing its inverse must be cheap
-    computationally, e.g., it should be block diagonal. Then, the Schur complement
-    of this system is assembled:
+    The present implementation assumes `A_ss` is invertible and can be permuted in a
+    block diagonal form, as this is the most relevant case for the intended usage. The
+    Schur complement of this system is assembled:
     ```
     S_pp = A_pp - A_ps * (A_ss)^-1 * A_sp.
     ```
@@ -101,17 +101,14 @@ class SchurComplementReductionLinearSolver(LinearSolverBase):
         self, linear_system: LinearSystem
     ) -> _SchurComplementReductionData:
         """Construct index arrays based on the linear system indexers."""
-        primary_eqs, secondary_eqs = _filter_by_tags(
-            all_operators=linear_system.equation_indexer.indices,
-            tags=self.primary_equation_tags,
-        )
-        primary_vars, secondary_vars = _filter_by_tags(
-            all_operators=linear_system.variable_indexer.indices,
-            tags=self.primary_variable_tags,
-        )
-
         eq_indexer = linear_system.equation_indexer
         var_indexer = linear_system.variable_indexer
+        primary_eqs, secondary_eqs = _filter_by_tags(
+            all_operators=eq_indexer.indices, tags=self.primary_equation_tags
+        )
+        primary_vars, secondary_vars = _filter_by_tags(
+            all_operators=var_indexer.indices, tags=self.primary_variable_tags
+        )
 
         # The function below requires that the secondary equations and variables are
         # defined on all subdomains (and does not care about where primary equations and

--- a/src/porepy/numerics/solvers/linear_solvers/schur_complement_reduction.py
+++ b/src/porepy/numerics/solvers/linear_solvers/schur_complement_reduction.py
@@ -68,7 +68,7 @@ class SchurComplementReductionLinearSolver(LinearSolverBase):
     Parameters:
         primary_equation_tags: Tags that define primary equations (rows).
         primary_variable_tags: Tags that define primary variables (columns).
-        primary_linear_solver: A linear solver to the linear system based on `S_pp`. If
+        primary_linear_solver: A linear solver for the linear system based on `S_pp`. If
             None (default), a direct solver is applied.
 
     """
@@ -86,10 +86,10 @@ class SchurComplementReductionLinearSolver(LinearSolverBase):
         if primary_linear_solver is None:
             primary_linear_solver = LinearSolverDirect()
         self.primary_linear_solver = primary_linear_solver
-        """A linear solver to the linear system based on `S_pp`."""
+        """A linear solver for the linear system based on `S_pp`."""
 
         self._data: _SchurComplementReductionData | None = None
-        """The indices arrays needed for the algorithm to operate. Initialized lazily in
+        """The index arrays needed for the algorithm to operate. Initialized lazily in
         :meth:`_initialize_data` the first time :meth:`solve_linear_system` is invoked.
 
         It assumes that the arrangement in the linear system does not change between
@@ -100,7 +100,7 @@ class SchurComplementReductionLinearSolver(LinearSolverBase):
     def _initialize_data(
         self, linear_system: LinearSystem
     ) -> _SchurComplementReductionData:
-        """Construct indices arrays based on the linear system indexers."""
+        """Construct index arrays based on the linear system indexers."""
         primary_eqs, secondary_eqs = _filter_by_tags(
             all_operators=linear_system.equation_indexer.equation_dofs,
             tags=self.primary_equation_tags,
@@ -152,7 +152,7 @@ class SchurComplementReductionLinearSolver(LinearSolverBase):
         t0 = time()
         assert linear_system.matrix is not None, "Matrix should be provided."
 
-        # Lasy initialization.
+        # Lazy initialization.
         if self._data is None:
             self._data = self._initialize_data(linear_system)
         data = self._data
@@ -166,7 +166,7 @@ class SchurComplementReductionLinearSolver(LinearSolverBase):
 
         # Slice the following submatrices and right-hand side vectors:
         # | A_ss A_sp |  | rhs_s |
-        # | A_ps A_pp |, | rhs_b |
+        # | A_ps A_pp |, | rhs_p |
         A_p = linear_system.matrix[data.primary_eq_dofs, :]
         A_pp = A_p[:, data.primary_var_dofs]
         A_ps = A_p[:, data.secondary_var_dofs]
@@ -177,7 +177,7 @@ class SchurComplementReductionLinearSolver(LinearSolverBase):
         del A_s
         rhs_s = linear_system.rhs[data.secondary_eq_dofs]
 
-        # Compute (A_ss)^-1. Hard-coded this invertor so far.
+        # Compute (A_ss)^-1. This inverter is hard-coded for now.
         A_ss_inv = invert_permuted_block_diag_matrix(
             A_ss,
             row_permutation=data.secondary_eq_perm,
@@ -237,13 +237,13 @@ def rearrange_matrix_as_array_of_structures(
         var_indexer: Variable indexer representing the block columns of the matrix.
 
     Raises:
-        ValueErrro: If not all equation-variable pairs are defined on the same set of
+        ValueError: If not all equation-variable pairs are defined on the same set of
             grids.
 
     Returns:
         A tuple of 3 elements:
-        - row_permutation: array to permute the columns of the matrix;
-        - col_permutation: array to permute the rows of the matrix;
+        - row_permutation: array to permute the rows of the matrix;
+        - col_permutation: array to permute the columns of the matrix;
         - block_sizes: the sizes `n` of small `(n x n)` blocks on the diagonal of the
             permuted matrix.
 
@@ -267,7 +267,7 @@ def rearrange_matrix_as_array_of_structures(
 
     # Sanity check that assumes that the number of equations and variables is the same
     # on every grid. If it turns out that we define some equations only on certain
-    # grids, this funciton can be extended. So far, no such case is known to YZ.
+    # grids, this function can be extended. So far, no such case is known to YZ.
     bs = 0
     for list_of_dofs in eq_dofs_by_grid.values():
         if bs == 0:

--- a/src/porepy/numerics/solvers/linear_solvers/schur_complement_reduction.py
+++ b/src/porepy/numerics/solvers/linear_solvers/schur_complement_reduction.py
@@ -1,0 +1,376 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from time import time
+from typing import Iterable, Optional, Sequence
+
+import numpy as np
+
+import porepy as pp
+from porepy.numerics.linalg.matrix_operations import invert_permuted_block_diag_matrix
+from porepy.numerics.solvers.equation_variable_tags import EquationTag, VariableTag
+from porepy.numerics.solvers.linear_solvers.linear_solver import (
+    LinearSolverBase,
+    LinearSolverDirect,
+    LinearSolverStatus,
+    LinearSolverStatusFailure,
+    LinearSolverStatusSuccess,
+    LinearSystem,
+)
+
+__all__ = [
+    "SchurComplementReductionStatusSuccess",
+    "SchurComplementReductionStatusFailure",
+    "SchurComplementReductionLinearSolver",
+]
+
+
+@dataclass
+class SchurComplementReductionStatusSuccess(LinearSolverStatusSuccess):
+    primary_solver_status: LinearSolverStatus
+
+
+@dataclass
+class SchurComplementReductionStatusFailure(LinearSolverStatusFailure):
+    primary_solver_status: LinearSolverStatus
+
+
+class SchurComplementReductionLinearSolver(LinearSolverBase):
+    """A linear solver for a linear system with the following block structure:
+    ```
+    | A_ss A_sp |   | x_s |   | b_s |
+    | A_ps A_pp | * | x_p | = | b_p |,
+    ```
+    where subscripts 'p' and 's' denote primary and secondary blocks, respectively. The
+    primary block is defined by parameters `primary_equation_tags` and
+    `primary_variable_tags`. The secondary block is a complement to it.
+
+    The submatrix `A_ss` must be invertible, and computing its inverse must be cheap
+    computationally, e.g., it should be block diagonal. Then, the Schur complement
+    of this system is assembled:
+    ```
+    S_pp = A_pp - A_ps * (A_ss)^-1 * A_sp.
+    ```
+    The solution algorithm involves two steps:
+    1. Solving the linear system with respect to `x_p` with the `primary_linear_solver`:
+    ```
+    S_pp * x_p = b_p - A_ps * (A_ss)^-1 * b_s
+    ```
+    2. Computing the secondary solution block:
+    ```
+    x_s = (A_ss)^-1 * (b_s - A_sp * x_p)
+    ```
+
+    The implementation assumes that the shape of the block matrix won't change between
+    subsequent linear systems.
+
+    Parameters:
+        primary_equation_tags: Tags that define primary equations (rows).
+        primary_variable_tags: Tags that define primary variables (columns).
+        primary_linear_solver: A linear solver to the linear system based on `S_pp`. If
+            None (default), a direct solver is applied.
+
+    """
+
+    def __init__(
+        self,
+        primary_equation_tags: list[EquationTag],
+        primary_variable_tags: list[VariableTag],
+        primary_linear_solver: Optional[LinearSolverBase] = None,
+    ) -> None:
+        self.primary_equation_tags = primary_equation_tags
+        """Tags that define primary equations (rows)."""
+        self.primary_variable_tags = primary_variable_tags
+        """Tags that define primary variables (columns)."""
+        if primary_linear_solver is None:
+            primary_linear_solver = LinearSolverDirect()
+        self.primary_linear_solver = primary_linear_solver
+        """A linear solver to the linear system based on `S_pp`."""
+
+        self._data: _SchurComplementReductionData | None = None
+        """The indices arrays needed for the algorithm to operate. Initialized lazily in
+        :meth:`_initialize_data` the first time :meth:`solve_linear_system` is invoked.
+
+        """
+
+    def _initialize_data(
+        self, linear_system: LinearSystem
+    ) -> _SchurComplementReductionData:
+        """Lazy initialization of arrays. Applied when"""
+        primary_eqs, secondary_eqs = _filter_by_tags(
+            all_operators=linear_system.equation_indexer.equation_dofs,
+            tags=self.primary_equation_tags,
+        )
+        primary_vars, secondary_vars = _filter_by_tags(
+            all_operators=linear_system.variable_indexer.variable_dofs,
+            tags=self.primary_variable_tags,
+        )
+
+        eq_indexer = linear_system.equation_indexer
+        var_indexer = linear_system.variable_indexer
+
+        secondary_eq_perm, secondary_var_perm, block_sizes = (
+            rearrange_matrix_as_array_of_structures(
+                eq_indexer=eq_indexer.construct_restricted_indexer(secondary_eqs),
+                var_indexer=var_indexer.construct_restricted_indexer(secondary_vars),
+            )
+        )
+
+        return _SchurComplementReductionData(
+            primary_eq_indexer=eq_indexer.construct_restricted_indexer(primary_eqs),
+            primary_var_indexer=var_indexer.construct_restricted_indexer(primary_vars),
+            primary_eq_dofs=eq_indexer.projection_indices(primary_eqs),
+            primary_var_dofs=var_indexer.projection_indices(primary_vars),
+            secondary_eq_dofs=eq_indexer.projection_indices(secondary_eqs),
+            secondary_var_dofs=var_indexer.projection_indices(secondary_vars),
+            secondary_eq_perm=secondary_eq_perm,
+            secondary_var_perm=secondary_var_perm,
+            secondary_block_sizes=block_sizes,
+        )
+
+    def initialize_with_model(self, model: pp.PorePyModel) -> None:
+        """It does not need initialization by itself, but the inner linear solver might
+        need it. TODO YZ: Test it."""
+        return self.primary_linear_solver.initialize_with_model(model)
+
+    def solve_linear_system(
+        self, linear_system: LinearSystem
+    ) -> tuple[np.ndarray, LinearSolverStatus]:
+        """Solve an assembled linear system applying the Schur complement factorization.
+
+        Parameters:
+            linear_system: System containing the matrix and right-hand side vector.
+
+        Returns:
+            The solution vector and a status describing the solver outcome.
+
+        """
+        t0 = time()
+        assert linear_system.matrix is not None, "Matrix should be provided."
+
+        # Lasy initialization.
+        if self._data is None:
+            self._data = self._initialize_data(linear_system)
+        data = self._data
+
+        # Shortcut if the secondary block is empty.
+        if len(data.secondary_eq_dofs) == 0 or len(data.secondary_var_dofs) == 0:
+            solution, status = self.primary_linear_solver.solve_linear_system(
+                linear_system
+            )
+            return solution, _wrap_primary_solver_status(status, solve_time=time() - t0)
+
+        # Slice the following submatrices and right-hand side vectors:
+        # | A_ss A_sp |  | rhs_s |
+        # | A_ps A_pp |, | rhs_b |
+        A_p = linear_system.matrix[data.primary_eq_dofs, :]
+        A_pp = A_p[:, data.primary_var_dofs]
+        A_ps = A_p[:, data.secondary_var_dofs]
+        del A_p
+        A_s = linear_system.matrix[data.secondary_eq_dofs, :]
+        A_sp = A_s[:, data.primary_var_dofs]
+        A_ss = A_s[:, data.secondary_var_dofs]
+        del A_s
+        rhs_s = linear_system.rhs[data.secondary_eq_dofs]
+
+        # Compute (A_ss)^-1. Hard-coded this invertor so far.
+        A_ss_inv = invert_permuted_block_diag_matrix(
+            A_ss,
+            row_permutation=data.secondary_eq_perm,
+            col_permutation=data.secondary_var_perm,
+            block_sizes=data.secondary_block_sizes,
+        )
+
+        # A_sp * (A_ss)^-1, pre-computed because we will need it multiple times.
+        A_ps_mul_Ass_inv = A_ps @ A_ss_inv
+        # S_pp = A_pp - A_ps * (A_ss)^-1 * A_sp.
+        S_pp = A_pp - A_ps_mul_Ass_inv @ A_sp
+        # Modified right-hand side: rhs_p - A_sp * (A_ss)^-1 * rhs_s.
+        rhs_p = linear_system.rhs[data.primary_eq_dofs] - A_ps_mul_Ass_inv @ rhs_s
+
+        # Solve for the primary block solution.
+        sol_p, status = self.primary_linear_solver.solve_linear_system(
+            LinearSystem(
+                matrix=S_pp,
+                rhs=rhs_p,
+                equation_indexer=data.primary_eq_indexer,
+                variable_indexer=data.primary_var_indexer,
+            )
+        )
+
+        # Compute the secondary block solution.
+        sol_s = A_ss_inv @ (rhs_s - A_sp @ sol_p)
+
+        # Concatenate the primary and the secondary solution blocks.
+        solution = np.empty(len(sol_s) + len(sol_p), dtype=sol_s.dtype)
+        solution[data.primary_var_dofs] = sol_p
+        solution[data.secondary_var_dofs] = sol_s
+
+        return solution, _wrap_primary_solver_status(status, solve_time=time() - t0)
+
+
+def rearrange_matrix_as_array_of_structures(
+    eq_indexer: pp.ad.EquationIndexer, var_indexer: pp.ad.VariableIndexer
+):
+    """Build permutation indices that rearrange the matrix in a block-diagonal form.
+
+    The original matrix must be a block matrix:
+    ```
+    A_00 A_01 . A_0n
+    A_10 A_11 . A_1n
+     .    .   .  .
+    A_n0 A_n1 . A_nn
+    ```
+    Each block A_ij corresponds to a single equation-variable pair defined on a single
+    grid. All equation-variable pairs must be defined on the same set of grids.
+
+    There is no requirement on how blocks A_ij should be arranged, e.g., different
+    equation-variable pairs can live next to each other, and the order of grids can be
+    different for different variables.
+
+    Parameters:
+        eq_indexer: Equation indexer representing the block rows of the matrix.
+        var_indexer: Variable indexer representing the block columns of the matrix.
+
+    Raises:
+        ValueErrro: If not all equation-variable pairs are defined on the same set of
+            grids.
+
+    Returns:
+        A tuple of 3 elements:
+        - row_permutation: array to permute the columns of the matrix;
+        - col_permutation: array to permute the rows of the matrix;
+        - block_sizes: the sizes `n` of small `(n x n)` blocks on the diagonal of the
+            permuted matrix.
+
+    """
+    unique_grids_equations = {eq.domain for eq in eq_indexer.equation_dofs}
+    unique_grids_variables = {var.domain for var in var_indexer.variable_dofs}
+    assert len(eq_indexer.equation_dofs) == len(var_indexer.variable_dofs)
+    assert unique_grids_equations == unique_grids_variables
+
+    eq_dofs_by_grid: dict[pp.GridLike, list[np.ndarray]] = {
+        grid: [] for grid in unique_grids_equations
+    }
+    for eq, dofs in eq_indexer.equation_dofs.items():
+        eq_dofs_by_grid[eq.domain].append(dofs)
+
+    var_dofs_by_grid: dict[pp.GridLike, list[np.ndarray]] = {
+        grid: [] for grid in unique_grids_variables
+    }
+    for var, dofs in var_indexer.variable_dofs.items():
+        var_dofs_by_grid[var.domain].append(dofs)
+
+    # Sanity check that assumes that the number of equations and variables is the same
+    # on every grid. If it turns out that we define some equations only on certain
+    # grids, this funciton can be extended. So far, no such case is known to YZ.
+    bs = 0
+    for list_of_dofs in eq_dofs_by_grid.values():
+        if bs == 0:
+            bs = len(list_of_dofs)
+        if bs != len(list_of_dofs):
+            raise ValueError(
+                "All equations must be defined on the same set of domains."
+            )
+    for list_of_dofs in var_dofs_by_grid.values():
+        if bs != len(list_of_dofs):
+            raise ValueError(
+                "All variables must be defined on the same set of domains."
+            )
+
+    if bs == 0:
+        return np.empty(0, dtype=int), np.empty(0, dtype=int), np.empty(0, dtype=int)
+
+    assert var_indexer.num_dofs % bs == 0
+    block_sizes = np.full(var_indexer.num_dofs // bs, bs, dtype=np.int64)
+
+    eq_dofs_by_grid_rearranged = [
+        np.stack(dofs).ravel(order="F") for dofs in eq_dofs_by_grid.values()
+    ]
+    var_dofs_by_grid_rearranged = [
+        np.stack(dofs).ravel(order="F") for dofs in var_dofs_by_grid.values()
+    ]
+    return (
+        _concatenate_safe(eq_dofs_by_grid_rearranged),
+        _concatenate_safe(var_dofs_by_grid_rearranged),
+        block_sizes,
+    )
+
+
+@dataclass
+class _SchurComplementReductionData:
+    primary_eq_indexer: pp.ad.EquationIndexer
+    primary_var_indexer: pp.ad.VariableIndexer
+
+    primary_eq_dofs: np.ndarray
+    primary_var_dofs: np.ndarray
+    secondary_eq_dofs: np.ndarray
+    secondary_var_dofs: np.ndarray
+
+    secondary_eq_perm: np.ndarray
+    secondary_var_perm: np.ndarray
+    secondary_block_sizes: np.ndarray
+
+
+def _concatenate_safe(arrays: list[np.ndarray]) -> np.ndarray:
+    """Concatenate a list of arrays and return an empty array if the list is empty."""
+    if len(arrays) > 0:
+        return np.concatenate(arrays)
+    return np.empty(0)
+
+
+def _wrap_primary_solver_status(
+    primary_solver_status: pp.solvers.LinearSolverStatus, solve_time: float
+) -> pp.solvers.LinearSolverStatus:
+    """Wrap a primary linear solver status with a Schur complement solver status."""
+    if primary_solver_status.is_success():
+        return SchurComplementReductionStatusSuccess(
+            solve_time=solve_time,
+            primary_solver_status=primary_solver_status,
+        )
+    else:
+        return SchurComplementReductionStatusFailure(
+            primary_solver_status=primary_solver_status,
+            reason="primary linear solver failed",
+        )
+
+
+def _filter_by_tags[T: (pp.ad.EquationOnDomain, pp.ad.Variable)](
+    all_operators: Iterable[T], tags: Sequence[EquationTag | VariableTag]
+) -> tuple[list[T], list[T]]:
+    """Split atomic equations or variables into two groups: the one covered by `tags`
+    and its complement.
+
+    Parameters:
+        all_operators: Atomic variables or equations to split into groups.
+
+    Result:
+        Two groups of atomic variables or equations.
+
+    """
+    # Organizing tags by eq/var names. Multiple tags with a single name are allowed.
+    # E.g. pressure on wells and pressure not on wells.
+    tags_by_name: dict[str, list[EquationTag | VariableTag]] = defaultdict(list)
+    for tag in tags:
+        tags_by_name[tag.name].append(tag)
+
+    # Two groups.
+    filtered_operators: list[T] = []
+    not_filtered_operators: list[T] = []
+
+    for operator in all_operators:
+        tags_for_this_name = tags_by_name[operator.name]
+
+        if len(tags_for_this_name) == 0:
+            # No tags for this eq/var name. It goes to the second group.
+            not_filtered_operators.append(operator)
+
+        for tag in tags_by_name[operator.name]:
+            if tag.defined_on.filter(operator.domain):
+                filtered_operators.append(operator)
+            else:
+                not_filtered_operators.append(operator)
+
+    assert len(filtered_operators) + len(not_filtered_operators) == len(all_operators)
+    return filtered_operators, not_filtered_operators

--- a/src/porepy/numerics/solvers/linear_solvers/schur_complement_reduction.py
+++ b/src/porepy/numerics/solvers/linear_solvers/schur_complement_reduction.py
@@ -113,6 +113,11 @@ class SchurComplementReductionLinearSolver(LinearSolverBase):
         eq_indexer = linear_system.equation_indexer
         var_indexer = linear_system.variable_indexer
 
+        # The function below requires that the secondary equations and variables are
+        # defined on all subdomains (and does not care about where primary equations and
+        # variables are defined). It will validate it and raise otherwise. If this ever
+        # happens, a slower alternative function is available that handles the  general
+        # case: generate_permutation_to_block_diag_matrix.
         secondary_eq_perm, secondary_var_perm, block_sizes = (
             rearrange_matrix_as_array_of_structures(
                 eq_indexer=eq_indexer.construct_restricted_indexer(secondary_eqs),
@@ -226,7 +231,8 @@ def rearrange_matrix_as_array_of_structures(
     A_n0 A_n1 . A_nn
     ```
     Each block A_ij corresponds to a single equation-variable pair defined on a single
-    grid. All equation-variable pairs must be defined on the same set of grids.
+    grid. All equation-variable pairs must be defined on the same set of grids. For a
+    more general case, see :func:`generate_permutation_to_block_diag_matrix`.
 
     There is no requirement on how blocks A_ij should be arranged, e.g., different
     equation-variable pairs can live next to each other, and the order of grids can be

--- a/src/porepy/numerics/solvers/nonlinear_solver_status.py
+++ b/src/porepy/numerics/solvers/nonlinear_solver_status.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 
 from .convergence_check import ConvergenceStatusCollection
-from .linear_solver import LinearSolverStatus
+from .linear_solvers.linear_solver import LinearSolverStatus
 
 __all__ = [
     "NonlinearSolverStatus",

--- a/src/porepy/numerics/solvers/nonlinear_solvers.py
+++ b/src/porepy/numerics/solvers/nonlinear_solvers.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
+from time import time
 from typing import Optional, cast
 
 import numpy as np
@@ -28,7 +29,11 @@ from .convergence_check import (
     ConvergenceStatusCollection,
     DivergenceCriteria,
 )
-from .linear_solver import LinearSolverBase, LinearSolverDirect, LinearSolverStatus
+from .linear_solvers.linear_solver import (
+    LinearSolverBase,
+    LinearSolverDirect,
+    LinearSolverStatus,
+)
 from .nonlinear_solver_status import (
     NonlinearSolverStatus,
     NonlinearSolverStatusConverged,
@@ -119,6 +124,11 @@ class NewtonSolver(NonlinearSolverBase):
         Initialization is done once at :meth:`solve`. It is now assumed that this class
         must be used with the same model, and should not be reused for a different
         model.
+
+        """
+        self.solver_progressbar = DummyProgressBar()
+        """The UI progress bar. By default, is a dummy object that does nothing.
+        Reinitialized every Newton loop at :meth:`init_progress_bar`.
 
         """
 
@@ -470,23 +480,12 @@ class NewtonSolver(NonlinearSolverBase):
             np.ndarray: Solution to linearized system, i.e. the update increment.
 
         """
-        linear_system = model.assemble_linear_system()
-        nonlinear_increment, linear_solver_status = (
-            self.linear_solver.solve_linear_system(linear_system)
-        )
+        t_0 = time()
 
-        # This is a temporary approach for compatability. It is a linear solver's
-        # responsibility and will be moved to a new linear solver class when tags and
-        # indexer are introduced.
-        if (
-            hasattr(model, "_apply_schur_complement_reduction")
-            and model._apply_schur_complement_reduction()
-        ):
-            return model.equation_system.expand_schur_complement_solution(
-                nonlinear_increment
-            ), linear_solver_status
+        linear_system = model.equation_system.assemble()
+        logger.debug(f"Assembled linear system in {time() - t_0:.2e} seconds.")
 
-        return nonlinear_increment, linear_solver_status
+        return self.linear_solver.solve_linear_system(linear_system)
 
     def after_nonlinear_iteration(
         self, model: pp.PorePyModel, nonlinear_increment: np.ndarray

--- a/src/porepy/numerics/solvers/nonlinear_solvers.py
+++ b/src/porepy/numerics/solvers/nonlinear_solvers.py
@@ -12,6 +12,7 @@ import logging
 from abc import ABC, abstractmethod
 from time import time
 from typing import Optional, cast
+from warnings import warn
 
 import numpy as np
 
@@ -340,6 +341,7 @@ class NewtonSolver(NonlinearSolverBase):
         # Model-dependent setup of a linear solver is done once.
         if not self._linear_solver_initialized:
             self.linear_solver.initialize_with_model(model)
+            _deprecation_warning_assemble_linear_system(model)
             self._linear_solver_initialized = True
 
         # Prepare for nonlinear loop.
@@ -760,3 +762,18 @@ def _summarize_solver_status(
             convergence_statuses=convergence_status,
             divergence_statuses=divergence_status,
         )
+
+
+def _deprecation_warning_assemble_linear_system(model: pp.PorePyModel):
+    assemble_linear_system = getattr(model, "assemble_linear_system", None)
+    if assemble_linear_system is not None:
+        implementation = getattr(
+            assemble_linear_system, "__func__", assemble_linear_system
+        )
+        if implementation is not pp.SolutionStrategy.assemble_linear_system:
+            warn(
+                "The model overrides assemble_linear_system method, but NewtonSolver no"
+                " longer calls it.",
+                category=FutureWarning,
+                stacklevel=3,
+            )

--- a/src/porepy/viz/diagnostics_mixin.py
+++ b/src/porepy/viz/diagnostics_mixin.py
@@ -15,11 +15,11 @@ from scipy.sparse import spmatrix
 from scipy.sparse.linalg import svds
 from typing_extensions import TypeAlias
 
+import porepy as pp
 from porepy import GridLike, solvers
 from porepy.grids.md_grid import MixedDimensionalGrid
 from porepy.grids.mortar_grid import MortarGrid
 from porepy.numerics.ad.equation_system import EquationSystem
-from porepy.numerics.ad.indexers import EquationIndexer, VariableIndexer
 from porepy.numerics.ad.operators import Variable
 
 # Type aliases. See the docs of `DiagnosticsMixin.show_diagnostics` for the details.
@@ -81,8 +81,6 @@ class DiagnosticsMixin:
         ) = None,
         default_handlers: Sequence[Literal["cond", "max"]] = ("max",),
         additional_handlers: Optional[dict[str, SubmatrixHandlerType]] = None,
-        equation_indexer: Optional[EquationIndexer] = None,
-        variable_indexer: Optional[VariableIndexer] = None,
     ) -> DiagnosticsData:
         """Collect and plot diagnostics for an assembled Jacobian matrix.
 
@@ -113,11 +111,6 @@ class DiagnosticsMixin:
                 equation name and the variable name. The equation and the variable names
                 are passed to allow the user for calculating the handler value only in a
                 subset of equations and variables of interest.
-            equation_indexer: Indexer describing the rows of ``linear_system.matrix``.
-                Defaults to the indexer for all equations in the equation system.
-            variable_indexer: Indexer describing the columns of
-                ``linear_system.matrix``. Defaults to the indexer for all variables in
-                the equation system.
 
         Returns:
             A dictionary with keys corresponding to block index and values of
@@ -177,10 +170,8 @@ class DiagnosticsMixin:
             "Cannot diagnose a linear system whose matrix was freed."
         )
 
-        if equation_indexer is None:
-            equation_indexer = self.equation_system.equation_indexer
-        if variable_indexer is None:
-            variable_indexer = self.equation_system.variable_indexer
+        equation_indexer = linear_system.equation_indexer
+        variable_indexer = linear_system.variable_indexer
 
         indexed_shape = (
             sum(dofs.size for dofs in equation_indexer.indices.values()),
@@ -387,7 +378,7 @@ class DiagnosticsMixin:
 
     def _variable_data(
         self,
-        variable_indexer: VariableIndexer,
+        variable_indexer: pp.ad.VariableIndexer,
         grouping: GridGroupingType,
         add_grid_info: bool,
     ) -> Sequence[dict[str, Any]]:

--- a/src/porepy/viz/diagnostics_mixin.py
+++ b/src/porepy/viz/diagnostics_mixin.py
@@ -322,7 +322,7 @@ class DiagnosticsMixin:
 
     def _equations_data(
         self,
-        equation_indexer: EquationIndexer,
+        equation_indexer: pp.ad.EquationIndexer,
         grouping: GridGroupingType,
         add_grid_info: bool,
     ) -> Sequence[dict[str, Any]]:

--- a/tests/functional/test_buoyancy_flow.py
+++ b/tests/functional/test_buoyancy_flow.py
@@ -89,7 +89,6 @@ def _run_buoyancy_model(
         "enable_buoyancy_effects": True,
         "material_constants": {"solid": solid_constants},
         "time_manager": time_manager,
-        "apply_schur_complement_reduction": False,
         "expected_order_loss": expected_order_loss,
     }
     # Combine geometry with model class.

--- a/tests/functional/test_linear_tracer.py
+++ b/tests/functional/test_linear_tracer.py
@@ -57,6 +57,10 @@ def results(request: pytest.FixtureRequest) -> list[LinearTracerSaveData]:
     )
     model.ad_time_step.set_value(dt)
     model.time_manager = time_manager
+
+    # The linear tracer model is solved with the Schur complement reduction linear
+    # solver. It is the intended solver for this model. It does not affect the test
+    # performance, as the linear systems are small.
     nonlinear_solver = pp.solvers.NewtonSolver(
         linear_solver=pp.solvers.SchurComplementReductionLinearSolver(
             primary_equation_tags=[

--- a/tests/functional/test_linear_tracer.py
+++ b/tests/functional/test_linear_tracer.py
@@ -57,7 +57,22 @@ def results(request: pytest.FixtureRequest) -> list[LinearTracerSaveData]:
     )
     model.ad_time_step.set_value(dt)
     model.time_manager = time_manager
-    pp.ModelRunner(model, model_params).run()
+    nonlinear_solver = pp.solvers.NewtonSolver(
+        linear_solver=pp.solvers.SchurComplementReductionLinearSolver(
+            primary_equation_tags=[
+                pp.solvers.DefaultEquationTags.mass_balance,
+                pp.solvers.DefaultEquationTags.energy_balance,
+                pp.solvers.EquationTag(name="component_mass_balance_equation_tracer"),
+            ],
+            primary_variable_tags=[
+                pp.solvers.DefaultVariableTags.pressure,
+                pp.solvers.DefaultVariableTags.enthalpy,
+                pp.solvers.VariableTag(name="z_tracer"),
+            ],
+            primary_linear_solver=pp.solvers.LinearSolverDirect(),
+        )
+    )
+    pp.ModelRunner(model, model_params, nonlinear_solver=nonlinear_solver).run()
     return model.results
 
 

--- a/tests/models/test_fluid_property_library.py
+++ b/tests/models/test_fluid_property_library.py
@@ -62,7 +62,6 @@ def _build_buoyancy_model(
         "enable_buoyancy_effects": True,
         "material_constants": {"solid": solid_constants},
         "time_manager": time_manager,
-        "apply_schur_complement_reduction": False,
         "nl_convergence_inc_atol": np.inf,
         "nl_convergence_res_atol": np.inf,
     }

--- a/tests/models/test_metric.py
+++ b/tests/models/test_metric.py
@@ -210,7 +210,7 @@ def test_equation_based_euclidean_metric_with_restricted_indexer(
         evaluate_jacobian=False, equations=[equation_name]
     )
     equation_indexer, _ = (
-        orthogonal_2d_model.equation_system.construct_assembled_matrix_indexers(
+        orthogonal_2d_model.equation_system._construct_assembled_matrix_indexers(
             equations=[equation_name]
         )
     )

--- a/tests/models/test_metric.py
+++ b/tests/models/test_metric.py
@@ -93,9 +93,9 @@ def test_variable_based_euclidean_metric_on_grids(
     variable_names = set(
         [v.name for v in orthogonal_2d_model.equation_system.variables]
     )
-    indices = {name: [] for name in variable_names}
+    variable_dofs = {name: [] for name in variable_names}
     for variable in orthogonal_2d_model.equation_system.variables:
-        indices[variable.name].extend(
+        variable_dofs[variable.name].extend(
             orthogonal_2d_model.equation_system.dofs_of([variable])
         )
 
@@ -104,7 +104,7 @@ def test_variable_based_euclidean_metric_on_grids(
         time_step_index=0
     )
     for name in variable_names:
-        dofs = indices[name]
+        dofs = variable_dofs[name]
         dummy_variable[dofs] = assignment(len(dofs))
 
     # Compute the corresponding Euclidean metric.
@@ -115,7 +115,7 @@ def test_variable_based_euclidean_metric_on_grids(
 
     # Check values
     for key, value in metric_values.items():
-        dofs = indices[key]
+        dofs = variable_dofs[key]
         assert np.isclose(value, expected_value(len(dofs)))
 
 
@@ -201,74 +201,75 @@ def test_equation_based_euclidean_metric_on_grids(
     assert deepdiff_result == {}
 
 
-def test_equation_based_euclidean_metric_with_restricted_indexer(
-    orthogonal_2d_model: pp.PorePyModel,
+@pytest.mark.parametrize(
+    "metric_class", [pp.EquationBasedEuclideanMetric, pp.EquationBasedLebesgueMetric]
+)
+def test_equation_based_metric_with_restricted_indexer(
+    orthogonal_2d_model: pp.PorePyModel, metric_class: type
 ):
-    """Compute only equation blocks represented by a restricted indexer."""
-    equation_name = next(iter(orthogonal_2d_model.equation_system.equations))
+    """Metric must compute residual only for the given equations."""
+    # Get the first 3 equations an assemble residual only for them. They are:
+    # [normal contact on grid 1; normal contact on grid 2; tangential contact on grid 1]
+    equations = {
+        "normal_fracture_deformation_equation": orthogonal_2d_model.mdg.subdomains(
+            dim=1
+        ),
+        "tangential_fracture_deformation_equation": [
+            orthogonal_2d_model.mdg.subdomains(dim=1)[0]
+        ],
+    }
     residual = orthogonal_2d_model.equation_system.assemble(
-        evaluate_jacobian=False, equations=[equation_name]
+        evaluate_jacobian=False,
+        equations=equations,
     )
+    # Get the corresponding indexer.
     equation_indexer, _ = (
         orthogonal_2d_model.equation_system._construct_assembled_matrix_indexers(
-            equations=[equation_name]
+            equations=equations
         )
     )
-    metric = pp.EquationBasedEuclideanMetric(orthogonal_2d_model, equation_indexer)
+    # Assemble and evaluate the metric.
+    metric = metric_class(orthogonal_2d_model, equation_indexer)
     norms = metric(residual)
 
-    assert set(norms) == {equation_name}
-    assert np.isclose(norms[equation_name], metric._euclidean_norm(residual))
+    # It will be only 2 norms: for normal contact (on both grids) and tangential (on a
+    # single grid).
+    assert len(norms) == 2
+    # The returned keys must only include expected equation names.
+    assert set(norms) == set(equations)
+    # The values must be scalar numbers.
+    assert all(np.isscalar(val) for val in norms.values())
 
 
-def test_equation_based_lebesgue_metric_on_grid(orthogonal_2d_model: pp.PorePyModel):
-    """Test whether the integration of 1-s over the domain results in volume."""
-
-    # Fetch the equation blocks from the full-system row indexer.
-    equation_indexer = orthogonal_2d_model.equation_system.equation_indexer
-    equation_blocks: dict[str, list[tuple[pp.GridLike, np.ndarray]]] = {}
-    for equation, indices in equation_indexer.indices.items():
-        equation_blocks.setdefault(equation.name, []).append((equation.domain, indices))
-
-    # Generate a dummy residual array filled with ones scaled with the cell volumes.
-    dummy_residual_array = orthogonal_2d_model.equation_system.assemble(
-        evaluate_jacobian=False
+@pytest.mark.parametrize(
+    "metric_class", [pp.VariableBasedEuclideanMetric, pp.VariableBasedLebesgueMetric]
+)
+def test_variable_based_metric_with_restricted_indexer(
+    orthogonal_2d_model: pp.PorePyModel, metric_class: type
+):
+    """Metric must compute residual only for the given variables."""
+    # Get the first 3 variables an assemble residual only for them. They are:
+    # [contact traction on grid 1; contact traction on grid 2; pressure on grid 0].
+    variables = list(orthogonal_2d_model.equation_system.variables)[:3]
+    residual = orthogonal_2d_model.equation_system.assemble(
+        evaluate_jacobian=False, variables=variables
     )
-    dummy_residual_array.fill(1.0)
-
-    # Scale with the right cell volumes.
-    # Simultaneously compute the expected L2 norm of the 1 vector (incl dimensionality).
-    result = {name: 0.0 for name in equation_blocks}
-    for equation_name, blocks in equation_blocks.items():
-        domains = [domain for domain, _ in blocks]
-        indices = np.concatenate([indices for _, indices in blocks])
-        if indices.size == 0:
-            continue
-        cell_volumes = np.hstack([domain.cell_volumes for domain in domains])
-        equation_dim = orthogonal_2d_model.equation_system.equation_image_size_info[
-            equation_name
-        ]["cells"]
-        dummy_residual_array[indices] *= np.repeat(cell_volumes, repeats=equation_dim)
-        result[equation_name] += sum(cell_volumes) * equation_dim
-
-    # Take square root to get L2 norm.
-    for name in result:
-        result[name] = np.sqrt(result[name])
-
-    # Compute Lebesgue metric values.
-    m = pp.EquationBasedLebesgueMetric(orthogonal_2d_model)
-    metric_values = m(dummy_residual_array)
-
-    # Make sure that the dictionaries are the same.
-    deepdiff_result = DeepDiff(
-        result,
-        metric_values,
-        significant_digits=6,
-        ignore_order=True,
-        number_format_notation="e",
-        ignore_numeric_type_changes=True,
+    # Get the corresponding indexer.
+    _, variable_indexer = (
+        orthogonal_2d_model.equation_system._construct_assembled_matrix_indexers(
+            variables=variables
+        )
     )
-    assert deepdiff_result == {}
+    # Assemble and evaluate the metric.
+    metric = metric_class(orthogonal_2d_model, variable_indexer)
+    norms = metric(residual)
+
+    # It will be only 2 norms: for contact traction (on both grids) and pressure.
+    assert len(norms) == 2
+    # The returned keys must only include expected variable names.
+    assert set(norms) == set(variable.name for variable in variables)
+    # The values must be scalar numbers.
+    assert all(np.isscalar(val) for val in norms.values())
 
 
 class UnitSquare:

--- a/tests/models/test_metric.py
+++ b/tests/models/test_metric.py
@@ -93,9 +93,9 @@ def test_variable_based_euclidean_metric_on_grids(
     variable_names = set(
         [v.name for v in orthogonal_2d_model.equation_system.variables]
     )
-    variable_dofs = {name: [] for name in variable_names}
+    indices = {name: [] for name in variable_names}
     for variable in orthogonal_2d_model.equation_system.variables:
-        variable_dofs[variable.name].extend(
+        indices[variable.name].extend(
             orthogonal_2d_model.equation_system.dofs_of([variable])
         )
 
@@ -104,7 +104,7 @@ def test_variable_based_euclidean_metric_on_grids(
         time_step_index=0
     )
     for name in variable_names:
-        dofs = variable_dofs[name]
+        dofs = indices[name]
         dummy_variable[dofs] = assignment(len(dofs))
 
     # Compute the corresponding Euclidean metric.
@@ -115,7 +115,7 @@ def test_variable_based_euclidean_metric_on_grids(
 
     # Check values
     for key, value in metric_values.items():
-        dofs = variable_dofs[key]
+        dofs = indices[key]
         assert np.isclose(value, expected_value(len(dofs)))
 
 

--- a/tests/models/test_metric.py
+++ b/tests/models/test_metric.py
@@ -463,7 +463,8 @@ def test_equation_based_lebesgue_metric_with_model(random_polynomial_setup):
 
     # Compute the Lebesgue norm of the equation which corresponds to the
     # mass weighted polynomial expression, defined above.
-    _, dummy_residual_array = model.equation_system.assemble()
+    linear_system = model.equation_system.assemble()
+    dummy_residual_array = linear_system.rhs
     metric_values_eq = m_eq(dummy_residual_array)
     l2_norm_numerical = metric_values_eq["sd_eq"]
 

--- a/tests/models/test_model_runner.py
+++ b/tests/models/test_model_runner.py
@@ -17,7 +17,7 @@ def test_failed_nonlinear_solve_dynamic_time_step():
     do not propagate into the residual vector of the next.
     """
     STATE_VALUE = 1.0  # The value for the primary variables.
-    num_times_visited_assemble_linear_system = 0
+    num_times_visited_before_nonlinear_iteration = 0
     num_times_visited_solve_linear_system = 0
 
     class FailingModel(pp.SinglePhaseFlow):
@@ -27,17 +27,17 @@ def test_failed_nonlinear_solve_dynamic_time_step():
             values = np.full(self.equation_system.num_dofs(), STATE_VALUE)
             self.equation_system.set_variable_values(values, iterate_index=0)
 
-        def assemble_linear_system(self) -> pp.solvers.LinearSystem:
+        def before_nonlinear_iteration(self) -> None:
             # The iterate array should be equal to the state array, since we never
             # proceed further than the 0-th Newton iteration.
-            nonlocal num_times_visited_assemble_linear_system
-            num_times_visited_assemble_linear_system += 1
+            nonlocal num_times_visited_before_nonlinear_iteration
+            num_times_visited_before_nonlinear_iteration += 1
 
             state = self.equation_system.get_variable_values(time_step_index=0)
             iterate = self.equation_system.get_variable_values(iterate_index=0)
             assert np.all(state == STATE_VALUE)
             assert np.all(iterate == STATE_VALUE)
-            return super().assemble_linear_system()
+            return super().before_nonlinear_iteration()
 
     class MockLinearSolver(pp.solvers.LinearSolverBase):
         def solve_linear_system(
@@ -76,6 +76,6 @@ def test_failed_nonlinear_solve_dynamic_time_step():
         model_runner.run()
 
     assert num_times_visited_solve_linear_system == 2, "Should do exactly 2 attempts."
-    assert num_times_visited_assemble_linear_system == 2, (
+    assert num_times_visited_before_nonlinear_iteration == 2, (
         "Should do exactly 2 attempts."
     )

--- a/tests/models/test_poromechanics.py
+++ b/tests/models/test_poromechanics.py
@@ -677,8 +677,14 @@ def test_poromechanics_empty_equation_filter(model_class):
         )
 
     # Check that the assembled system does not include empty domain equations.
-    A_all, b_all = equation_system.assemble(all_equations)
-    A_filtered, b_filtered = equation_system.assemble(not_empty_equations)
+    linear_system_all = equation_system.assemble(equations=all_equations)
+    linear_system_filtered = equation_system.assemble(equations=not_empty_equations)
+    A_all = linear_system_all.matrix
+    A_filtered = linear_system_filtered.matrix
+    assert A_all is not None
+    assert A_filtered is not None
+    b_all = linear_system_all.rhs
+    b_filtered = linear_system_filtered.rhs
 
     assert A_all.shape == A_filtered.shape
     assert np.allclose(b_all, b_filtered)

--- a/tests/models/test_solution_strategy.py
+++ b/tests/models/test_solution_strategy.py
@@ -28,8 +28,6 @@ from typing import Callable, Optional, cast
 
 import numpy as np
 import pytest
-import scipy.sparse as sps
-from scipy.sparse.linalg import spsolve
 
 import porepy as pp
 from porepy.applications.md_grids.domains import nd_cube_domain
@@ -194,23 +192,7 @@ def test_restart(solid_vals: dict, north_displacement: float):
 
 
 class RediscretizationTest(pp.PorePyModel):
-    """Class to short-circuit the solution strategy to a single iteration.
-
-    The class is used as a mixin which partially replaces the SolutionStrategy class.
-
-    Relevant parts of simulation flow:
-    1. Discretize the problem
-    2. Assemble the linear system
-    3. Solve the linear system
-    4. Update the state variables
-    5. Check convergence first time (expected not to pass)
-    6. Rediscretize at the beginning of the next iteration
-    7. Assemble the linear system
-    8. Check convergence second time (passes by hard-coding)
-
-    Then, quit the simulation and compare stored linear systems.
-
-    """
+    """Mixin that selects full or targeted rediscretization."""
 
     def rediscretize(self):
         if self.params["full_rediscretization"]:
@@ -218,13 +200,23 @@ class RediscretizationTest(pp.PorePyModel):
         else:
             return super().rediscretize()
 
-    def assemble_linear_system(self) -> pp.solvers.LinearSystem:
-        """Store all assembled linear systems for later comparison."""
-        linear_system = super().assemble_linear_system()
-        if not hasattr(self, "stored_linear_system"):
-            self.stored_linear_system = []
-        self.stored_linear_system.append(copy.deepcopy(linear_system))
-        return linear_system
+
+class RecordingLinearSolver(pp.solvers.LinearSolverDirect):
+    """Direct linear solver that records each system before solving it.
+
+    The recorded systems are used to compare full and targeted rediscretization across
+    nonlinear iterations.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.linear_systems: list[pp.solvers.LinearSystem] = []
+
+    def solve_linear_system(
+        self, linear_system: pp.solvers.LinearSystem
+    ) -> tuple[np.ndarray, pp.solvers.LinearSolverStatus]:
+        self.linear_systems.append(copy.deepcopy(linear_system))
+        return super().solve_linear_system(linear_system)
 
 
 # Non-trivial solution achieved through BCs.
@@ -281,35 +273,40 @@ def test_targeted_rediscretization(model_class):
         "nl_convergence_res_atol": 0,
         "nl_max_iterations": 2,
     }
+
+    def run_and_collect(model: pp.PorePyModel) -> list[pp.solvers.LinearSystem]:
+        """Run a model and return the linear systems passed to its solver."""
+        linear_solver = RecordingLinearSolver()
+        nonlinear_solver = pp.solvers.NewtonSolver(
+            params=solver_params, linear_solver=linear_solver
+        )
+        try:
+            pp.ModelRunner(
+                model, solver_params, nonlinear_solver=nonlinear_solver
+            ).run()
+        except RuntimeError:
+            # RuntimeError expected due to unattainable convergence criteria
+            # with only two iterations and zero tolerances.
+            pass
+        return linear_solver.linear_systems
+
     # Finalize the model class by adding the rediscretization mixin.
     rediscretization_model_class = models.add_mixin(RediscretizationTest, model_class)
     # A model object with full rediscretization.
     full_model: pp.PorePyModel = rediscretization_model_class(model_params)
-    try:
-        pp.ModelRunner(full_model, solver_params).run()
-    except RuntimeError:
-        # RuntimeError expected due to unattainable convergence criteria
-        # with only two iterations and zero tolerances. Allow RuntimeError without
-        # stopping the test.
-        pass
+    full_systems = run_and_collect(full_model)
 
     # A model object with targeted rediscretization.
     targeted_model_params = model_params.copy()
     targeted_model_params["full_rediscretization"] = False
     # Set up the model.
     targeted_model = rediscretization_model_class(targeted_model_params)
-    try:
-        pp.ModelRunner(targeted_model, solver_params).run()
-    except RuntimeError:
-        # See comment above.
-        pass
+    targeted_systems = run_and_collect(targeted_model)
 
     # Check that the linear systems are the same.
-    assert len(full_model.stored_linear_system) == 2
-    assert len(targeted_model.stored_linear_system) == 2
-    for i in range(len(full_model.stored_linear_system)):
-        full_system = full_model.stored_linear_system[i]
-        targeted_system = targeted_model.stored_linear_system[i]
+    assert len(full_systems) == 2
+    assert len(targeted_systems) == 2
+    for full_system, targeted_system in zip(full_systems, targeted_systems):
         A_full, b_full = full_system.matrix, full_system.rhs
         A_targeted, b_targeted = targeted_system.matrix, targeted_system.rhs
 
@@ -322,8 +319,8 @@ def test_targeted_rediscretization(model_class):
     # Check that the discretization matrix changes between iterations. Without this
     # check, missing rediscretization may go unnoticed.
     tol = 1e-2
-    first_matrix = full_model.stored_linear_system[0].matrix
-    second_matrix = full_model.stored_linear_system[1].matrix
+    first_matrix = full_systems[0].matrix
+    second_matrix = full_systems[1].matrix
     assert first_matrix is not None
     assert second_matrix is not None
     diff = first_matrix - second_matrix
@@ -513,161 +510,3 @@ def test_linear_or_nonlinear_model(params: dict):
 
     model = models.model(model_type=model_name, dim=2, num_fracs=num_fracs)
     assert model._is_nonlinear_problem() == is_nonlinear
-
-
-# ---------------------------------------------------------------------
-# Tests for block‐permutation and inversion in SolutionStrategy
-# ---------------------------------------------------------------------
-
-
-def _get_primary_equ_and_vars_cf(model: pp.PorePyModel) -> tuple[list[str], list[str]]:
-    """Returns the primary equations and variables of a CF model."""
-
-    equ_names: list[str] = []
-    if isinstance(model, pp.fluid_mass_balance.FluidMassBalanceEquations):
-        equ_names += [
-            pp.fluid_mass_balance.FluidMassBalanceEquations.primary_equation_name()
-        ]
-    if isinstance(model, pp.energy_balance.TotalEnergyBalanceEquations):
-        equ_names += [
-            pp.energy_balance.TotalEnergyBalanceEquations.primary_equation_name()
-        ]
-    if isinstance(model, pp.compositional_flow.ComponentMassBalanceEquations):
-        equ_names += model.component_mass_balance_equation_names()
-
-    for n in model.equation_system.equations.keys():
-        if "_flux" in n:
-            equ_names.append(n)
-
-    var_names: list[str] = []
-    if isinstance(model, pp.fluid_mass_balance.SolutionStrategySinglePhaseFlow):
-        var_names += [model.pressure_variable]
-
-    if isinstance(
-        model, pp.compositional_flow.SolutionStrategyExtendedFluidMassAndEnergy
-    ):
-        var_names += [model.enthalpy_variable]
-    elif isinstance(model, pp.energy_balance.SolutionStrategyEnergyBalance):
-        var_names += [model.temperature_variable]
-
-    if isinstance(model, pp.compositional.CompositionalVariables):
-        var_names += model.overall_fraction_variables
-        var_names += model.tracer_fraction_variables
-
-    for var in model.equation_system.variables:
-        if "_flux" in var.name:
-            var_names.append(var.name)
-
-    return list(set(equ_names)), list(set(var_names))
-
-
-@pytest.mark.parametrize(
-    "test_model_class,get_primary_equs_vars",
-    [
-        (TracerFlowModel_3p, _get_primary_equ_and_vars_cf),
-    ],
-)
-@pytest.mark.parametrize(
-    "mdg",
-    [
-        square_with_orthogonal_fractures("cartesian", {"cell_size": 0.25}, [0, 1])[0],
-        cube_with_orthogonal_fractures("cartesian", {"cell_size": 0.25}, [0, 1, 2])[0],
-    ],
-)
-def test_schur_complement_inverter_on_model(
-    mdg: pp.MixedDimensionalGrid,
-    test_model_class: type[pp.PorePyModel],
-    get_primary_equs_vars: Callable[[pp.PorePyModel], tuple[list[str], list[str]]],
-):
-    """Tests the block-diagonal inverter for the secondary block of the linear system
-    of a porepy model."""
-
-    # NOTE: Depending on what which model class the tests are performed, the local
-    # geometry mixin and model parameters need adaption in order to overwrite the
-    # geometry and parametrization already contained within the tested model class.
-    # The adaption must be consistent with the mdg's the tests are performed on.
-    class LocalGeometry(pp.PorePyModel):
-        def create_mdg(self) -> None:
-            self.mdg = mdg
-
-        def set_domain(self) -> None:
-            self._domain = nd_cube_domain(
-                mdg.dim_max(), self.units.convert_units(1.0, "m")
-            )
-
-    model_params = {
-        "apply_schur_complement_reduction": True,
-        "equilibrium_condition": "dummy",
-        "meshing_arguments": {
-            "cell_size": 0.1,
-        },
-    }
-
-    model_class = add_mixin(LocalGeometry, test_model_class)
-
-    model = model_class(model_params)
-    model = cast(pp.SolutionStrategy, model)
-    model.prepare_simulation()
-    prim_equs, prim_vars = get_primary_equs_vars(model)
-
-    # Set primary equations and variables to get the secondary ones for assembly of
-    # secondary block.
-    model.schur_complement_primary_equations = prim_equs
-    model.schur_complement_primary_variables = prim_vars
-
-    secondary_equs = list(
-        set(model.equation_system.equations.keys()).difference(set(prim_equs))
-    )
-    secondary_vars = list(
-        set([var.name for var in model.equation_system.variables]).difference(
-            set(prim_vars)
-        )
-    )
-
-    N = model.equation_system.dofs_of(secondary_vars).size
-    model.equation_system.set_variable_values(
-        np.ones(model.equation_system.num_dofs()), iterate_index=0, time_step_index=0
-    )
-
-    model.before_time_step()
-    model.before_nonlinear_loop()
-    model.before_nonlinear_iteration()
-    model.assemble_linear_system()
-    inv_A_ss = model.equation_system._Schur_complement[0]
-
-    # NOTE A_ss is not stored explicitly as part of the linear system assembly.
-    A_ss, _ = model.equation_system.assemble(
-        equations=secondary_equs,
-        variables=secondary_vars,
-    )
-
-    # NOTE: Do not convert to dense array, 3D test case will run out of memory.
-    approx_identity = cast(sps.csr_matrix, A_ss @ inv_A_ss)
-    identity = cast(sps.csr_matrix, sps.eye(N, format="csr"))
-
-    assert (
-        np.all(approx_identity.indices == identity.indices)
-        and np.all(approx_identity.indptr == identity.indptr)
-        and np.allclose(
-            approx_identity.data,
-            np.ones(N),
-            rtol=0.0,
-            atol=1e-16,
-        )
-        and np.all(approx_identity.shape == identity.shape)
-    )
-
-    # Test that we expand the solution correctly. This is currently hard-coded in
-    # NewtonSolver.iteration. This test will be moved and restructured when a linear
-    # solver for the schur complement strategy is introduced.
-    assert model._apply_schur_complement_reduction()
-    nonlinear_solver = pp.solvers.NewtonSolver()
-    expanded_sol, status = nonlinear_solver.iteration(model)
-    assert status.is_success()
-
-    # Solving the full matrix without taking the Schur complement as a reference.
-    mat, rhs = model.equation_system.assemble()
-    sol_expected = spsolve(mat, rhs)
-
-    assert expanded_sol.shape == sol_expected.shape, "Shapes must match."
-    np.testing.assert_allclose(sol_expected - expanded_sol, 0, atol=1e-9, rtol=0)

--- a/tests/numerics/ad/test_equation_system.py
+++ b/tests/numerics/ad/test_equation_system.py
@@ -1311,7 +1311,7 @@ def test_domain_restricted_assembly_has_local_equation_indices(
     assembled_indexer = linear_system.equation_indexer
     assert isinstance(assembled_indexer, pp.ad.EquationIndexer)
     np.testing.assert_array_equal(
-        assembled_indexer.equation_dofs[
+        assembled_indexer.indices[
             pp.ad.EquationOnDomain(name=equation.name, domain=domain)
         ],
         local_rows,
@@ -1478,21 +1478,17 @@ def test_assemble(model: EquationSystemMockModel, equation_variables):
             equations=eq_names, variables=variables
         )
     )
-    equation_dofs = equation_indexer.indices
+    indices = equation_indexer.indices
     if eq_names is None:
         eq_names = list(model.equation_system.equations)
 
     for name in eq_names:
-        num_dofs = sum(
-            [dofs.size for var, dofs in equation_dofs.items() if var.name == name]
-        )
+        num_dofs = sum([dofs.size for var, dofs in indices.items() if var.name == name])
         assert num_dofs == model.block_size(name)
 
-    variable_dofs = variable_indexer.indices
+    indices = variable_indexer.indices
     for name in var_names:
-        num_dofs = sum(
-            [dofs.size for var, dofs in variable_dofs.items() if var.name == name]
-        )
+        num_dofs = sum([dofs.size for var, dofs in indices.items() if var.name == name])
         assert num_dofs == model.dof_ind(name).size
 
 

--- a/tests/numerics/ad/test_equation_system.py
+++ b/tests/numerics/ad/test_equation_system.py
@@ -17,13 +17,11 @@ The tests focus on various assembly methods:
         present.
     * test_assemble: Assemble sub-blocks of the full set of equations.
     * test_extract_subsystem: Extract a new EquationSystem for a subset of equations.
-    * test_schur_complement: Assemble a subsystem, using a Schur complement reduction.
 
 """
 
 import numpy as np
 import pytest
-import scipy.sparse as sps
 
 import porepy as pp
 from porepy.applications.md_grids.mdg_library import square_with_orthogonal_fractures
@@ -545,7 +543,9 @@ class EquationSystemMockModel:
         ]
         self.all_variable_names = ["x", "y", "z", "w"]
 
-        self.A, self.b = equation_system.assemble()
+        linear_system = equation_system.assemble()
+        self.A = linear_system.matrix
+        self.b = linear_system.rhs
         self.equation_system = equation_system
 
         # Store subdomains and interfaces
@@ -1286,6 +1286,38 @@ def test_parse_equations(model: EquationSystemMockModel):
     }
 
 
+def test_domain_restricted_assembly_has_local_equation_indices(
+    model: EquationSystemMockModel,
+) -> None:
+    """The assembled indexer uses row indices after the domain restriction."""
+    equation_system = model.equation_system
+    equation = model.eq_all_subdomains
+    domain = next(sd for sd in model.subdomains if sd is not model.sd_top)
+    restriction = {equation.name: [domain]}
+
+    # _parse_equations selects these rows from the equation's full AD result.
+    full_equation_indexer = equation_system.equation_indexer
+    full_result_rows = full_equation_indexer.equation_image_space_composition[
+        equation.name
+    ][domain]
+    assert full_result_rows[0] > 0
+
+    linear_system = equation_system.assemble(equations=restriction)
+    local_rows = np.arange(domain.num_cells)
+    np.testing.assert_array_equal(linear_system.rhs, model.b[full_result_rows])
+    assert linear_system.matrix is not None
+    assert linear_system.matrix.shape[0] == local_rows.size
+
+    assembled_indexer = linear_system.equation_indexer
+    assert isinstance(assembled_indexer, pp.ad.EquationIndexer)
+    np.testing.assert_array_equal(
+        assembled_indexer.equation_dofs[
+            pp.ad.EquationOnDomain(name=equation.name, domain=domain)
+        ],
+        local_rows,
+    )
+
+
 @pytest.mark.parametrize(
     "var_names",
     [
@@ -1310,7 +1342,10 @@ def test_secondary_variable_assembly(model: EquationSystemMockModel, var_names):
     variables = [
         var for var in model.equation_system.variables if var.name not in var_names
     ]
-    A, b = model.equation_system.assemble(variables=variables)
+    linear_system = model.equation_system.assemble(variables=variables)
+    A = linear_system.matrix
+    assert A is not None
+    b = linear_system.rhs
 
     # Get dof indices of the variables that have been eliminated
     if len(var_names) > 0:
@@ -1394,7 +1429,10 @@ def test_assemble(model: EquationSystemMockModel, equation_variables):
         var for var in model.equation_system.variables if var.name in var_names
     ]
 
-    A_sub, b_sub = equation_system.assemble(equations=eq_names, variables=var_names)
+    linear_system = equation_system.assemble(equations=eq_names, variables=var_names)
+    A_sub = linear_system.matrix
+    assert A_sub is not None
+    b_sub = linear_system.rhs
     b_sub_only_rhs = equation_system.assemble(
         evaluate_jacobian=False, equations=eq_names, variables=var_names
     )
@@ -1480,7 +1518,7 @@ def test_assembled_matrix_indexers_match_assembly_order(
     """Restricted indexers must use the canonical matrix assembly order."""
     equation_system = model.equation_system
 
-    _, _ = equation_system.assemble(equations=equations, variables=variables)
+    _ = equation_system.assemble(equations=equations, variables=variables)
     equation_indexer, variable_indexer = (
         equation_system.construct_assembled_matrix_indexers(
             equations=equations, variables=variables
@@ -1580,132 +1618,6 @@ def test_extract_subsystem(model: EquationSystemMockModel, equation_variables):
         assert var in variables
 
 
-@pytest.mark.parametrize(
-    "eq_var_to_exclude",
-    # Combinations of variables and variables. These cannot be set independently, since
-    # the block to be eliminated should be square and invertible.
-    [
-        [["eq_single_interface"], ["w"]],  # Single equation, variable on one interface
-        [["eq_all_interfaces"], ["y"]],  # Multiple interfaces
-        [  # Set of equations and variable on all subdomains. NOTE: This will be
-            # modified so that the equation and variable are partly included among the
-            # primary quantities, but only on one subdomani. See 'if eq_to_exclude[0] ==
-            # "eq_all_subdomains"' below.
-            ["eq_all_subdomains"],
-            ["x"],
-        ],
-        [
-            ["eq_all_interfaces", "eq_single_subdomain"],
-            ["z", "y"],
-        ],  # Two equations, two variables
-    ],
-)
-def test_schur_complement(eq_var_to_exclude):
-    """Test assembly by a Schur complement.
-
-    The test constructs the Schur complement 'manually', using known information on
-    the ordering of equations and unknowns, and compares with the method in
-    EquationSystem.
-
-    Input parameters to this test are interpreted as equations and variables to be
-    eliminated (this makes interpretation of test results easier), while the method in
-    EquationSystem expects equations and variables to be kept. Some work is needed to
-    invert the sets.
-
-    Note that for the test run for 'eq_all_subdomains' and 'x', we do some extra work
-    to test the ability to exclude specific grids, rather than full equations.
-
-    """
-    # Parse the input parameters.
-    eq_to_exclude, var_to_exclude = eq_var_to_exclude
-
-    # Ensure the system is square by leaving out eq_combined
-    model = EquationSystemMockModel(square_system=True)
-    equation_system = model.equation_system
-    # Always exclude eq_combined to get a square system.
-    eq_to_exclude.append("eq_combined")
-
-    # Equations to keep
-    # This construction preserves the order
-    eq_names = [eq for eq in model.all_equation_names if eq not in eq_to_exclude]
-
-    if eq_to_exclude[0] == "eq_all_subdomains":
-        # In this case, we use a dictionary to define the equations to keep.
-        # For all equations not to be eliminated (e.g., present in eq_names), they are
-        # kept on all subdomains.
-        equations = {
-            eq: list(
-                equation_system.equation_indexer.equation_image_space_composition[eq]
-            )
-            for eq in eq_names
-        }
-        # In addition, we keep 'eq_all_subdomains' on the top subdomain.
-        equations["eq_all_subdomains"] = [model.sd_top]
-
-        # Next, variables to keep: We keep all of them, expect for the one to be
-        # excluded, which is kept on the top subdomain only.
-        domain_to_exclude = model.subdomains[1:]
-        variables = []
-        for var in equation_system.variables:
-            if not (var.name in var_to_exclude and var.domain in domain_to_exclude):
-                variables.append(var)
-    else:
-        # Simply use a list of string to define the equations.
-        equations = eq_names
-        variables = [
-            var for var in model.all_variable_names if var not in var_to_exclude
-        ]
-
-    inverter = lambda A: sps.csr_matrix(np.linalg.inv(A.toarray()))
-
-    # Rows and columns to keep
-    rows_keep = np.sort(np.hstack([model.eq_ind(name) for name in eq_names]))
-    cols_keep = np.sort(np.hstack([model.dof_ind(var) for var in variables]))
-
-    # Rows and columns to eliminate
-    rows_elim = np.setdiff1d(np.arange(sum(model.eq_inds)), rows_keep)
-    cols_elim = np.setdiff1d(np.arange(model.equation_system.num_dofs()), cols_keep)
-
-    if eq_to_exclude[0] == "eq_all_subdomains":
-        # If we have let the all-subdomanis equation be present on the top subdomain,
-        # we need to remove the corresponding rows and columns from the elimination.
-        # We know that the indices of the top subdomain are the first ones (since this
-        # is the order in which the equations are added to the system).
-        sd_top = model.sd_top
-        rows_to_transfer = np.arange(sd_top.num_cells)
-        rows_keep = np.sort(np.hstack([rows_keep, rows_to_transfer]))
-        rows_elim = np.sort(np.setdiff1d(rows_elim, rows_to_transfer))
-
-    # Split the full matrix into [[A, B], [C, D]], where D is to be eliminated
-    A = model.A[rows_keep][:, cols_keep]
-    B = model.A[rows_keep][:, cols_elim]
-    C = model.A[rows_elim][:, cols_keep]
-    D = model.A[rows_elim][:, cols_elim]
-
-    b_1 = model.b[rows_elim]
-    b_2 = model.b[rows_keep]
-
-    S_known = A - B * inverter(D) * C
-    b_known = b_2 - B * inverter(D) * b_1
-
-    # Compute Schur complement with method to be tested
-    S, bS = equation_system.assemble_schur_complement_system(
-        equations, variables, inverter=inverter
-    )
-
-    assert np.allclose(bS, b_known)
-    assert pp.test_utils.arrays.compare_matrices(S, S_known)
-
-    # Finally, test that the solution computed from a Schur complement and then
-    # expanded to the full system (using the relevant method in EquationSystem) is
-    # the same as the solution computed directly from the full system.
-    x_schur = sps.linalg.spsolve(S, bS)
-    x_expected = sps.linalg.spsolve(model.A, model.b)
-    x_reconstructed = equation_system.expand_schur_complement_solution(x_schur)
-
-    assert np.allclose(x_reconstructed, x_expected)
-
-
 def test_assemble_ignores_empty_equations(model: EquationSystemMockModel):
     """Test that assemble() ignores equations defined on empty domains.
 
@@ -1718,13 +1630,19 @@ def test_assemble_ignores_empty_equations(model: EquationSystemMockModel):
     equation_system = model.equation_system
 
     # Store Baseline system matrix and vector.
-    A_ref, b_ref = equation_system.assemble()
+    linear_system_ref = equation_system.assemble()
+    A_ref = linear_system_ref.matrix
+    assert A_ref is not None
+    b_ref = linear_system_ref.rhs
 
     # Add equation on empty domain using the empty variable
     model.add_equation_on_empty_domain()
 
     # Check that the assembled system does not include the empty equation.
-    A, b = equation_system.assemble()
+    linear_system = equation_system.assemble()
+    A = linear_system.matrix
+    assert A is not None
+    b = linear_system.rhs
     assert np.allclose(b, b_ref)
     assert pp.test_utils.arrays.compare_matrices(A, A_ref)
 
@@ -1734,45 +1652,3 @@ def test_assemble_ignores_empty_equations(model: EquationSystemMockModel):
     for eq_on_domain in equation_indexer.indices:
         assert eq_on_domain.name != "empty_equation"
     assert "empty_equation" not in equation_indexer.equation_image_space_composition
-
-
-def test_schur_complement_empty_equation_filter():
-    """Test the filtering function in schur complement assembly.
-
-    This test verified that equations defined on empty domains do not
-    affect the schur complement system. So the resulting schur complement
-    system is unchanged.
-    """
-
-    model = EquationSystemMockModel(square_system=True)
-    equation_system = model.equation_system
-
-    inverter = lambda A: sps.csr_matrix(np.linalg.inv(A.toarray()))
-
-    # Generate a reference Schur system.
-    S_ref, bS_ref = equation_system.assemble_schur_complement_system(
-        primary_equations=["eq_all_subdomains"],
-        primary_variables=["x"],
-        inverter=inverter,
-    )
-
-    # Add equation on empty domain using the empty variable
-    model.add_equation_on_empty_domain()
-
-    # Check the empty equation exists in system.
-    assert "empty_equation" in equation_system.equations
-    # Check whether parsing filters the empty equation out.
-    assert "empty_equation" not in {
-        item.name for item in equation_system._parse_equations(None)
-    }
-
-    # Check Schur complement should be unchanged.
-    S, bS = equation_system.assemble_schur_complement_system(
-        primary_equations=["eq_all_subdomains"],
-        primary_variables=["x"],
-        inverter=inverter,
-    )
-
-    assert np.allclose(bS, bS_ref)
-    assert S.shape == S_ref.shape
-    assert pp.test_utils.arrays.compare_matrices(S, S_ref)

--- a/tests/numerics/ad/test_equation_system.py
+++ b/tests/numerics/ad/test_equation_system.py
@@ -8,13 +8,10 @@ The tests focus on various assembly methods:
     * test_variable_tags: Tagging of variables, used for filtering in an EquationSystem.
     * test_set_get_methods: Get and set methods for variables, including methods for
         shifting between time steps and iterates.
-    * test_variable_indexer_subset: Indexing a subset of variables.
     * test_set_remove_equations: Set and remove equations from an EquationSystem.
     * test_parse_variable_like, test_parse_single_equation, test_parse_equations:
         Parsing of equations, and the methods used to do so. Thorough testing here means
         other tests can get away with fewer parameter checks.
-    * test_secondary_variable_assembly: Test of assembly when secondary variables are
-        present.
     * test_assemble: Assemble sub-blocks of the full set of equations.
     * test_extract_subsystem: Extract a new EquationSystem for a subset of equations.
 
@@ -611,15 +608,6 @@ class EquationSystemMockModel:
         )
 
 
-def _eliminate_columns_from_matrix(A, indices, reverse):
-    # Helper method to extract submatrix by column indices
-    if reverse:
-        inds = np.setdiff1d(np.arange(A.shape[1]), indices)
-    else:
-        inds = indices
-    return A[:, inds]
-
-
 @pytest.fixture(scope="function")
 def model() -> EquationSystemMockModel:
     # Method to deliver a model to all tests
@@ -952,7 +940,10 @@ def test_set_remove_equations(model: EquationSystemMockModel):
     )
 
     # Check that the mapping of equation to subdomain to global dof
-    # indices is correctly set.
+    # indices is correctly set. Note: in this test, we access the indexer through
+    # equation_system.equation_indexer (and don't assign it to a local variable),
+    # because it recomputes every time the equations are changed. So it's a new indexer
+    # each time it is accessed.
     equation_subdomain_blocks = (
         equation_system.equation_indexer.equation_image_space_composition
     )
@@ -1048,18 +1039,6 @@ def test_set_remove_equations(model: EquationSystemMockModel):
     assert (
         list(equation_subdomain_blocks["eq_all_interfaces"].keys()) == model.interfaces
     )
-
-
-def test_update_equation_on_empty_domain(model: EquationSystemMockModel) -> None:
-    """Updating an empty-domain equation should reuse its empty domain by default."""
-    equation_system = model.equation_system
-    model.add_equation_on_empty_domain()
-    old_equation = equation_system.equations["empty_equation"]
-    new_equation = old_equation * old_equation
-
-    equation_system.update_equation("empty_equation", new_equation)
-
-    assert equation_system.equations["empty_equation"] is new_equation
 
 
 def test_parse_variable_like(model: EquationSystemMockModel):
@@ -1191,6 +1170,7 @@ def test_parse_single_equation(model: EquationSystemMockModel):
         # First parse the equation as it is, without any restriction.
         # This should give back the full equation with no restriction.
         restriction_1 = equation_system._parse_equations([eq_or_name])
+        # Four atomic equations (corresponding to this equation of 4 subdomains).
         assert len(restriction_1) == 4
 
         assert all(eq.name == eq_on_domain.name for eq_on_domain in restriction_1)
@@ -1286,127 +1266,38 @@ def test_parse_equations(model: EquationSystemMockModel):
     }
 
 
-def test_domain_restricted_assembly_has_local_equation_indices(
-    model: EquationSystemMockModel,
-) -> None:
-    """The assembled indexer uses row indices after the domain restriction."""
-    equation_system = model.equation_system
-    equation = model.eq_all_subdomains
-    domain = next(sd for sd in model.subdomains if sd is not model.sd_top)
-    restriction = {equation.name: [domain]}
-
-    # _parse_equations selects these rows from the equation's full AD result.
-    full_equation_indexer = equation_system.equation_indexer
-    full_result_rows = full_equation_indexer.equation_image_space_composition[
-        equation.name
-    ][domain]
-    assert full_result_rows[0] > 0
-
-    linear_system = equation_system.assemble(equations=restriction)
-    local_rows = np.arange(domain.num_cells)
-    np.testing.assert_array_equal(linear_system.rhs, model.b[full_result_rows])
-    assert linear_system.matrix is not None
-    assert linear_system.matrix.shape[0] == local_rows.size
-
-    assembled_indexer = linear_system.equation_indexer
-    assert isinstance(assembled_indexer, pp.ad.EquationIndexer)
-    np.testing.assert_array_equal(
-        assembled_indexer.indices[
-            pp.ad.EquationOnDomain(name=equation.name, domain=domain)
-        ],
-        local_rows,
-    )
-
-
+@pytest.mark.parametrize(
+    "eq_names",
+    [
+        None,  # None gives the full system.
+        [],  # An empty list will give a system with zero rows.
+        ["eq_single_subdomain"],  # A single equation.
+        ["eq_single_interface", "eq_all_subdomains"],  # Combination of two equations.
+        # Combination of two equations, reversed order.
+        ["eq_all_subdomains", "eq_single_interface"],
+    ],
+)
 @pytest.mark.parametrize(
     "var_names",
     [
-        [],  # No secondary variables
-        ["x"],  # A simple variable which is also part of a merged one
-        ["y"],  # mixed-dimensional variable
-        ["z"],  # Simple variable not available as merged
-        ["z", "w"],  # Combination of simple and merged.
+        None,  # None gives the full system.
+        [],  # An empty list will give a system with zero columns.
+        ["x"],  # A single variable.
+        ["x", "w"],  # Combination of two variables.
+        ["w", "x"],  # Combination of two variables, reversed order.
     ],
 )
-def test_secondary_variable_assembly(model: EquationSystemMockModel, var_names):
-    # Test of the standard assemble method. The only interesting test is the
-    # secondary variable functionality (the other functionality is tested elsewhere).
-
-    # The tests compare assembly by an EquationManager with explicitly defined
-    # secondary variables with a 'truth' based on direct elimination of columns
-    # in the Jacobian matrix.
-    # The expected behavior is that the residual vector is fixed, while the
-    # Jacobian matrix is altered only in columns that correspond to eliminated
-    # variables.
-
-    variables = [
-        var for var in model.equation_system.variables if var.name not in var_names
-    ]
-    linear_system = model.equation_system.assemble(variables=variables)
-    A = linear_system.matrix
-    assert A is not None
-    b = linear_system.rhs
-
-    # Get dof indices of the variables that have been eliminated
-    if len(var_names) > 0:
-        dofs = np.sort(
-            np.hstack([model.equation_system.dofs_of([var]) for var in var_names])
-        )
-    else:
-        dofs = []
-
-    # The residual vectors should be the same
-    assert np.allclose(b, model.b)
-    # Compare system matrices. Since the variables specify columns to eliminate,
-    # we use the reverse argument
-    assert pp.test_utils.arrays.compare_matrices(
-        A, _eliminate_columns_from_matrix(model.A, dofs, reverse=True)
-    )
-    # Check that the equation blocks were correctly recorded.
-    equation_indexer, variable_indexer = (
-        model.equation_system._construct_assembled_matrix_indexers(variables=variables)
-    )
-    for name in model.equation_system.equations:
-        actual_dofs = [
-            dofs for eq, dofs in equation_indexer.indices.items() if eq.name == name
-        ]
-        assert np.allclose(np.concatenate(actual_dofs), model.eq_ind(name))
-
-    # Check that the sizes of variable blocks were correctly recorded.
-    for var in variables:
-        assert variable_indexer.indices[var].size == model.dof_ind(var).size
-
-
-@pytest.mark.parametrize(
-    "equation_variables",
-    [
-        [None, None],  # Two Nones will give the full system
-        [[], []],  # Two empty lists will give a system with zero rows and columns
-        [["eq_single_subdomain"], None],  # A single equation, all variables
-        [None, ["x"]],  # All equations, a single variable
-        [
-            [
-                "eq_single_interface",
-                "eq_all_subdomains",
-            ],  # Combination of two equations
-            ["x", "w"],  # Combination of two variables
-        ],
-        [
-            [
-                "eq_all_subdomains",
-                "eq_single_interface",
-            ],  # The combination in reverse order
-            ["w", "x"],  # The combination in reverse order
-        ],
-    ],
-)
-def test_assemble(model: EquationSystemMockModel, equation_variables):
+def test_assemble(
+    model: EquationSystemMockModel,
+    eq_names: list[str] | None,
+    var_names: list[str] | None,
+):
     """Test of functionality to assemble subsystems from an EquationSystem.
 
     The test is based on assembly of a subsystem and comparing this to a truth
     from assembly of the full system, and then explicitly dump rows and columns.
 
-    We test combinations of one or more equations, together with one or more variables.
+    We test combinations of 0 or more equations, together with 0 or more variables.
     Variables are only defined by strings; the alternative format of a variables is
     not considered, since the variables are only passed to EquationSystem.dofs_of()
     (via the method projection_to()), which is tested elsewhere.
@@ -1418,16 +1309,15 @@ def test_assemble(model: EquationSystemMockModel, equation_variables):
     and columns are extracted from the full system.
 
     """
-    eq_names, var_names = equation_variables
-
     equation_system = model.equation_system
 
     # Convert variable names into variables
     if var_names is None:
-        var_names = []
-    variables = [
-        var for var in model.equation_system.variables if var.name in var_names
-    ]
+        variables = None
+    else:
+        variables = [
+            var for var in model.equation_system.variables if var.name in var_names
+        ]
 
     linear_system = equation_system.assemble(equations=eq_names, variables=var_names)
     A_sub = linear_system.matrix
@@ -1472,108 +1362,66 @@ def test_assemble(model: EquationSystemMockModel, equation_variables):
     assert np.allclose(b_sub, model.b[rows])
     assert pp.test_utils.arrays.compare_matrices(A_sub, model.A[rows][:, cols])
 
-    # Also check that the equation row sizes were correctly recorded.
-    equation_indexer, variable_indexer = (
-        equation_system._construct_assembled_matrix_indexers(
-            equations=eq_names, variables=variables
-        )
-    )
-    indices = equation_indexer.indices
-    if eq_names is None:
-        eq_names = list(model.equation_system.equations)
+    # The restricted linear system comes with indexers local to it. Check that they
+    # point to correct atomic variables and equations by comparing them to the globals.
+    local_row_indexer = linear_system.equation_indexer
+    local_col_indexer = linear_system.variable_indexer
+    global_row_indexer = equation_system.equation_indexer
+    global_col_indexer = equation_system.variable_indexer
+    for eq, local_row_index in local_row_indexer.indices.items():
+        global_row_index = global_row_indexer.indices[eq]
+        for var, local_col_index in local_col_indexer.indices.items():
+            global_col_index = global_col_indexer.indices[var]
+            actual = A_sub[local_row_index][:, local_col_index]
+            expected = model.A[global_row_index][:, global_col_index]
+            assert pp.test_utils.arrays.compare_matrices(actual, expected)
+            actual_rhs = b_sub[local_row_index]
+            expected_rhs = model.b[global_row_index]
+            assert pp.test_utils.arrays.compare_arrays(actual_rhs, expected_rhs)
 
-    for name in eq_names:
-        num_dofs = sum([dofs.size for var, dofs in indices.items() if var.name == name])
-        assert num_dofs == model.block_size(name)
-
-    indices = variable_indexer.indices
-    for name in var_names:
-        num_dofs = sum([dofs.size for var, dofs in indices.items() if var.name == name])
-        assert num_dofs == model.dof_ind(name).size
+    # The order of equations and variables should be the same, even if they were passed
+    # to assembly in the reversed order.
+    it = iter(global_row_indexer.indices)
+    # This walks once over atomic equations in the global and local indexers (think
+    # fast and slow pointers, respectively). There should be no permutation to succeed.
+    assert all(x in it for x in local_row_indexer.indices)
+    # Same for variables.
+    it = iter(global_col_indexer.indices)
+    assert all(x in it for x in local_col_indexer.indices)
 
 
 @pytest.mark.parametrize(
-    "equations",
+    "eq_names",
     [
-        ["eq_single_interface", "eq_all_subdomains"],
+        None,  # None gives the full system.
+        [],  # An empty list will give a system with zero rows.
+        ["eq_single_subdomain"],  # A single equation.
+        ["eq_single_interface", "eq_all_subdomains"],  # Combination of two equations.
+        # Combination of two equations, reversed order.
         ["eq_all_subdomains", "eq_single_interface"],
     ],
 )
 @pytest.mark.parametrize(
-    "variables",
+    "var_names",
     [
-        ["w", "x"],
-        ["x", "w"],
+        None,  # None gives the full system.
+        [],  # An empty list will give a system with zero columns.
+        ["x"],  # A single variable.
+        ["x", "w"],  # Combination of two variables.
+        ["w", "x"],  # Combination of two variables, reversed order.
     ],
 )
-def test_assembled_matrix_indexers_match_assembly_order(
+def test_extract_subsystem(
     model: EquationSystemMockModel,
-    equations: list[str],
-    variables: list[str],
-) -> None:
-    """Restricted indexers must use the canonical matrix assembly order."""
-    equation_system = model.equation_system
-
-    _ = equation_system.assemble(equations=equations, variables=variables)
-    equation_indexer, variable_indexer = (
-        equation_system._construct_assembled_matrix_indexers(
-            equations=equations, variables=variables
-        )
-    )
-
-    expected_equations = [
-        equation
-        for equation in equation_system.equation_indexer.indices
-        if equation.name in equations
-    ]
-    expected_variables = [
-        variable
-        for variable in equation_system.variable_indexer.indices
-        if variable.name in variables
-    ]
-
-    actual_order = (
-        [equation.name for equation in equation_indexer.indices],
-        [variable.name for variable in variable_indexer.indices],
-    )
-    expected_order = (
-        [equation.name for equation in expected_equations],
-        [variable.name for variable in expected_variables],
-    )
-    assert actual_order == expected_order
-
-
-@pytest.mark.parametrize(
-    "equation_variables",
-    [
-        [None, None],  # Two Nones will give the full system
-        [[], []],  # Two empty lists will give a system with zero rows and columns
-        [["eq_single_subdomain"], None],  # A single equation, all variables
-        [None, ["x"]],  # All equations, a single variable
-        [
-            [
-                "eq_single_interface",
-                "eq_all_subdomains",
-            ],  # Combination of two equations
-            ["x", "w"],  # Combination of two variables
-        ],
-        [
-            [
-                "eq_all_subdomains",
-                "eq_single_interface",
-            ],  # The combination in reverse order
-            ["w", "x"],  # The combination in reverse order
-        ],
-    ],
-)
-def test_extract_subsystem(model: EquationSystemMockModel, equation_variables):
-    """
-    Check functionality to extract subsystems from the EquationManager.
+    eq_names: list[str] | None,
+    var_names: list[str] | None,
+):
+    """Check functionality to extract subsystems from the EquationManager.
 
     The tests check that the expected variables and equations are present in
     the subsystem.
 
-    We test combinations of one or more equations, together with one or more variables.
+    We test combinations of 0 or more equations, together with 0 or more variables.
     Variables are only defined by strings; the alternative format of a variables is
     not considered, since the variables are only passed to EquationSystem.dofs_of()
     (via the method projection_to()) which is tested elsewhere.
@@ -1585,8 +1433,6 @@ def test_extract_subsystem(model: EquationSystemMockModel, equation_variables):
     and columns are extracted from the full system.
 
     """
-    eq_names, var_names = equation_variables
-
     equation_system = model.equation_system
 
     # Convert variable names into variables
@@ -1620,6 +1466,7 @@ def test_assemble_ignores_empty_equations(model: EquationSystemMockModel):
     An equation defined on an empty domain (no grids) should not contribute to the
     assembled system. After adding such an equation, assembling the system should
     produce the same matrix and residual vector as before the equation was added.
+
     """
 
     # Get the system of equations from the model.
@@ -1643,8 +1490,5 @@ def test_assemble_ignores_empty_equations(model: EquationSystemMockModel):
     assert pp.test_utils.arrays.compare_matrices(A, A_ref)
 
     # Check bookkeeping does not suddenly include the empty equation.
-    equation_indexer, _ = equation_system._construct_assembled_matrix_indexers()
-
-    for eq_on_domain in equation_indexer.indices:
+    for eq_on_domain in linear_system.equation_indexer.indices:
         assert eq_on_domain.name != "empty_equation"
-    assert "empty_equation" not in equation_indexer.equation_image_space_composition

--- a/tests/numerics/ad/test_equation_system.py
+++ b/tests/numerics/ad/test_equation_system.py
@@ -1364,7 +1364,7 @@ def test_secondary_variable_assembly(model: EquationSystemMockModel, var_names):
     )
     # Check that the equation blocks were correctly recorded.
     equation_indexer, variable_indexer = (
-        model.equation_system.construct_assembled_matrix_indexers(variables=variables)
+        model.equation_system._construct_assembled_matrix_indexers(variables=variables)
     )
     for name in model.equation_system.equations:
         actual_dofs = [
@@ -1474,7 +1474,7 @@ def test_assemble(model: EquationSystemMockModel, equation_variables):
 
     # Also check that the equation row sizes were correctly recorded.
     equation_indexer, variable_indexer = (
-        equation_system.construct_assembled_matrix_indexers(
+        equation_system._construct_assembled_matrix_indexers(
             equations=eq_names, variables=variables
         )
     )
@@ -1516,7 +1516,7 @@ def test_assembled_matrix_indexers_match_assembly_order(
 
     _ = equation_system.assemble(equations=equations, variables=variables)
     equation_indexer, variable_indexer = (
-        equation_system.construct_assembled_matrix_indexers(
+        equation_system._construct_assembled_matrix_indexers(
             equations=equations, variables=variables
         )
     )
@@ -1643,7 +1643,7 @@ def test_assemble_ignores_empty_equations(model: EquationSystemMockModel):
     assert pp.test_utils.arrays.compare_matrices(A, A_ref)
 
     # Check bookkeeping does not suddenly include the empty equation.
-    equation_indexer, _ = equation_system.construct_assembled_matrix_indexers()
+    equation_indexer, _ = equation_system._construct_assembled_matrix_indexers()
 
     for eq_on_domain in equation_indexer.indices:
         assert eq_on_domain.name != "empty_equation"

--- a/tests/numerics/ad/test_equation_system.py
+++ b/tests/numerics/ad/test_equation_system.py
@@ -1302,12 +1302,6 @@ def test_assemble(
     not considered, since the variables are only passed to EquationSystem.dofs_of()
     (via the method projection_to()), which is tested elsewhere.
 
-    This test is run on a relatively limited set of equation-variable combinations
-    (in particular compared to how the test was set up in the past). The reason is that
-    parsing of variable and equation input is tested in separate tests, thus what
-    remains is to test that given a set of equations and variables, the correct rows
-    and columns are extracted from the full system.
-
     """
     equation_system = model.equation_system
 
@@ -1368,13 +1362,16 @@ def test_assemble(
     local_col_indexer = linear_system.variable_indexer
     global_row_indexer = equation_system.equation_indexer
     global_col_indexer = equation_system.variable_indexer
+
     for eq, local_row_index in local_row_indexer.indices.items():
         global_row_index = global_row_indexer.indices[eq]
+
         for var, local_col_index in local_col_indexer.indices.items():
             global_col_index = global_col_indexer.indices[var]
             actual = A_sub[local_row_index][:, local_col_index]
             expected = model.A[global_row_index][:, global_col_index]
             assert pp.test_utils.arrays.compare_matrices(actual, expected)
+
             actual_rhs = b_sub[local_row_index]
             expected_rhs = model.b[global_row_index]
             assert pp.test_utils.arrays.compare_arrays(actual_rhs, expected_rhs)

--- a/tests/numerics/ad/test_indexers.py
+++ b/tests/numerics/ad/test_indexers.py
@@ -7,6 +7,7 @@ import porepy as pp
 from porepy.numerics.ad.indexers import (
     EquationIndexer,
     EquationOnDomain,
+    EquationSystemIndexer,
     VariableIndexer,
 )
 
@@ -96,29 +97,31 @@ def test_variable_indexer_duplicate_restriction(
         indexer.construct_restricted_indexer([x, x])
 
 
-def test_equation_indexer_offsets(
+def test_equation_system_indexer_offsets(
     domains: tuple[pp.Grid, pp.Grid, pp.Grid],
 ) -> None:
-    """Equation indexers expose local and globally offset equation indices."""
+    """Equation-system indexers expose local and global equation indices."""
     first, second, third = domains
     composition = {
         "equation_a": {
-            first: np.array([0, 1]),
-            second: np.array([2, 3, 4]),
+            first: np.array([4, 1]),
+            second: np.array([7, 3, 9]),
         },
         "equation_b": {
-            second: np.array([0]),
-            third: np.array([1, 2]),
+            second: np.array([5]),
+            third: np.array([8, 2]),
         },
     }
 
-    indexer = EquationIndexer(equation_image_composition=composition)
+    indexer = EquationSystemIndexer(equation_image_space_composition=composition)
+
+    assert isinstance(indexer, EquationIndexer)
 
     np.testing.assert_array_equal(
-        indexer.equation_image_space_composition["equation_a"][first], [0, 1]
+        indexer.equation_image_space_composition["equation_a"][first], [4, 1]
     )
     np.testing.assert_array_equal(
-        indexer.equation_image_space_composition["equation_b"][third], [1, 2]
+        indexer.equation_image_space_composition["equation_b"][third], [8, 2]
     )
     expected_keys = [
         EquationOnDomain("equation_a", first),
@@ -141,8 +144,8 @@ def test_equation_indexer_restriction(
     equation_a_second = EquationOnDomain("equation_a", second)
     equation_b_second = EquationOnDomain("equation_b", second)
     equation_b_third = EquationOnDomain("equation_b", third)
-    indexer = EquationIndexer(
-        equation_image_composition={
+    indexer = EquationSystemIndexer(
+        equation_image_space_composition={
             "equation_a": {first: np.arange(2), second: np.arange(2, 5)},
             "equation_b": {second: np.arange(1), third: np.arange(1, 3)},
         }
@@ -166,21 +169,13 @@ def test_equation_indexer_restriction(
     np.testing.assert_array_equal(
         restricted.indices[equation_a_second], np.arange(3, 6)
     )
-    np.testing.assert_array_equal(
-        restricted.equation_image_space_composition["equation_b"][third],
-        np.arange(1, 3),
-    )
-    np.testing.assert_array_equal(
-        restricted.equation_image_space_composition["equation_a"][second],
-        np.arange(3),
-    )
 
 
 def test_empty_indexers() -> None:
     """Indexers support empty systems and restrictions."""
     variable_indexer = VariableIndexer(indices={})
     restricted_indexer = variable_indexer.construct_restricted_indexer([])
-    equation_indexer = EquationIndexer(equation_image_composition={})
+    equation_indexer = EquationSystemIndexer(equation_image_space_composition={})
 
     assert variable_indexer.size == 0
     assert variable_indexer.indices == {}

--- a/tests/numerics/ad/test_indexers.py
+++ b/tests/numerics/ad/test_indexers.py
@@ -1,4 +1,11 @@
-"""Unit tests for indexers used by the AD equation system."""
+"""Unit tests for indexers used by the AD equation system.
+
+TODO YZ: These tests should be generalized and test all methods of the equation and
+variable indexers. It would be convinient to do it in #1727 (generic indexer PR).
+
+"""
+
+from dataclasses import dataclass
 
 import numpy as np
 import pytest
@@ -9,6 +16,9 @@ from porepy.numerics.ad.indexers import (
     EquationOnDomain,
     EquationSystemIndexer,
     VariableIndexer,
+)
+from porepy.numerics.solvers.linear_solvers.schur_complement_reduction import (
+    _filter_by_tags,
 )
 
 
@@ -184,3 +194,41 @@ def test_empty_indexers() -> None:
     assert restricted_indexer.indices == {}
     assert equation_indexer.indices == {}
     assert equation_indexer.equation_image_space_composition == {}
+
+
+# TODO YZ: Filter by tags is about to become a method of indexers in the next PR
+# (generic indexer).
+
+
+def test_filter_by_tags_handles_duplicate_tags() -> None:
+    """Must raise ValueError if tags lead to duplicated operators."""
+
+    domain = pp.CartGrid([1])
+    variable = pp.ad.Variable("x", {"cells": 1}, domain)
+    tags = [pp.solvers.VariableTag("x"), pp.solvers.VariableTag("x")]
+
+    with pytest.raises(ValueError):
+        _ = _filter_by_tags([variable], tags)
+
+
+def test_filter_by_tags_allows_disjoint_tags_with_same_name() -> None:
+    """Tags with the same name may select disjoint subsets of domains."""
+
+    @dataclass(frozen=True)
+    class OnDomain(pp.solvers.DomainFilter):
+        domain: pp.GridLike
+
+        def filter(self, domain: pp.GridLike) -> bool:
+            return domain is self.domain
+
+    domains = [pp.CartGrid([1]) for _ in range(3)]
+    variables = [pp.ad.Variable("x", {"cells": 1}, domain) for domain in domains]
+    tags = [
+        pp.solvers.VariableTag("x", defined_on=OnDomain(domain))
+        for domain in domains[:2]
+    ]
+
+    filtered, not_filtered = _filter_by_tags(variables, tags)
+
+    assert filtered == variables[:2]
+    assert not_filtered == variables[2:]

--- a/tests/numerics/solvers/linear_solvers/test_schur_complement_reduction.py
+++ b/tests/numerics/solvers/linear_solvers/test_schur_complement_reduction.py
@@ -112,6 +112,29 @@ def test_filter_by_tags_handles_duplicate_tags() -> None:
         _ = _filter_by_tags([variable], tags)
 
 
+def test_filter_by_tags_allows_disjoint_tags_with_same_name() -> None:
+    """Tags with the same name may select disjoint subsets of domains."""
+
+    @dataclass(frozen=True)
+    class OnDomain(pp.solvers.DomainFilter):
+        domain: pp.GridLike
+
+        def filter(self, domain: pp.GridLike) -> bool:
+            return domain is self.domain
+
+    domains = [pp.CartGrid([1]) for _ in range(3)]
+    variables = [pp.ad.Variable("x", {"cells": 1}, domain) for domain in domains]
+    tags = [
+        pp.solvers.VariableTag("x", defined_on=OnDomain(domain))
+        for domain in domains[:2]
+    ]
+
+    filtered, not_filtered = _filter_by_tags(variables, tags)
+
+    assert filtered == variables[:2]
+    assert not_filtered == variables[2:]
+
+
 def test_default_primary_solver() -> None:
     """A direct solver is created when no primary solver is supplied."""
     solver = pp.solvers.SchurComplementReductionLinearSolver(

--- a/tests/numerics/solvers/linear_solvers/test_schur_complement_reduction.py
+++ b/tests/numerics/solvers/linear_solvers/test_schur_complement_reduction.py
@@ -355,3 +355,24 @@ def test_schur_complement_reduction_on_model(
 
     model = model_class(model_params)
     model.prepare_simulation()
+    model.before_time_step()
+    model.before_nonlinear_loop()
+    model.before_nonlinear_iteration()
+    model.equation_system.set_variable_values(
+        np.ones(model.equation_system.num_dofs()), iterate_index=0
+    )
+    linear_system = model.equation_system.assemble()
+
+    primary_eq_tags, primary_var_tags = get_primary_tags(model)
+
+    direct_solver = pp.solvers.LinearSolverDirect()
+    expected_sol, status = direct_solver.solve_linear_system(linear_system)
+    assert status.is_success()
+
+    schur_solver = pp.solvers.SchurComplementReductionLinearSolver(
+        primary_equation_tags=primary_eq_tags, primary_variable_tags=primary_var_tags
+    )
+    actual_sol, status = schur_solver.solve_linear_system(linear_system)
+    assert status.is_success()
+
+    np.testing.assert_allclose(expected_sol - actual_sol, 0, atol=1e-9, rtol=0)

--- a/tests/numerics/solvers/linear_solvers/test_schur_complement_reduction.py
+++ b/tests/numerics/solvers/linear_solvers/test_schur_complement_reduction.py
@@ -14,9 +14,6 @@ from porepy.applications.md_grids.mdg_library import (
     square_with_orthogonal_fractures,
 )
 from porepy.applications.test_utils.models import add_mixin
-from porepy.numerics.solvers.linear_solvers.schur_complement_reduction import (
-    _filter_by_tags,
-)
 from tests.functional.setups.linear_tracer import TracerFlowModel_3p
 
 
@@ -102,52 +99,8 @@ def linear_system_data() -> LinearSystemData:
     )
 
 
-def test_filter_by_tags_handles_duplicate_tags() -> None:
-    """Must raise ValueError if tags lead to duplicated operators."""
-
-    domain = pp.CartGrid([1])
-    variable = pp.ad.Variable("x", {"cells": 1}, domain)
-    tags = [pp.solvers.VariableTag("x"), pp.solvers.VariableTag("x")]
-
-    with pytest.raises(ValueError):
-        _ = _filter_by_tags([variable], tags)
-
-
-def test_filter_by_tags_allows_disjoint_tags_with_same_name() -> None:
-    """Tags with the same name may select disjoint subsets of domains."""
-
-    @dataclass(frozen=True)
-    class OnDomain(pp.solvers.DomainFilter):
-        domain: pp.GridLike
-
-        def filter(self, domain: pp.GridLike) -> bool:
-            return domain is self.domain
-
-    domains = [pp.CartGrid([1]) for _ in range(3)]
-    variables = [pp.ad.Variable("x", {"cells": 1}, domain) for domain in domains]
-    tags = [
-        pp.solvers.VariableTag("x", defined_on=OnDomain(domain))
-        for domain in domains[:2]
-    ]
-
-    filtered, not_filtered = _filter_by_tags(variables, tags)
-
-    assert filtered == variables[:2]
-    assert not_filtered == variables[2:]
-
-
-def test_default_primary_solver() -> None:
-    """A direct solver is created when no primary solver is supplied."""
-    solver = pp.solvers.SchurComplementReductionLinearSolver(
-        primary_equation_tags=[],
-        primary_variable_tags=[],
-    )
-
-    assert isinstance(solver.primary_linear_solver, pp.solvers.LinearSolverDirect)
-
-
-def test_initialize_with_model_is_forwarded_to_primary_solver() -> None:
-    """Initialization only forwards a shallow model mock to the inner solver."""
+def test_initialize_with_model() -> None:
+    """Test that initialization forwards a model mock to the inner solver."""
 
     class ShallowMockModel:
         pass
@@ -163,7 +116,7 @@ def test_initialize_with_model_is_forwarded_to_primary_solver() -> None:
     )
     model = ShallowMockModel()
 
-    solver.initialize_with_model(model)  # type: ignore[arg-type]
+    solver.initialize_with_model(model)
 
     assert primary_solver.model is model
 
@@ -192,22 +145,35 @@ def test_solve_reduces_system_and_wraps_primary_status(
 
     solution, status = solver.solve_linear_system(linear_system_data.linear_system)
 
+    # Primary dofs are [1, 3]. Secondary dofs are [0, 2].
     np.testing.assert_allclose(solution, [1.0, -1.0, 2.0, 3.0])
+    # Primary solver was called once.
     assert len(primary_solver.linear_systems) == 1
     reduced_system = primary_solver.linear_systems[0]
     assert reduced_system.matrix is not None
+    # Compare against hard-coded Schur complement values.
     np.testing.assert_allclose(
         reduced_system.matrix.toarray(),
         np.array([[50.0, 23.0], [18.0, 58.0]]) / 11.0,
     )
     np.testing.assert_allclose(reduced_system.rhs, np.array([19.0, 156.0]) / 11.0)
-    assert reduced_system.equation_indexer.projection_indices(
-        list(reduced_system.equation_indexer.indices)
-    ).tolist() == [0, 1]
-    assert reduced_system.variable_indexer.projection_indices(
-        list(reduced_system.variable_indexer.indices)
-    ).tolist() == [0, 1]
+    # Indices in the reduced linear system are local to it.
+    assert [0, 1] == np.concatenate(
+        list(reduced_system.equation_indexer.indices.values())
+    ).tolist()
+    assert [0, 1] == np.concatenate(
+        list(reduced_system.variable_indexer.indices.values())
+    ).tolist()
 
+    # Status must be the subclass.
+    assert isinstance(
+        status,
+        (
+            pp.solvers.SchurComplementReductionStatusSuccess,
+            pp.solvers.SchurComplementReductionStatusFailure,
+        ),
+    )
+    # It must contain what the primary solver returned.
     assert status.primary_solver_status is primary_status
     if primary_solver_succeeds:
         assert isinstance(status, pp.solvers.SchurComplementReductionStatusSuccess)
@@ -220,7 +186,10 @@ def test_solve_reduces_system_and_wraps_primary_status(
 def test_solve_delegates_when_secondary_block_is_empty(
     linear_system_data: LinearSystemData,
 ) -> None:
-    """A fully primary system is passed unchanged to the primary solver."""
+    """A system with no secondary variables/equations is passed unchanged to the primary
+    solver.
+
+    """
     primary_status = pp.solvers.LinearSolverStatusSuccess(solve_time=1.0)
     expected_solution = np.array([1.0, -1.0, 2.0, 3.0])
     primary_solver = MockPrimaryLinearSolver(expected_solution, primary_status)

--- a/tests/numerics/solvers/linear_solvers/test_schur_complement_reduction.py
+++ b/tests/numerics/solvers/linear_solvers/test_schur_complement_reduction.py
@@ -274,7 +274,7 @@ def _get_primary_equ_and_vars_cf(
         equ_tags += [pp.solvers.DefaultEquationTags.mass_balance]
         var_tags += [pp.solvers.DefaultVariableTags.pressure]
 
-    # Eergy balance. Can have either enthalpy or temperature as a primary variable.
+    # Energy balance. Can have either enthalpy or temperature as a primary variable.
     if isinstance(model, pp.energy_balance.TotalEnergyBalanceEquations):
         equ_tags += [pp.solvers.DefaultEquationTags.energy_balance]
     if isinstance(
@@ -335,10 +335,6 @@ def test_schur_complement_reduction_on_model(
 ):
     """Compare direct and Schur-complement solutions of a model linear system."""
 
-    # NOTE: Depending on what which model class the tests are performed, the local
-    # geometry mixin and model parameters need adaption in order to overwrite the
-    # geometry and parametrization already contained within the tested model class.
-    # The adaption must be consistent with the mdg's the tests are performed on.
     class LocalGeometry(pp.PorePyModel):
         def create_mdg(self) -> None:
             self.mdg = mdg

--- a/tests/numerics/solvers/linear_solvers/test_schur_complement_reduction.py
+++ b/tests/numerics/solvers/linear_solvers/test_schur_complement_reduction.py
@@ -1,0 +1,139 @@
+from typing import Callable
+
+import numpy as np
+import pytest
+
+import porepy as pp
+from porepy.applications.md_grids.domains import nd_cube_domain
+from porepy.applications.md_grids.mdg_library import (
+    cube_with_orthogonal_fractures,
+    square_with_orthogonal_fractures,
+)
+from porepy.applications.test_utils.models import add_mixin
+from tests.functional.setups.linear_tracer import TracerFlowModel_3p
+
+# ---------------------------------------------------------------------
+# Integration test
+# ---------------------------------------------------------------------
+
+
+def _get_primary_equ_and_vars_cf(
+    model: pp.PorePyModel,
+) -> tuple[list[pp.solvers.EquationTag], list[pp.solvers.VariableTag]]:
+    """Return the primary equation and variable tags of a CF model."""
+
+    equ_tags: list[pp.solvers.EquationTag] = []
+    var_tags: list[pp.solvers.VariableTag] = []
+    # Overall mass balance.
+    if isinstance(model, pp.fluid_mass_balance.FluidMassBalanceEquations):
+        equ_tags += [pp.solvers.DefaultEquationTags.mass_balance]
+        var_tags += [pp.solvers.DefaultVariableTags.pressure]
+
+    # Eergy balance. Can have either enthalpy or temperature as a primary variable.
+    if isinstance(model, pp.energy_balance.TotalEnergyBalanceEquations):
+        equ_tags += [pp.solvers.DefaultEquationTags.energy_balance]
+    if isinstance(
+        model, pp.compositional_flow.SolutionStrategyExtendedFluidMassAndEnergy
+    ):
+        var_tags += [pp.solvers.VariableTag(name=model.enthalpy_variable)]
+    elif isinstance(model, pp.energy_balance.SolutionStrategyEnergyBalance):
+        var_tags += [pp.solvers.VariableTag(name=model.temperature_variable)]
+
+    # Individual component mass balances.
+    if isinstance(model, pp.compositional_flow.ComponentMassBalanceEquations):
+        equ_tags += [
+            pp.solvers.EquationTag(name=name)
+            for name in model.component_mass_balance_equation_names()
+        ]
+    if isinstance(model, pp.compositional.CompositionalVariables):
+        var_tags += [
+            pp.solvers.VariableTag(name=name)
+            for name in model.overall_fraction_variables
+        ]
+        var_tags += [
+            pp.solvers.VariableTag(name=name)
+            for name in model.tracer_fraction_variables
+        ]
+
+    # Fluxes.
+    for eq_name in model.equation_system.equations.keys():
+        if "_flux" in eq_name:
+            equ_tags.append(pp.solvers.EquationTag(name=eq_name))
+    variable_names = {var.name for var in model.equation_system.variables}
+    for var_name in variable_names:
+        if "_flux" in var_name:
+            var_tags.append(pp.solvers.VariableTag(name=var_name))
+
+    return equ_tags, var_tags
+
+
+@pytest.mark.parametrize(
+    "test_model_class,get_primary_tags",
+    [
+        (TracerFlowModel_3p, _get_primary_equ_and_vars_cf),
+    ],
+)
+@pytest.mark.parametrize(
+    "mdg",
+    [
+        square_with_orthogonal_fractures("cartesian", {"cell_size": 0.25}, [0, 1])[0],
+        cube_with_orthogonal_fractures("cartesian", {"cell_size": 0.25}, [0, 1, 2])[0],
+    ],
+)
+def test_schur_complement_reduction_on_model(
+    mdg: pp.MixedDimensionalGrid,
+    test_model_class: type[pp.PorePyModel],
+    get_primary_tags: Callable[
+        [pp.PorePyModel],
+        tuple[list[pp.solvers.EquationTag], list[pp.solvers.VariableTag]],
+    ],
+):
+    """Compare direct and Schur-complement solutions of a model linear system."""
+
+    # NOTE: Depending on what which model class the tests are performed, the local
+    # geometry mixin and model parameters need adaption in order to overwrite the
+    # geometry and parametrization already contained within the tested model class.
+    # The adaption must be consistent with the mdg's the tests are performed on.
+    class LocalGeometry(pp.PorePyModel):
+        def create_mdg(self) -> None:
+            self.mdg = mdg
+
+        def set_domain(self) -> None:
+            self._domain = nd_cube_domain(
+                mdg.dim_max(), self.units.convert_units(1.0, "m")
+            )
+
+    model_params = {
+        "equilibrium_condition": "dummy",
+        "meshing_arguments": {
+            "cell_size": 0.1,
+        },
+    }
+
+    model_class = add_mixin(LocalGeometry, test_model_class)
+
+    model = model_class(model_params)
+    model.prepare_simulation()
+    primary_equation_tags, primary_variable_tags = get_primary_tags(model)
+    model.equation_system.set_variable_values(
+        np.ones(model.equation_system.num_dofs()), iterate_index=0, time_step_index=0
+    )
+
+    model.before_time_step()
+    model.before_nonlinear_loop()
+    model.before_nonlinear_iteration()
+    linear_system = model.equation_system.assemble()
+
+    direct_solver = pp.solvers.LinearSolverDirect()
+    direct_solution, direct_status = direct_solver.solve_linear_system(linear_system)
+    assert direct_status.is_success()
+
+    schur_solver = pp.solvers.SchurComplementReductionLinearSolver(
+        primary_equation_tags=primary_equation_tags,
+        primary_variable_tags=primary_variable_tags,
+        primary_linear_solver=pp.solvers.LinearSolverDirect(),
+    )
+    schur_solution, schur_status = schur_solver.solve_linear_system(linear_system)
+    assert schur_status.is_success()
+
+    np.testing.assert_allclose(schur_solution, direct_solution, atol=1e-9, rtol=0.0)

--- a/tests/numerics/solvers/linear_solvers/test_schur_complement_reduction.py
+++ b/tests/numerics/solvers/linear_solvers/test_schur_complement_reduction.py
@@ -1,6 +1,7 @@
 """Unit tests for the Schur-complement reduction linear solver."""
 
 from dataclasses import dataclass
+from typing import Callable
 
 import numpy as np
 import pytest
@@ -60,7 +61,7 @@ def linear_system_data() -> LinearSystemData:
     primary_equation = pp.ad.EquationOnDomain("primary", domain)
     secondary_equation_1 = pp.ad.EquationOnDomain("secondary_1", domain)
     equation_indexer = pp.ad.EquationIndexer(
-        equation_dofs={
+        indices={
             secondary_equation_0: np.array([0]),
             primary_equation: np.array([1, 3]),
             secondary_equation_1: np.array([2]),
@@ -71,7 +72,7 @@ def linear_system_data() -> LinearSystemData:
     primary_variable = pp.ad.Variable("primary", {"cells": 1}, domain)
     secondary_variable_1 = pp.ad.Variable("secondary_1", {"cells": 1}, domain)
     variable_indexer = pp.ad.VariableIndexer(
-        variable_dofs={
+        indices={
             secondary_variable_0: np.array([0]),
             primary_variable: np.array([1, 3]),
             secondary_variable_1: np.array([2]),
@@ -201,10 +202,10 @@ def test_solve_reduces_system_and_wraps_primary_status(
     )
     np.testing.assert_allclose(reduced_system.rhs, np.array([19.0, 156.0]) / 11.0)
     assert reduced_system.equation_indexer.projection_indices(
-        list(reduced_system.equation_indexer.equation_dofs)
+        list(reduced_system.equation_indexer.indices)
     ).tolist() == [0, 1]
     assert reduced_system.variable_indexer.projection_indices(
-        list(reduced_system.variable_indexer.variable_dofs)
+        list(reduced_system.variable_indexer.indices)
     ).tolist() == [0, 1]
 
     assert status.primary_solver_status is primary_status
@@ -225,11 +226,11 @@ def test_solve_delegates_when_secondary_block_is_empty(
     primary_solver = MockPrimaryLinearSolver(expected_solution, primary_status)
     equation_tags = [
         pp.solvers.EquationTag(equation.name)
-        for equation in linear_system_data.linear_system.equation_indexer.equation_dofs
+        for equation in linear_system_data.linear_system.equation_indexer.indices
     ]
     variable_tags = [
         pp.solvers.VariableTag(variable.name)
-        for variable in linear_system_data.linear_system.variable_indexer.variable_dofs
+        for variable in linear_system_data.linear_system.variable_indexer.indices
     ]
     solver = pp.solvers.SchurComplementReductionLinearSolver(
         primary_equation_tags=equation_tags,

--- a/tests/numerics/solvers/linear_solvers/test_schur_complement_reduction.py
+++ b/tests/numerics/solvers/linear_solvers/test_schur_complement_reduction.py
@@ -1,7 +1,10 @@
-from typing import Callable
+"""Unit tests for the Schur-complement reduction linear solver."""
+
+from dataclasses import dataclass
 
 import numpy as np
 import pytest
+from scipy.sparse import csr_matrix
 
 import porepy as pp
 from porepy.applications.md_grids.domains import nd_cube_domain
@@ -11,6 +14,211 @@ from porepy.applications.md_grids.mdg_library import (
 )
 from porepy.applications.test_utils.models import add_mixin
 from tests.functional.setups.linear_tracer import TracerFlowModel_3p
+
+
+class MockPrimaryLinearSolver(pp.solvers.LinearSolverBase):
+    """Return a prescribed result and record calls made by the outer solver."""
+
+    def __init__(
+        self,
+        solution: np.ndarray,
+        status: pp.solvers.LinearSolverStatus,
+    ) -> None:
+        self.solution = solution
+        self.status = status
+        self.linear_systems: list[pp.solvers.LinearSystem] = []
+        self.model: object | None = None
+
+    def initialize_with_model(self, model: pp.PorePyModel) -> None:
+        self.model = model
+
+    def solve_linear_system(
+        self, linear_system: pp.solvers.LinearSystem
+    ) -> tuple[np.ndarray, pp.solvers.LinearSolverStatus]:
+        self.linear_systems.append(linear_system)
+        return self.solution.copy(), self.status
+
+
+@dataclass
+class LinearSystemData:
+    """The algebraic system and the tags identifying its primary block."""
+
+    linear_system: pp.solvers.LinearSystem
+    primary_equation_tag: pp.solvers.EquationTag
+    primary_variable_tag: pp.solvers.VariableTag
+
+
+@pytest.fixture
+def linear_system_data() -> LinearSystemData:
+    """Construct a tagged block system without constructing a PorePy model."""
+    domain = pp.CartGrid([1])
+
+    secondary_equation_0 = pp.ad.EquationOnDomain("secondary_0", domain)
+    primary_equation = pp.ad.EquationOnDomain("primary", domain)
+    secondary_equation_1 = pp.ad.EquationOnDomain("secondary_1", domain)
+    equation_indexer = pp.ad.EquationIndexer(
+        equation_dofs={
+            secondary_equation_0: np.array([0]),
+            primary_equation: np.array([1, 3]),
+            secondary_equation_1: np.array([2]),
+        }
+    )
+
+    secondary_variable_0 = pp.ad.Variable("secondary_0", {"cells": 1}, domain)
+    primary_variable = pp.ad.Variable("primary", {"cells": 1}, domain)
+    secondary_variable_1 = pp.ad.Variable("secondary_1", {"cells": 1}, domain)
+    variable_indexer = pp.ad.VariableIndexer(
+        variable_dofs={
+            secondary_variable_0: np.array([0]),
+            primary_variable: np.array([1, 3]),
+            secondary_variable_1: np.array([2]),
+        }
+    )
+
+    matrix = csr_matrix(
+        [
+            [4.0, 2.0, 1.0, 0.0],
+            [1.0, 5.0, 0.0, 2.0],
+            [1.0, 1.0, 3.0, 1.0],
+            [0.0, 2.0, 2.0, 6.0],
+        ]
+    )
+    # This right-hand side is matrix @ [1, -1, 2, 3].
+    rhs = np.array([4.0, 2.0, 9.0, 20.0])
+
+    return LinearSystemData(
+        linear_system=pp.solvers.LinearSystem(
+            matrix=matrix,
+            rhs=rhs,
+            equation_indexer=equation_indexer,
+            variable_indexer=variable_indexer,
+        ),
+        primary_equation_tag=pp.solvers.EquationTag("primary"),
+        primary_variable_tag=pp.solvers.VariableTag("primary"),
+    )
+
+
+def test_default_primary_solver() -> None:
+    """A direct solver is created when no primary solver is supplied."""
+    solver = pp.solvers.SchurComplementReductionLinearSolver(
+        primary_equation_tags=[],
+        primary_variable_tags=[],
+    )
+
+    assert isinstance(solver.primary_linear_solver, pp.solvers.LinearSolverDirect)
+
+
+def test_initialize_with_model_is_forwarded_to_primary_solver() -> None:
+    """Initialization only forwards a shallow model mock to the inner solver."""
+
+    class ShallowMockModel:
+        pass
+
+    primary_solver = MockPrimaryLinearSolver(
+        solution=np.empty(0),
+        status=pp.solvers.LinearSolverStatusSuccess(solve_time=0.0),
+    )
+    solver = pp.solvers.SchurComplementReductionLinearSolver(
+        primary_equation_tags=[],
+        primary_variable_tags=[],
+        primary_linear_solver=primary_solver,
+    )
+    model = ShallowMockModel()
+
+    solver.initialize_with_model(model)  # type: ignore[arg-type]
+
+    assert primary_solver.model is model
+
+
+@pytest.mark.parametrize("primary_solver_succeeds", [True, False])
+def test_solve_reduces_system_and_wraps_primary_status(
+    linear_system_data: LinearSystemData,
+    primary_solver_succeeds: bool,
+) -> None:
+    """The inner solver receives the Schur system and its status is preserved."""
+    if primary_solver_succeeds:
+        primary_status: pp.solvers.LinearSolverStatus = (
+            pp.solvers.LinearSolverStatusSuccess(solve_time=1.0)
+        )
+    else:
+        primary_status = pp.solvers.LinearSolverStatusFailure(reason="mock failure")
+    primary_solver = MockPrimaryLinearSolver(
+        solution=np.array([-1.0, 3.0]),
+        status=primary_status,
+    )
+    solver = pp.solvers.SchurComplementReductionLinearSolver(
+        primary_equation_tags=[linear_system_data.primary_equation_tag],
+        primary_variable_tags=[linear_system_data.primary_variable_tag],
+        primary_linear_solver=primary_solver,
+    )
+
+    solution, status = solver.solve_linear_system(linear_system_data.linear_system)
+
+    np.testing.assert_allclose(solution, [1.0, -1.0, 2.0, 3.0])
+    assert len(primary_solver.linear_systems) == 1
+    reduced_system = primary_solver.linear_systems[0]
+    assert reduced_system.matrix is not None
+    np.testing.assert_allclose(
+        reduced_system.matrix.toarray(),
+        np.array([[50.0, 23.0], [18.0, 58.0]]) / 11.0,
+    )
+    np.testing.assert_allclose(reduced_system.rhs, np.array([19.0, 156.0]) / 11.0)
+    assert reduced_system.equation_indexer.projection_indices(
+        list(reduced_system.equation_indexer.equation_dofs)
+    ).tolist() == [0, 1]
+    assert reduced_system.variable_indexer.projection_indices(
+        list(reduced_system.variable_indexer.variable_dofs)
+    ).tolist() == [0, 1]
+
+    assert status.primary_solver_status is primary_status
+    if primary_solver_succeeds:
+        assert isinstance(status, pp.solvers.SchurComplementReductionStatusSuccess)
+        assert status.solve_time >= 0.0
+    else:
+        assert isinstance(status, pp.solvers.SchurComplementReductionStatusFailure)
+        assert status.reason == "primary linear solver failed"
+
+
+def test_solve_delegates_when_secondary_block_is_empty(
+    linear_system_data: LinearSystemData,
+) -> None:
+    """A fully primary system is passed unchanged to the primary solver."""
+    primary_status = pp.solvers.LinearSolverStatusSuccess(solve_time=1.0)
+    expected_solution = np.array([1.0, -1.0, 2.0, 3.0])
+    primary_solver = MockPrimaryLinearSolver(expected_solution, primary_status)
+    equation_tags = [
+        pp.solvers.EquationTag(equation.name)
+        for equation in linear_system_data.linear_system.equation_indexer.equation_dofs
+    ]
+    variable_tags = [
+        pp.solvers.VariableTag(variable.name)
+        for variable in linear_system_data.linear_system.variable_indexer.variable_dofs
+    ]
+    solver = pp.solvers.SchurComplementReductionLinearSolver(
+        primary_equation_tags=equation_tags,
+        primary_variable_tags=variable_tags,
+        primary_linear_solver=primary_solver,
+    )
+
+    solution, status = solver.solve_linear_system(linear_system_data.linear_system)
+
+    np.testing.assert_array_equal(solution, expected_solution)
+    assert primary_solver.linear_systems == [linear_system_data.linear_system]
+    assert isinstance(status, pp.solvers.SchurComplementReductionStatusSuccess)
+    assert status.primary_solver_status is primary_status
+
+
+def test_solve_requires_matrix(linear_system_data: LinearSystemData) -> None:
+    """A released matrix is rejected before data initialization."""
+    linear_system_data.linear_system.release_matrix_reference()
+    solver = pp.solvers.SchurComplementReductionLinearSolver(
+        primary_equation_tags=[linear_system_data.primary_equation_tag],
+        primary_variable_tags=[linear_system_data.primary_variable_tag],
+    )
+
+    with pytest.raises(AssertionError, match="Matrix should be provided"):
+        solver.solve_linear_system(linear_system_data.linear_system)
+
 
 # ---------------------------------------------------------------------
 # Integration test
@@ -114,26 +322,3 @@ def test_schur_complement_reduction_on_model(
 
     model = model_class(model_params)
     model.prepare_simulation()
-    primary_equation_tags, primary_variable_tags = get_primary_tags(model)
-    model.equation_system.set_variable_values(
-        np.ones(model.equation_system.num_dofs()), iterate_index=0, time_step_index=0
-    )
-
-    model.before_time_step()
-    model.before_nonlinear_loop()
-    model.before_nonlinear_iteration()
-    linear_system = model.equation_system.assemble()
-
-    direct_solver = pp.solvers.LinearSolverDirect()
-    direct_solution, direct_status = direct_solver.solve_linear_system(linear_system)
-    assert direct_status.is_success()
-
-    schur_solver = pp.solvers.SchurComplementReductionLinearSolver(
-        primary_equation_tags=primary_equation_tags,
-        primary_variable_tags=primary_variable_tags,
-        primary_linear_solver=pp.solvers.LinearSolverDirect(),
-    )
-    schur_solution, schur_status = schur_solver.solve_linear_system(linear_system)
-    assert schur_status.is_success()
-
-    np.testing.assert_allclose(schur_solution, direct_solution, atol=1e-9, rtol=0.0)

--- a/tests/numerics/solvers/linear_solvers/test_schur_complement_reduction.py
+++ b/tests/numerics/solvers/linear_solvers/test_schur_complement_reduction.py
@@ -13,6 +13,9 @@ from porepy.applications.md_grids.mdg_library import (
     square_with_orthogonal_fractures,
 )
 from porepy.applications.test_utils.models import add_mixin
+from porepy.numerics.solvers.linear_solvers.schur_complement_reduction import (
+    _filter_by_tags,
+)
 from tests.functional.setups.linear_tracer import TracerFlowModel_3p
 
 
@@ -96,6 +99,17 @@ def linear_system_data() -> LinearSystemData:
         primary_equation_tag=pp.solvers.EquationTag("primary"),
         primary_variable_tag=pp.solvers.VariableTag("primary"),
     )
+
+
+def test_filter_by_tags_handles_duplicate_tags() -> None:
+    """Must raise ValueError if tags lead to duplicated operators."""
+
+    domain = pp.CartGrid([1])
+    variable = pp.ad.Variable("x", {"cells": 1}, domain)
+    tags = [pp.solvers.VariableTag("x"), pp.solvers.VariableTag("x")]
+
+    with pytest.raises(ValueError):
+        _ = _filter_by_tags([variable], tags)
 
 
 def test_default_primary_solver() -> None:

--- a/tests/numerics/solvers/test_linear_solver.py
+++ b/tests/numerics/solvers/test_linear_solver.py
@@ -6,7 +6,11 @@ import numpy as np
 import pytest
 from scipy.sparse import csr_matrix
 
-from porepy.numerics.solvers.linear_solver import LinearSolverDirect, LinearSystem
+from porepy.numerics.ad.indexers import EquationIndexer, VariableIndexer
+from porepy.numerics.solvers.linear_solvers.linear_solver import (
+    LinearSolverDirect,
+    LinearSystem,
+)
 
 
 def make_linear_system(case: Literal["nonsingular", "singular"]) -> LinearSystem:
@@ -37,7 +41,12 @@ def make_linear_system(case: Literal["nonsingular", "singular"]) -> LinearSystem
         rhs = np.array([1, 2, 3], dtype=float)
     else:
         raise ValueError(case)
-    return LinearSystem(matrix=mat, rhs=rhs)
+    return LinearSystem(
+        matrix=mat,
+        rhs=rhs,
+        equation_indexer=EquationIndexer(equation_dofs={}),
+        variable_indexer=VariableIndexer(variable_dofs={}),
+    )
 
 
 @pytest.mark.parametrize("case", ["nonsingular", "singular"])

--- a/tests/numerics/solvers/test_linear_solver.py
+++ b/tests/numerics/solvers/test_linear_solver.py
@@ -44,8 +44,8 @@ def make_linear_system(case: Literal["nonsingular", "singular"]) -> LinearSystem
     return LinearSystem(
         matrix=mat,
         rhs=rhs,
-        equation_indexer=EquationIndexer(equation_dofs={}),
-        variable_indexer=VariableIndexer(variable_dofs={}),
+        equation_indexer=EquationIndexer(indices={}),
+        variable_indexer=VariableIndexer(indices={}),
     )
 
 

--- a/tests/numerics/solvers/test_nonlinear_solvers.py
+++ b/tests/numerics/solvers/test_nonlinear_solvers.py
@@ -121,8 +121,15 @@ class MockEquationSystem:
     def get_variable_values(self, **wkwargs):
         return np.array([1.0])
 
-    def assemble(self, evaluate_jacobian=False):
-        return self.residual
+    def assemble(self, evaluate_jacobian: bool = True, **kwargs):
+        if not evaluate_jacobian:
+            return self.residual
+        return pp.solvers.LinearSystem(
+            matrix=csr_matrix(np.array([[1.0]])),
+            rhs=np.array([1e-11]),
+            equation_indexer=pp.ad.EquationIndexer(equation_dofs={}),
+            variable_indexer=pp.ad.VariableIndexer(variable_dofs={}),
+        )
 
 
 class MockMdg:
@@ -165,7 +172,7 @@ class MockModel:
         self.equation_system.residual = np.array(self.residual_history[0])
         self.residual_history = self.residual_history[1:]
 
-    def after_nonlinear_iteration(self, inc):
+    def after_nonlinear_iteration(self, nonlinear_increment: np.ndarray):
         pass
 
     def after_nonlinear_convergence(self):
@@ -173,9 +180,6 @@ class MockModel:
 
     def after_nonlinear_failure(self):
         self.nonlinear_solver_statistics.save()
-
-    def assemble_linear_system(self) -> pp.solvers.LinearSystem:
-        return pp.solvers.LinearSystem(csr_matrix((0, 0)), np.zeros(shape=()))
 
     def _is_time_dependent(self):
         return False
@@ -709,10 +713,6 @@ def test_summarize_solver_status(
     model = MockModel()
     solver = default_newton_solver()
 
-    # Mock the solver progressbar. Usually it is initialized in
-    # NewtonSolver.before_nonlinear_loop, which is never called in this test.
-    solver.solver_progressbar = DummyProgressBar()
-
     # Minimal mimicking of loop.
     solver_status = _summarize_solver_status(
         ConvergenceStatusCollection({"convergence": convergence_status}),
@@ -729,10 +729,6 @@ def test_before_nonlinear_iteration():
     # Init model and solver.
     model = MockModel(residual_history=[1.0])
     solver = default_newton_solver(nonlinear_increment_history=[2.0])
-
-    # Mock the solver progressbar. Usually it is initialized in
-    # NewtonSolver.before_nonlinear_loop, which is never called in this test.
-    solver.solver_progressbar = DummyProgressBar()
 
     # Check initial iteration index.
     assert solver.iteration_index == 0
@@ -770,10 +766,6 @@ def test_after_nonlinear_iteration(
     # Init model and solver.
     model = MockModel()
     solver = default_newton_solver()
-
-    # Mock the solver progressbar. Usually it is initialized in
-    # NewtonSolver.before_nonlinear_loop, which is never called in this test.
-    solver.solver_progressbar = DummyProgressBar()
 
     # Mock the nonlinear increment and residual for the last iteration.
     model.nonlinear_increment = np.array([inc])

--- a/tests/numerics/solvers/test_nonlinear_solvers.py
+++ b/tests/numerics/solvers/test_nonlinear_solvers.py
@@ -127,8 +127,8 @@ class MockEquationSystem:
         return pp.solvers.LinearSystem(
             matrix=csr_matrix(np.array([[1.0]])),
             rhs=np.array([1e-11]),
-            equation_indexer=pp.ad.EquationIndexer(equation_dofs={}),
-            variable_indexer=pp.ad.VariableIndexer(variable_dofs={}),
+            equation_indexer=pp.ad.EquationIndexer(indices={}),
+            variable_indexer=pp.ad.VariableIndexer(indices={}),
         )
 
 

--- a/tests/time_stepper/test_time_stepper.py
+++ b/tests/time_stepper/test_time_stepper.py
@@ -34,8 +34,8 @@ class MockEquationSystem:
         return pp.solvers.LinearSystem(
             matrix=csr_matrix(np.array([[1.0]])),
             rhs=np.array([1e-11]),
-            equation_indexer=pp.ad.EquationIndexer(equation_dofs={}),
-            variable_indexer=pp.ad.VariableIndexer(variable_dofs={}),
+            equation_indexer=pp.ad.EquationIndexer(indices={}),
+            variable_indexer=pp.ad.VariableIndexer(indices={}),
         )
 
     def get_variable_values(self, iterate_index: int):

--- a/tests/time_stepper/test_time_stepper.py
+++ b/tests/time_stepper/test_time_stepper.py
@@ -27,9 +27,16 @@ from porepy.viz.solver_statistics import (
 class MockEquationSystem:
     """Used internally in MockModel."""
 
-    def assemble(self, evaluate_jacobian: bool):
-        assert evaluate_jacobian == False
-        return np.ones(5)
+    def assemble(self, evaluate_jacobian: bool = True, **kwargs):
+        if not evaluate_jacobian:
+            # Artificially satisfy residual norm convergence criterion.
+            return np.array([1e-11])
+        return pp.solvers.LinearSystem(
+            matrix=csr_matrix(np.array([[1.0]])),
+            rhs=np.array([1e-11]),
+            equation_indexer=pp.ad.EquationIndexer(equation_dofs={}),
+            variable_indexer=pp.ad.VariableIndexer(variable_dofs={}),
+        )
 
     def get_variable_values(self, iterate_index: int):
         assert iterate_index == 0
@@ -78,11 +85,7 @@ class MockModel(PorePyModel):
     def before_nonlinear_iteration(self):
         self.sequence_of_calls.append("before_nonlinear_iteration")
 
-    def assemble_linear_system(self) -> pp.solvers.LinearSystem:
-        self.sequence_of_calls.append("assemble_linear_system")
-        return pp.solvers.LinearSystem(csr_matrix((0, 0)), np.ndarray(shape=0))
-
-    def after_nonlinear_iteration(self, nonlinear_increment):
+    def after_nonlinear_iteration(self, nonlinear_increment: np.ndarray):
         self.sequence_of_calls.append("after_nonlinear_iteration")
 
     def after_nonlinear_convergence(self):
@@ -219,7 +222,6 @@ def test_model_delegate_methods_called(
     ]
     main_loop = [
         "before_nonlinear_iteration",
-        "assemble_linear_system",
         "after_nonlinear_iteration",
     ]
     after_main_loop_success = [
@@ -303,10 +305,6 @@ class DynamicTimeStepTestCaseModel(SinglePhaseFlow):
 
     def _is_nonlinear_problem(self):
         return True
-
-    # Minimizing computational expenses.
-    def assemble_linear_system(self) -> pp.solvers.LinearSystem:
-        return pp.solvers.LinearSystem(csr_matrix((0, 0)), np.ndarray(shape=()))
 
 
 class DynamicNewtonSolver(pp.solvers.NewtonSolver):

--- a/tests/utils/test_matrix_operations.py
+++ b/tests/utils/test_matrix_operations.py
@@ -1005,11 +1005,13 @@ def test_invert_permuted_block_diag_mat_on_mdg(mdg: pp.MixedDimensionalGrid):
     secondaryVarList = ["sf1", "sf2"]
 
     # Extract the secondary block matrix.
-    A_ss, _ = equation_system.assemble(
+    secondary_linear_system = equation_system.assemble(
         equations=secondaryEqList,
         variables=secondaryVarList,
         state=np.zeros(equation_system.num_dofs()),
     )
+    A_ss = secondary_linear_system.matrix
+    assert A_ss is not None
 
     # Invert the non-diagonal block matrix A_ss.
     row_perm, col_perm, block_sizes = (

--- a/tests/utils/test_ui_and_logging.py
+++ b/tests/utils/test_ui_and_logging.py
@@ -11,9 +11,16 @@ mock_logger = logging.getLogger(__name__)
 
 
 class MockEquationSystem:
-    def assemble(self, **kwargs) -> np.ndarray:
-        # Artificially satisfy residual norm convergence criterion.
-        return np.array([1e-11])
+    def assemble(self, evaluate_jacobian: bool = True, **kwargs):
+        if not evaluate_jacobian:
+            # Artificially satisfy residual norm convergence criterion.
+            return np.array([1e-11])
+        return pp.solvers.LinearSystem(
+            matrix=csr_matrix(np.array([[1.0]])),
+            rhs=np.array([1e-11]),
+            equation_indexer=pp.ad.EquationIndexer(equation_dofs={}),
+            variable_indexer=pp.ad.VariableIndexer(variable_dofs={}),
+        )
 
     def get_variable_values(self, **kwargs) -> np.ndarray:
         return np.array([0.0])
@@ -89,9 +96,6 @@ class MockModel:
 
     def after_nonlinear_failure(self):
         pass
-
-    def assemble_linear_system(self) -> pp.solvers.LinearSystem:
-        return pp.solvers.LinearSystem(csr_matrix((0, 0)), np.ones(shape=()))
 
 
 class MockLinearSolver(pp.solvers.LinearSolverBase):

--- a/tests/utils/test_ui_and_logging.py
+++ b/tests/utils/test_ui_and_logging.py
@@ -18,8 +18,8 @@ class MockEquationSystem:
         return pp.solvers.LinearSystem(
             matrix=csr_matrix(np.array([[1.0]])),
             rhs=np.array([1e-11]),
-            equation_indexer=pp.ad.EquationIndexer(equation_dofs={}),
-            variable_indexer=pp.ad.VariableIndexer(variable_dofs={}),
+            equation_indexer=pp.ad.EquationIndexer(indices={}),
+            variable_indexer=pp.ad.VariableIndexer(indices={}),
         )
 
     def get_variable_values(self, **kwargs) -> np.ndarray:

--- a/tests/viz/test_diagnostics_mixin.py
+++ b/tests/viz/test_diagnostics_mixin.py
@@ -33,7 +33,7 @@ def model() -> PoromechanicsWithDiagnostics:
 def test_diagnostics_mixin_basic(_, model: PoromechanicsWithDiagnostics) -> None:
     """Tests basic functionality."""
     diagnostics_data = model.run_diagnostics(
-        model.assemble_linear_system(),
+        model.equation_system.assemble(),
         default_handlers=("max", "cond"),
         grouping=None,
     )
@@ -134,25 +134,13 @@ def test_diagnostics_mixin_restricted_system(
     equations = [equation_name]
     variables = [variable]
 
-    matrix, rhs = model.equation_system.assemble(
+    linear_system = model.equation_system.assemble(
         equations=equations, variables=variables
     )
-    linear_system = pp.solvers.LinearSystem(matrix=matrix, rhs=rhs)
-    equation_indexer, variable_indexer = (
-        model.equation_system.construct_assembled_matrix_indexers(
-            equations=equations, variables=variables
-        )
-    )
 
-    with pytest.raises(ValueError, match="indexers do not describe"):
-        model.run_diagnostics(linear_system, grouping="dense")
-
-    diagnostics_data = model.run_diagnostics(
-        linear_system,
-        grouping="dense",
-        equation_indexer=equation_indexer,
-        variable_indexer=variable_indexer,
-    )
+    diagnostics_data = model.run_diagnostics(linear_system, grouping="dense")
+    matrix = linear_system.matrix
+    assert matrix is not None
 
     assert len(diagnostics_data) == 1
     block_data = diagnostics_data[0, 0]

--- a/tutorials/equations.ipynb
+++ b/tutorials/equations.ipynb
@@ -877,7 +877,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "jacobian, vals = model.equation_system.assemble()"
+    "linear_system = model.equation_system.assemble()\n",
+    "jacobian = linear_system.matrix\n",
+    "vals = linear_system.rhs"
    ]
   },
   {


### PR DESCRIPTION
## Proposed changes

Making Schur complement reduction a standalone linear solver, instead of spreading its logic throughout the equation system and the model.

This PR follows after #1724.

It is a breaking change for those who rely on Schur complement reduction. The new usage example is provided.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [x] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [x] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
