### PR TITLE
Let numpy defer to the Ad operator overloads instead of broadcasting

### DIFF
--- a/src/porepy/numerics/ad/forward_mode.py
+++ b/src/porepy/numerics/ad/forward_mode.py
@@ -73,9 +73,11 @@ class AdArray:
 
     """
 
-    # Numpy defers binary operations to the __r*__ methods below only if this is set
-    # to None; without it, `numpy_array * ad_array` broadcasts into an object array
-    # holding one full AdArray, Jacobian included, per element (#819).
+    # Turn off numpy's ufuncs for this class, to avoid unexpected behavior when
+    # combining with numpy arrays. See
+    # https://numpy.org/neps/nep-0013-ufunc-overrides.html#turning-ufuncs-off for
+    # technical information and GH issue #819 for a description of the problem that can
+    # arise if this is not done.
     __array_ufunc__ = None
 
     def __init__(self, val: np.ndarray, jac: sps.spmatrix) -> None:

--- a/src/porepy/numerics/ad/forward_mode.py
+++ b/src/porepy/numerics/ad/forward_mode.py
@@ -56,10 +56,8 @@ class AdArray:
         be handled and maintained, the scalar must be a float.
       * Numpy arrays are assumed to be 1d and have the same size as the ``AdArray``.
         Numpy arrays can be used for any operation except matrix multiplication.
-        When adding, subtracting or multiplying a numpy array and an AdArray, the
-        AdArray should be placed first, so, DO: AdArray + numpy.array,
-        DO NOT: numpy.array + AdArray. The latter will give erratic behavior, see
-        https://stackoverflow.com/a/6129099.
+        The operand order is irrelevant: both ``AdArray + numpy.array`` and
+        ``numpy.array + AdArray`` give an ``AdArray``.
       * Scipy matrices can only be used for matrix-vector products (the @ operator), and
         then only for left multiplication. While right multiplication could technically
         work, depending on the size of the matrix, this is not the way the Ad framework
@@ -74,6 +72,11 @@ class AdArray:
         jac: The Jacobian matrix of the AdArray, stored as a sparse matrix.
 
     """
+
+    # Numpy defers binary operations to the __r*__ methods below only if this is set
+    # to None; without it, `numpy_array * ad_array` broadcasts into an object array
+    # holding one full AdArray, Jacobian included, per element (#819).
+    __array_ufunc__ = None
 
     def __init__(self, val: np.ndarray, jac: sps.spmatrix) -> None:
         # Consistency checks, to limit the possibilities for errors when combining this

--- a/src/porepy/numerics/ad/operators.py
+++ b/src/porepy/numerics/ad/operators.py
@@ -154,6 +154,11 @@ class Operator:
 
     """
 
+    # Numpy defers binary operations to the __r*__ methods below only if this is set
+    # to None; without it, `numpy_array * operator` broadcasts into an object array
+    # holding one operator tree per element (#819).
+    __array_ufunc__ = None
+
     def __init__(
         self,
         name: Optional[str] = None,
@@ -640,8 +645,9 @@ class Operator:
         """
         # When using the sum operator on a list with a single item, Python will call the
         # addition operator with other == 0. Convert that other to an Ad Scalar with
-        # value 0 to avoid errors in the addition operator.
-        if other == 0:
+        # value 0 to avoid errors in the addition operator. The isinstance check keeps
+        # the comparison from being elementwise for numpy arrays and sparse matrices.
+        if isinstance(other, (int, float)) and other == 0:
             other = Scalar(0)
 
         children = self._parse_other(other)

--- a/src/porepy/numerics/ad/operators.py
+++ b/src/porepy/numerics/ad/operators.py
@@ -645,8 +645,7 @@ class Operator:
         """
         # When using the sum operator on a list with a single item, Python will call the
         # addition operator with other == 0. Convert that other to an Ad Scalar with
-        # value 0 to avoid errors in the addition operator. The isinstance check keeps
-        # the comparison from being elementwise for numpy arrays and sparse matrices.
+        # value 0 to avoid errors in the addition operator.
         if isinstance(other, (int, float)) and other == 0:
             other = Scalar(0)
 

--- a/src/porepy/numerics/ad/operators.py
+++ b/src/porepy/numerics/ad/operators.py
@@ -154,11 +154,6 @@ class Operator:
 
     """
 
