### PR TITLE
Remove protocol from mro

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,25 @@ Beyond what tools can check, we also value:
 * No speculative generality: avoid abstractions, configuration options, or error handling for cases the code
   does not actually need to support yet.
 
+## Models and mixins
+
+Models are assembled by multiple inheritance from a large number of mixin classes, and the method resolution
+order (MRO) decides which implementation wins. A few conventions keep that tractable:
+
+* Inherit `pp.PorePyModel` in every model mixin, and do not re-declare members the protocol already provides.
+  At runtime the protocol is replaced by a placeholder that contributes nothing to the MRO, so inheriting it is
+  safe in any base position: it can neither reorder sibling mixins nor cause an inconsistent-MRO `TypeError`.
+* Prefer `pp.PorePyModel` over a concrete mixin (`pp.BalanceEquation`, `pp.VariableMixin`, `pp.SolutionStrategy`,
+  ...) for a mixin that is only bundled into other mixins. A concrete base imposes a category ordering on every
+  model the bundle is mixed into, which may contradict the ordering that model already uses.
+* Never import `typing.Protocol` outside an `if TYPE_CHECKING:` block.
+* `isinstance(model, pp.PorePyModel)` raises `TypeError` by design; annotate with the protocol instead of testing
+  against it.
+* Mypy and the interpreter compute different MROs, since the protocol is a base class only for mypy. This is why
+  `# type: ignore[safe-super]` is occasionally needed on `super()` calls into sibling mixins. The divergence is
+  safe only as long as every implementation of a protocol member stays signature-compatible with its declaration,
+  which `mypy src` enforces. See the `Note` in `porepy.models.protocol` for details.
+
 ## Documentation
 
 All public functions, classes, and modules should be documented following the

--- a/src/porepy/models/constitutive_laws.py
+++ b/src/porepy/models/constitutive_laws.py
@@ -3142,7 +3142,7 @@ class LinearElasticMechanicalStress(pp.PorePyModel):
         return pp.ad.MpsaAd(self.stress_keyword, subdomains)
 
 
-class ThreeFieldLinearElasticMechanicalStress:
+class ThreeFieldLinearElasticMechanicalStress(pp.PorePyModel):
     """Constitutive laws related to the three-field formulation of a linear elastic
     medium.
 
@@ -3176,17 +3176,6 @@ class ThreeFieldLinearElasticMechanicalStress:
     """The stiffness tensor, defined on a subdomain."""
     rotation_dimension: Callable[[], Literal[1, 3]]
     """The dimension of the rotation variable. Either 1 (2D) or 3 (3D)."""
-    nd: int
-    """The ambient dimension."""
-    mdg: pp.MixedDimensionalGrid
-    """The mixed-dimensional grid."""
-    subdomains_to_interfaces: Callable[[list[pp.Grid], list[int]], list[pp.MortarGrid]]
-    """Method that maps subdomains to their interfaces."""
-    interfaces_to_subdomains: Callable[[list[pp.MortarGrid]], list[pp.Grid]]
-    """Method that maps interfaces to their subdomains."""
-    create_boundary_operator: Callable[[str, Sequence[pp.BoundaryGrid]], pp.ad.Operator]
-    """Method that creates a boundary operator given a keyword and a list of
-    boundary grids."""
 
     def mechanical_stress(self, domains: pp.SubdomainsOrBoundaries) -> pp.ad.Operator:
         """Linear elastic mechanical stress [Pa] as defined in the three-field
@@ -3423,7 +3412,7 @@ class ThreeFieldLinearElasticMechanicalStress:
         return pp.ad.DenseArray(np.hstack(lmbda), name="second_lame_parameter")
 
 
-class ConstitutiveLawsTpsaPoromechanics:
+class ConstitutiveLawsTpsaPoromechanics(pp.PorePyModel):
     """Mixin class containing constitutive laws for Tpsa discretization of
     poromechanics.
 
@@ -4275,7 +4264,7 @@ class ElasticTangentialFractureDeformation(pp.PorePyModel):
         return u_t
 
 
-class FractureDamageEvolutionCoefficients:
+class FractureDamageEvolutionCoefficients(pp.PorePyModel):
     r"""Fracture damage coefficients according to Gao et al. (2024). These are used for
     computing the history variables according to
 
@@ -4311,9 +4300,6 @@ class FractureDamageEvolutionCoefficients:
 
     contact_traction: Callable[[list[pp.Grid]], pp.ad.Operator]
     """Method returning the fracture contact traction."""
