### PR TITLE
Fix misleading docstring of convert_units

### DIFF
--- a/src/porepy/models/units.py
+++ b/src/porepy/models/units.py
@@ -145,7 +145,7 @@ class Units:
         Parameters:
             value: Value to be converted. Either a number (int, float) or a numpy array.
             units: Units of ``value`` defined as a string in the form of
-                ``unit1 * unit2 * unit3^-1``, e.g., ``"Pa*m^3/kg"``.
+                ``unit1 * unit2 * unit3^-1``, e.g., ``"Pa*m^3*kg^-1"``.
 
                 Valid units are the attributes and properties of the :attr:`units`
                 defined at instantiation.


### PR DESCRIPTION
## Proposed changes

DOC: Almost trivial

The `convert_units` docstring advertises `"Pa*m^3/kg"` as a valid unit string, but the
parser accepts only `*` and `^`, never `/`. A user following the example gets an error.
Corrected to `"Pa*m^3*kg^-1"`, which is the form the surrounding text already describes.

Documentation only; no behaviour change.

## Types of changes

- [x] Documentation (contribution related to adding, improving, or fixing documentation).

## Checklist

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update. — n/a, docstring only.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR). — n/a, no behaviour change.
- [x] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag. — n/a, no new tests.
