### PR TITLE
Refactor damage utilities

### DIFF
--- a/src/porepy/applications/test_utils/models.py
+++ b/src/porepy/applications/test_utils/models.py
@@ -313,10 +313,17 @@ def subdomains_or_interfaces_from_method_name(
 _T = TypeVar("_T", bound=pp.PorePyModel)
 
 
-def add_mixin(mixin: type[pp.PorePyModel], parent: type[_T]) -> type[_T]:
+def add_mixin(mixin: type[Any], parent: type[_T]) -> type[_T]:
     """Helper method to dynamically construct a class by adding a mixin.
 
     Multiple mixins can be added by nested calls to this method.
+
+    Typing notes:
+        - ``parent`` is typed as ``type[_T]`` (with ``_T`` bound to
+            :class:`pp.PorePyModel`). The return class is also cast to ``type[_T]`` so
+            callers keep a useful model-class return type.
+        - ``mixin`` is intentionally typed as ``type[Any]`` to allow abstract mixins and
+            protocol-like classes in dynamic class assembly.
 
     Reference:
         https://www.geeksforgeeks.org/create-classes-dynamically-in-python/
@@ -330,7 +337,7 @@ def add_mixin(mixin: type[pp.PorePyModel], parent: type[_T]) -> type[_T]:
     # this as an extra parameter to this function, but at the moment it is unclear why
     # such an addition could not be made in the mixin class instead.
     cls = type(name, (mixin, parent), {})
-    return cls
+    return cast(type[_T], cls)
 
 
 def create_local_model_class(

--- a/src/porepy/examples/example_params.py
+++ b/src/porepy/examples/example_params.py
@@ -138,7 +138,7 @@ solver_params = {
     "global_line_search": 0,  # Set to 1 to use turn on a residual-based line search.
     "residual_line_search_interval_size": 1e-1,
     "residual_line_search_num_steps": 5,
-    "local_line_search": 1,  # Set to 0 to use turn off the tailored line search.
+    "local_line_search": False,  # Set to True to use turn on the tailored line search.
     "relative_constraint_transition_tolerance": 2e-1,
     "constraint_violation_tolerance": 3e-1,
     "min_line_search_weight": 1e-10,

--- a/src/porepy/examples/example_params.py
+++ b/src/porepy/examples/example_params.py
@@ -138,7 +138,7 @@ solver_params = {
     "global_line_search": 0,  # Set to 1 to use turn on a residual-based line search.
     "residual_line_search_interval_size": 1e-1,
     "residual_line_search_num_steps": 5,
-    "local_line_search": False,  # Set to True to use turn on the tailored line search.
+    "local_line_search": False,  # Set to True to turn on the tailored line search.
     "relative_constraint_transition_tolerance": 2e-1,
     "constraint_violation_tolerance": 3e-1,
     "min_line_search_weight": 1e-10,

--- a/src/porepy/examples/fracture_damage.py
+++ b/src/porepy/examples/fracture_damage.py
@@ -516,8 +516,8 @@ def run_example(damages: Sequence[str] = ("dilation",)) -> list[pp.PorePyModel]:
     """Run a selected fracture damage example and return the model.
 
     This thin wrapper is motivated by the contract for testing of examples, namely that
-    the example should return a list of models. For details on the setup, see the
-    function ``run_displacement_controlled_setup``.
+    the example should return a list of models. For details on the setup, see
+    ``create_displacement_controlled_setup``.
 
     Parameters:
         damages: A sequence of strings specifying which damage mechanisms to activate.
@@ -527,39 +527,38 @@ def run_example(damages: Sequence[str] = ("dilation",)) -> list[pp.PorePyModel]:
         A list containing the model(s) used in the simulation. Length of the list equals
         the number of damages specified.
     """
-    _, model = run_displacement_controlled_setup(
+    model_class, params, solver_params = create_displacement_controlled_setup(
         isotropic=True,
         dim=2,
         damages=damages,
     )
+    model = model_class(params)
+    pp.ModelRunner(
+        model,
+        nonlinear_solver=pp.solvers.ConstraintLineSearchNonlinearSolver(solver_params),
+    ).run()
     return [model]
 
 
-def run_displacement_controlled_setup(
+def create_displacement_controlled_setup(
     isotropic: bool,
     dim: int,
     damages: Sequence[str],
-    custom_model_params: dict[str, Any] | None = None,
-    custom_solver_params: dict[str, Any] | None = None,
-) -> tuple[list[Any], pp.PorePyModel]:
-    """Run a time-dependent simulation with displacement-controlled BCs.
+) -> tuple[type[Any], dict[str, Any], dict[str, Any]]:
+    """Create a displacement-controlled fracture damage setup.
 
-    This function provides a lightweight demonstration of running a fracture damage
-    model. The model is the momentum balance model including fracture damage with
-    time-dependent displacement boundary conditions set by the key "north_displacements"
-    in the parameter dictionary.
+    This builder assembles the model class and returns mutable model and solver
+    parameter dictionaries. Callers may update the returned dictionaries before
+    instantiating the model and running the simulation.
 
     Parameters:
         isotropic: If True, use isotropic damage length; otherwise anisotropic.
         dim: Spatial dimension of the bulk domain (2 or 3).
         damages: Damage types to include (subset of {"dilation", "friction"}).
-        custom_model_params: Optional dictionary of model parameters used .
-        custom_solver_params: Optional dictionary of solver parameters overriding the
-            defaults.
 
     Returns:
-        Tuple ``(results, model)`` where ``results`` contains one DamageSaveData
-        instance per forward time step.
+        Tuple ``(model_class, model_params, solver_params)`` with caller-owned mutable
+        objects ready for post-processing before execution.
     """
     params = copy.deepcopy(model_params)
     model_class: type[Any] = FractureDamageMomentumBalance
