### PR TITLE
Split and reorder logging of time step/status during stepping.

### DIFF
--- a/src/porepy/time_stepper/time_stepper.py
+++ b/src/porepy/time_stepper/time_stepper.py
@@ -108,7 +108,7 @@ class TimeStepper:
             )
 
             # Log time step status for statistics.
-            self._update_statistics(model, time_step_status)
+            self._update_nonlinear_solver_statistics(model, time_step_status)
 
             # Update model (also saves logged statistics) based on trial results.
             self._update_model_after_trial(model, time_step_status)
@@ -227,7 +227,7 @@ class TimeStepper:
             self.time_manager.final_time_reached(),
         )
 
-    def _update_statistics(
+    def _update_nonlinear_solver_statistics(
         self, model: pp.PorePyModel, time_step_status: TimeStepperStatus
     ) -> None:
         """Update statistics from the time step."""

--- a/src/porepy/time_stepper/time_stepper.py
+++ b/src/porepy/time_stepper/time_stepper.py
@@ -110,6 +110,9 @@ class TimeStepper:
             # Log time step status for statistics.
             self._update_statistics(model, time_step_status)
 
+            # Update model (also saves logged statistics) based on trial results.
+            self._update_model_after_trial(model, time_step_status)
+
             # Return on success or error when there is no way to continue trying.
             if isinstance(
                 time_step_status, (TimeStepperStatusSuccess, TimeStepperStatusFailure)
@@ -201,13 +204,16 @@ class TimeStepper:
         model.before_time_step()
         nonlinear_solver_status = solver.solve(model)  # type: ignore
 
-        # Model update based on trial results.
-        if nonlinear_solver_status.is_converged():
-            model.after_time_step_convergence()
-        elif nonlinear_solver_status.is_failed():
-            model.after_time_step_failure()
-
         return nonlinear_solver_status
+
+    def _update_model_after_trial(
+        self, model: pp.PorePyModel, time_step_status: TimeStepperStatus
+    ) -> None:
+        """Model update based on trial results."""
+        if time_step_status.is_success():
+            model.after_time_step_convergence()
+        elif time_step_status.is_failure():
+            model.after_time_step_failure()
 
     def _update_time_statistics(self, model: pp.PorePyModel) -> None:
         """Update statistics from the time step."""

--- a/src/porepy/time_stepper/time_stepper.py
+++ b/src/porepy/time_stepper/time_stepper.py
@@ -91,6 +91,9 @@ class TimeStepper:
             self.time_manager.time = previous_time + self.time_manager.dt
             self.time_manager.time_index += 1
 
+            # Log time step information for statistics.
+            self._update_time_statistics(model)
+
             # Attempt a standard time step.
             nonlinear_solver_status = self._perform_trial_time_step(model, solver)
 
@@ -104,8 +107,8 @@ class TimeStepper:
                 nonlinear_solver_status, model, attempt
             )
 
-            # Save statistics.
-            self._update_time_statistics(model, time_step_status)
+            # Log time step status for statistics.
+            self._update_statistics(model, time_step_status)
 
             # Return on success or error when there is no way to continue trying.
             if isinstance(
@@ -206,19 +209,22 @@ class TimeStepper:
 
         return nonlinear_solver_status
 
-    def _update_time_statistics(
-        self, model: pp.PorePyModel, time_step_status: TimeStepperStatus
-    ) -> None:
+    def _update_time_statistics(self, model: pp.PorePyModel) -> None:
         """Update statistics from the time step."""
         assert isinstance(model.nonlinear_solver_statistics, pp.TimeStatistics)
-        model.nonlinear_solver_statistics.log_simulation_status(
-            simulation_status=time_step_status
-        )
         model.nonlinear_solver_statistics.log_time_information(
             self.time_manager.time_index,
             self.time_manager.time,
             self.time_manager.dt,
             self.time_manager.final_time_reached(),
+        )
+
+    def _update_statistics(
+        self, model: pp.PorePyModel, time_step_status: TimeStepperStatus
+    ) -> None:
+        """Update statistics from the time step."""
+        model.nonlinear_solver_statistics.log_simulation_status(
+            simulation_status=time_step_status
         )
 
 

--- a/src/porepy/time_stepper/time_stepper.py
+++ b/src/porepy/time_stepper/time_stepper.py
@@ -212,7 +212,9 @@ class TimeStepper:
         """Model update based on trial results."""
         if time_step_status.is_success():
             model.after_time_step_convergence()
-        elif time_step_status.is_failure():
+        elif time_step_status.is_failure() or isinstance(
+            time_step_status, TimeStepperStatusContinueIterating
+        ):
             model.after_time_step_failure()
 
     def _update_time_statistics(self, model: pp.PorePyModel) -> None:

--- a/tests/time_stepper/test_time_stepper.py
+++ b/tests/time_stepper/test_time_stepper.py
@@ -96,9 +96,13 @@ class MockModel(PorePyModel):
 
     def after_time_step_convergence(self):
         self.sequence_of_calls.append("after_time_step_convergence")
+        # Mimick the behavior of the real model.
+        self.nonlinear_solver_statistics.save()
 
     def after_time_step_failure(self):
         self.sequence_of_calls.append("after_time_step_failure")
+        # Mimick the behavior of the real model.
+        self.nonlinear_solver_statistics.save()
 
 
 class MockLinearSolver(pp.solvers.LinearSolverBase):
@@ -660,11 +664,9 @@ def test_solve_convergence_time_dependent_statistics(statistics_path: Path):
     # Making two time steps.
     status = time_stepper.perform_time_step(model=model, solver=solver)
     assert status.is_success()
-    model.nonlinear_solver_statistics.save()
 
     status = time_stepper.perform_time_step(model=model, solver=solver)
     assert status.is_success()
-    model.nonlinear_solver_statistics.save()
 
     # Check solver statistics.
     with open(statistics_path, "r") as f:
@@ -690,24 +692,16 @@ def test_solve_failure_time_dependent_statistics(statistics_path: Path):
     # fail after two unsuccessful nonlinear iterations.
     status = time_stepper.perform_time_step(model=model, solver=solver)
     assert status.is_failure()
-    # Note that the first attempt (with dt=1) will not be saved in the file. The second
-    # attempt overrides it, because `model.save_data_time_step()` is not called in
-    # `model.after_time_step_failure()` in the SolutionStrategy. This behavior is
-    # inconsistent, but EK and YZ decided to keep it for compatability. This must be
-    # revisited when the whole statistics logging is reconsidered.
-    model.nonlinear_solver_statistics.save()
 
     # The time stepper gave up and the real simulation would be stopped at this moment.
     # But we use a mock convergence criterion, so we can try one more time with the same
     # dt=0.5. This time, the time step will converge after 1 nonlinear iteration.
     status = time_stepper.perform_time_step(model=model, solver=solver)
     assert status.is_success()
-    model.nonlinear_solver_statistics.save()
 
     # The 4th time step will converge after 1 iteration with dt=4.
     status = time_stepper.perform_time_step(model=model, solver=solver)
     assert status.is_success()
-    model.nonlinear_solver_statistics.save()
 
     # Check solver statistics.
     with open(statistics_path, "r") as f:
@@ -744,13 +738,31 @@ def test_solve_failure_time_dependent_statistics(statistics_path: Path):
                 "res_nan": "converged",
             },
         },