-
-    normal_component: Callable[[list[pp.Grid]], pp.ad.Operator]
-    """Method returning the normal component of a vector on the fracture."""
 
     solid: FractureDamageSolidConstants
     """SolidConstants with damage parameters."""

--- a/src/porepy/models/contact_mechanics.py
+++ b/src/porepy/models/contact_mechanics.py
@@ -8,7 +8,7 @@ combination with the momentum balance model, but can be used as a standalone mod
 """
 
 from functools import partial
-from typing import Callable, Optional, Sequence, cast
+from typing import Callable, Optional, cast
 
 import numpy as np
 
@@ -589,20 +589,11 @@ class ContactMechanics(
 # ! ---- VARIANT BASED ON RADIAL RETURN ---- ! #
 
 
-class RadialReturnTangentialContactMechanicsEquation:
+class RadialReturnTangentialContactMechanicsEquation(pp.PorePyModel):
     """Alternative formulation for tangential fracture deformation based on the
     classical radial return projection.
 
     """
-
-    tangential_component: Callable[[list[pp.Grid]], pp.ad.Operator]
-    """Mapping from a full vector to the tangential component."""
-
-    basis: Callable[[Sequence[pp.GridLike], int], list[pp.ad.Projection]]
-    """Basis vectors for the tangential components."""
-
-    nd: int
-    """Ambient dimension of the problem."""
 
     contact_traction: Callable[[list[pp.Grid]], pp.ad.Operator]
     """Contact traction variable. Normally defined in a mixin instance of
@@ -614,9 +605,6 @@ class RadialReturnTangentialContactMechanicsEquation:
     instance of
     :class:`~porepy.models.constitutive_laws.DisplacementJump`.
     """
-
-    numerical: pp.NumericalConstants
-    """Numerical parameters of the model, used for the open state tolerance."""
 
     friction_bound: Callable[[list[pp.Grid]], pp.ad.Operator]
     """Friction bound of a fracture. Normally provided by a mixin instance of

--- a/src/porepy/models/momentum_balance.py
+++ b/src/porepy/models/momentum_balance.py
@@ -197,7 +197,7 @@ class MomentumBalanceEquations(pp.BalanceEquation):
         )
 
 
-class AngularMomentumEquation:
+class AngularMomentumEquation(pp.PorePyModel):
     """Conservation equation for the angular momentum balance.
 
     Intended used for mechanics formulations that employ the two-point stress
@@ -212,16 +212,7 @@ class AngularMomentumEquation:
     """Operator for the total rotation over a face."""
     rotation_stress: Callable[[list[pp.Grid]], pp.ad.Operator]
     """Rotation stress variable."""
-    nd: int
-    """Ambient spatial dimension."""
-    mdg: pp.MixedDimensionalGrid
-    """The mixed-dimensional grid."""
-    equation_system: pp.EquationSystem
-    """The equation system."""
-    volume_integral: Callable[
-        [pp.ad.Operator, pp.SubdomainsOrBoundaries, int], pp.ad.Operator
-    ]
-    """Method to compute volume integrals."""
+
     balance_equation: Callable[
         [
             pp.SubdomainsOrBoundaries,
@@ -232,14 +223,16 @@ class AngularMomentumEquation:
         ],
         pp.ad.Operator,
     ]
-    """Method to construct balance equations."""
+    """Method to construct balance equations. Provided by
+    :class:`~porepy.models.abstract_equations.BalanceEquation`."""
 
     def set_equations(self) -> None:
         """Add the angular momentum equation to the set of equations."""
 
         # Set other equations, including for momentum balance and fracture deformation,
-        # by calling the parent class.
-        super().set_equations()  # type: ignore[misc]
+        # by calling the parent class. Mypy only sees the protocol's trivial body here;
+        # the call resolves to a sibling mixin at runtime.
+        super().set_equations()  # type: ignore[safe-super]
         matrix_subdomains = self.mdg.subdomains(dim=self.nd)
 
         angular_momentum = self.angular_momentum_equation(matrix_subdomains)
@@ -297,7 +290,7 @@ class AngularMomentumEquation:
         )
 
 
-class SolidMassEquation:
+class SolidMassEquation(pp.PorePyModel):
     """Conservation equation for the solid mass balance.
 
     Intended used for mechanics formulations that employ the two-point stress
