### PR TITLE
Fixes #1743

### DIFF
--- a/src/porepy/geometry/distances.py
+++ b/src/porepy/geometry/distances.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import Union
+from warnings import warn
 
 import numpy as np
 from scipy.spatial import distance as scidist
@@ -654,6 +655,10 @@ def segment_overlap_segment_set(
 
     The function currently works only for 2D geometries: ``nd == 2``.
 
+    Warning:
+        This function is not tested regularly and should be used with extreme caution.
+        It will be removed in a future version of PorePy.
+
     Parameters:
         start: ``shape=(nd,)``
 
@@ -687,16 +692,18 @@ def segment_overlap_segment_set(
         Otherwise, the 0th element of the tuple is returned.
 
     """
+    s = "This function is deprecated and will be removed in a future version of PorePy."
+    warn(s, category=FutureWarning, stacklevel=2)
 
     # reshape the input points
-    start_set = np.atleast_2d(start_set)[:2].reshape((2, -1))
-    end_set = np.atleast_2d(end_set)[:2].reshape((2, -1))
+    start_set = np.atleast_2d(start_set).reshape((3, -1))
+    end_set = np.atleast_2d(end_set).reshape((3, -1))
 
-    start = start.reshape(-1)[:2]
-    end = end.reshape(-1)[:2]
+    start = start.reshape(-1)
+    end = end.reshape(-1)
     norm = np.linalg.norm(start - end)
 
-    # compute the 2d-cross product useful for the collinearity
+    # Compute the 2d-cross product useful for the collinearity.
     cross = np.empty((2, start_set.shape[1]))
     for idx, (i, j) in enumerate(zip(start_set.T, end_set.T)):
         cross[0, idx] = np.cross(j - i, end - start) / norm

--- a/src/porepy/numerics/fracture_deformation/conforming_propagation.py
+++ b/src/porepy/numerics/fracture_deformation/conforming_propagation.py
@@ -547,7 +547,12 @@ class ConformingFracturePropagation(FracturePropagation):
             # Propagation vector, with sign assuring a positive orientation
             # of the basis
             if nd == 2:
-                sign = np.cross(tip_bases[0, :, i], tip_bases[1, :, i])
+                # Manual cross product in 2d, avoid having to reshape to 3d and back
+                # to be compatible with numpy versions >= 2.5.
+                sign = (
+                    tip_bases[0, 0, i] * tip_bases[1, 1, i]
+                    - tip_bases[0, 1, i] * tip_bases[1, 0, i]
+                )
                 e2 = np.array([0, 0, sign])
             else:
                 e2 = tip_bases[2, :, i]

--- a/tests/fracs/test_line_fracture.py
+++ b/tests/fracs/test_line_fracture.py
@@ -17,9 +17,9 @@ def test_frac_2d():
     # Simple line, known center.
     f_1 = make_line_fracture()
     c_known = np.array([1, 1]).reshape((2, 1))
-    n_known = np.array([1, -1]).reshape((1, 2))
+    n_known = np.array([1, -1, 0])
     assert np.allclose(c_known, f_1.center)
-    assert np.allclose(np.cross(n_known, f_1.normal.T), 0)
+    assert np.allclose(np.cross(n_known, np.hstack((f_1.normal.ravel(), 0))), 0)
 
 
 def test_frac_index_2d():


### PR DESCRIPTION
## Proposed changes
Takes care of two failing tests after update to numpy v2.5. Resolves #1743

As noted in the issue, we use `np.cross` extensively in the core of PorePy. I did a search in the full code base and came across one instance in an untested and (AFAIK) unused function - here I made a best-effort of a fix, deprecated the function and added a warning that the function should be used with caution. I did not verify that the fix actually worked, in my opinion this is not worth the effort. 

Beyond the fix, the remaining usages of `np.cross` should be fine from what I can tell.


## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
