### PR TITLE
BUG: Use norm, not component sum, in damage history zero-skip test

### DIFF
--- a/src/porepy/models/fracture_damage.py
+++ b/src/porepy/models/fracture_damage.py
@@ -236,11 +236,11 @@ class FractureDamageEquations(pp.PorePyModel):
 
         Parameters:
             length_function: Function that takes (subdomains, time_step_index) and
-                returns (contribution, constant_part) tuple.
+                returns a (contribution, increment_norm) tuple.
             damage_coefficient_function: Function returning the damage coefficient
                 operator for the current time step.
             subdomains: List of fracture subdomains.
-            tolerance: Tolerance for checking if constant part is non-zero.
+            tolerance: Tolerance for checking if the increment norm is non-zero.
 
         Returns:
             Operator for the damage equation.
@@ -256,14 +256,14 @@ class FractureDamageEquations(pp.PorePyModel):
         for i in range(1, num_steps):
             # i = number of steps back in time.
             damage_coefficient_i = damage_coefficient.previous_timestep(i)
-            length_i, constant_part_i = length_function(subdomains, i)
-            # Provided the contribution is the product of the constant part and some
-            # variable, constant_part_i = 0 implies contribution_i = 0 regardless of the
-            # variable's value. The damage coefficient is also treated as constant (it
-            # is evaluated at the previous time step).
+            length_i, increment_norm_i = length_function(subdomains, i)
+            # A vanishing slip increment gives a vanishing contribution for both length
+            # functions, regardless of the current state they are evaluated against, so
+            # such terms can be dropped from the sum. Both factors are evaluated at a
+            # previous time step and are therefore constant.
             constant_value = cast(
                 np.ndarray,
-                (constant_part_i * damage_coefficient_i).value(self.equation_system),
+                (increment_norm_i * damage_coefficient_i).value(self.equation_system),
             )
             if np.any(np.abs(constant_value) > tolerance):  # tolerance for zero check
                 eq += length_i * damage_coefficient_i
@@ -407,15 +407,11 @@ class IsotropicFractureDamageLength(pp.PorePyModel):
             time_step_index: Index of the time step.
 
         Returns:
-            Tuple containing the contribution to the equation and the displacement
-            increment at the specified time step. If the displacement increment is zero,
-            the full contribution is also zero.
+            Tuple containing the contribution to the equation and the norm of the
+            displacement increment at the specified time step. If the increment norm is
+            zero, the full contribution is also zero.
         """
         nd_vec_to_tangential = self.tangential_component(subdomains)
-        tangential_basis = self.basis(subdomains, dim=self.nd - 1)
-        tangential_to_scalar = pp.ad.sum_projection_list(
-            [e_i.T for e_i in tangential_basis]
-        )
         u_t = nd_vec_to_tangential @ self.plastic_displacement_jump(subdomains)
         u_t_increment = u_t.previous_timestep(time_step_index) - u_t.previous_timestep(
             time_step_index + 1
@@ -423,9 +419,12 @@ class IsotropicFractureDamageLength(pp.PorePyModel):
 
         f_norm = pp.ad.Function(partial(pp.ad.l2_norm, self.nd - 1), "norm_function")
 
-        contribution = f_norm(u_t_increment)
+        # The norm vanishes if and only if the increment does, which is what the caller
+        # needs in order to discard a history term. Summing the tangential components
+        # instead would report an increment such as (a, -a) as zero.
+        increment_norm = f_norm(u_t_increment)
 
-        return contribution, tangential_to_scalar @ u_t_increment
+        return increment_norm, increment_norm
 
 
 class AnisotropicFractureDamageLength(pp.PorePyModel):
@@ -467,9 +466,9 @@ class AnisotropicFractureDamageLength(pp.PorePyModel):
             time_step_index: Index of the time step.
 
         Returns:
-            Tuple containing the contribution to the equation and the displacement
-            increment at the specified time step. If the displacement increment is zero,
-            the full contribution is also zero.
+            Tuple containing the contribution to the equation and the norm of the
+            displacement increment at the specified time step. If the increment norm is
+            zero, the full contribution is also zero.
         """
         # Fracture coordinate basis functions.
         tangential_basis = self.basis(subdomains, dim=self.nd - 1)
@@ -501,10 +500,13 @@ class AnisotropicFractureDamageLength(pp.PorePyModel):
         f_abs = pp.ad.Function(pp.ad.abs, "abs_function")
         contribution = f_abs(max_1 - max_0)
         # If time_step_index > 0, we can safely disregard the contribution if the
