### PR TITLE
Remove redundant solver_status_history from solver statistics

### DIFF
--- a/src/porepy/viz/solver_statistics.py
+++ b/src/porepy/viz/solver_statistics.py
@@ -68,10 +68,6 @@ class SolverStatistics:
         )
     )
     """Nonlinear solver status."""
-    solver_status_history: list[solvers.NonlinearSolverStatus] = field(
-        default_factory=list
-    )
-    """Nonlinear solver status history."""
     simulation_status: TimeStepperStatus = field(
         default_factory=lambda: TimeStepperStatusContinueIterating(
             attempt=-1,
@@ -145,7 +141,6 @@ class SolverStatistics:
         """
         if solver_status is not None:
             self.solver_status = solver_status
-            self.solver_status_history.append(self.solver_status)
 
     def log_custom_data(self, append: bool = False, **kwargs) -> None:
         """Log custom data to be added to the statistics object with custom keys.
@@ -336,7 +331,6 @@ class NonlinearSolverStatistics(SolverStatistics):
         self.num_iterations = 0
         self.convergence_status.clear()
         self.convergence_info.clear()
-        self.solver_status_history.clear()
 
     def log_convergence_status(
         self, convergence_status: solvers.ConvergenceStatusCollection, **kwargs
@@ -414,15 +408,6 @@ class NonlinearSolverStatistics(SolverStatistics):
     def append_iterative_data(self, data: dict[str, dict]) -> dict[str, dict]:
         """Append the current statistics to the data dictionary at current index."""
 
-        str_solver_status_history = [
-            status.serialize() for status in self.solver_status_history
-        ]
-        str_solver_status = (
-            None
-            if len(self.solver_status_history) == 0
-            else str_solver_status_history[-1]
-        )
-
         data = super().append_iterative_data(data)
         data[str(self.index)].update(
             {
@@ -432,8 +417,7 @@ class NonlinearSolverStatistics(SolverStatistics):
                     if len(self.simulation_status_history) == 0
                     else self.simulation_status_history[-1].serialize()
                 ),
-                "solver_status_history": str_solver_status_history,
-                "solver_status": str_solver_status,
+                "solver_status": self.solver_status.serialize(),
                 "convergence_status": self.convergence_status.to_str().copy(),
                 "convergence_info": self.convergence_info.copy(),
             }

--- a/src/porepy/viz/solver_statistics.py
+++ b/src/porepy/viz/solver_statistics.py
@@ -243,6 +243,10 @@ class SolverStatistics:
         if self.index == -1:
             return data
 
+        # Initialize global entry if non-existing.
+        if "global" not in data:
+            data["global"] = {}
+
         # Initialize index entry if non-existing.
         if str(self.index) not in data:
             data[str(self.index)] = {}

--- a/tests/numerics/solvers/test_nonlinear_solvers.py
+++ b/tests/numerics/solvers/test_nonlinear_solvers.py
@@ -427,7 +427,6 @@ def test_solve_convergence_statistics():
                 "0": {
                     "num_iterations": 2,
                     "simulation_status": "successful",
-                    "solver_status_history": ["successful"],
                     "solver_status": "successful",
                     "convergence_status": {
                         "inc_abs": ["continue_iterating", "converged"],
@@ -537,7 +536,6 @@ def test_solve_failure_statistics():
                 "0": {
                     "num_iterations": 2,
                     "simulation_status": "failed",
-                    "solver_status_history": ["failed"],
                     "solver_status": "failed",
                     "convergence_status": {
                         "inc_abs": ["continue_iterating", "continue_iterating"],
@@ -716,14 +714,6 @@ def test_summarize_solver_status(
     solver.solver_progressbar = DummyProgressBar()
 
     # Minimal mimicking of loop.
-    model.nonlinear_solver_statistics.solver_status_history = [
-        NonlinearSolverStatusConverged(
-            linear_solver_statuses=linear_solver_statuses(2),
-            convergence_statuses=ConvergenceStatusCollection(),
-            divergence_statuses=ConvergenceStatusCollection(),
-        )
-    ]
-
     solver_status = _summarize_solver_status(
         ConvergenceStatusCollection({"convergence": convergence_status}),
         ConvergenceStatusCollection({"divergence": divergence_status}),

--- a/tests/time_stepper/test_time_stepper.py
+++ b/tests/time_stepper/test_time_stepper.py
@@ -621,7 +621,6 @@ def test_solve_convergence_time_dependent_statistics(statistics_path: Path):
             "dt": 0.5,
             "num_iterations": 2,
             "simulation_status": "successful",
-            "solver_status_history": ["successful"],
             "solver_status": "successful",
             "convergence_status": {
                 "crit1": ["converged", "converged"],
@@ -643,7 +642,6 @@ def test_solve_convergence_time_dependent_statistics(statistics_path: Path):
             "dt": 0.5,
             "num_iterations": 1,
             "simulation_status": "successful",
-            "solver_status_history": ["successful"],
             "solver_status": "successful",
             "convergence_status": {
                 "crit1": ["converged"],
@@ -757,7 +755,6 @@ def test_solve_failure_time_dependent_statistics(statistics_path: Path):
             "time": 0,
             "dt": 0.5,
             "num_iterations": 2,
-            "solver_status_history": ["failed"],
             "convergence_status": {
                 "crit1": ["converged", "converged"],
                 "crit2": ["continue_iterating", "continue_iterating"],
@@ -777,7 +774,6 @@ def test_solve_failure_time_dependent_statistics(statistics_path: Path):
             "time": 0.5,
             "dt": 0.5,
             "num_iterations": 1,
-            "solver_status_history": ["successful"],
             "convergence_status": {
                 "crit1": ["converged"],
                 "crit2": ["converged"],
@@ -797,7 +793,6 @@ def test_solve_failure_time_dependent_statistics(statistics_path: Path):
             "time": 1.0,
             "dt": 0.5,
             "num_iterations": 1,
-            "solver_status_history": ["successful"],
             "convergence_status": {
                 "crit1": ["converged"],
                 "crit2": ["converged"],

--- a/tests/viz/test_solver_statistics.py
+++ b/tests/viz/test_solver_statistics.py
@@ -144,7 +144,6 @@ def reference_nonlinear_solver_statistics_dict() -> dict:
             # NonlinearSolverStatistics data for first outer iteration
             "num_iterations": 2,
             "solver_status": None,
-            "solver_status_history": [],
             "simulation_status": "failed",
             "convergence_status": {
                 "crit1": [
@@ -167,7 +166,6 @@ def reference_nonlinear_solver_statistics_dict() -> dict:
             # NonlinearSolverStatistics data for second outer iteration
             "num_iterations": 1,
             "solver_status": None,
-            "solver_status_history": [],
             "simulation_status": "successful",
             "convergence_status": {
                 "crit1": ["converged"],
@@ -286,7 +284,6 @@ def test_solver_statistics_initialization():
         convergence_statuses=pp.solvers.ConvergenceStatusCollection(),
         divergence_statuses=pp.solvers.ConvergenceStatusCollection(),
     )
-    assert stats.solver_status_history == []
     assert stats.custom_data == {}
 
 
@@ -303,7 +300,6 @@ def test_solver_statistic_attributes():
     assert hasattr(model.nonlinear_solver_statistics, "simulation_status")
     assert hasattr(model.nonlinear_solver_statistics, "simulation_status_history")
     assert hasattr(model.nonlinear_solver_statistics, "solver_status")
-    assert hasattr(model.nonlinear_solver_statistics, "solver_status_history")
     assert hasattr(model.nonlinear_solver_statistics, "custom_data")
 
     # Check that SolverStatistics has not path for storing.
@@ -676,7 +672,6 @@ def test_nonlinear_solver_statistics_attributes():
     assert hasattr(model.nonlinear_solver_statistics, "simulation_status")
     assert hasattr(model.nonlinear_solver_statistics, "solver_status")
     assert hasattr(model.nonlinear_solver_statistics, "simulation_status_history")
-    assert hasattr(model.nonlinear_solver_statistics, "solver_status_history")
     assert hasattr(model.nonlinear_solver_statistics, "custom_data")
 
     # Check that SolverStatistics has not path for storing.
@@ -835,7 +830,6 @@ def test_nonlinear_solver_statistics_append_iterative_data():
     stats.simulation_status_history = [
         time_stepper_status("failed"),
     ]
-    stats.solver_status_history = [nonlinear_solver_status("failed")]
     stats.convergence_status = pp.solvers.ConvergenceStatusHistory(
         {
             "crit1": ["continue_iterating", "failed"],
@@ -862,7 +856,6 @@ def test_nonlinear_solver_statistics_append_iterative_data():
     reference_data["0"].pop("foo")
     failed_solver_status = "failed"
     reference_data["0"]["solver_status"] = failed_solver_status
-    reference_data["0"]["solver_status_history"] = [failed_solver_status]
     assert (
         DeepDiff(
             out,
@@ -970,7 +963,6 @@ def test_nonlinear_solver_statistics_save():
         time_stepper_status("failed"),
         time_stepper_status("converged"),
     ]
-    stats.solver_status_history = [nonlinear_solver_status("converged")]
     stats.index = 1
     stats.num_iterations_history = [2, 1]
     stats.num_iterations = 1
@@ -1001,7 +993,6 @@ def test_nonlinear_solver_statistics_save():
 
     successful_solver_status = "successful"
     reference_data["1"]["solver_status"] = successful_solver_status
-    reference_data["1"]["solver_status_history"] = [successful_solver_status]
 
     assert (
         DeepDiff(
@@ -1118,7 +1109,6 @@ def test_time_statistics_initialization():
     assert stats.num_domains == {}
     assert stats.simulation_status == SolverStatistics().simulation_status
     assert stats.simulation_status_history == []
-    assert stats.solver_status_history == []
     assert stats.custom_data == {}
 
     # Check TimeStatistics attributes.
@@ -1141,7 +1131,6 @@ def test_time_statistics_attributes():
     assert hasattr(model.nonlinear_solver_statistics, "simulation_status")
     assert hasattr(model.nonlinear_solver_statistics, "solver_status")
     assert hasattr(model.nonlinear_solver_statistics, "simulation_status_history")
-    assert hasattr(model.nonlinear_solver_statistics, "solver_status_history")
     assert hasattr(model.nonlinear_solver_statistics, "custom_data")
 
     # Check that SolverStatistics has not path for storing.
@@ -1430,7 +1419,6 @@ def test_nonlinear_solver_and_time_statistics_initialization():
     assert stats.num_domains == {}
     assert stats.simulation_status == SolverStatistics().simulation_status
     assert stats.simulation_status_history == []
-    assert stats.solver_status_history == []
     assert stats.custom_data == {}
 
     # Check NonlinearSolverStatistics attributes.
@@ -1459,7 +1447,6 @@ def test_nonlinear_solver_and_time_statistics_attributes():
     assert hasattr(model.nonlinear_solver_statistics, "simulation_status")
     assert hasattr(model.nonlinear_solver_statistics, "solver_status")
     assert hasattr(model.nonlinear_solver_statistics, "simulation_status_history")
-    assert hasattr(model.nonlinear_solver_statistics, "solver_status_history")
     assert hasattr(model.nonlinear_solver_statistics, "custom_data")
 
     # Check that SolverStatistics has not path for storing.
@@ -1584,7 +1571,6 @@ def test_nonlinear_solver_and_time_statistics_save():
         time_stepper_status("failed"),
         time_stepper_status("converged"),
     ]
-    stats.solver_status_history = [nonlinear_solver_status("converged")]
     stats.solver_status = nonlinear_solver_status("converged")
     stats.index = 1
     stats.num_iterations_history = [2, 1]
@@ -1620,7 +1606,6 @@ def test_nonlinear_solver_and_time_statistics_save():
 
     successful_solver_status = "successful"
     reference_data["1"]["solver_status"] = successful_solver_status
-    reference_data["1"]["solver_status_history"] = [successful_solver_status]
 
     assert (
         DeepDiff(

--- a/tests/viz/test_solver_statistics.py
+++ b/tests/viz/test_solver_statistics.py
@@ -845,6 +845,7 @@ def test_nonlinear_solver_statistics_append_iterative_data():
             "crit2": [2.0, 1.5],
         }
     )
+    stats.solver_status = nonlinear_solver_status("failed")
 
     # Make sure that the data dict has the correct 'index' key before appending.
     # Typically prepared when calling the `append_data` method.
@@ -854,8 +855,7 @@ def test_nonlinear_solver_statistics_append_iterative_data():
     # Compare against reference data. Restrict to "0", ignore custom data, and cast.
     reference_data = {"0": reference_nonlinear_solver_statistics_dict()["0"]}
     reference_data["0"].pop("foo")
-    failed_solver_status = "failed"
-    reference_data["0"]["solver_status"] = failed_solver_status
+    reference_data["0"]["solver_status"] = nonlinear_solver_status("failed").serialize()
     assert (
         DeepDiff(
             out,

--- a/tests/viz/test_solver_statistics.py
+++ b/tests/viz/test_solver_statistics.py
@@ -143,7 +143,7 @@ def reference_nonlinear_solver_statistics_dict() -> dict:
         {
             # NonlinearSolverStatistics data for first outer iteration
             "num_iterations": 2,
-            "solver_status": None,
+            "solver_status": "successful",
             "simulation_status": "failed",
             "convergence_status": {
                 "crit1": [
@@ -165,7 +165,7 @@ def reference_nonlinear_solver_statistics_dict() -> dict:
         {
             # NonlinearSolverStatistics data for second outer iteration
             "num_iterations": 1,
-            "solver_status": None,
+            "solver_status": "successful",
             "simulation_status": "successful",
             "convergence_status": {
                 "crit1": ["converged"],


### PR DESCRIPTION
## Proposed changes

Minor maintenance on solver statistics. The history of solver status was identical with the solver status (just stored as a list with a single member). This PR removes the redundant history.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [X] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
