### PR TITLE
Improved documentation of Ad operator current iterate concept

### DIFF
--- a/src/porepy/numerics/ad/_operator_states.py
+++ b/src/porepy/numerics/ad/_operator_states.py
@@ -247,13 +247,21 @@ class IterativeOperator:
         """Returns a copy of the iterative operator with an advanced iterate index.
 
         Note:
-            Calling this method on an operator, with steps=1, on an operator
+            Calling this method on an operator, with ``steps=1``, on an operator
             representing the current iterate (the next iterate to be computed in an
             iterative scheme) will return an operator representing the last accepted
             iterate. When evaluated, the current and last accepted iterate will return
             the same values, but only the former will have a non-zero Jacobian. To get
             the difference between the current and second to last accepted iterate, call
-            this method with steps=2.
+            this method with ``steps=2``.
+
+        Example:
+            To obtain the Newton update of an operator
+            ```
+            op = ...
+            newton_update = op - op.previous_iteration(steps=2)
+            newton_update_value = newton_update.value(equation_system)
+            ```
 
         Note:
             You cannot create operators at the previous iterates from operators which

--- a/src/porepy/numerics/ad/_operator_states.py
+++ b/src/porepy/numerics/ad/_operator_states.py
@@ -247,13 +247,13 @@ class IterativeOperator:
         """Returns a copy of the iterative operator with an advanced iterate index.
 
         Note:
-            Calling this method on an operator, with ``steps=1``, on an operator
-            representing the current iterate (the next iterate to be computed in an
-            iterative scheme) will return an operator representing the last accepted
-            iterate. When evaluated, the current and last accepted iterate will return
-            the same values, but only the former will have a non-zero Jacobian. To get
-            the difference between the current and second to last accepted iterate, call
-            this method with ``steps=2``.
+            Calling this method with ``steps=1`` on an operator representing the current
+            iterate (the next iterate to be computed in an iterative scheme) will return
+            an operator representing the last accepted iterate. When evaluated, the
+            current and last accepted iterate will return the same values, but only the
+            former will have a non-zero Jacobian. To get the difference between the
+            current and second to last accepted iterate, call this method with
+            ``steps=2``.
 
         Example:
             To obtain the Newton update of an operator

--- a/src/porepy/numerics/ad/_operator_states.py
+++ b/src/porepy/numerics/ad/_operator_states.py
@@ -91,8 +91,9 @@ class TimeDependentOperator:
 
         - None indicates the current time (unknown value) or that the operator
           represents a reference value.
-        - 0 indicates this is an operator at the first previous time step
-        - 1 at the time step before
+        - 0 indicates this is an operator at the first previous time step (the last
+          accepted time step).
+        - 1 at the time step before that
         - ...
 
         """
@@ -111,9 +112,6 @@ class TimeDependentOperator:
         """Returns a copy of the time-dependent operator with an advanced time-step
         index.
 
-        Time-dependent operators do not invoke the recursion (like the base class), but
-        represent a leaf in the recursion tree.
-
         Note:
             You cannot create operators at the previous time step from operators which
             are at some previous iterate. Use the :attr:`original_operator` instead.
@@ -121,12 +119,12 @@ class TimeDependentOperator:
         Parameters:
             steps: ``default=1``
 
-                Number of steps backwards in time. If steps=0, the current time is
-                represented.
+                Number of steps backwards in time. If steps=0, a copy of the operator at
+                the current time is represented.
 
         Raises:
             ValueError: If this instance represents an operator at a previous iterate.
-            ValueError: If ``steps`` is not non-negative.
+            ValueError: If ``steps`` is negative.
 
         """
         if isinstance(self, ReferenceOperator) and self.is_reference:
@@ -212,13 +210,18 @@ class IterativeOperator:
         """Returns the iterate index this instance represents, at the current time.
 
         - None indicates this instance is at a previous time or reference.
-        - 0 represents the most recently computed iterate.
+        - 0 represents the most recently computed iterate (e.g. the last accepted
+          iterate of a non-linear solver).
         - 1 represents the iterate before that
         - ...
 
         Note:
-            Operators at current time (unknown value) also have the index 0, since those
-            values are used to linearize the system and construct the Jacobian.
+            Operators representing the current iterate (that is, an operator on which
+            the method previous_iteration has not been called, hence it represents the
+            next iterate to be computed in an iterative scheme) will also have the index
+            0, since it will also evaluate to the last accepted iterate. The difference
+            is that the current iterate will have a non-zero Jacobian, while the
+            previous iterate will not.
 
         """
         # Operators at previous time have no iterate indices.
@@ -243,8 +246,14 @@ class IterativeOperator:
     ) -> _IterativeOperator:
         """Returns a copy of the iterative operator with an advanced iterate index.
 