@@ -310,16 +303,7 @@ class SolidMassEquation:
     """The second Lamé parameter."""
     total_pressure: Callable[[list[pp.Grid]], pp.ad.Operator]
     """The total pressure variable."""
-    nd: int
-    """Ambient spatial dimension."""
-    mdg: pp.MixedDimensionalGrid
-    """The mixed-dimensional grid."""
-    equation_system: pp.EquationSystem
-    """The equation system."""
-    volume_integral: Callable[
-        [pp.ad.Operator, pp.SubdomainsOrBoundaries, int], pp.ad.Operator
-    ]
-    """Method to compute volume integrals."""
+
     balance_equation: Callable[
         [
             pp.SubdomainsOrBoundaries,
@@ -330,11 +314,12 @@ class SolidMassEquation:
         ],
         pp.ad.Operator,
     ]
-    """Method to construct balance equations."""
+    """Method to construct balance equations. Provided by
+    :class:`~porepy.models.abstract_equations.BalanceEquation`."""
 
     def set_equations(self) -> None:
         """Add the solid mass conservation equation to the system."""
-        super().set_equations()  # type: ignore[misc]
+        super().set_equations()  # type: ignore[safe-super]
         matrix_subdomains = self.mdg.subdomains(dim=self.nd)
 
         solid_mass = self.solid_mass_equation(matrix_subdomains)
@@ -506,7 +491,7 @@ class VariablesMomentumBalance(VariableMixin):
         )
 
 
-class VariablesThreeFieldMomentumBalance:
+class VariablesThreeFieldMomentumBalance(pp.PorePyModel):
     """Variables used in the three-field formulation of the momentum balance, needed to
     use the Tpsa discretization scheme.
 
@@ -522,12 +507,6 @@ class VariablesThreeFieldMomentumBalance:
     """String name of the rotation stress variable."""
     total_pressure_variable: str
     """String name of the total pressure variable."""
-    nd: int
-    """Ambient spatial dimension."""
-    mdg: pp.MixedDimensionalGrid
-    """The mixed-dimensional grid."""
-    equation_system: pp.EquationSystem
-    """The equation system."""
 
     def create_variables(self) -> None:
         """Set variables related to the three-field formulation of momentum balance.
@@ -542,12 +521,8 @@ class VariablesThreeFieldMomentumBalance:
             ValueError: If the spatial dimension is less than 2.
 
         """
-        # Call super to create variables defined by other mixin classes. EK: This class
-        # should really inherit from VariableMixin, which contains the necessary
-        # super().create_variables(). However, doing so lead to a completely
-        # incomprehensible MRO issue. Various workarounds did not work, and ignoring a
-        # safe-super issue seemed like the only reasonable approach.
-        super().create_variables()  # type:ignore[misc]
+        # Call super to create variables defined by other mixin classes.
+        super().create_variables()  # type: ignore[safe-super]
 
         # It is unclear to EK what to do with a 1d medium, so we raise an error.
         if self.nd < 2:
@@ -713,7 +688,7 @@ class SolutionStrategyMomentumBalance(pp.SolutionStrategy):
         return self.mdg.dim_min() < self.nd
 
 
-class SolutionStrategyThreeFieldMomentumBalance:
+class SolutionStrategyThreeFieldMomentumBalance(pp.PorePyModel):
     """Solution strategy for the three-field formulation of the momentum balance.
 
     This class is not meant to be mixed in directly, but is used by other mixin classes,
@@ -722,9 +697,9 @@ class SolutionStrategyThreeFieldMomentumBalance:
     """
 
     def __init__(self, params: Optional[dict] = None) -> None:
-        # No explicit parent class, but we expect different mixins with __init__ methods
-        # to be available.
-        super().__init__(params)  # type: ignore[call-arg]
+        # Mypy sees the protocol's trivial __init__; at runtime this reaches the
+        # SolutionStrategy of whichever model this is mixed into.
+        super().__init__(params)  # type: ignore[safe-super]
 
         # The only task is to set some keywords.
         self.rotation_stress_variable: str = "rotation_stress"
@@ -896,7 +871,7 @@ class InitialConditionsMomentumBalance(pp.InitialConditionMixin):
         return np.zeros(intf.num_cells * self.nd)
 
 
-class InitialConditionsThreeFieldMomentumBalance:
+class InitialConditionsThreeFieldMomentumBalance(pp.PorePyModel):
     """Mixin for setting initial conditions for the rotation and total pressure
     variables."""
 
@@ -906,12 +881,6 @@ class InitialConditionsThreeFieldMomentumBalance:
     """Operator for the rotation stress variable."""
     total_pressure: Callable[[list[pp.Grid]], pp.ad.Operator]
     """Operator for the total pressure variable."""
-    nd: int
-    """Ambient spatial dimension."""
-    equation_system: pp.ad.EquationSystem
-    """The equation system."""
-    mdg: pp.MixedDimensionalGrid
-    """The mixed-dimensional grid."""
 
     def set_initial_values_primary_variables(self) -> None:
         """Method to set initial values for displacement, contact traction and interface