-        # displacement increment is zero. Return increment for checking before adding
-        # the contribution.
+        # displacement increment is zero. Return the increment norm for checking before
+        # adding the contribution; the norm vanishes if and only if the increment does,
+        # whereas summing the tangential components would report an increment such as
+        # (a, -a) as zero.
         increment = u_t_0 - u_t_1
-        return contribution, tangential_to_scalar @ increment
+        f_norm = pp.ad.Function(partial(pp.ad.l2_norm, self.nd - 1), "norm_function")
+        return contribution, f_norm(increment)
 
     def normalized_tangential_plastic_jump(
         self, subdomains: list[pp.Grid]

--- a/src/porepy/models/fracture_damage.py
+++ b/src/porepy/models/fracture_damage.py
@@ -261,14 +261,30 @@ class FractureDamageEquations(pp.PorePyModel):
             # functions, regardless of the current state they are evaluated against, so
             # such terms can be dropped from the sum. Both factors are evaluated at a
             # previous time step and are therefore constant.
-            constant_value = cast(
-                np.ndarray,
-                (increment_norm_i * damage_coefficient_i).value(self.equation_system),
-            )
-            if np.any(np.abs(constant_value) > tolerance):  # tolerance for zero check
+            if self._check_constant_contribution(
+                increment_norm_i * damage_coefficient_i, tolerance
+            ):
                 eq += length_i * damage_coefficient_i
 
         return eq
+
+    def _check_constant_contribution(
+        self, constant_operator: pp.ad.Operator, tolerance: float = 1e-14
+    ) -> bool:
+        """Check if the constant operator has a non-zero contribution.
+
+        Parameters:
+            constant_operator: Operator to check.
+            tolerance: Tolerance for checking if the operator is non-zero.
+
+        Returns:
+            True if the operator has a non-zero contribution, False otherwise.
+        """
+        constant_value = cast(
+            np.ndarray,
+            constant_operator.value(self.equation_system),
+        )
+        return bool(np.any(np.abs(constant_value) > tolerance))
 
 
 class DilationDamageEquation(FractureDamageEquations):
@@ -419,9 +435,7 @@ class IsotropicFractureDamageLength(pp.PorePyModel):
 
         f_norm = pp.ad.Function(partial(pp.ad.l2_norm, self.nd - 1), "norm_function")
 
-        # The norm vanishes if and only if the increment does, which is what the caller
-        # needs in order to discard a history term. Summing the tangential components
-        # instead would report an increment such as (a, -a) as zero.
+        # Compute norm of the increment.
         increment_norm = f_norm(u_t_increment)
 
         return increment_norm, increment_norm
@@ -499,12 +513,9 @@ class AnisotropicFractureDamageLength(pp.PorePyModel):
         )
         f_abs = pp.ad.Function(pp.ad.abs, "abs_function")
         contribution = f_abs(max_1 - max_0)
-        # If time_step_index > 0, we can safely disregard the contribution if the
-        # displacement increment is zero. Return the increment norm for checking before
-        # adding the contribution; the norm vanishes if and only if the increment does,
-        # whereas summing the tangential components would report an increment such as
-        # (a, -a) as zero.
+
         increment = u_t_0 - u_t_1
+        # Compute norm of the increment.
         f_norm = pp.ad.Function(partial(pp.ad.l2_norm, self.nd - 1), "norm_function")
         return contribution, f_norm(increment)
 

--- a/tests/models/test_fracture_damage_unit.py
+++ b/tests/models/test_fracture_damage_unit.py
@@ -683,3 +683,30 @@ class TestDamageLength:
             d * np.sqrt(2.0) * np.ones(nc),
             rtol=1e-10,
         )
+
+    @pytest.mark.parametrize(
+        "isotropic", [True, False], ids=["isotropic", "anisotropic"]
+    )
+    def test_3d_zero_check_uses_norm_not_component_sum(self, isotropic: bool):
+        """The increment measure must not vanish for a cancelling 3D increment.
+
+        ``damage_convolution_integral`` drops a history term when this second return
+        value falls below tolerance, so it may vanish only when the increment itself
+        does. With ``u_t = (a, -a)`` the tangential components sum to zero while the
+        increment is plainly non-zero. A failure here means the check has reverted to
+        summing components, which silently discards real slip history in 3D.
+        """
+        model = _prepared_model(isotropic=isotropic, damages=["dilation"], dim=3)
+        fractures = self._fractures(model)
+        nc = sum(sd.num_cells for sd in fractures)
+        a = 3.0e-4
+
+        self._set_tangential_jump(model, a, -a, iterate=True)
+        self._set_tangential_jump(model, 0.0, 0.0, time_step_index=0)
+
+        _, increment_norm = model.damage_length(fractures, 0)
+        np.testing.assert_allclose(
+            increment_norm.value(model.equation_system),
+            a * np.sqrt(2.0) * np.ones(nc),
+            rtol=1e-10,
+        )

