### PR TITLE
Detach solver statistics save from data save, and always save

### DIFF
--- a/src/porepy/models/protocol.py
+++ b/src/porepy/models/protocol.py
@@ -1020,9 +1020,10 @@ else:
                 * `list`: Export if time is in the list. If the list is empty, then no
                 times are exported.
 
-            In addition, save the solver statistics to file if the option is set.
-
             """
+
+        def save_statistics(self) -> None:
+            """Save the solver statistics to file if the option is set."""
 
         def initialize_data_saving(self) -> None:
             """Initialize data saving.

--- a/src/porepy/models/solution_strategy.py
+++ b/src/porepy/models/solution_strategy.py
@@ -467,7 +467,6 @@ class SolutionStrategy(pp.PorePyModel):
         Use this method for loop-specific post-processing.
 
         """
-        pass
 
     def after_nonlinear_failure(self) -> None:
         """Called after a nonlinear solver loop fails to converge.
@@ -478,7 +477,6 @@ class SolutionStrategy(pp.PorePyModel):
         nonlinear loops per time step and call this method after each failed loop.
 
         """
-        pass
 
     def after_time_step_convergence(self) -> None:
         """Called after a new time step solution has been achieved.

--- a/src/porepy/models/solution_strategy.py
+++ b/src/porepy/models/solution_strategy.py
@@ -467,6 +467,7 @@ class SolutionStrategy(pp.PorePyModel):
         Use this method for loop-specific post-processing.
 
         """
+        pass
 
     def after_nonlinear_failure(self) -> None:
         """Called after a nonlinear solver loop fails to converge.
@@ -477,6 +478,7 @@ class SolutionStrategy(pp.PorePyModel):
         nonlinear loops per time step and call this method after each failed loop.
 
         """
+        pass
 
     def after_time_step_convergence(self) -> None:
         """Called after a new time step solution has been achieved.
@@ -485,18 +487,22 @@ class SolutionStrategy(pp.PorePyModel):
 
         1. Call :meth:`update_time_step_solution`.
         2. Call :meth:`save_data_time_step`.
+        3. Call :meth:`save_statistics`.
 
         """
         self.update_time_step_solution()
         self.save_data_time_step()
+        self.save_statistics()
 
     def after_time_step_failure(self) -> None:
         """Called after a time step has failed to converge.
 
         The base method reverts the trial time step being executed.
+        It also calls :meth:`save_statistics`.
 
         """
         self.revert_trial_time_step_solution()
+        self.save_statistics()
 
     def reset_state_from_file(self) -> None:
         """Reset states but through a restart from file.
@@ -777,7 +783,7 @@ class SolutionStrategy(pp.PorePyModel):
 
     def after_simulation(self) -> None:
         """Run at the end of simulation. Can be used for cleanup etc."""
-        pass
+        self.save_statistics()
 
     def assemble_linear_system(self) -> solvers.LinearSystem:
         """Assemble and return the linearized system.

--- a/src/porepy/numerics/solvers/nonlinear_solvers.py
+++ b/src/porepy/numerics/solvers/nonlinear_solvers.py
@@ -536,8 +536,7 @@ class NewtonSolver(NonlinearSolverBase):
         """Check convergence and divergence based on passed criteria.
 
         Parameters:
-            model: The model instance specifying the problem to be solved, knowing
-                of its metrics for measuring states and residuals.
+            model: The model instance specifying the problem to be solved.
             nonlinear_increment: Newly obtained solution increment vector.
 
         Returns:

--- a/src/porepy/viz/data_saving_model_mixin.py
+++ b/src/porepy/viz/data_saving_model_mixin.py
@@ -58,9 +58,6 @@ class DataSavingMixin(pp.PorePyModel):
         if do_export:
             self.write_pvd_and_vtu()
 
-        # Save solver statistics to file.
-        self.nonlinear_solver_statistics.save()
-
         # Collecting and storing data in runtime for analysis. If default value of None
         # is returned, nothing is stored to not burden memory.
         if not self._is_time_dependent():
@@ -74,6 +71,10 @@ class DataSavingMixin(pp.PorePyModel):
                 collected_data = self.collect_data()
                 if collected_data is not None:
                     self.results.append(collected_data)
+
+    def save_statistics(self):
+        """Save solver statistics to file."""
+        self.nonlinear_solver_statistics.save()
 
     def collect_data(self) -> Any:
         """Collect relevant simulation data to be stored in attr:`results`.

--- a/tests/viz/test_solver_statistics.py
+++ b/tests/viz/test_solver_statistics.py
@@ -624,6 +624,9 @@ def test_solver_statistics_save_in_model(path, exists):
     model = DummyModel(params)
     model.prepare_simulation()
 
+    # Save the solver statistics explicitly.
+    model.save_statistics()
+
     # Check whether file was saved and has correct suffix.
     if exists:
         assert model.nonlinear_solver_statistics.path.exists()


### PR DESCRIPTION
## Proposed changes

This PR suggests to detach saving solver statistics from solving data. While the latter only is performed after successful simulation (of a single time step for instationary simulations), the former shall be always performed, including after the simulation. This makes ensures that the solver statistics is up-to-date even in case of a failing simulation. In part related to #1421  and #1471.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [X] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