@@ -578,6 +577,7 @@ def run_displacement_controlled_setup(
         SquareDomainOrthogonalFractures if dim == 2 else CubeDomainOrthogonalFractures
     )
     model_class = add_mixin(geom, model_class)
+
     displacements = north_displacements_3d.copy()
     displacements = displacements[:dim]
     # Keep compression for the first steps and open the fracture in the last one.
@@ -590,12 +590,9 @@ def run_displacement_controlled_setup(
             "north_displacements": displacements,
         }
     )
-
     params["material_constants"] = {
         "solid": FractureDamageSolidConstants(**solid_params.copy()),  # type: ignore[arg-type]
     }
-    if custom_model_params is not None:
-        params.update(custom_model_params)
 
     solver_params = {
         "nl_max_iterations": 30,
@@ -603,15 +600,8 @@ def run_displacement_controlled_setup(
         "nl_convergence_inc_atol": 1e-8,
         "local_line_search": True,
     }
-    if custom_solver_params is not None:
-        solver_params.update(custom_solver_params)
 
-    model = model_class(params)
-    pp.ModelRunner(
-        model,
-        nonlinear_solver=pp.solvers.ConstraintLineSearchNonlinearSolver(solver_params),
-    ).run()
-    return model.results, model
+    return model_class, params, solver_params
 
 
 # If executed as main, run simulation.

--- a/src/porepy/examples/fracture_damage.py
+++ b/src/porepy/examples/fracture_damage.py
@@ -1,6 +1,6 @@
 import copy
 from dataclasses import dataclass
-from typing import Any, Callable, cast
+from typing import Any, Callable, Sequence, cast
 
 import numpy as np
 
@@ -10,6 +10,7 @@ from porepy.applications.boundary_conditions.model_boundary_conditions import (
 )
 from porepy.applications.convergence_analysis import ConvergenceAnalysis
 from porepy.applications.md_grids.model_geometries import (
+    CubeDomainOrthogonalFractures,
     SquareDomainOrthogonalFractures,
 )
 from porepy.applications.test_utils import models
@@ -503,8 +504,6 @@ model_params = {
     # Set the schedule using arange to save data from all time steps.
     "time_manager": pp.TimeManager(np.arange(0, num_time_steps), 1, True),
     "north_displacements": north_displacements_3d,
-    "interface_displacement_parameter_values": north_displacements_3d,
-    # "times_to_export": [],  # Suppress export of data for testing.
     "material_constants": {
         "solid": FractureDamageSolidConstants(**solid_params),  # type: ignore[arg-type]
         "numerical": pp.NumericalConstants(characteristic_displacement=1e-2),
@@ -516,10 +515,9 @@ model_params = {
 def run_example(regimes=["dilation"]) -> list[pp.PorePyModel]:
     """Run a selected fracture damage example and return the model.
 
-    This function provides a lightweight demonstration of running a fracture damage
-    model. The model is the momentum balance model including fracture damage with
-    time-dependent displacement boundary conditions set by the key "north_displacements"
-    in the parameter dictionary.
+    This thin wrapper is motivated by the contract for testing of examples, namely that
+    the example should return a list of models. For details on setup, see the function
+    ``run_displacement_controlled_setup``.
 
     Parameters:
         regimes: A list of strings specifying which damage mechanisms to activate.
@@ -529,57 +527,90 @@ def run_example(regimes=["dilation"]) -> list[pp.PorePyModel]:
         A list containing the model(s) used in the simulation. Length of the list equals
         the number of regimes specified.
     """
+    _, model = run_displacement_controlled_setup(
+        isotropic=True,
+        dim=2,
+        damages=regimes,
+    )
+    return [model]
 
-    models: list[pp.PorePyModel] = []
 
-    dim = 2  # 2D case
-    time_steps = 5
+def run_displacement_controlled_setup(
+    isotropic: bool,
+    dim: int,
+    damages: Sequence[str],
+    custom_model_params: dict[str, Any] | None = None,
+    custom_solver_params: dict[str, Any] | None = None,
+) -> tuple[list[Any], pp.PorePyModel]:
+    """Run a time-dependent simulation with displacement-controlled BCs.
 
+    This function provides a lightweight demonstration of running a fracture damage
+    model. The model is the momentum balance model including fracture damage with
+    time-dependent displacement boundary conditions set by the key "north_displacements"
+    in the parameter dictionary.
+
+    Parameters:
+        isotropic: If True, use isotropic damage length; otherwise anisotropic.
+        dim: Spatial dimension of the bulk domain (2 or 3).
+        damages: Damage types to include (subset of {"dilation", "friction"}).
+        custom_model_params: Optional dictionary of model parameters used .
+        custom_solver_params: Optional dictionary of solver parameters overriding the
+            defaults.
+
+    Returns:
+        Tuple ``(results, model)`` where ``results`` contains one DamageSaveData
+        instance per forward time step.
+    """
     params = copy.deepcopy(model_params)
+    model_class = FractureDamageMomentumBalance
+
+    if isotropic:
+        params["exact_solution"] = ExactSolutionIsotropic
+        model_class = add_mixin(damage.IsotropicFractureDamageLength, model_class)
+    else:
+        params["exact_solution"] = ExactSolutionAnisotropic
+        model_class = add_mixin(damage.AnisotropicFractureDamageLength, model_class)
+
+    for name in damages:
+        model_class = add_mixin(damage_types[name], model_class)
+
+    geom = (
+        SquareDomainOrthogonalFractures if dim == 2 else CubeDomainOrthogonalFractures
+    )
+    model_class = add_mixin(geom, model_class)
+
     params.update(
         {
-            "time_manager": pp.TimeManager(np.arange(0, time_steps), 1, True),
+            "time_manager": pp.TimeManager(np.arange(0.0, 5.0), 1.0, True),
+            "north_displacements": params["north_displacements"][:dim],
         }
     )
 
-    # Build the model class by adding the requested damage mechanisms as mixins to the
-    # momentum balance model and the geometry mixin for the target dimension.
-    class _Model(  # type: ignore[misc]
-        SquareDomainOrthogonalFractures,
-        # Can be replaced by AnisotropicFractureDamageLength if desired:
-        damage.IsotropicFractureDamageLength,
-        FractureDamageMomentumBalance,
-    ):
-        pass
+    # Keep compression for the first steps and open the fracture in the last one.
+    params["north_displacements"][1] = 0.98e-3
+    params["north_displacements"][1, 4] = 3e-3
 
-    for regime in regimes:
-        model_class = add_mixin(
-            damage_types[regime],  # type: ignore[type-abstract]
-            _Model,  # type: ignore[type-abstract]
-        )
-
-    # Parameter setup for the momentum balance model.
-    params["exact_solution"] = ExactSolutionIsotropic
-    # Only pass active dimensions.
-    active_dimensions = params["north_displacements"][:dim]  # type: ignore[index]
-    params["north_displacements"] = active_dimensions
-
-    model = model_class(params)  # type: ignore[abstract]
-    # In some cases, the momentum balance model cannot converge with the default solver
-    # settings. A relaxed nonlinear solver setting is used for the executable example.
-    solver_params = {
-        "nl_convergence_inc_atol": 1e-6,
-        "nl_convergence_res_atol": 1e-6,
-        "nl_max_iterations": 35,
-        "nonlinear_solver": pp.solvers.ConstraintLineSearchNonlinearSolver,
-        "local_line_search": True,
-        "constraint_violation_tolerance": 1e-5,
+    params["material_constants"] = {
+        "solid": FractureDamageSolidConstants(**solid_params.copy()),  # type: ignore[arg-type]
     }
-    pp.ModelRunner(model, solver_params).run()
+    if custom_model_params is not None:
+        params.update(custom_model_params)
 
-    models.append(model)
+    solver_params = {
+        "nl_max_iterations": 30,
+        "nl_convergence_res_atol": 1e-8,
+        "nl_convergence_inc_atol": 1e-8,
+        "local_line_search": True,
+    }
+    if custom_solver_params is not None:
+        solver_params.update(custom_solver_params)
 
-    return models
+    model = model_class(params)
+    pp.ModelRunner(
+        model,
+        nonlinear_solver=pp.solvers.ConstraintLineSearchNonlinearSolver(solver_params),
+    ).run()
+    return model.results, model
 
 
 # If executed as main, run simulation.

--- a/src/porepy/examples/fracture_damage.py
+++ b/src/porepy/examples/fracture_damage.py
@@ -578,17 +578,18 @@ def run_displacement_controlled_setup(
         SquareDomainOrthogonalFractures if dim == 2 else CubeDomainOrthogonalFractures
     )
     model_class = add_mixin(geom, model_class)
+    displacements = north_displacements_3d.copy()
+    displacements = displacements[:dim]
+    # Keep compression for the first steps and open the fracture in the last one.
+    displacements[1] = 0.98e-3
+    displacements[1, 4] = 3e-3
 
     params.update(
         {
             "time_manager": pp.TimeManager(np.arange(0.0, 5.0), 1.0, True),
-            "north_displacements": params["north_displacements"][:dim],
+            "north_displacements": displacements,
         }
     )
-
-    # Keep compression for the first steps and open the fracture in the last one.
-    params["north_displacements"][1] = 0.98e-3
-    params["north_displacements"][1, 4] = 3e-3
 
     params["material_constants"] = {
         "solid": FractureDamageSolidConstants(**solid_params.copy()),  # type: ignore[arg-type]

--- a/src/porepy/examples/fracture_damage.py
+++ b/src/porepy/examples/fracture_damage.py
@@ -562,7 +562,7 @@ def run_displacement_controlled_setup(
         instance per forward time step.
     """
     params = copy.deepcopy(model_params)
-    model_class = FractureDamageMomentumBalance
+    model_class: type[Any] = FractureDamageMomentumBalance
 
     if isotropic:
         params["exact_solution"] = ExactSolutionIsotropic

--- a/src/porepy/examples/fracture_damage.py
+++ b/src/porepy/examples/fracture_damage.py
@@ -512,7 +512,7 @@ model_params = {
 }
 
 
-def run_example(regimes=["dilation"]) -> list[pp.PorePyModel]:
+def run_example(damages: Sequence[str] = ("dilation",)) -> list[pp.PorePyModel]:
     """Run a selected fracture damage example and return the model.
 
     This thin wrapper is motivated by the contract for testing of examples, namely that
@@ -520,17 +520,17 @@ def run_example(regimes=["dilation"]) -> list[pp.PorePyModel]:
     ``run_displacement_controlled_setup``.
 
     Parameters:
-        regimes: A list of strings specifying which damage mechanisms to activate.
-            Options are "dilation", "friction", or both. Defaults to ["dilation"].
+        damages: A sequence of strings specifying which damage mechanisms to activate.
+            Options are "dilation", "friction", or both. Defaults to ("dilation",).
 
     Returns:
         A list containing the model(s) used in the simulation. Length of the list equals
-        the number of regimes specified.
+        the number of damages specified.
     """
     _, model = run_displacement_controlled_setup(
         isotropic=True,
         dim=2,
-        damages=regimes,
+        damages=damages,
     )
     return [model]
 

--- a/src/porepy/examples/fracture_damage.py
+++ b/src/porepy/examples/fracture_damage.py
@@ -516,8 +516,8 @@ def run_example(damages: Sequence[str] = ("dilation",)) -> list[pp.PorePyModel]:
     """Run a selected fracture damage example and return the model.
 
     This thin wrapper is motivated by the contract for testing of examples, namely that
-    the example should return a list of models. For details on setup, see the function
-    ``run_displacement_controlled_setup``.
+    the example should return a list of models. For details on the setup, see the
+    function ``run_displacement_controlled_setup``.
 
     Parameters:
         damages: A sequence of strings specifying which damage mechanisms to activate.

--- a/tests/models/test_fracture_damage.py
+++ b/tests/models/test_fracture_damage.py
@@ -11,7 +11,7 @@ from typing import Sequence, cast
 import numpy as np
 import pytest
 
-import porepy as pp
+from porepy.compositional.materials import FractureDamageSolidConstants
 from porepy.examples import fracture_damage as damage_example
 
 
@@ -50,7 +50,7 @@ def _assert_increment_damage_length_zero(length_1: np.ndarray, step: int) -> Non
 # dilation damage with zero dilation angle is mathematically well-defined.
 _solid_paramms = damage_example.solid_params.copy()
 _solid_paramms.update({"dilation_angle": 0.0})
-material_constants = {"solid": pp.FractureDamageSolidConstants(**_solid_paramms)}  # type: ignore[arg-type]
+material_constants = {"solid": FractureDamageSolidConstants(**_solid_paramms)}  # type: ignore[arg-type]
 
 
 @pytest.mark.parametrize("dim", [2, 3])

--- a/tests/models/test_fracture_damage.py
+++ b/tests/models/test_fracture_damage.py
@@ -10,8 +10,8 @@ from typing import Sequence, cast
 
 import numpy as np
 import pytest
-import porepy as pp
 
+import porepy as pp
 from porepy.examples import fracture_damage as damage_example
 
 

--- a/tests/models/test_fracture_damage.py
+++ b/tests/models/test_fracture_damage.py
@@ -73,6 +73,7 @@ def run_displacement_controlled_setup(
             damages=damages,
         )
     )
+    # Copy to avoid messing with entries of the custom paramameters.
     if custom_model_params is not None:
         params.update(copy.deepcopy(custom_model_params))
     if custom_solver_params is not None:

--- a/tests/models/test_fracture_damage.py
+++ b/tests/models/test_fracture_damage.py
@@ -10,6 +10,7 @@ from typing import Sequence, cast
 
 import numpy as np
 import pytest
+import porepy as pp
 
 from porepy.examples import fracture_damage as damage_example
 

--- a/tests/models/test_fracture_damage.py
+++ b/tests/models/test_fracture_damage.py
@@ -6,101 +6,12 @@ response to load reversal, and expected damage lengths. Tests are marked skipped
 to their runtime (~1 min each) and are intended as a complement to the unit tests.
 """
 
-import copy
 from typing import Sequence, cast
 
 import numpy as np
 import pytest
 
-import porepy as pp
-from porepy.applications.md_grids.model_geometries import (
-    CubeDomainOrthogonalFractures,
-    SquareDomainOrthogonalFractures,
-)
-from porepy.applications.test_utils.models import add_mixin
-from porepy.compositional.materials import FractureDamageSolidConstants
-from porepy.examples import fracture_damage as damage_examples
-from porepy.models import fracture_damage as damage_models
-from porepy.numerics.solvers.line_search import ConstraintLineSearchNonlinearSolver
-
-
-def run_displacement_controlled_setup(
-    isotropic: bool,
-    dim: int,
-    damages: Sequence[str],
-):
-    """Run a time-dependent simulation with displacement-controlled BCs.
-
-    Parameters:
-        isotropic: If True, use isotropic damage length; otherwise anisotropic.
-        dim: Spatial dimension of the bulk domain (2 or 3).
-        damages: Iterable of damage types to include (subset of
-            {"dilation", "friction"}).
-
-    Returns:
-        A list of VerificationDataSaving instances containing results for each time
-        step.
-    """
-    params = copy.deepcopy(damage_examples.model_params)
-    model_class = damage_examples.FractureDamageMomentumBalance
-
-    # Choose damage length (isotropic vs anisotropic) and exact solution.
-    if isotropic:
-        params["exact_solution"] = damage_examples.ExactSolutionIsotropic
-        model_class = add_mixin(
-            damage_models.IsotropicFractureDamageLength, model_class
-        )
-    else:
-        params["exact_solution"] = damage_examples.ExactSolutionAnisotropic
-        model_class = add_mixin(
-            damage_models.AnisotropicFractureDamageLength, model_class
-        )
-
-    # Add requested damage equations and variables.
-    for name in damages:
-        model_class = add_mixin(damage_examples.damage_types[name], model_class)
-
-    # Add geometry mixin for the target dimension.
-    geom = (
-        SquareDomainOrthogonalFractures if dim == 2 else CubeDomainOrthogonalFractures
-    )
-    model_class = add_mixin(geom, model_class)
-
-    # 5 time instants => 4 forward steps.
-    params.update(
-        {
-            "time_manager": pp.TimeManager(np.arange(0, 5), 1, True),
-            "north_displacements": params["north_displacements"][:dim],
-        }
-    )
-    params["material_constants"] = {
-        "solid": FractureDamageSolidConstants(**damage_examples.solid_params),  # type: ignore[arg-type]
-    }
-    solver_params = {
-        "nl_max_iterations": 50,  # Hard nonlinear problems - expect slow convergence
-        "nl_convergence_res_atol": 1e-8,
-        "nl_convergence_inc_atol": 1e-8,
-        "nonlinear_solver": ConstraintLineSearchNonlinearSolver,
-        "local_line_search": True,
-    }
-
-    # Set y component somewhat smaller than (fracture gap + maximum elastic opening).
-    # This results in compression and sensible tractions.
-    params["north_displacements"][1] = 0.98e-3
-    # Modify north displacement BC to get open fracture (=> no additional damage) in
-    # 4th time increment.
-    params["north_displacements"][1, 4] = 3e-3
-    # Turn off shear dilation to better control the test. Although physically
-    # nonsensical, dilation damage with zero dilation angle is mathematically
-    # well-defined.
-    solid_params = damage_examples.solid_params.copy()
-    solid_params["dilation_angle"] = 0.0
-    # Similarly, simplify problem by removing elastic normal deformation.
-    params["material_constants"]["solid"] = FractureDamageSolidConstants(**solid_params)  # type: ignore[arg-type]
-    m = model_class(params)
-    pp.ModelRunner(m, solver_params).run()
-
-    return m.results, m
+from porepy.examples import fracture_damage as damage_example
 
 
 def _assert_damage_values_equal_between_steps(
@@ -134,6 +45,13 @@ def _assert_increment_damage_length_zero(length_1: np.ndarray, step: int) -> Non
     )
 
 
+# Turn off shear dilation to better control the test. Although physically nonsensical,
+# dilation damage with zero dilation angle is mathematically well-defined.
+_solid_paramms = damage_example.solid_params.copy()
+_solid_paramms.update({"dilation_angle": 0.0})
+material_constants = {"solid": pp.FractureDamageSolidConstants(**_solid_paramms)}  # type: ignore[arg-type]
+
+
 @pytest.mark.parametrize("dim", [2, 3])
 def test_isotropic_damage(dim: int):
     """Run one time step with both dilation and friction and verify against physically
@@ -156,7 +74,15 @@ def test_isotropic_damage(dim: int):
     """
     damages = ["dilation", "friction"]
     # Model instance may be useful for debugging.
-    vals, model = run_displacement_controlled_setup(True, dim, damages)
+    vals, model = damage_example.run_displacement_controlled_setup(
+        True,
+        dim,
+        damages,
+        custom_model_params={
+            "material_constants": material_constants,
+            "times_to_export": [],  # Suppress export of data for testing.
+        },
+    )
     # Note on counting time steps: The initial time step is not included in the results.
     # Thus, vals[0] corresponds to t=1 in the time manager, and vals[1]-vals[0] is
     # referred to as "first increment" below.
@@ -249,8 +175,17 @@ def test_anisotropic_damage(dim: int):
         AssertionError: If the results do not match the exact solution.
     """
     damages = ["dilation", "friction"]
+
     # Model instance may be useful for debugging.
-    vals, model = run_displacement_controlled_setup(False, dim, damages)
+    vals, model = damage_example.run_displacement_controlled_setup(
+        False,
+        dim,
+        damages,
+        custom_model_params={
+            "material_constants": material_constants,
+            "times_to_export": [],
+        },  # Suppress export of data for testing.
+    )
     # Note on counting time steps: The initial time step is not included in the results.
     # Thus, vals[0] corresponds to t=1 in the time manager, and vals[1]-vals[0] is
     # referred to as "first increment" below.

--- a/tests/models/test_fracture_damage.py
+++ b/tests/models/test_fracture_damage.py
@@ -6,11 +6,13 @@ response to load reversal, and expected damage lengths. Tests are marked skipped
 to their runtime (~1 min each) and are intended as a complement to the unit tests.
 """
 
-from typing import Sequence, cast
+import copy
+from typing import Any, Sequence, cast
 
 import numpy as np
 import pytest
 
+import porepy as pp
 from porepy.compositional.materials import FractureDamageSolidConstants
 from porepy.examples import fracture_damage as damage_example
 
@@ -53,6 +55,37 @@ _solid_paramms.update({"dilation_angle": 0.0})
 material_constants = {"solid": FractureDamageSolidConstants(**_solid_paramms)}  # type: ignore[arg-type]
 
 
+def run_displacement_controlled_setup(
+    isotropic: bool,
+    dim: int,
+    damages: Sequence[str],
+    custom_model_params: dict[str, object] | None = None,
+    custom_solver_params: dict[str, object] | None = None,
+) -> tuple[list[Any], Any]:
+    """Build and run the fracture damage setup used in these integration tests.
+
+    Any custom parameters are used to update the default model or solver parameters.
+    """
+    model_class, params, solver_params = (
+        damage_example.create_displacement_controlled_setup(
+            isotropic=isotropic,
+            dim=dim,
+            damages=damages,
+        )
+    )
+    if custom_model_params is not None:
+        params.update(copy.deepcopy(custom_model_params))
+    if custom_solver_params is not None:
+        solver_params.update(copy.deepcopy(custom_solver_params))
+
+    model = model_class(params)
+    pp.ModelRunner(
+        model,
+        nonlinear_solver=pp.solvers.ConstraintLineSearchNonlinearSolver(solver_params),
+    ).run()
+    return model.results, model
+
+
 @pytest.mark.parametrize("dim", [2, 3])
 def test_isotropic_damage(dim: int):
     """Run one time step with both dilation and friction and verify against physically
@@ -75,7 +108,7 @@ def test_isotropic_damage(dim: int):
     """
     damages = ["dilation", "friction"]
     # Model instance may be useful for debugging.
-    vals, model = damage_example.run_displacement_controlled_setup(
+    vals, model = run_displacement_controlled_setup(
         True,
         dim,
         damages,
@@ -178,7 +211,7 @@ def test_anisotropic_damage(dim: int):
     damages = ["dilation", "friction"]
 
     # Model instance may be useful for debugging.
-    vals, model = damage_example.run_displacement_controlled_setup(
+    vals, model = run_displacement_controlled_setup(
         False,
         dim,
         damages,

--- a/tests/models/test_fracture_damage.py
+++ b/tests/models/test_fracture_damage.py
@@ -135,8 +135,6 @@ def _assert_increment_damage_length_zero(length_1: np.ndarray, step: int) -> Non
 
 
 @pytest.mark.parametrize("dim", [2, 3])
-# The tests take about a minute and are not critical, rather a supplement to test_damage
-@pytest.mark.skipped  # reason: slow
 def test_isotropic_damage(dim: int):
     """Run one time step with both dilation and friction and verify against physically
     sensible/intuitive expectations.
@@ -231,8 +229,6 @@ def test_isotropic_damage(dim: int):
 
 
 @pytest.mark.parametrize("dim", [2, 3])
-# The tests take about a minute and are not critical, rather a supplement to test_damage
-@pytest.mark.skipped  # reason: slow
 def test_anisotropic_damage(dim: int):
     """Run one time step with both dilation and friction and verify against physically
     sensible/intuitive expectations.

--- a/tests/models/test_fracture_damage_properties.py
+++ b/tests/models/test_fracture_damage_properties.py
@@ -25,20 +25,14 @@ could be placed in test_fracture_damage.py. Kept here until review for a less cl
 test_fracture_damage.py.
 """
 
-import copy
 from typing import Sequence, cast
 
 import numpy as np
 import pytest
 
 import porepy as pp
-from porepy.applications.md_grids.model_geometries import (
-    SquareDomainOrthogonalFractures,
-)
-from porepy.applications.test_utils.models import add_mixin
 from porepy.compositional.materials import FractureDamageSolidConstants
 from porepy.examples import fracture_damage as damage_example
-from porepy.models import fracture_damage as damage_models
 from porepy.numerics.solvers.line_search import ConstraintLineSearchNonlinearSolver
 
 # ---------------------------------------------------------------------------
@@ -104,7 +98,11 @@ def build_and_run(
 
     num_time_steps = north_displacements.shape[1]
 
-    params = copy.deepcopy(damage_example.model_params)
+    model_class, params, _ = damage_example.create_displacement_controlled_setup(
+        isotropic=isotropic,
+        dim=2,
+        damages=damages,
+    )
     params["north_displacements"] = north_displacements
     params["time_manager"] = pp.TimeManager(np.arange(0, num_time_steps), 1, True)
     params["material_constants"] = {
@@ -117,18 +115,6 @@ def build_and_run(
         if isotropic
         else damage_example.ExactSolutionAnisotropic
     )
-
-    # Assemble model class.
-    model_class = damage_example.FractureDamageMomentumBalance
-    length_mixin = (
-        damage_models.IsotropicFractureDamageLength
-        if isotropic
-        else damage_models.AnisotropicFractureDamageLength
-    )
-    model_class = add_mixin(length_mixin, model_class)
-    for name in damages:
-        model_class = add_mixin(damage_example.damage_types[name], model_class)
-    model_class = add_mixin(SquareDomainOrthogonalFractures, model_class)
 
     model = model_class(params)
     pp.ModelRunner(model, _solver_params()).run()

--- a/tests/models/test_fracture_damage_properties.py
+++ b/tests/models/test_fracture_damage_properties.py
@@ -37,7 +37,7 @@ from porepy.applications.md_grids.model_geometries import (
 )
 from porepy.applications.test_utils.models import add_mixin
 from porepy.compositional.materials import FractureDamageSolidConstants
-from porepy.examples import fracture_damage as damage_examples
+from porepy.examples import fracture_damage as damage_example
 from porepy.models import fracture_damage as damage_models
 from porepy.numerics.solvers.line_search import ConstraintLineSearchNonlinearSolver
 
@@ -63,7 +63,7 @@ def _solid_params(dilation_angle: float = 0.0) -> dict:
     the example defaults) means that fracture slip approximately equals the applied BC
     displacement, making the expected behaviour easy to reason about.
     """
-    p = damage_examples.solid_params.copy()
+    p = damage_example.solid_params.copy()
     p["dilation_angle"] = dilation_angle
     return p
 
@@ -104,7 +104,7 @@ def build_and_run(
 
     num_time_steps = north_displacements.shape[1]
 
-    params = copy.deepcopy(damage_examples.model_params)
+    params = copy.deepcopy(damage_example.model_params)
     params["north_displacements"] = north_displacements
     params["time_manager"] = pp.TimeManager(np.arange(0, num_time_steps), 1, True)
     params["material_constants"] = {
@@ -113,13 +113,13 @@ def build_and_run(
     # The exact_solution key is required by DamageDataSaving.  We set it here so
     # collect_data does not raise, but the tests only inspect approx_* values.
     params["exact_solution"] = (
-        damage_examples.ExactSolutionIsotropic
+        damage_example.ExactSolutionIsotropic
         if isotropic
-        else damage_examples.ExactSolutionAnisotropic
+        else damage_example.ExactSolutionAnisotropic
     )
 
     # Assemble model class.
-    model_class = damage_examples.FractureDamageMomentumBalance
+    model_class = damage_example.FractureDamageMomentumBalance
     length_mixin = (
         damage_models.IsotropicFractureDamageLength
         if isotropic
@@ -127,7 +127,7 @@ def build_and_run(
     )
     model_class = add_mixin(length_mixin, model_class)
     for name in damages:
-        model_class = add_mixin(damage_examples.damage_types[name], model_class)
+        model_class = add_mixin(damage_example.damage_types[name], model_class)
     model_class = add_mixin(SquareDomainOrthogonalFractures, model_class)
 
     model = model_class(params)

--- a/tests/models/test_fracture_damage_unit.py
+++ b/tests/models/test_fracture_damage_unit.py
@@ -44,7 +44,7 @@ from porepy.applications.md_grids.model_geometries import (
 )
 from porepy.applications.test_utils.models import add_mixin
 from porepy.compositional.materials import FractureDamageSolidConstants
-from porepy.examples import fracture_damage as damage_examples
+from porepy.examples import fracture_damage as damage_example
 from porepy.models import fracture_damage as damage_models
 
 # ---------------------------------------------------------------------------
@@ -79,20 +79,20 @@ def _prepared_model(
     if damages is None:
         damages = ["dilation", "friction"]
 
-    params = copy.deepcopy(damage_examples.model_params)
+    params = copy.deepcopy(damage_example.model_params)
     # Zero displacement BCs: shape (dim, 2) — dim components × 2 time steps.
     params["north_displacements"] = np.zeros((dim, 2))
     params["time_manager"] = pp.TimeManager([0, 1], 1, True)
     params["material_constants"] = {
-        "solid": FractureDamageSolidConstants(**damage_examples.solid_params),
+        "solid": FractureDamageSolidConstants(**damage_example.solid_params),
     }
     params["exact_solution"] = (
-        damage_examples.ExactSolutionIsotropic
+        damage_example.ExactSolutionIsotropic
         if isotropic
-        else damage_examples.ExactSolutionAnisotropic
+        else damage_example.ExactSolutionAnisotropic
     )
 
-    model_class = damage_examples.FractureDamageMomentumBalance
+    model_class = damage_example.FractureDamageMomentumBalance
     length_mixin = (
         damage_models.IsotropicFractureDamageLength
         if isotropic
@@ -100,7 +100,7 @@ def _prepared_model(
     )
     model_class = add_mixin(length_mixin, model_class)
     for name in damages:
-        model_class = add_mixin(damage_examples.damage_types[name], model_class)
+        model_class = add_mixin(damage_example.damage_types[name], model_class)
     geom = (
         SquareDomainOrthogonalFractures if dim == 2 else CubeDomainOrthogonalFractures
     )

--- a/tests/models/test_fracture_damage_unit.py
+++ b/tests/models/test_fracture_damage_unit.py
@@ -32,20 +32,13 @@ operator, which is defined in the momentum models.fracture_damage.
 
 """
 
-import copy
+from typing import Any
 
 import numpy as np
 import pytest
 
 import porepy as pp
-from porepy.applications.md_grids.model_geometries import (
-    CubeDomainOrthogonalFractures,
-    SquareDomainOrthogonalFractures,
-)
-from porepy.applications.test_utils.models import add_mixin
-from porepy.compositional.materials import FractureDamageSolidConstants
 from porepy.examples import fracture_damage as damage_example
-from porepy.models import fracture_damage as damage_models
 
 # ---------------------------------------------------------------------------
 # Internal helpers
@@ -56,7 +49,7 @@ def _prepared_model(
     isotropic: bool = True,
     damages: list[str] | None = None,
     dim: int = 2,
-) -> object:
+) -> Any:
     """Build and prepare (but not run) a fracture damage model.
 
     ``prepare_simulation`` is called so that the equation system, all variables, and the
@@ -79,32 +72,19 @@ def _prepared_model(
     if damages is None:
         damages = ["dilation", "friction"]
 
-    params = copy.deepcopy(damage_example.model_params)
+    model_class, params, _ = damage_example.create_displacement_controlled_setup(
+        isotropic=isotropic,
+        damages=damages,
+        dim=dim,
+    )
     # Zero displacement BCs: shape (dim, 2) — dim components × 2 time steps.
     params["north_displacements"] = np.zeros((dim, 2))
     params["time_manager"] = pp.TimeManager([0, 1], 1, True)
-    params["material_constants"] = {
-        "solid": FractureDamageSolidConstants(**damage_example.solid_params),
-    }
     params["exact_solution"] = (
         damage_example.ExactSolutionIsotropic
         if isotropic
         else damage_example.ExactSolutionAnisotropic
     )
-
-    model_class = damage_example.FractureDamageMomentumBalance
-    length_mixin = (
-        damage_models.IsotropicFractureDamageLength
-        if isotropic
-        else damage_models.AnisotropicFractureDamageLength
-    )
-    model_class = add_mixin(length_mixin, model_class)
-    for name in damages:
-        model_class = add_mixin(damage_example.damage_types[name], model_class)
-    geom = (
-        SquareDomainOrthogonalFractures if dim == 2 else CubeDomainOrthogonalFractures
-    )
-    model_class = add_mixin(geom, model_class)
 
     model = model_class(params)
     model.prepare_simulation()
@@ -129,7 +109,7 @@ class TestDamageStateFormula:
         isotropic: bool = True,
         damages: list[str] | None = None,
         dim: int = 2,
-    ) -> tuple[object, list[pp.Grid], int]:
+    ) -> tuple[Any, list[pp.Grid], int]:
         """Return a prepared model together with fracture subdomains and cell count."""
         model = _prepared_model(isotropic=isotropic, damages=damages, dim=dim)
         fractures = model.mdg.subdomains(dim=model.nd - 1)


### PR DESCRIPTION
## Proposed changes

Refactors functions for defining and running simple fracture damage setup as used in tests and examples. Reduces line count somewhat while increasing reuse potential outside core. Also tiny out-of-scope fixes for typing of add_mixin and in example_params (more aligned with actual default).
The un-skipped tests were revealed to actually be very fast.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [x] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