-    # Numpy defers binary operations to the __r*__ methods below only if this is set
-    # to None; without it, `numpy_array * operator` broadcasts into an object array
-    # holding one operator tree per element (#819).
-    __array_ufunc__ = None
-
     def __init__(
         self,
         name: Optional[str] = None,

--- a/src/porepy/numerics/linalg/matrix_operations.py
+++ b/src/porepy/numerics/linalg/matrix_operations.py
@@ -514,14 +514,10 @@ class ArraySlicer:
         delayed evaluation to first carry out the slicing (S @ y), and then apply 'A x'
         to the result.
 
-        *However*, this only works if the methods __rmul__ etc. are called in the first
-        place. Fundamental data types in python (int, float) will do so, as will scipy
-        sparse matrices. *Numpy arrays will most likely not do so*. Instead, it will use
-        its own __mul__ method with the ArraySlicer as the right operand, and probably
-        return a numpy array with data type object. Some rules of thumb therefore apply:
-            1. Be careful when using the ArraySlicer in chained operations, in
-               particular with numpy arrays.
-            2. If in doubt, use parantheses.
+        This requires that the methods __rmul__ etc. are called in the first place.
+        Fundamental data types in python (int, float) will do so, as will scipy sparse
+        matrices. Numpy arrays do so only because this class opts out of numpy's
+        operator capture by setting __array_ufunc__ to None.
 
     Parameters:
         domain_indices: Row indices to be selected. If not provided, the dimensions of
@@ -538,6 +534,11 @@ class ArraySlicer:
             is added since the domain indices are 0-offset).
 
     """
+
+    # Numpy defers binary operations to the __r*__ methods below only if this is set
+    # to None; without it, `numpy_array * slicer` broadcasts into an object array
+    # holding one ArraySlicer per element (#819).
+    __array_ufunc__ = None
 
     def __init__(
         self,

--- a/src/porepy/numerics/linalg/matrix_operations.py
+++ b/src/porepy/numerics/linalg/matrix_operations.py
@@ -517,7 +517,9 @@ class ArraySlicer:
         This requires that the methods __rmul__ etc. are called in the first place.
         Fundamental data types in python (int, float) will do so, as will scipy sparse
         matrices. Numpy arrays do so only because this class opts out of numpy's
-        operator capture by setting __array_ufunc__ to None.
+        operator capture by setting __array_ufunc__ to None. To stay safe, it is
+        recommended to be careful when using the ArraySlicer in chanied operations, and
+        if in doubt, use parentheses to enforce the desired order of operations.
 
     Parameters:
         domain_indices: Row indices to be selected. If not provided, the dimensions of

--- a/tests/numerics/ad/test_forward_mode.py
+++ b/tests/numerics/ad/test_forward_mode.py
@@ -363,10 +363,11 @@ def test_logical_operation(
 
 @pytest.mark.parametrize("operator", ["+", "-", "*", "/", "**"])
 def test_numpy_array_as_left_operand(operator: str, create_csr):
-    """A numpy array to the left of an AdArray should give an AdArray (#819).
+    """A numpy array to the left of an AdArray should give an AdArray.
 
-    Without AdArray.__array_ufunc__ = None, numpy broadcasts instead of deferring to
-    __radd__ etc., and returns an object array holding one full AdArray -- values and
+    This tests the disabling of numpy's ufuncs for AdArray, by setting
+    AdArray.__array_ufunc__ = None. By this trick, numpy broadcasts instead of deferring
+    to __radd__ etc., and returns an object array holding one full AdArray -- values and
     Jacobian -- per element.
 
     """
@@ -395,7 +396,10 @@ def test_numpy_array_as_left_operand(operator: str, create_csr):
 
 @pytest.mark.parametrize("logical_op", [">", ">=", "<", "<=", "==", "!="])
 def test_numpy_array_as_left_operand_logical(logical_op: str, create_csr):
-    """Comparisons are numpy ufuncs too, so they are captured the same way (#819)."""
+    """Test disabling of numpy's ufuncs for AdArray when used with logical operators.
+
+    See test test_numpy_array_as_left_operand for details.
+    """
     val = np.array([2.0, 3.0, 4.0])
     ad = AdArray(val, create_csr(np.eye(3)))
     b = np.array([3.0, 3.0, 1.0])

--- a/tests/numerics/ad/test_forward_mode.py
+++ b/tests/numerics/ad/test_forward_mode.py
@@ -359,3 +359,48 @@ def test_logical_operation(
         assert result_ad.shape == result_numpy.shape
         assert result_ad.dtype == result_numpy.dtype
         assert np.all(result_ad == result_numpy)
+
+
+@pytest.mark.parametrize("operator", ["+", "-", "*", "/", "**"])
+def test_numpy_array_as_left_operand(operator: str, create_csr):
+    """A numpy array to the left of an AdArray should give an AdArray (#819).
+
+    Without AdArray.__array_ufunc__ = None, numpy broadcasts instead of deferring to
+    __radd__ etc., and returns an object array holding one full AdArray -- values and
+    Jacobian -- per element.
+
+    """
+    val = np.array([2.0, 3.0, 4.0])
+    jac = create_csr(np.diag([5.0, 6.0, 7.0]))
+    ad = AdArray(val, jac)
+    b = np.array([3.0, 2.0, 5.0])
+
+    res = eval(f"b {operator} ad")
+
+    # d/dx of (b op x), differentiated by hand.
+    derivative = {
+        "+": np.ones_like(val),
+        "-": -np.ones_like(val),
+        "*": b,
+        "/": -b / val**2,
+        "**": b**val * np.log(b),
+    }[operator]
+
+    assert isinstance(res, AdArray)
+    assert np.allclose(res.val, eval(f"b {operator} val"))
+    assert np.allclose(res.jac.toarray(), np.diag(derivative) @ jac.toarray())
+    # One Jacobian, not one per element.
+    assert res.jac.nnz == jac.nnz
+
+
+@pytest.mark.parametrize("logical_op", [">", ">=", "<", "<=", "==", "!="])
+def test_numpy_array_as_left_operand_logical(logical_op: str, create_csr):
+    """Comparisons are numpy ufuncs too, so they are captured the same way (#819)."""
+    val = np.array([2.0, 3.0, 4.0])
+    ad = AdArray(val, create_csr(np.eye(3)))
+    b = np.array([3.0, 3.0, 1.0])
+
+    res = eval(f"b {logical_op} ad")
+
+    assert isinstance(res, np.ndarray) and res.dtype == np.bool_
+    assert np.all(res == eval(f"b {logical_op} val"))

--- a/tests/numerics/ad/test_operators.py
+++ b/tests/numerics/ad/test_operators.py
@@ -1824,39 +1824,3 @@ def test_operator_method_caching():
         assert inherited_model.method_with_list_arg([1, 2]) == 1
     assert inherited_model.method_with_list_arg([3, 4]) == 2
     assert inherited_model.method_with_list_arg([1, 2]) == 1
-
-
-@pytest.mark.parametrize("operand", ["dense", "sparse"])
-@pytest.mark.parametrize("left", [True, False])
-def test_addition_with_numpy_and_sparse_operands(operand: str, left: bool):
-    """Adding a numpy array or a sparse matrix to an operator should work either way.
-
-    The guard that converts a zero ``other`` (which Python passes when summing a
-    single-item list) to a Scalar used to be evaluated elementwise for these types,
-    raising 'truth value of an array is ambiguous'. With the operator to the right,
-    numpy captured the operation altogether (#819).
-
-    """
-    op = pp.ad.DenseArray(np.array([1.0, 2.0, 3.0]))
-    if operand == "dense":
-        other, wrapper = _get_dense_array(False), pp.ad.DenseArray
-    else:
-        other = _get_sparse_array(False, use_csr_matrix=True)
-        wrapper = pp.ad.SparseArray
-
-    res = other + op if left else op + other
-
-    assert isinstance(res, pp.ad.Operator)
-    assert res.operation is _operations.add
-    assert res.children[0] is op
-    assert isinstance(res.children[1], wrapper)
-
-
-def test_sum_of_single_operator():
-    """Python's sum starts from the integer 0, which must still short-circuit to a
-    Scalar rather than being parsed as an operand."""
-    op = pp.ad.DenseArray(np.array([1.0, 2.0, 3.0]))
-    res = sum([op])
-    assert isinstance(res, pp.ad.Operator)
-    assert res.children[0] is op
-    assert isinstance(res.children[1], pp.ad.Scalar)

--- a/tests/numerics/ad/test_operators.py
+++ b/tests/numerics/ad/test_operators.py
@@ -1479,18 +1479,6 @@ def test_arithmetic_operations_on_ad_objects(
         # correctly implemented. For the wrapped case, we need to test that the parsing
         # is okay, thus we do not skip if wrapped is True.
         return
-    if not wrapped and var_1 == "dense" and var_2 == "ad":
-        # This is the case where the first operand is a numpy array. This is a
-        # problematic setting, since numpy's operators (__add__ etc.) will be invoked.
-        # Despite numpy not knowing anything about AdArrays, numpy somehow uses
-        # broadcasting to compute and return a value, but the result is not in any sense
-        # what is to be expected. In forward mode there is nothing we can do about this
-        # (see GH issue #819, tagged as won't fix); the user just has to know that this
-        # should not be done. If the arrays are wrapped, we can circumvent the problem
-        # in parsing by rewriting the expression so that the AdArray's right  operators
-        # (e.g., __radd__) are invoked instead of numpy's left operators. Thus, if
-        # wrapped is True, we do not skip the test.
-        return
 
     def _var_from_string(v, do_wrap: bool):
         if v == "scalar":
@@ -1836,3 +1824,39 @@ def test_operator_method_caching():
         assert inherited_model.method_with_list_arg([1, 2]) == 1
     assert inherited_model.method_with_list_arg([3, 4]) == 2
     assert inherited_model.method_with_list_arg([1, 2]) == 1
+
+
+@pytest.mark.parametrize("operand", ["dense", "sparse"])
+@pytest.mark.parametrize("left", [True, False])
+def test_addition_with_numpy_and_sparse_operands(operand: str, left: bool):
+    """Adding a numpy array or a sparse matrix to an operator should work either way.
+
+    The guard that converts a zero ``other`` (which Python passes when summing a
+    single-item list) to a Scalar used to be evaluated elementwise for these types,
+    raising 'truth value of an array is ambiguous'. With the operator to the right,
+    numpy captured the operation altogether (#819).
+
+    """
+    op = pp.ad.DenseArray(np.array([1.0, 2.0, 3.0]))
+    if operand == "dense":
+        other, wrapper = _get_dense_array(False), pp.ad.DenseArray
+    else:
+        other = _get_sparse_array(False, use_csr_matrix=True)
+        wrapper = pp.ad.SparseArray
+
+    res = other + op if left else op + other
+
+    assert isinstance(res, pp.ad.Operator)
+    assert res.operation is _operations.add
+    assert res.children[0] is op
+    assert isinstance(res.children[1], wrapper)
+
+
+def test_sum_of_single_operator():
+    """Python's sum starts from the integer 0, which must still short-circuit to a
+    Scalar rather than being parsed as an operand."""
+    op = pp.ad.DenseArray(np.array([1.0, 2.0, 3.0]))
+    res = sum([op])
+    assert isinstance(res, pp.ad.Operator)
+    assert res.children[0] is op
+    assert isinstance(res.children[1], pp.ad.Scalar)

--- a/tests/utils/test_matrix_operations.py
+++ b/tests/utils/test_matrix_operations.py
@@ -347,9 +347,6 @@ def test_matrix_slicer_delayed_evaluation_ad_dense_float(
     """Test the application of the ArraySlicer to numpy and AdArrays, as well as scalars
     (floats), with delayed evaluation.
 
-    A numpy array as the leftmost operand only works because ArraySlicer sets
-    __array_ufunc__ to None; without it numpy captures the operation and returns an
-    object array.
     """
     # The actual test is left to a backend function, to avoid code duplication.
     _matrix_slicer_delayed_evaluation_backend(A, other_mode, target_mode, operator)

--- a/tests/utils/test_matrix_operations.py
+++ b/tests/utils/test_matrix_operations.py
@@ -335,21 +335,21 @@ def test_matrix_slicer_delayed_evaluation_sparse(
     _matrix_slicer_delayed_evaluation_backend(A, other_mode, target_mode, operator)
 
 
-@pytest.mark.parametrize("other_mode", ["ad", "float"])
+@pytest.mark.parametrize("other_mode", ["ad", "float", "dense"])
 @pytest.mark.parametrize("target_mode", ["ad", "dense", "float"])
 @pytest.mark.parametrize("operator", ["*", "/", "+", "-", "**"])
 def test_matrix_slicer_delayed_evaluation_ad_dense_float(
     A: sps.spmatrix,
-    other_mode: Literal["ad", "float"],
+    other_mode: Literal["ad", "float", "dense"],
     target_mode: Literal["ad", "dense", "float"],
     operator: Literal["*", "/", "+", "-", "**"],
 ):
     """Test the application of the ArraySlicer to numpy and AdArrays, as well as scalars
     (floats), with delayed evaluation.
 
-    Note that the parametrization of 'other_mode' does not include 'dense' (i.e. a numpy
-    array), since this does not make sense in the context of the ArraySlicer. See the
-    docstring of that class for more information.
+    A numpy array as the leftmost operand only works because ArraySlicer sets
+    __array_ufunc__ to None; without it numpy captures the operation and returns an
+    object array.
     """
     # The actual test is left to a backend function, to avoid code duplication.
     _matrix_slicer_delayed_evaluation_backend(A, other_mode, target_mode, operator)


### PR DESCRIPTION
#819 is tagged `wontfix` — "I am afraid it will never be solved. It is just what it is." — but numpy has a documented opt-out for exactly this case: with `__array_ufunc__ = None` on the class, `ndarray.__mul__` returns `NotImplemented` and Python calls the `__rmul__` that `AdArray`, `Operator` and `ArraySlicer` already implement. Without it, `numpy_array * ad_array` silently returns an object array holding one full `AdArray`, Jacobian included, per element: 4,000,000 stored Jacobian nonzeros instead of 2,000 at n=2000. The comparison operators are ufuncs too, so `numpy_array < ad_array` was captured the same way.

Auditing the rest of the surface turned up a second instance of the same "numpy compares elementwise" problem: the `if other == 0` guard in `Operator.__add__`, which is there to catch the `0` that `sum()` starts from, means `DenseArray + numpy_array` and `DenseArray + sparse_matrix` raise "truth value of an array is ambiguous" today — in the *supported* operand order. It now checks for a scalar before comparing.

Tested: the `dense`/`ad` case that `test_arithmetic_operations_on_ad_objects` skipped with a reference to this issue now passes, as does `other_mode="dense"` in `test_matrix_slicer_delayed_evaluation_ad_dense_float`; plus new tests for the arithmetic, comparison and addition cases. Full suite 3566 passed vs 3524 before, identical set of 45 pre-existing failures (tutorials, `warnings.deprecated` on py3.11); ruff, isort and mypy unchanged. One behaviour change worth flagging: a 0-d numpy array on the left now raises, consistently with `AdArray + np.array(2.0)`, which already did.

Closes #819.
