### PR TITLE
Generalized lithostatic stress

### DIFF
--- a/src/porepy/applications/boundary_conditions/model_boundary_conditions.py
+++ b/src/porepy/applications/boundary_conditions/model_boundary_conditions.py
@@ -531,7 +531,7 @@ class LithostaticBoundaryStressValues(GravityMagnitude):
 
         """
         datum_lithostatic_stress = self.params.get(
-            "datum_lithostatic_stress", np.zeros(3)
+            "datum_lithostatic_stress", np.zeros(self.nd)
         )
         return self.units.convert_units(datum_lithostatic_stress, units="Pa")
 
@@ -544,7 +544,7 @@ class LithostaticBoundaryStressValues(GravityMagnitude):
             Default is an array of ones.
 
         """
-        return self.params.get("lithostatic_stress_multipliers", np.ones(3))
+        return self.params.get("lithostatic_stress_multipliers", np.ones(self.nd))
 
     def bc_values_stress(self, boundary_grid: pp.BoundaryGrid) -> np.ndarray:
         """Stress values.
@@ -558,7 +558,7 @@ class LithostaticBoundaryStressValues(GravityMagnitude):
 
         """
         # Initialize array for stress values.
-        values = np.zeros((3, boundary_grid.num_cells))
+        values = np.zeros((self.nd, boundary_grid.num_cells))
         # Assume zero initial stress state.
         if self.time_manager.is_at_initial_time():
             return values.ravel("F")

--- a/src/porepy/applications/boundary_conditions/model_boundary_conditions.py
+++ b/src/porepy/applications/boundary_conditions/model_boundary_conditions.py
@@ -356,8 +356,8 @@ class BoundaryConditionsMechanicsNeumann:
                 raise ValueError(
                     f"Anchor mask shape {mask.shape} incompatible with nd={self.nd}."
                 )
-            bc.is_dir[:, face] = mask
-            bc.is_neu[:, face] = ~mask  # Negate for Neumann
+            bc.is_dir[:, np.atleast_1d(face)] = mask[:, None]
+            bc.is_neu[:, np.atleast_1d(face)] = ~mask[:, None]  # Negate for Neumann
         return bc
 
     def _anchor_dirichlet_component_masks(self) -> list[np.ndarray]:

--- a/src/porepy/applications/boundary_conditions/model_boundary_conditions.py
+++ b/src/porepy/applications/boundary_conditions/model_boundary_conditions.py
@@ -505,6 +505,8 @@ class LithostaticBoundaryStressValues(GravityMagnitude):
 
     """
 
+    nd: int
+    """Number of spatial dimensions."""
     params: dict
     """Model parameters."""
     depth: Callable[[np.ndarray], np.ndarray]

--- a/tests/applications/boundary_conditions/test_model_boundary_conditions.py
+++ b/tests/applications/boundary_conditions/test_model_boundary_conditions.py
@@ -187,25 +187,28 @@ def test_lithostatic_boundary_stress_values(momentum_model):
     # Lithostatic boundary condition requires non-zero time.
     model.time_manager.time = 1
 
+    nd = model.nd
+
     for boundary_grid in model.mdg.boundaries():
         values = model.bc_values_stress(boundary_grid)
         sides = model.domain_boundary_sides(boundary_grid)
 
-        # Expanding the indices to reflect vector data, 3 DoFs per cell.
-        bottom = np.repeat(sides.bottom, 3)
-        top = np.repeat(sides.top, 3)
-        west = np.repeat(sides.west, 3)
-        east = np.repeat(sides.east, 3)
-        north = np.repeat(sides.north, 3)
-        south = np.repeat(sides.south, 3)
+        # Expanding the indices to reflect vector data, `nd` DoFs per cell.
+        bottom = np.repeat(sides.bottom, nd)
+        top = np.repeat(sides.top, nd)
+        west = np.repeat(sides.west, nd)
+        east = np.repeat(sides.east, nd)
+        north = np.repeat(sides.north, nd)
+        south = np.repeat(sides.south, nd)
 
         # Shear stresses must be zeros.
-        np.testing.assert_array_equal(values[bottom | top][0::3], 0)
-        np.testing.assert_array_equal(values[bottom | top][1::3], 0)
-        np.testing.assert_array_equal(values[east | west][1::3], 0)
-        np.testing.assert_array_equal(values[east | west][2::3], 0)
-        np.testing.assert_array_equal(values[north | south][0::3], 0)
-        np.testing.assert_array_equal(values[north | south][2::3], 0)
+        np.testing.assert_array_equal(values[east | west][1::nd], 0)
+        np.testing.assert_array_equal(values[north | south][0::nd], 0)
+        if model.nd == 3:
+            np.testing.assert_array_equal(values[bottom | top][0::nd], 0)
+            np.testing.assert_array_equal(values[bottom | top][1::nd], 0)
+            np.testing.assert_array_equal(values[east | west][2::nd], 0)
+            np.testing.assert_array_equal(values[north | south][2::nd], 0)
 
         vertical_index = 2 if model.nd == 3 else 1
 
@@ -229,13 +232,13 @@ def test_lithostatic_boundary_stress_values(momentum_model):
         # Values from the model should be equal to explicitly expected results.
         expected_east = -expected_stress[0][sides.east]
         expected_west = +expected_stress[0][sides.east]
-        np.testing.assert_allclose(values[east][0::3], expected_east)
-        np.testing.assert_allclose(values[west][0::3], expected_west)
+        np.testing.assert_allclose(values[east][0::nd], expected_east)
+        np.testing.assert_allclose(values[west][0::nd], expected_west)
         if model.nd == 3:
             expected_north = -expected_stress[1][sides.north]
             expected_south = +expected_stress[1][sides.south]
-            np.testing.assert_allclose(values[north][1::3], expected_north)
-            np.testing.assert_allclose(values[south][1::3], expected_south)
+            np.testing.assert_allclose(values[north][1::nd], expected_north)
+            np.testing.assert_allclose(values[south][1::nd], expected_south)
 
         # For this geometry, some sides contain no cells for the fracture boundary.
         east_value = values[east].mean() if np.any(east) else 0.0


### PR DESCRIPTION
This PR combines three extensions for the lithostatic stress boundary condition and closely related Neumann BC:
- The Neumann BC class can be customized to conveniently fix components of displacements, not only in single points (like mid points or corners as done currently) but on e.g. entire sides etc. The current change enables fixing a list/array of indices alongside single indices as before.
- The Lithostatic BC now is applicable also to 2D models.
- REMOVED from githistory: In view of initialization routines, in which consistent boundary conditions at time t=0 are required, a simple approach is suggested to control the activity of the lithostatic stress at time t=0. The original behavior remains to be the default behavior. If not liked, this is added as a single commit, which is easy to remove.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [X] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [X] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