@@ -923,7 +892,8 @@ class InitialConditionsThreeFieldMomentumBalance:
             - :meth:`ic_values_total_pressure`
 
         """
-        # Super call for compatibility with multi-physics.
+        # Super call for compatibility with multi-physics. The method is not part
+        # of the protocol, so mypy cannot see the sibling mixin providing it.
         super().set_initial_values_primary_variables()  # type: ignore[misc]
 
         for sd in self.mdg.subdomains():

--- a/src/porepy/models/momentum_balance.py
+++ b/src/porepy/models/momentum_balance.py
@@ -892,9 +892,10 @@ class InitialConditionsThreeFieldMomentumBalance(pp.PorePyModel):
             - :meth:`ic_values_total_pressure`
 
         """
-        # Super call for compatibility with multi-physics. The method is not part
-        # of the protocol, so mypy cannot see the sibling mixin providing it.
-        super().set_initial_values_primary_variables()  # type: ignore[misc]
+        # Super call for compatibility with multi-physics. Mypy only sees the protocol's
+        # trivial body; the call resolves to a sibling mixin at runtime.
+        super().set_initial_values_primary_variables()  # type: ignore[safe-super]
+
 
         for sd in self.mdg.subdomains():
             # Displacement is only defined on grids with ambient dimension.

--- a/src/porepy/models/momentum_balance.py
+++ b/src/porepy/models/momentum_balance.py
@@ -896,7 +896,6 @@ class InitialConditionsThreeFieldMomentumBalance(pp.PorePyModel):
         # trivial body; the call resolves to a sibling mixin at runtime.
         super().set_initial_values_primary_variables()  # type: ignore[safe-super]
 
-
         for sd in self.mdg.subdomains():
             # Displacement is only defined on grids with ambient dimension.
             if sd.dim == self.nd:

--- a/src/porepy/models/protocol.py
+++ b/src/porepy/models/protocol.py
@@ -13,6 +13,34 @@ Warning:
     Protocols use ``__slot__`` which leads to unforeseeable behaviour when combined
     with multiple inheritance and mixing.
 