-        # Note that the key "0" is abscent. See the comment above for details.
+        "0": {
+            "simulation_status": "in_progress",
+            "solver_status": "failed",
+            "final_time_reached": 1,
+            "time_index": 1,
+            "time": 1,
+            "dt": 1,
+            "num_iterations": 2,
+            "convergence_status": {
+                "crit1": ["converged", "converged"],
+                "crit2": ["continue_iterating", "continue_iterating"],
+                "max_iter": ["converged", "failed"],
+                "inc_inf": ["converged", "converged"],
+                "res_inf": ["converged", "converged"],
+                "inc_nan": ["converged", "converged"],
+                "res_nan": ["converged", "converged"],
+            },
+            "convergence_info": {"crit1": [0, 0], "crit2": [0.1, 0.1]},
+        },
         "1": {
             "simulation_status": "failed",
             "solver_status": "failed",
             "final_time_reached": 0,
-            "time_index": 0,
-            "time": 0,
+            "time_index": 1,
+            "time": 0.5,
             "dt": 0.5,
             "num_iterations": 2,
             "convergence_status": {


### PR DESCRIPTION
## Proposed changes

The time stepper logs time information and status during stepping. This is done after computing the new dt (as this also return the time_step_status). Before that time is rolled back if the nonlinear solver did not converge. Thus, mutated time and dt are potentially logged. This PR suggests a split in the logging and places the logging of the time information at the start of the time step, such that always time and dt during the solver attempt is logged.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [x] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
