### PR TITLE
SPEED: AdParser dispatches binary operations directly instead of eval()

### DIFF
--- a/src/porepy/numerics/ad/_ad_parser.py
+++ b/src/porepy/numerics/ad/_ad_parser.py
@@ -7,6 +7,7 @@ the functionality is thoroughly tested through the test suit for the models.
 
 from __future__ import annotations
 
+import operator as _operator
 from typing import Any, Literal, overload
 
 import numpy as np
@@ -15,6 +16,23 @@ import scipy.sparse as sps
 import porepy as pp
 
 from .operators import Operations
+
+# Maps each binary Operations member to the callable that implements it, so
+# _evaluate_single can dispatch directly instead of building and eval()-ing a source
+# string per node (the latter is costly when repeated many times in a large operator
+# tree).
+_BINARY_OP = {
+    Operations.add: _operator.add,
+    Operations.sub: _operator.sub,
+    Operations.mul: _operator.mul,
+    Operations.rmul: _operator.mul,
+    Operations.div: _operator.truediv,
+    Operations.rdiv: _operator.truediv,
+    Operations.pow: _operator.pow,
+    Operations.rpow: _operator.pow,
+    Operations.matmul: _operator.matmul,
+    Operations.rmatmul: _operator.matmul,
+}
 
 
 class AdParser:
@@ -260,8 +278,7 @@ class AdParser:
                     child_values = child_values[::-1]
                     flipped = True
                 try:
-                    symbol = Operations.to_symbol(operation)
-                    res = eval(f"child_values[0] {symbol} child_values[1]")
+                    res = _BINARY_OP[operation](child_values[0], child_values[1])
 
                 except ValueError as exc:
                     msg = self._get_error_message(
@@ -344,8 +361,7 @@ class AdParser:
                         )
                         raise ValueError(msg) from exc
                 try:
-                    symbol = Operations.to_symbol(operation)
-                    res = eval(f"child_values[0] {symbol} child_values[1]")
+                    res = _BINARY_OP[operation](child_values[0], child_values[1])
                     return res
                 except ValueError as exc:
                     msg = self._get_error_message(


### PR DESCRIPTION
Profiling indicated that a substantial part (10% on my benchmark, will vary significantly) of Ad assembly time was spent on lines `eval(operand_1 operation operand_2)`. It turns out that Python's inner machinery spend some time dealing with this and that some time * many times = substantial time.

The fix is simple and review should be straightforward.

All credit goes to Claude.

## Proposed changes

Contributions to PorePy are highly appreciated. Clearly explain why this pull request (PR) is needed and why it should be accepted. If this PR solves an issue, explain how it is done. Please, also summarise the changes to the code.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