--- a/tests/models/test_fracture_damage_unit.py
+++ b/tests/models/test_fracture_damage_unit.py
@@ -687,26 +687,52 @@ class TestDamageLength:
     @pytest.mark.parametrize(
         "isotropic", [True, False], ids=["isotropic", "anisotropic"]
     )
-    def test_3d_zero_check_uses_norm_not_component_sum(self, isotropic: bool):
+    def test_3d_zero_check_does_not_trigger_for_cancelling_increment(
+        self, isotropic: bool
+    ):
         """The increment measure must not vanish for a cancelling 3D increment.
 
         ``damage_convolution_integral`` drops a history term when this second return
         value falls below tolerance, so it may vanish only when the increment itself
-        does. With ``u_t = (a, -a)`` the tangential components sum to zero while the
-        increment is plainly non-zero. A failure here means the check has reverted to
-        summing components, which silently discards real slip history in 3D.
+        does. With ``u_t = (a, -a)`` and (0, 0) at the previous time step, the
+        tangential components sum to zero while the increment is plainly non-zero.
         """
+        add_contribution = self._compute_add_contribution(
+            time_val=0.0, isotropic=isotropic
+        )
+        assert add_contribution, (
+            "Increment norm must not vanish for cancelling 3D increment"
+        )
+
+    @pytest.mark.parametrize(
+        "isotropic", [True, False], ids=["isotropic", "anisotropic"]
+    )
+    def test_3d_zero_check_triggers_for_zero_increment(self, isotropic: bool):
+        """The increment norm must vanish when the tangential jump is unchanged.
+
+        The second return value of ``damage_length`` is used to determine whether a
+        history term contributes to the convolution integral.  It must vanish only
+        when the tangential jump is unchanged, which is tested here in 3D.
+        """
+        # Same time_val as used for iterate in the helper implies a zero increment (no
+        # change from previous time step).
+        add_contribution = self._compute_add_contribution(
+            time_val=3.0e-4, isotropic=isotropic
+        )
+        assert not add_contribution, (
+            "Increment norm must vanish for unchanged tangential jump."
+        )
+
+    def _compute_add_contribution(self, time_val: float, isotropic: bool) -> bool:
+        """Return whether the increment norm is non-zero for a 3D tangential jump."""
         model = _prepared_model(isotropic=isotropic, damages=["dilation"], dim=3)
         fractures = self._fractures(model)
-        nc = sum(sd.num_cells for sd in fractures)
         a = 3.0e-4
 
         self._set_tangential_jump(model, a, -a, iterate=True)
-        self._set_tangential_jump(model, 0.0, 0.0, time_step_index=0)
-
+        self._set_tangential_jump(model, time_val, -time_val, time_step_index=0)
+        coeff = model.dilation_damage_evolution_coefficient(
+            fractures
+        ).previous_timestep(0)
         _, increment_norm = model.damage_length(fractures, 0)
-        np.testing.assert_allclose(
-            increment_norm.value(model.equation_system),
-            a * np.sqrt(2.0) * np.ones(nc),
-            rtol=1e-10,
-        )
+        return model._check_constant_contribution(increment_norm * coeff)


### PR DESCRIPTION
## Proposed changes

`damage_convolution_integral` drops a history term when the quantity returned alongside
the damage length falls below tolerance. Both length functions (isotropic and anisotropic) returned the *sum* of the
tangential components of the slip increment. In 3D that sum vanishes for an increment
such as `(a, -a)` while the increment itself does not, so a genuine contribution could be
discarded. The norm is returned instead, which vanishes exactly when the increment does.

Latent rather than active: dropping a term requires every cell's component sum to fall
below tolerance, so realistic 3D slip would not have triggered it. Fixed because the
guard is wrong, not because a failure was observed. 2D is unaffected, there being one
tangential component.

Adds a regression test, parametrised over the isotropic and anisotropic length
functions, which fails on the previous implementation and passes on this one.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue).
- [x] Testing (contribution related to testing of existing or new functionality).

## Checklist

- [x] The documentation is up-to-date. — docstrings and the tolerance comment updated to match.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [x] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag. — n/a, no skipped tests added.