+    Beyond that, the protocol must not appear in the runtime MRO *at all*, not even
+    as an empty placeholder class. Being a common base of most - but not all - mixins,
+    such a placeholder acts as a linearisation barrier: C3 must order it after every
+    class that inherits it, so anything following it in one base's MRO is pushed
+    behind everything preceding it in another. The effect is silent, since an empty
+    class shadows nothing, but it can demote an override mixin behind the very class
+    it was written to override. The runtime stand-in therefore returns an empty tuple
+    from ``__mro_entries__`` (PEP 560), so that ``class X(pp.PorePyModel)`` is
+    compiled as ``class X:``.
+
+Note:
+    Because the protocol is a base class for mypy but not at runtime, the two see
+    different linearisations of a composed model. Mypy resolves an inter-mixin call to
+    the protocol's declaration and computes an MRO that still contains
+    :class:`PorePyModel`; at runtime the call resolves to whichever mixin the
+    composition actually put first, and :class:`PorePyModel` is absent from
+    ``__mro__`` entirely.
+
+    This is why ``# type: ignore[safe-super]`` is occasionally needed on ``super()``
+    calls into sibling mixins - mypy sees the protocol's trivial body - and why
+    ``isinstance(model, PorePyModel)`` raises a ``TypeError``: the runtime object is
+    not a class, and the protocol is not ``runtime_checkable``. Annotate with the
+    protocol instead of testing against it.
+
+    The divergence is benign precisely as long as every implementation of a protocol
+    member stays signature-compatible with the declaration here, which ``mypy src``
+    enforces.
+
 """
 
 from pathlib import Path
@@ -26,8 +54,36 @@ import numpy as np
 if not TYPE_CHECKING:
     # This branch is accessed in python runtime.
     # NOTE See Warning in module docstring before attempting anything here.
-    class PorePyModel:
-        """This is an empty placeholder of the protocol, used mainly for type hints."""
+    class _PorePyModelPlaceholder:
+        """Runtime stand-in for the PorePyModel protocol.
+
+        Returning an empty tuple from ``__mro_entries__`` (PEP 560) means that
+        ``class X(pp.PorePyModel)`` is compiled as ``class X:``. The protocol
+        contributes *nothing* to the MRO and can therefore never act as a
+        linearisation barrier between mixins.
+
+        Note that this makes ``pp.PorePyModel`` an instance rather than a class at
+        runtime. Annotations, ``type[...]``, ``Optional[...]`` and ``TypeVar``
+        bounds are unaffected; ``isinstance`` against it raises a ``TypeError``.
+
+        Dynamic class assembly must use ``types.new_class`` rather than the
+        three-argument ``type``: only the former resolves ``__mro_entries__``. This
+        concerns the protocol alone - ``type`` remains fine for assembling models from
+        ordinary mixins, as :func:`porepy.applications.test_utils.models.add_mixin`
+        does.
+
+        """
+
+        __name__ = "PorePyModel"
+        __qualname__ = "PorePyModel"
+
+        def __mro_entries__(self, bases: tuple) -> tuple:
+            return ()
+
+        def __repr__(self) -> str:
+            return "<protocol porepy.models.protocol.PorePyModel>"
+
+    PorePyModel = _PorePyModelPlaceholder()
 
 else:
     # This branch is accessed by mypy and linters.
@@ -1200,9 +1256,15 @@ else:
         such as VSCode can properly autocomplete these hints. You must either inherit
         from this class or provide it as a type annotation for the PorePy model object.
 
+        Inheriting from it is safe in any base position: at runtime the protocol is
+        replaced by a placeholder which contributes nothing to the MRO, so it can
+        neither reorder sibling mixins nor provoke a ``TypeError`` about an
+        inconsistent MRO. See the Warning in the module docstring.
+
         Note:
             This can also be considered the list of the functionality which must be
             implemented by an instanciated model, although it does not verify it in
-            runtime, since it is not an abstract base class.
+            runtime, since it is not an abstract base class. In particular,
+            ``isinstance`` cannot be used against this protocol.
 
         """

--- a/src/porepy/models/protocol.py
+++ b/src/porepy/models/protocol.py
@@ -1024,7 +1024,7 @@ else:
             """Interface method for the solution strategy to be called to set initial
             values for all variables.
 
-            Calls the methods :meth:`set_initial_values_primary_variables`.
+            Calls the method :meth:`set_initial_values_primary_variables`.
 
             Can be overridden to set other initial conditions after a super-call.
 
@@ -1034,6 +1034,10 @@ else:
                 get a runable model.
 
             """
+
+        def set_initial_values_primary_variables(self) -> None:
+            """Set the initial values for the primary variables."""
+
 
     class EquationProtocol(Protocol):
         """This protocol provides declarations of methods and properties related to

--- a/src/porepy/models/protocol.py
+++ b/src/porepy/models/protocol.py
@@ -1038,7 +1038,6 @@ else:
         def set_initial_values_primary_variables(self) -> None:
             """Set the initial values for the primary variables."""
 
-
     class EquationProtocol(Protocol):
         """This protocol provides declarations of methods and properties related to
         equations.

