### PR TITLE
Basic convenience functions for time

### DIFF
--- a/src/porepy/applications/boundary_conditions/model_boundary_conditions.py
+++ b/src/porepy/applications/boundary_conditions/model_boundary_conditions.py
@@ -287,7 +287,7 @@ class TimeDependentMechanicalBCsDirNorthSouth(BoundaryConditionsMechanicsDirNort
         else:
             frac_val = 0
         values[1, domain_sides.north] = frac_val
-        if self.time_manager.time > 1e-5:
+        if not self.time_manager.is_at_initial_time():
             return values.ravel("F") + super().bc_values_displacement(bg)
         else:
             return values.ravel("F")
@@ -560,7 +560,7 @@ class LithostaticBoundaryStressValues(GravityMagnitude):
         # Initialize array for stress values.
         values = np.zeros((3, boundary_grid.num_cells))
         # Assume zero initial stress state.
-        if self.time_manager.time < 1e-5:
+        if self.time_manager.is_at_initial_time():
             return values.ravel("F")
 
         gravity = self.gravity_force_magnitude("bulk")

--- a/src/porepy/examples/mandel_biot.py
+++ b/src/porepy/examples/mandel_biot.py
@@ -824,12 +824,10 @@ class MandelUtils(VerificationUtils):
         nu_s = self.poisson_coefficient()  # [-]
         nu_u = self.undrained_poisson_coefficient()  # [-]
 
-        t = self.time_manager.time  # scaled [s]
-
         # Retrieve face displacement
         u_faces = self.face_displacement(sd)
 
-        if t == 0:  # soil is initially unconsolidated
+        if self.time_manager.is_at_initial_time():  # soil is initially unconsolidated
             consol_deg_x, consol_deg_y = 0, 0
         else:
             # Consolidation degree in the horizontal direction

--- a/src/porepy/examples/terzaghi_biot.py
+++ b/src/porepy/examples/terzaghi_biot.py
@@ -381,10 +381,11 @@ class TerzaghiUtils(VerificationUtils):
         h = self.height()  # scaled [m]
         m_v = self.confined_compressibility()  # scaled [m * s^-2]
         vertical_load = self.applied_load()  # scaled [Pa]
-        t = self.time_manager.time  # scaled [s]
         u_faces = self.face_displacement(sd)
 
-        if t == 0:  # initially, the soil is unconsolidated
+        if (
+            self.time_manager.is_at_initial_time()
+        ):  # initially, the soil is unconsolidated
             consol_deg = 0.0
         else:
             u_inf = m_v * h * vertical_load

--- a/src/porepy/time_stepper/time_step_control.py
+++ b/src/porepy/time_stepper/time_step_control.py
@@ -434,7 +434,7 @@ class TimeManager:
     def is_at_initial_time(self) -> bool:
         """Check whether the time manager is at the initial time."""
         return self.time < self.time_init or np.isclose(
-            self.time, self.time_init, rtol=self.rtol, atol=self.dt_min_max[0]
+            self.time, self.time_init, rtol=self.rtol, atol=0.5 * self.dt_min_max[0]
         )
 
     def final_time_reached(self) -> bool:

--- a/src/porepy/time_stepper/time_step_control.py
+++ b/src/porepy/time_stepper/time_step_control.py
@@ -427,6 +427,16 @@ class TimeManager:
 
         return s
 
+    def elapsed_time(self) -> float:
+        """Return the elapsed simulation time."""
+        return self.time - self.time_init
+
+    def is_at_initial_time(self) -> bool:
+        """Check whether the time manager is at the initial time."""
+        return self.time < self.time_init or np.isclose(
+            self.time, self.time_init, rtol=self.rtol, atol=self.dt_min_max[0]
+        )
+
     def final_time_reached(self) -> bool:
         """Check whether the time manager has reached the end of the schedule.
 


### PR DESCRIPTION
This PR adds simple functions (mainly) for checking that the current time is the initial time and replaces hardcoded comparisons in the code base.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [X] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [X] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