-        Iterative operators do not invoke the recursion (like the base class),
-        but represent a leaf in the recursion tree.
+        Note:
+            Calling this method on an operator, with steps=1, on an operator
+            representing the current iterate (the next iterate to be computed in an
+            iterative scheme) will return an operator representing the last accepted
+            iterate. When evaluated, the current and last accepted iterate will return
+            the same values, but only the former will have a non-zero Jacobian. To get
+            the difference between the current and second to last accepted iterate, call
+            this method with steps=2.
 
         Note:
             You cannot create operators at the previous iterates from operators which
@@ -253,12 +262,12 @@ class IterativeOperator:
         Parameters:
             steps: ``default=1``
 
-                Number of steps backwards in the iterate sense. If ``steps`` is 0, the
-                current iterate is returned.
+                Number of steps backwards in the iterate sense. If ``steps`` is 0, a
+                copy of the operator at the same iteration index is returned.
 
         Raises:
             ValueError: If this instance represents an operator at a previous time step.
-            ValueError: If ``steps`` is not non-negative.
+            ValueError: If ``steps`` is negative.
 
         """
         if isinstance(self, ReferenceOperator) and self.is_reference:

--- a/src/porepy/numerics/ad/ad_utils.py
+++ b/src/porepy/numerics/ad/ad_utils.py
@@ -13,12 +13,6 @@ Functions:
     discretize_from_list: Perform the actual discretization for a list of AD
         discretizations.
 
-    set_solution_values: Set values to the data dictionary providing parameter name and
-        time step/iterate index.
-
-    get_solution_values: Get values from the data dictionary providing parameter name
-        and time step/iterate index.
-
 Classes:
     MergedOperator: Representation of specific discretization fields for an AD
         discretization or a set of AD discretizations.

--- a/src/porepy/numerics/ad/get_set_values.py
+++ b/src/porepy/numerics/ad/get_set_values.py
@@ -39,22 +39,22 @@ def set_solution_values(
         name: Name of the quantity that is to be assigned values.
         values: The values that are set in the data dictionary.
         data: Data dictionary corresponding to the subdomain or interface in question.
-        time_step_index: ``default=None``
+        time_step_index:
 
             Determines the key of where ``values`` are to be stored in
             ``data[pp.TIME_STEP_SOLUTIONS][name]``.
             0 is the most recent time step, 1 the one before that and so on.
-        iterate_index: ``default=None``
+        iterate_index:
 
             Determines the key of where ``values`` are to be stored in
             ``data[pp.ITERATE_SOLUTIONS][name]``.
             0 is the current iterate, 1 the previous iterate, and so on.
-        additive: ``default=False``
+        additive:
 
             Flag to decide whether the values already stored in the data dictionary
             should be added to or overwritten.
+        reference:
 
-        reference: ``default=False``
             Flag to decide whether reference values should be set instead of time step
             or iterate values. If ``True``, the setter will store values in
             ``data[pp.REFERENCE_SOLUTIONS][name]``.
@@ -113,7 +113,9 @@ def get_solution_values(
 
     Parameters:
         name: Name of the parameter whose values we are interested in. data: The data
-        dictionary. time_step_index:
+        dictionary.
+
+        time_step_index:
 
             Determines the key of where ``values`` are to be stored in
             ``data[pp.TIME_STEP_SOLUTIONS][name]``. 0 is the most recent time step, 1

--- a/src/porepy/numerics/ad/get_set_values.py
+++ b/src/porepy/numerics/ad/get_set_values.py
@@ -47,8 +47,8 @@ def set_solution_values(
         iterate_index:
 
             Determines the key of where ``values`` are to be stored in
-            ``data[pp.ITERATE_SOLUTIONS][name]``.
-            0 is the current iterate, 1 the previous iterate, and so on.
+            ``data[pp.ITERATE_SOLUTIONS][name]``. 0 is the current (last accepted)
+            value, 1 the previous value, and so on.
         additive:
 
             Flag to decide whether the values already stored in the data dictionary
@@ -123,8 +123,8 @@ def get_solution_values(
         iterate_index:
 
             Determines the key of where ``values`` are to be stored in
-            ``data[pp.ITERATE_SOLUTIONS][name]``. 0 is the current iterate, 1 the
-            previous iterate, and so on.
+            ``data[pp.ITERATE_SOLUTIONS][name]``. 0 is the current (last accepted)
+            value, 1 the second-to-last accepted value, and so on.
         reference:
             Flag to decide whether reference values should be fetched instead of time
             step or iterate values. If ``True``, the getter will look for values in


### PR DESCRIPTION
## Proposed changes
Improves the documentation of the behavior described in #1729. 

Please review the wording carefully and feel free to improve.

Resolves #1729

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