--- a/tests/models/test_protocol.py
+++ b/tests/models/test_protocol.py
@@ -1,0 +1,108 @@
+"""Tests of the runtime behaviour of the PorePyModel protocol.
+
+The protocol is a ``typing.Protocol`` for static type checkers only. At runtime it is
+replaced by a placeholder which returns an empty tuple from ``__mro_entries__``, so that
+``class X(pp.PorePyModel)`` is compiled as ``class X:``.
+
+Testing covers:
+    The protocol is absent from the MRO of the composed models.
+    The protocol can be listed in any base position without provoking a TypeError.
+    Override mixins keep their intended precedence over the model they are mixed into.
+
+See the Warning in :mod:`porepy.models.protocol` for why this matters: a placeholder
+which *is* a class becomes a linearisation barrier, silently demoting override mixins
+behind the classes they were written to override.
+
+"""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+import porepy as pp
+from porepy.models import constitutive_laws, momentum_balance
+from porepy.models.contact_mechanics import ContactMechanics
+from porepy.models.derived_models.biot import BiotPoromechanics
+from porepy.models.fluid_mass_balance import SinglePhaseFlow
+from porepy.models.mass_and_energy_balance import MassAndEnergyBalance
+from porepy.models.momentum_balance import MomentumBalance
+from porepy.models.poromechanics import Poromechanics
+from porepy.models.thermoporomechanics import Thermoporomechanics
+
+# The composed models shipped with PorePy. Every mixin they are built from inherits the
+# protocol, so if the protocol ever re-enters the MRO, it does so here.
+composed_models = [
+    SinglePhaseFlow,
+    MassAndEnergyBalance,
+    MomentumBalance,
+    ContactMechanics,
+    Poromechanics,
+    Thermoporomechanics,
+    BiotPoromechanics,
+]
+
+
+@pytest.mark.parametrize("model_class", composed_models)
+def test_protocol_absent_from_mro(model_class: type) -> None:
+    """The protocol must not contribute anything to the runtime MRO."""
+    names = [cls.__name__ for cls in model_class.__mro__]
+    assert "PorePyModel" not in names
+    assert "_PorePyModelPlaceholder" not in names
+
+
+@pytest.mark.parametrize("model_class", composed_models)
+def test_protocol_can_be_listed_before_a_model(model_class: type) -> None:
+    """Listing the protocol first is the natural way for a user to pick up type hints.
+
+    With a placeholder class as base this raised ``TypeError: Cannot create a consistent
+    method resolution order``, since the placeholder must follow its own subclasses.
+
+    Note that ``types.new_class`` is used rather than the three-argument ``type``: only
+    the former performs ``__mro_entries__`` resolution.
+
+    """
+    combined = types.new_class("CombinedModel", (pp.PorePyModel, model_class))
+    assert combined.__mro__[1] is model_class
+
+
+def test_protocol_does_not_reorder_mixins() -> None:
+    """An override mixin must keep precedence over the model it is mixed into.
+
+    ``VariablesThreeFieldMomentumBalance`` inheriting ``VariableMixin`` used to drag the
+    protocol into the middle of ``TpsaMomentumBalanceMixin``'s linearisation. Everything
+    behind the protocol there - including
+    ``ThreeFieldLinearElasticMechanicalStress`` - was then demoted behind the whole of
+    ``MomentumBalance``, so the default ``stress()`` silently won.
+
+    """
+    combined = type(
+        "TpsaMomentumBalance",
+        (momentum_balance.TpsaMomentumBalanceMixin, MomentumBalance),
+        {},
+    )
+    mro = combined.__mro__
+    # The stress law which overrides the default must precede it in the MRO.
+    override = constitutive_laws.ThreeFieldLinearElasticMechanicalStress
+    default = constitutive_laws.LinearElasticMechanicalStress
+    assert mro.index(override) < mro.index(default)
+
+    # The whole TPSA bundle, not just the stress law, must precede the model it
+    # overrides.
+    assert mro.index(momentum_balance.TpsaMomentumBalanceMixin) < mro.index(
+        MomentumBalance
+    )
+    for mixin in momentum_balance.TpsaMomentumBalanceMixin.__bases__:
+        assert mro.index(mixin) < mro.index(default)
+
+
+def test_protocol_is_not_usable_with_isinstance() -> None:
+    """``isinstance`` against the protocol fails loudly rather than lying.
+
+    The protocol is not ``runtime_checkable``, so such a check could never be
+    meaningful. Annotate with the protocol instead.
+
+    """
+    with pytest.raises(TypeError):
+        isinstance(object(), pp.PorePyModel)


### PR DESCRIPTION
## Proposed changes

`PorePyModel` is a `typing.Protocol` under `TYPE_CHECKING` and an empty placeholder class
at runtime ([protocol.py:26-30](src/porepy/models/protocol.py#L26-L30)). 122 classes inherit it.

The placeholder is empty, so it can never shadow a method. But it is a real class, so C3 must
order it after every class that inherits it. This can mess up the MRO.

**Fix:** make the runtime placeholder contribute nothing to the MRO via PEP 560
`__mro_entries__` returning `()`. `class DarcysLaw(pp.PorePyModel)` then compiles to
`class DarcysLaw:`. mypy is untouched — it only reads the `else:` branch.

The PR also 
- Adds testing of the PorePyModel protocol
- Reclaims old usage of PorePyModel for existing mixins, removing explicit type declaration.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Testing (contribution related to testing of existing or new functionality).
- [x] Documentation (contribution related to adding, improving, or fixing documentation).
- [x] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
