### PR TITLE
Remove double unit conversion for hydrostatic pressure offset

### DIFF
--- a/src/porepy/applications/boundary_conditions/model_boundary_conditions.py
+++ b/src/porepy/applications/boundary_conditions/model_boundary_conditions.py
@@ -636,9 +636,7 @@ class HydrostaticPressureValues(GravityMagnitude):
 
         """
         gravity = self.gravity_force_magnitude("fluid")
-        pressure = gravity * depth + self.units.convert_units(
-            self.hydrostatic_pressure_offset, units="Pa"
-        )
+        pressure = gravity * depth + self.hydrostatic_pressure_offset
         return pressure
 
 


### PR DESCRIPTION
Previously, the hydrostatic pressure offset went twice through unit conversion, resulting in wrong values. This PR removes one of the conversion and fixes the issue.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [X] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
