### PR TITLE
 API: Linear damage driver with a single wear-energy history

### DIFF
--- a/src/porepy/compositional/materials.py
+++ b/src/porepy/compositional/materials.py
@@ -436,20 +436,58 @@ class FractureDamageSolidConstants(SolidConstants):
         {
             "residual_dilation_damage": "-",
             "residual_friction_damage": "-",
-            "dilation_damage_decay": "-",
-            "friction_damage_decay": "-",
-            "characteristic_fracture_roughness": "m",
-            "uniaxial_compressive_strength": "Pa",
+            "dilation_wear_energy_scale": "J * m^-2",
+            "friction_wear_energy_scale": "J * m^-2",
         }
     )
-    # Initial value 1 implies no frictional damage, 0.0 implies no damage at all.
-    # Consider renaming to `friction_damage_weight`.
     residual_friction_damage: float = 1.0
-    friction_damage_decay: float = 0.0
+    r"""Residual friction damage state :math:`d_0^f` [-].
+
+    The value the friction damage state decays to as the history variable grows, in
+    :math:`d^f = d_0^f + (1 - d_0^f)\exp(-\Lambda^f / \Lambda_c^f)`.
+
+    :math:`d_0^f = 1` holds :math:`d^f \equiv 1` and thereby switches friction damage
+    off, leaving the intact coefficient; this is how an undamaged reference run is
+    configured. :math:`d_0^f` is a floor on the friction coefficient, since the damage
+    state multiplies it in full.
+
+    """
+
     residual_dilation_damage: float = 1.0
-    dilation_damage_decay: float = 0.0
-    characteristic_fracture_roughness: float = 1.0
-    uniaxial_compressive_strength: float = 1.0
+    r"""Residual dilation damage state :math:`d_0^d` [-].
+
+    As :attr:`residual_friction_damage`, but multiplying the shear dilation gap.
+
+    :math:`d_0^d = 1` switches dilation damage off. Unlike the friction channel, the
+    natural choice here is :math:`d_0^d > 0`, leaving a finite residual dilation rate
+    and hence a bounded but non-vanishing aperture; :math:`d_0^d = 0` would drive the
+    aperture back to zero under sustained shear, since the gap is proportional to
+    :math:`d^d`. The asymmetry with the friction channel is deliberate.
+
+    """
+
+    dilation_wear_energy_scale: float = 1.0
+    r"""Wear energy scale for dilation damage :math:`\Lambda_c^d` [J * m^-2].
+
+    The frictional work per unit area that must be dissipated against the asperities for
+    the dilation damage state to decay by a factor :math:`e` towards its residual; see
+    :class:`~porepy.constitutive_laws.DilationDamage`. It absorbs Archard's
+    dimensionless wear coefficient and is therefore an effective calibrated quantity
+    rather than a purely geometric one.
+
+    Associated with the longer-wavelength waviness of the fracture surface, which is the
+    scale that produces resolvable aperture change.
+
+    """
+
+    friction_wear_energy_scale: float = 1.0
+    r"""Wear energy scale for friction damage :math:`\Lambda_c^f` [J * m^-2].
+
+    As :attr:`dilation_wear_energy_scale`, but for the friction channel, and associated
+    with the shorter-wavelength unevenness, which contributes frictional resistance
+    without geometrically resolvable dilation.
+
+    """
 
 
 @dataclass(kw_only=True, eq=False)

--- a/src/porepy/examples/fracture_damage.py
+++ b/src/porepy/examples/fracture_damage.py
@@ -65,10 +65,9 @@ class TimeDependentDamageBCs:
 DATA_SAVING_METHOD_NAMES = [
     "damage_length",
     "damage_evolution_coefficient",
+    "damage_history",
     "dilation_damage_state",
-    "dilation_damage_history",
     "friction_damage_state",
-    "friction_damage_history",
 ]
 
 
@@ -93,14 +92,12 @@ class DamageDataSaving(pp.PorePyModel):
 
     damage_length: Callable[[list[pp.Grid], int], tuple[pp.ad.Operator, pp.ad.Operator]]
     """Damage length operator."""
+    damage_history: Callable[[list[pp.Grid]], pp.ad.Variable]
+    """Damage history."""
     dilation_damage_state: Callable[[list[pp.Grid]], pp.ad.Operator]
     """Dilation damage operator."""
-    dilation_damage_history: Callable[[list[pp.Grid]], pp.ad.Variable]
-    """Dilation damage history."""
     friction_damage_state: Callable[[list[pp.Grid]], pp.ad.Operator]
     """Friction damage operator."""
-    friction_damage_history: Callable[[list[pp.Grid]], pp.ad.Variable]
-    """Friction damage history."""
     solid: FractureDamageSolidConstants
 
     def initialize_data_saving(self) -> None:
@@ -177,41 +174,26 @@ class FractureDamageMomentumBalance(  # type: ignore[misc]
     """
 
 
-class DilationDamageMixin(
-    pp.constitutive_laws.DilationDamage,
-    damage.DilationDamageEquation,
-    damage.DilationDamageVariable,
+class FractureDamageHistoryMixin(
+    damage.FractureDamageEquation,
+    damage.FractureDamageVariable,
 ):
-    """Fracture damage model with dilation damage.
+    """The damage history variable and its convolution equation.
 
-    To be used as a mixin for the momentum balance model and isotropic or anisotropic
-    damage models when dilation damage is activated. Can be used on its own or together
-    with friction damage.
-    """
-
-    pass
-
-
-class FrictionDamageMixin(
-    pp.constitutive_laws.FrictionDamage,
-    damage.FrictionDamageEquation,
-    damage.FrictionDamageVariable,
-):
-    """Fracture damage model with friction damage.
-
-    To be used as a mixin for the momentum balance model and isotropic or anisotropic
-    damage models when friction damage is activated. Can be used on its own or together
-    with dilation damage.
+    Mixed in whenever any damage channel is active, since the history is common to
+    them. The channels themselves are added by the constitutive mixins in
+    :data:`damage_types`.
     """
 
     pass
 
 
 # Collect the damage types in a dictionary for easy access when building models with
-# different regimes.
+# different regimes. These supply the constitutive laws only; the history they read is
+# provided once by :class:`FractureDamageHistoryMixin`.
 damage_types = {
-    "dilation": DilationDamageMixin,
-    "friction": FrictionDamageMixin,
+    "dilation": pp.constitutive_laws.DilationDamage,
+    "friction": pp.constitutive_laws.FrictionDamage,
 }
 
 
@@ -309,19 +291,19 @@ class ExactSolution:
             Array of friction damage for the given time step.
 
         """
-        h = self.friction_damage_history(sd, n)
+        h = self.damage_history(sd, n)
         d0 = self.model.solid.residual_friction_damage
         return d0 + (1 - d0) * np.exp(-h / self._wear_energy_scale("friction"))
 
-    def friction_damage_history(self, sd: pp.Grid, n: int) -> np.ndarray:
-        """Return the friction damage history at time step n.
+    def damage_history(self, sd: pp.Grid, n: int) -> np.ndarray:
+        """Return the damage history at time step n.
 
         Parameters:
             sd: Subdomain where the boundary displacement is defined.
             n: Time step index.
 
         Returns:
-            Array of friction damage history for the given time step.
+            Array of damage history for the given time step.
 
         """
         return self.convolution(sd, n, self.damage_evolution_coefficient)
@@ -337,22 +319,9 @@ class ExactSolution:
             Array of dilation damage for the given time step.
 
         """
-        h = self.dilation_damage_history(sd, n)
+        h = self.damage_history(sd, n)
         d0 = self.model.solid.residual_dilation_damage
         return d0 + (1 - d0) * np.exp(-h / self._wear_energy_scale("dilation"))
-
-    def dilation_damage_history(self, sd: pp.Grid, n: int) -> np.ndarray:
-        """Return the dilation damage history at time step n.
-
-        Parameters:
-            sd: Subdomain where the boundary displacement is defined.
-            n: Time step index.
-
-        Returns:
-            Array of dilation damage history for the given time step.
-
-        """
-        return self.convolution(sd, n, self.damage_evolution_coefficient)
 
     def convolution(self, sd: pp.Grid, n: int, coefficient_function) -> np.ndarray:
         """Return the convolution of the displacement increment with the damage kernel.
@@ -575,6 +544,7 @@ def create_displacement_controlled_setup(
 
     for name in damages:
         model_class = add_mixin(damage_types[name], model_class)
+    model_class = add_mixin(FractureDamageHistoryMixin, model_class)
 
     geom = (
         SquareDomainOrthogonalFractures if dim == 2 else CubeDomainOrthogonalFractures

--- a/src/porepy/examples/fracture_damage.py
+++ b/src/porepy/examples/fracture_damage.py
@@ -63,13 +63,11 @@ class TimeDependentDamageBCs:
 
 
 DATA_SAVING_METHOD_NAMES = [
-    "normalized_traction_for_damage",
     "damage_length",
+    "damage_evolution_coefficient",
     "dilation_damage_state",
-    "dilation_damage_evolution_coefficient",
     "dilation_damage_history",
     "friction_damage_state",
-    "friction_damage_evolution_coefficient",
     "friction_damage_history",
 ]
 
@@ -166,8 +164,13 @@ class FractureDamageMomentumBalance(  # type: ignore[misc]
 
     This model combines fracture damage mechanics with momentum balance and force
     balance across interfaces. Variables are matrix and interface displacements, contact
-    traction, and damage. The model is isotropic, i.e., the damage is independent of the
-    loading direction.
+    traction, and damage.
+
+    The class carries no damage length of its own: mix in either
+    :class:`~porepy.models.fracture_damage.IsotropicFractureDamageLength` or
+    :class:`~porepy.models.fracture_damage.AnisotropicFractureDamageLength` to choose
+    whether the damage depends on the loading direction, as
+    :func:`create_displacement_controlled_setup` does via its ``isotropic`` argument.
 
     Also contains specifics defining a test case in terms of the boundary conditions.
 
@@ -308,7 +311,7 @@ class ExactSolution:
         """
         h = self.friction_damage_history(sd, n)
         d0 = self.model.solid.residual_friction_damage
-        return d0 + (1 - d0) * np.exp(-h)
+        return d0 + (1 - d0) * np.exp(-h / self._wear_energy_scale("friction"))
 
     def friction_damage_history(self, sd: pp.Grid, n: int) -> np.ndarray:
         """Return the friction damage history at time step n.
@@ -321,7 +324,7 @@ class ExactSolution:
             Array of friction damage history for the given time step.
 
         """
-        return self.convolution(sd, n, self.friction_damage_evolution_coefficient)
+        return self.convolution(sd, n, self.damage_evolution_coefficient)
 
     def dilation_damage_state(self, sd: pp.Grid, n: int) -> np.ndarray:
         """Return the exact solution at time step n.
@@ -336,7 +339,7 @@ class ExactSolution:
         """
         h = self.dilation_damage_history(sd, n)
         d0 = self.model.solid.residual_dilation_damage
-        return d0 + (1 - d0) * np.exp(-h)
+        return d0 + (1 - d0) * np.exp(-h / self._wear_energy_scale("dilation"))
 
     def dilation_damage_history(self, sd: pp.Grid, n: int) -> np.ndarray:
         """Return the dilation damage history at time step n.
@@ -349,7 +352,7 @@ class ExactSolution:
             Array of dilation damage history for the given time step.
 
         """
-        return self.convolution(sd, n, self.dilation_damage_evolution_coefficient)
+        return self.convolution(sd, n, self.damage_evolution_coefficient)
 
     def convolution(self, sd: pp.Grid, n: int, coefficient_function) -> np.ndarray:
         """Return the convolution of the displacement increment with the damage kernel.
@@ -372,52 +375,48 @@ class ExactSolution:
             var += var_i
         return var
 
-    def normalized_traction_for_damage(self, sd: pp.Grid, n: int) -> np.ndarray:
-        """Convenience funtion for common parts of the damage functions.
+    def _wear_energy_scale(self, damage: str) -> float:
+        """Wear energy scale of a channel, scaled as the history variable is.
+
+        The history is nondimensionalised by the characteristic wear energy, so the
+        scale it is divided by must be too.
 
         Parameters:
-            sd: Subdomain where the boundary displacement is defined.
-            n: Time step index.
+            damage: Damage type, either ``"dilation"`` or ``"friction"``.
 
         Returns:
-            Array of damage for the given time step."""
-        t = self.normal_traction(sd, n)
-        transitional_strength = 0.2 * self.model.solid.uniaxial_compressive_strength
-        return -t / (transitional_strength)
-
-    def dilation_damage_evolution_coefficient(self, sd: pp.Grid, n: int) -> np.ndarray:
-        """Return the dilation damage coefficient at time step n.
-
-        Parameters:
-            sd: Subdomain where the boundary displacement is defined.
-            n: Time step index.
-
-        Returns:
-            Array of dilation damage for the given time step.
+            The nondimensionalised wear energy scale.
 
         """
-        K_ad = np.log(
-            -self.model.solid.uniaxial_compressive_strength
-            / np.clip(self.normal_traction(sd, n), None, -1e-15)
+        scale = getattr(self.model.solid, f"{damage}_wear_energy_scale")
+        reference_energy = np.sqrt(
+            self.model.solid.dilation_wear_energy_scale
+            * self.model.solid.friction_wear_energy_scale
         )
-        roughness = self.model.solid.characteristic_fracture_roughness
+        return float(scale / reference_energy)
 
-        return self.normalized_traction_for_damage(sd, n) * K_ad / roughness
+    def damage_evolution_coefficient(self, sd: pp.Grid, n: int) -> np.ndarray:
+        """Archard damage evolution coefficient, ``k = -t_n / sqrt(Lc_d * Lc_f)``.
 
-    def friction_damage_evolution_coefficient(self, sd: pp.Grid, n: int) -> np.ndarray:
-        """Return the friction damage coefficient at time step n.
+        Mirrors the constitutive-law method of the same name in
+        :class:`~porepy.constitutive_laws.FractureDamageEvolutionCoefficients`; the two
+        must be changed together. ``normal_traction`` is dimensional, so the whole of
+        the nondimensionalisation is the division by the characteristic wear energy.
 
         Parameters:
             sd: Subdomain where the boundary displacement is defined.
             n: Time step index.
 
         Returns:
-            Array of friction damage for the given time step.
+            Array of damage evolution coefficients for the given time step.
 
         """
-        roughness = self.model.solid.characteristic_fracture_roughness
-
-        return self.normalized_traction_for_damage(sd, n) * 3 / roughness
+        t = self.normal_traction(sd, n)
+        reference_energy = np.sqrt(
+            self.model.solid.dilation_wear_energy_scale
+            * self.model.solid.friction_wear_energy_scale
+        )
+        return -t / reference_energy
 
 
 class ExactSolutionIsotropic(ExactSolution):
@@ -481,8 +480,12 @@ solid_params = pp.solid_values.extended_granite_values_for_testing.copy()
 solid_params.update(
     {
         "friction_coefficient": 0.01,  # Low friction => slip \approx bc displacement
-        "uniaxial_compressive_strength": 1e8,
-        "characteristic_fracture_roughness": 1e-4,  # Same order as bc displacements.
+        # Wear energy scales, order 1e2-1e3 Pa m so that the boundary displacements
+        # below accumulate softening exponents of order one, i.e. visible but not
+        # saturated damage. The ratio of the two sets which channel degrades faster.
+        # IS: Could be changed later to more physically motivated values.
+        "friction_wear_energy_scale": 666.6666666666667,
+        "dilation_wear_energy_scale": 408.8726586591035,
         "residual_friction_damage": 0.3,
         "residual_dilation_damage": 0.6,
         "dilation_angle": 0.01,  # [rad] # Low but nonzero dilation angle to get some

--- a/src/porepy/models/constitutive_laws.py
+++ b/src/porepy/models/constitutive_laws.py
@@ -4482,8 +4482,9 @@ class FrictionDamage(pp.PorePyModel):
     """Method returning the friction wear energy scale. Normally defined in a mixin
     instance of :class:`FractureDamageEvolutionCoefficients`."""
 
-    friction_damage_history: Callable[[list[pp.Grid]], pp.ad.Variable]
-    """Damage history variable provided by the DamageHistoryVariables mixin."""
+    damage_history: Callable[[list[pp.Grid]], pp.ad.Variable]
+    """Damage history variable. Normally defined in a mixin instance of
+    :class:`~porepy.models.fracture_damage.FractureDamageVariable`."""
 
     def friction_damage_state(self, subdomains: list[pp.Grid]) -> pp.ad.Operator:
         """Frictional damage [-].
@@ -4507,7 +4508,7 @@ class FrictionDamage(pp.PorePyModel):
             partial(pp.ad.functions.clip, min_val=0.0, max_val=np.inf),
             "clip_function",
         )
-        history = f_clip(self.friction_damage_history(subdomains))
+        history = f_clip(self.damage_history(subdomains))
 
         # Get the material parameters. Nondimensionalize the wear energy scale, since
         # the history variable is nondimensional.
@@ -4608,8 +4609,9 @@ class DilationDamage(pp.PorePyModel):
     """Method returning the dilation wear energy scale. Normally defined in a mixin
     instance of :class:`FractureDamageEvolutionCoefficients`."""
 
-    dilation_damage_history: Callable[[list[pp.Grid]], pp.ad.Variable]
-    """Damage history variable provided by the DamageHistoryVariables mixin."""
+    damage_history: Callable[[list[pp.Grid]], pp.ad.Variable]
+    """Damage history variable. Normally defined in a mixin instance of
+    :class:`~porepy.models.fracture_damage.FractureDamageVariable`."""
 
     def dilation_damage_state(self, subdomains: list[pp.Grid]) -> pp.ad.Operator:
         """Dilation damage state [-].
@@ -4633,7 +4635,7 @@ class DilationDamage(pp.PorePyModel):
             partial(pp.ad.functions.clip, min_val=0.0, max_val=np.inf),
             "clip_function",
         )
-        history = f_clip(self.dilation_damage_history(subdomains))
+        history = f_clip(self.damage_history(subdomains))
 
         # Get the material parameters. Nondimensionalize the wear energy scale, since
         # the history variable is nondimensional.

--- a/src/porepy/models/constitutive_laws.py
+++ b/src/porepy/models/constitutive_laws.py
@@ -4265,33 +4265,48 @@ class ElasticTangentialFractureDeformation(pp.PorePyModel):
 
 
 class FractureDamageEvolutionCoefficients(pp.PorePyModel):
-    r"""Fracture damage coefficients according to Gao et al. (2024). These are used for
-    computing the history variables according to
+    r"""Damage evolution coefficient following Archard's wear law.
 
-    ... math::
-        \Lambda^{\alpha} = \int_0^t k^{\alpha} l dt
+    This is used for computing the history variable according to
 
-    where :math:`k^{\alpha}` is the damage evolution coefficient for damage type
-    :math:`\alpha` (friction or dilation) and :math:`l` is a length function defined in
+    .. math::
+        \Lambda(t) = \int_0^t k(s)\, \ell(t, s)\, \mathrm{d}s,
+
+    where :math:`k` is the damage evolution coefficient and :math:`\ell` is a length
+    function defined in
     :class:`~porepy.models.fracture_damage.AnisotropicFractureDamageLength` or
     :class:`~porepy.models.fracture_damage.IsotropicFractureDamageLength`.
 
-    The damage evolution coefficients are computed as functions of the contact traction,
-    the characteristic fracture roughness, and the uniaxial compressive strength of the
-    solid. For dilation, we have
+    Archard's law states that the volume of material removed by sliding wear is
+    proportional to the normal load and the sliding distance (Archard, 1953,
+    https://doi.org/10.1063/1.1721448). Taking the damage increment to be proportional
+    to the volume worn, the driver is the normal traction,
 
     .. math::
-        k^{dilation} = K_ad \frac{t_n,p}{t_trans \cdot u_char},
+        k = -\lambda_n,
 
-    where :math:`K_ad=log(UCS/t_n,p)` is the logarithm of the ratio of the uniaxial
-    compressive strength and the positive normal traction, :math:`t_n,p`, t_trans is the
-    transitional normal strength, and :math:`u_char` is the characteristic fracture
-    roughness.
+    with the convention of negative compressive stress implying :math:`k \geq 0`. The
+    history :math:`\Lambda` is then the frictional work per unit area dissipated against
+    the asperities, a wear energy with SI units J m^-2.
 
-    For friction damage, we have
+    Both damage channels share this single history. They are distinguished by their wear
+    energy scales :math:`\Lambda_c^{\alpha}`, which enter the softening functions rather
+    than the driver; see :class:`FrictionDamage` and :class:`DilationDamage`. Placing
+    the per-channel scale in the softening rather than in :math:`k` is what makes one
+    history sufficient: driving two histories that differ only by a constant factor
+    would duplicate the convolution without adding information.
 
-    .. math::
-        k^{friction} = 3 \frac{t_n,p}{t_trans \cdot u_char}.
+    Both :math:`\Lambda` and :math:`\Lambda_c^{\alpha}` are nondimensionalised by
+    :meth:`characteristic_wear_energy`. Only the ratio
+    :math:`\Lambda / \Lambda_c^{\alpha}` enters the constitutive laws, so the scaling
+    cancels exactly; it is there to keep the damage equation's residual commensurate
+    with the rest of the system, which is measured in a single Euclidean norm.
+
+    The framework requires only that :math:`k` be a non-negative function of the local
+    state. Richer descriptions -- multi-scale roughness, stress-dependent wear
+    coefficients, or explicitly distinguished adhesive and abrasive mechanisms -- may be
+    substituted by overriding :meth:`damage_evolution_coefficient`, without altering the
+    formulation, its discretisation, or the rest of this implementation.
 
     """
 
@@ -4304,67 +4319,98 @@ class FractureDamageEvolutionCoefficients(pp.PorePyModel):
     solid: FractureDamageSolidConstants
     """SolidConstants with damage parameters."""
 
-    def characteristic_fracture_roughness(
-        self, subdomains: list[pp.Grid]
-    ) -> pp.ad.Operator:
-        """Characteristic roughness of the fracture [-].
+    def characteristic_wear_energy(self, subdomains: list[pp.Grid]) -> pp.ad.Operator:
+        r"""Characteristic wear energy per unit area [Pa m].
+
+        The geometric mean :math:`\sqrt{\Lambda_c^d \Lambda_c^f}` of the two wear energy
+        scales, used to nondimensionalise both the damage history and the scales
+        themselves.
+
+        The two scales are the only wear energies the model knows, so one of them, or a
+        symmetric combination, is the only reference with the right physical content.
+        The geometric mean is used rather than either scale alone so that neither
+        channel is privileged; it puts the nondimensional history at order unity
+        whatever the two scales are, since the nondimensional scales it produces are
+        reciprocal square roots of their ratio.
 
         Parameters:
-            subdomains: List of subdomains where the characteristic roughness is
-                defined.
+            subdomains: List of subdomains where the characteristic energy is defined.
 
         Returns:
-            Operator for the characteristic roughness.
+            Operator for the characteristic wear energy.
+
+        """
+        # Go through the scale methods rather than the material constants they
+        # currently wrap, so that a subclass deriving either scale from something else
+        # keeps the reference consistent with the scales it nondimensionalises.
+        op = (
+            self.dilation_wear_energy_scale(subdomains)
+            * self.friction_wear_energy_scale(subdomains)
+        ) ** Scalar(0.5)
+        op.set_name("characteristic_wear_energy")
+        return op
+
+    def dilation_wear_energy_scale(self, subdomains: list[pp.Grid]) -> pp.ad.Scalar:
+        r"""Wear energy scale for dilation damage :math:`\Lambda_c^d` [Pa m].
+
+        Defined here rather than on :class:`DilationDamage` because
+        :meth:`characteristic_wear_energy` needs both scales even when only one channel
+        is active, and both are material constants regardless.
+
+        Parameters:
+            subdomains: List of subdomains where the scale is defined.
+
+        Returns:
+            Scalar for the dilation wear energy scale.
+
         """
         return Scalar(
-            self.solid.characteristic_fracture_roughness,
-            "characteristic_fracture_roughness",
+            self.solid.dilation_wear_energy_scale, "dilation_wear_energy_scale"
         )
 
-    def transitional_normal_strength(self, subdomains: list[pp.Grid]) -> pp.ad.Operator:
-        """Transitional normal strength for fractures [Pa].
+    def friction_wear_energy_scale(self, subdomains: list[pp.Grid]) -> pp.ad.Scalar:
+        r"""Wear energy scale for friction damage :math:`\Lambda_c^f` [Pa m].
 
-        From Li et al. (2020), https://doi.org/10.1007/s00603-019-01976-5.
+        As :meth:`dilation_wear_energy_scale`, but for the friction channel.
 
         Parameters:
-            subdomains: List of subdomains where the strength is defined.
+            subdomains: List of subdomains where the scale is defined.
 
         Returns:
-            Operator for the transitional normal strength.
-        """
-        strength = Scalar(0.2) * self.uniaxial_compressive_strength(subdomains)
-        strength.set_name("transitional_normal_strength")
-        return strength
+            Scalar for the friction wear energy scale.
 
-    def dilation_damage_evolution_coefficient(
-        self, subdomains: list[pp.Grid]
-    ) -> pp.ad.Operator:
-        """Damage evolution coefficient for dilation damage [-].
+        """
+        return Scalar(
+            self.solid.friction_wear_energy_scale, "friction_wear_energy_scale"
+        )
+
+    def damage_evolution_coefficient(self, subdomains: list[pp.Grid]) -> pp.ad.Operator:
+        r"""Damage evolution coefficient [1/m].
+
+        Implements :math:`k = -\lambda_n`, nondimensionalised by
+        :meth:`characteristic_wear_energy`. The contact traction is itself
+        nondimensionalised by the characteristic contact traction, which is therefore
+        multiplied back in here.
+
+        Since :meth:`_positive_normal_traction` clips to the compressive branch, the
+        coefficient is non-negative for any state, and it is linear in the normal
+        traction: the wear rate is monotone in the load, with no turning point above
+        which further confinement would slow the wear.
 
         Parameters:
             subdomains: List of subdomains where the damage coefficient is defined.
                 Should be of co-dimension one, i.e. fractures.
 
         Returns:
-            Operator for the dilation damage evolution coefficient.
-        """
-        # The damage evolution coefficient is defined as the logarithm of the ratio of
-        # the uniaxial compressive strength and the tangential component of the contact
-        # traction.
-        f_log = Function(pp.ad.functions.log, "log")
+            Operator for the damage evolution coefficient.
 
-        # Nondimensionlize, since the contact traction is nondimensionalized.
-        dimensionless_strength = self.uniaxial_compressive_strength(
-            subdomains
-        ) / self.characteristic_contact_traction(subdomains)
-        K_ad = f_log(
-            dimensionless_strength / self._positive_normal_traction(subdomains)
+        """
+        coefficient = (
+            self._positive_normal_traction(subdomains)
+            * self.characteristic_contact_traction(subdomains)
+            / self.characteristic_wear_energy(subdomains)
         )
-        coefficient = K_ad * (
-            self.normalized_traction_for_damage(subdomains)
-            / self.characteristic_fracture_roughness(subdomains)
-        )
-        coefficient.set_name("dilation_damage_evolution_coefficient")
+        coefficient.set_name("damage_evolution_coefficient")
         return coefficient
 
     def _positive_normal_traction(self, subdomains: list[pp.Grid]) -> pp.ad.Operator:
@@ -4375,13 +4421,14 @@ class FractureDamageEvolutionCoefficients(pp.PorePyModel):
 
         Returns:
             Operator for the positive normal traction.
+
         """
-        # Clip the contact traction to avoid division by zero. The clip is set to
-        # negative values, since the contact traction is negative when the fracture is
-        # in contact, and the dilation effect is only relevant when the fracture is in
-        # contact. As used in this class, the below common factor is linear in traction.
-        # Thus, the product with the log(1/traction) should indeed vanish in the limit
-        # of zero traction.
+        # Clip the contact traction to negative values, i.e. compression, so that the
+        # returned quantity is non-negative. Wear is driven by contact, and a fracture
+        # in tension carries no load to wear against; without the clip a tensile state
+        # would give a negative damage evolution coefficient, i.e. healing. The open
+        # state is additionally excluded by the open-state characteristic in the damage
+        # equations, so this clip guards only the intermediate evaluation.
         f_clip = Function(
             partial(pp.ad.functions.clip, min_val=-np.inf, max_val=-1e-15),
             "clip_function",
@@ -4393,71 +4440,6 @@ class FractureDamageEvolutionCoefficients(pp.PorePyModel):
         op.set_name("positive_normal_traction")
         return op
 
-    def uniaxial_compressive_strength(
-        self, subdomains: list[pp.Grid]
-    ) -> pp.ad.Operator:
-        """uniaxial compressive strength for fractures [Pa].
-
-        Parameters:
-            subdomains: List of subdomains where the strength is defined.
-
-        Returns:
-            Operator for the uniaxial compressive strength.
-        """
-        return Scalar(
-            self.solid.uniaxial_compressive_strength,
-            name="uniaxial_compressive_strength",
-        )
-
-    def friction_damage_evolution_coefficient(
-        self, subdomains: list[pp.Grid]
-    ) -> pp.ad.Operator:
-        """Damage evolution coefficient for friction damage [-].
-
-        Parameters:
-            subdomains: List of subdomains where the damage evolution coefficient is
-                defined. Should be of co-dimension one, i.e. fractures.
-
-        Returns:
-            Operator for the friction damage evolution coefficient.
-        """
-        # The damage evolution coefficient is, according to Gao et al (2024), a purely
-        # geometric factor which may be set to 3.
-        characteristic_roughness = self.characteristic_fracture_roughness(subdomains)
-
-        coefficient = Scalar(3.0) * (
-            self.normalized_traction_for_damage(subdomains) / characteristic_roughness
-        )
-        coefficient.set_name("friction_damage_evolution_coefficient")
-        return coefficient
-
-    def normalized_traction_for_damage(
-        self,
-        subdomains: list[pp.Grid],
-    ) -> pp.ad.Operator:
-        """Utility method used for the normalized traction in damage calculations.
-
-        The traction is normalized by the transitional normal strength. We use the
-        positive normal traction to helper method to avoid upstream issues if the
-        traction is passed to a logarithm function, as in the dilation damage
-        coefficient.
-
-        Parameters:
-            subdomains: List of subdomains where the traction is defined.
-
-            Returns:
-                Operator for the normalized traction.
-        """
-        # Nondimensionalize the characteristic contact traction, since the contact
-        # traction is nondimensional.
-        strength = self.transitional_normal_strength(
-            subdomains
-        ) / self.characteristic_contact_traction(subdomains)
-
-        coefficient = self._positive_normal_traction(subdomains) / strength
-        coefficient.set_name("normalized_traction_for_damage")
-        return coefficient
-
 
 class FrictionDamage(pp.PorePyModel):
     r"""Frictional damage relations.
@@ -4466,28 +4448,39 @@ class FrictionDamage(pp.PorePyModel):
         1. the computation of the friction coefficient from the frictional damage,
         2. the computation of the friction damage state from the history variable.
 
-
     The friction damage state is the factor by which the friction coefficient is
     modified compared to the non-damaged case:
 
     .. math::
-        F = d F_0,
+        F = d^f F_0,
 
-    where :math:`F_0` is the non-damaged friction coefficient. d is dimensionless and
-    takes values between 0 and 1, where 0 means no friction and 1 means intact friction.
-    The damage evolution coefficient is computed from the history variable
+    where :math:`F_0` is the non-damaged friction coefficient. :math:`d^f` is
+    dimensionless and takes values between :math:`d_0^f` and 1, where 0 would mean no
+    friction and 1 means intact friction. It is computed from the history variable
     :math:`\Lambda`, according to J. White (2014) https://doi.org/10.1002/nag.2247 and
     Stefansson in preparation, as
 
     .. math::
-        d = d_0 + (1 - d_0) \exp(-\Lambda)
+        d = d_0 + (1 - d_0) \exp(-\Lambda / \Lambda_c^f)
 
-    where :math:`d_0` is the residual friction damage.
+    where :math:`d_0` is the residual friction damage and :math:`\Lambda_c^f` the wear
+    energy scale of the friction channel.
+
+    The wear energy scale is what distinguishes this channel from
+    :class:`DilationDamage`; the history they read is the same.
 
     """
 
     solid: FractureDamageSolidConstants
     """SolidConstants with frictional damage parameters."""
+
+    characteristic_wear_energy: Callable[[list[pp.Grid]], pp.ad.Operator]
+    """Method returning the characteristic wear energy. Normally defined in a mixin
+    instance of :class:`FractureDamageEvolutionCoefficients`."""
+
+    friction_wear_energy_scale: Callable[[list[pp.Grid]], pp.ad.Scalar]
+    """Method returning the friction wear energy scale. Normally defined in a mixin
+    instance of :class:`FractureDamageEvolutionCoefficients`."""
 
     friction_damage_history: Callable[[list[pp.Grid]], pp.ad.Variable]
     """Damage history variable provided by the DamageHistoryVariables mixin."""
@@ -4503,20 +4496,30 @@ class FrictionDamage(pp.PorePyModel):
             Operator for nondimensionalized frictional damage.
 
         """
+        # Guard against negative history. The history is non-decreasing in exact
+        # arithmetic, since both the evolution coefficient and the length function are
+        # non-negative, but it is a solved variable and a Newton iterate may undershoot.
+        # A negative value would make exp(-history) blow up rather than decay, so the
+        # lower bound is retained. No upper bound is imposed: exp(-history) decays
+        # smoothly and underflows gracefully, whereas clipping introduces a kink in the
+        # Jacobian at the clip value.
         f_clip = Function(
-            partial(pp.ad.functions.clip, min_val=0.0, max_val=10.0),
+            partial(pp.ad.functions.clip, min_val=0.0, max_val=np.inf),
             "clip_function",
         )
-        # Get the history variable. Guard against negative values.
         history = f_clip(self.friction_damage_history(subdomains))
 
-        # Get the material parameter.
+        # Get the material parameters. Nondimensionalize the wear energy scale, since
+        # the history variable is nondimensional.
         d0 = self.residual_friction_damage(subdomains)
+        scale = self.friction_wear_energy_scale(
+            subdomains
+        ) / self.characteristic_wear_energy(subdomains)
 
         # Compute the damage.
         f_exp = Function(pp.ad.functions.exp, "exp")
         one = pp.ad.Scalar(1.0)
-        return d0 + (one - d0) * f_exp(-history)
+        return d0 + (one - d0) * f_exp(-(history / scale))
 
     def residual_friction_damage(self, subdomains: list[pp.Grid]) -> pp.ad.Scalar:
         """Residual friction damage [-].
@@ -4565,24 +4568,45 @@ class DilationDamage(pp.PorePyModel):
         2. the computation of the dilation damage state from the history variable.
 
     The dilation damage state is the factor by which shear dilation is modified compared
-    to the non-damaged case:
+    to the intact case:
 
     .. math::
-        g = d g_0,
+        \widetilde{g} = d^d \tan\psi \left\| u_t^p \right\|,
 
-    where :math:`g_0` is the non-damaged dilation gap. The dilation damage state is
-    computed from the damage history variable :math:`\Lambda` according to J. White
-    (2014) https://doi.org/10.1002/nag.2247, as
+    with :math:`\psi` the dilation angle. Note that no residual gap is included; a
+    fracture with a non-vanishing aperture in the mated configuration would add one, and
+    the residual *hydraulic* aperture enters through the permeability relation instead.
+
+    The damage state is computed from the damage history variable :math:`\Lambda`
+    following the exponential softening of J. White (2014)
+    https://doi.org/10.1002/nag.2247, as
 
     .. math::
-        d = d_0 + (1 - d_0)  \exp⁡(-\Lambda)
+        d = d_0 + (1 - d_0)  \exp⁡(-\Lambda / \Lambda_c^d)
 
-    where :math:`d_0` is the initial dilation  damage.
+    where :math:`d_0` is the *residual* dilation damage, towards which the value
+    :math:`d` decays, and :math:`\Lambda_c^d` is the wear energy scale of the dilation
+    channel. The wear energy scale is what distinguishes this channel from
+    :class:`FrictionDamage`; the history they read is the same. Applying the damage to
+    the dilation angle is an extension of White, who applies his multiplier to the yield
+    function alone and leaves the dilation curve unaltered.
+
+    Unlike the friction channel, the natural choice here is :math:`d_0 > 0`: taking
+    :math:`d_0 = 0` would drive the aperture back to zero under sustained shear, since
+    the gap is proportional to :math:`d^d`.
 
     """
 
     solid: FractureDamageSolidConstants
     """SolidConstants with dilation damage parameters."""
+
+    characteristic_wear_energy: Callable[[list[pp.Grid]], pp.ad.Operator]
+    """Method returning the characteristic wear energy. Normally defined in a mixin
+    instance of :class:`FractureDamageEvolutionCoefficients`."""
+
+    dilation_wear_energy_scale: Callable[[list[pp.Grid]], pp.ad.Scalar]
+    """Method returning the dilation wear energy scale. Normally defined in a mixin
+    instance of :class:`FractureDamageEvolutionCoefficients`."""
 
     dilation_damage_history: Callable[[list[pp.Grid]], pp.ad.Variable]
     """Damage history variable provided by the DamageHistoryVariables mixin."""
@@ -4598,20 +4622,30 @@ class DilationDamage(pp.PorePyModel):
             Operator for dimensionless dilation damage.
 
         """
+        # Guard against negative history. The history is non-decreasing in exact
+        # arithmetic, since both the evolution coefficient and the length function are
+        # non-negative, but it is a solved variable and a Newton iterate may undershoot.
+        # A negative value would make exp(-history) blow up rather than decay, so the
+        # lower bound is retained. No upper bound is imposed: exp(-history) decays
+        # smoothly and underflows gracefully, whereas clipping introduces a kink in the
+        # Jacobian at the clip value.
         f_clip = Function(
-            partial(pp.ad.functions.clip, min_val=0.0, max_val=10.0),
+            partial(pp.ad.functions.clip, min_val=0.0, max_val=np.inf),
             "clip_function",
         )
-        # Get the history variable. Guard against negative values.
         history = f_clip(self.dilation_damage_history(subdomains))
 
-        # Get the material parameter.
+        # Get the material parameters. Nondimensionalize the wear energy scale, since
+        # the history variable is nondimensional.
         d0 = self.residual_dilation_damage(subdomains)
+        scale = self.dilation_wear_energy_scale(
+            subdomains
+        ) / self.characteristic_wear_energy(subdomains)
 
         # Compute the damage.
         f_exp = Function(pp.ad.functions.exp, "exp")
         one = pp.ad.Scalar(1.0)
-        return d0 + (one - d0) * f_exp(-history)
+        return d0 + (one - d0) * f_exp(-(history / scale))
 
     def residual_dilation_damage(self, subdomains: list[pp.Grid]) -> pp.ad.Scalar:
         """Residual dilation damage [-].

--- a/src/porepy/models/fracture_damage.py
+++ b/src/porepy/models/fracture_damage.py
@@ -236,11 +236,11 @@ class FractureDamageEquations(pp.PorePyModel):
 
         Parameters:
             length_function: Function that takes (subdomains, time_step_index) and
-                returns (contribution, constant_part) tuple.
+                returns a (contribution, increment_norm) tuple.
             damage_coefficient_function: Function returning the damage coefficient
                 operator for the current time step.
             subdomains: List of fracture subdomains.
-            tolerance: Tolerance for checking if constant part is non-zero.
+            tolerance: Tolerance for checking if the increment norm is non-zero.
 
         Returns:
             Operator for the damage equation.
@@ -256,14 +256,14 @@ class FractureDamageEquations(pp.PorePyModel):
         for i in range(1, num_steps):
             # i = number of steps back in time.
             damage_coefficient_i = damage_coefficient.previous_timestep(i)
-            length_i, constant_part_i = length_function(subdomains, i)
-            # Provided the contribution is the product of the constant part and some
-            # variable, constant_part_i = 0 implies contribution_i = 0 regardless of the
-            # variable's value. The damage coefficient is also treated as constant (it
-            # is evaluated at the previous time step).
+            length_i, increment_norm_i = length_function(subdomains, i)
+            # A vanishing slip increment gives a vanishing contribution for both length
+            # functions, regardless of the current state they are evaluated against, so
+            # such terms can be dropped from the sum. Both factors are evaluated at a
+            # previous time step and are therefore constant.
             constant_value = cast(
                 np.ndarray,
-                (constant_part_i * damage_coefficient_i).value(self.equation_system),
+                (increment_norm_i * damage_coefficient_i).value(self.equation_system),
             )
             if np.any(np.abs(constant_value) > tolerance):  # tolerance for zero check
                 eq += length_i * damage_coefficient_i
@@ -407,15 +407,11 @@ class IsotropicFractureDamageLength(pp.PorePyModel):
             time_step_index: Index of the time step.
 
         Returns:
-            Tuple containing the contribution to the equation and the displacement
-            increment at the specified time step. If the displacement increment is zero,
-            the full contribution is also zero.
+            Tuple containing the contribution to the equation and the norm of the
+            displacement increment at the specified time step. If the increment norm is
+            zero, the full contribution is also zero.
         """
         nd_vec_to_tangential = self.tangential_component(subdomains)
-        tangential_basis = self.basis(subdomains, dim=self.nd - 1)
-        tangential_to_scalar = pp.ad.sum_projection_list(
-            [e_i.T for e_i in tangential_basis]
-        )
         u_t = nd_vec_to_tangential @ self.plastic_displacement_jump(subdomains)
         u_t_increment = u_t.previous_timestep(time_step_index) - u_t.previous_timestep(
             time_step_index + 1
@@ -423,9 +419,12 @@ class IsotropicFractureDamageLength(pp.PorePyModel):
 
         f_norm = pp.ad.Function(partial(pp.ad.l2_norm, self.nd - 1), "norm_function")
 
-        contribution = f_norm(u_t_increment)
+        # The norm vanishes if and only if the increment does, which is what the caller
+        # needs in order to discard a history term. Summing the tangential components
+        # instead would report an increment such as (a, -a) as zero.
+        increment_norm = f_norm(u_t_increment)
 
-        return contribution, tangential_to_scalar @ u_t_increment
+        return increment_norm, increment_norm
 
 
 class AnisotropicFractureDamageLength(pp.PorePyModel):
@@ -467,9 +466,9 @@ class AnisotropicFractureDamageLength(pp.PorePyModel):
             time_step_index: Index of the time step.
 
         Returns:
-            Tuple containing the contribution to the equation and the displacement
-            increment at the specified time step. If the displacement increment is zero,
-            the full contribution is also zero.
+            Tuple containing the contribution to the equation and the norm of the
+            displacement increment at the specified time step. If the increment norm is
+            zero, the full contribution is also zero.
         """
         # Fracture coordinate basis functions.
         tangential_basis = self.basis(subdomains, dim=self.nd - 1)
@@ -501,10 +500,13 @@ class AnisotropicFractureDamageLength(pp.PorePyModel):
         f_abs = pp.ad.Function(pp.ad.abs, "abs_function")
         contribution = f_abs(max_1 - max_0)
         # If time_step_index > 0, we can safely disregard the contribution if the
-        # displacement increment is zero. Return increment for checking before adding
-        # the contribution.
+        # displacement increment is zero. Return the increment norm for checking before
+        # adding the contribution; the norm vanishes if and only if the increment does,
+        # whereas summing the tangential components would report an increment such as
+        # (a, -a) as zero.
         increment = u_t_0 - u_t_1
-        return contribution, tangential_to_scalar @ increment
+        f_norm = pp.ad.Function(partial(pp.ad.l2_norm, self.nd - 1), "norm_function")
+        return contribution, f_norm(increment)
 
     def normalized_tangential_plastic_jump(
         self, subdomains: list[pp.Grid]

--- a/src/porepy/models/fracture_damage.py
+++ b/src/porepy/models/fracture_damage.py
@@ -12,23 +12,22 @@ The main components are the following:
        respectively k and l in the paper.
         .. math::
 
-            \Lambda^{\alpha}(t) = \int_0^t k(s)\, \ell(t, s)\, \mathrm{d}s,
+            \Lambda(t) = \int_0^t k(s)\, \ell(t, s)\, \mathrm{d}s,
 
-        where :math:`\alpha` is either friction or dilation damage, :math:`t` is the
-        current time and :math:`s` the integration variable. The length function
-        depends on both: in the anisotropic case it is projected onto the accumulated
-        slip direction evaluated at the *current* time, which is why the history
-        cannot be accumulated incrementally. The damage evolution coefficient is
-        specified in constitutive_laws.py and is shared by the two channels, so the
-        histories differ only in that they are separate unknowns.
-    3. Constitutive laws that compute the damage states from the history variables and
-       modify the friction and dilation accordingly. k is common to both channels and l
-       depends on the damage being anisotropic or isotropic. The damage states are
+        where :math:`t` is the current time and :math:`s` the integration variable. The
+        length function depends on both: in the anisotropic case it is projected onto
+        the accumulated slip direction evaluated at the *current* time, which is why the
+        history cannot be accumulated incrementally. The damage evolution coefficient is
+        specified in constitutive_laws.py. A single history serves both channels, since
+        the driver is common to them.
+    3. Constitutive laws that compute the damage states from the history variable and
+       modify the friction and dilation accordingly. l depends on the damage being
+       anisotropic or isotropic. The damage states are
 
         .. math::
 
             d^{\alpha} = d_0^{\alpha}
-                + (1 - d_0^{\alpha}) \exp(-\Lambda^{\alpha} / \Lambda_c^{\alpha}),
+                + (1 - d_0^{\alpha}) \exp(-\Lambda / \Lambda_c^{\alpha}),
 
         where :math:`d_0^{\alpha}` is the *residual* damage state for type
         :math:`\alpha`: :math:`d^{\alpha}` starts at one and decays towards
@@ -50,13 +49,21 @@ import numpy as np
 import porepy as pp
 
 
-class FractureDamageVariables(pp.VariableMixin):
-    """Base class for fracture damage variables.
+class FractureDamageVariable(pp.PorePyModel):
+    """Fracture damage history variable.
 
-    Common functionality for fracture damage variables. Currently related to storing of
-    multiple time steps of the variables entering the history integral.
+    Defines the variable and sets it to the equation system, and arranges for the
+    variables entering the history integral to be stored at all time steps.
+
+    A single history serves both damage channels: the driver is common to them, so two
+    histories would carry the same number. The channels are distinguished by their wear
+    energy scales in the softening functions, see
+    :class:`~porepy.constitutive_laws.FrictionDamage` and
+    :class:`~porepy.constitutive_laws.DilationDamage`.
 
     """
+
+    damage_history_variable = "damage_history"
 
     interface_displacement_variable: str
     """Interface displacement variable."""
@@ -64,15 +71,43 @@ class FractureDamageVariables(pp.VariableMixin):
     contact_traction_variable: str
     """Contact traction variable."""
 
-    def update_time_step_solution(self) -> None:
-        """Update the solution with the damage variables.
+    def damage_history(self, subdomains: list[pp.Grid]) -> pp.ad.Variable:
+        """Fracture damage history [-].
 
         Parameters:
-            solution: Solution to update.
+            subdomains: List of subdomains where the damage is defined. Should be of co-
+                dimension one, i.e. fractures.
+
+        Returns:
+            Variable for the nondimensionalized fracture damage history.
 
         """
+        for sd in subdomains:
+            if sd.dim != self.nd - 1:
+                raise ValueError("Damage only defined on fractures")
+
+        return self.equation_system.md_variable(
+            self.damage_history_variable, subdomains
+        )
+
+    def create_variables(self) -> None:
+        """Create variables for the model."""
+        # Call super to create variables defined by other mixin classes. Mypy only sees
+        # the protocol's trivial body here; the call resolves to a sibling mixin at
+        # runtime.
+        super().create_variables()  # type: ignore[safe-super]
+
+        self.equation_system.create_variables(
+            dof_info={"cells": 1},
+            name=self.damage_history_variable,
+            subdomains=self.mdg.subdomains(dim=self.nd - 1),
+            tags={"si_units": "-"},
+        )
+
+    def update_time_step_solution(self) -> None:
+        """Update the solution with the damage variables."""
         assert isinstance(self, pp.SolutionStrategy), (
-            "The FractureDamageHistoryVariables class should be combined with the "
+            "The FractureDamageVariable class should be combined with the "
             "SolutionStrategy class."
         )
         # Check that the only other class in the model implementing this method is
@@ -82,7 +117,7 @@ class FractureDamageVariables(pp.VariableMixin):
         # stored at, say, two time steps for other purposes than computing the damage
         # history.
         for cls in self.__class__.__mro__:
-            if cls is FractureDamageVariables:
+            if cls is FractureDamageVariable:
                 continue
             if cls is pp.SolutionStrategy:
                 continue
@@ -91,12 +126,12 @@ class FractureDamageVariables(pp.VariableMixin):
             if update_solution_method is not None:
                 raise AssertionError(
                     f"""The class {cls.__name__} implements update_time_step_solution,
-                    but the FractureDamageHistoryVariables class assumes only
+                    but the FractureDamageVariable class assumes only
                     pp.SolutionStrategy implements this method."""
                 )
 
         damage_variables = cast(
-            FractureDamageVariables, self
+            FractureDamageVariable, self
         ).variables_stored_all_time_steps()
         other_vars = [
             var for var in self.equation_system.variables if var not in damage_variables
@@ -142,90 +177,14 @@ class FractureDamageVariables(pp.VariableMixin):
         )
 
 
-class DilationDamageVariable(FractureDamageVariables):
-    """Dilation damage variable for fractures.
+class FractureDamageEquation(pp.PorePyModel):
+    """Convolution equation for the fracture damage history.
 
-    Defines the variable and sets it to the equation system.
-
+    One equation serves both damage channels, matching the single history variable of
+    :class:`FractureDamageVariable`.
     """
 
-    dilation_damage_history_variable = "dilation_damage_history"
-
-    def dilation_damage_history(self, subdomains: list[pp.Grid]) -> pp.ad.Variable:
-        """Fracture dilation damage history [-].
-
-        Parameters:
-            subdomains: List of subdomains where the damage is defined. Should be of co-
-                dimension one, i.e. fractures.
-
-        Returns:
-            Variable for nondimensionalized fracture dilation damage.
-        """
-        for sd in subdomains:
-            if sd.dim != self.nd - 1:
-                raise ValueError("Damage only defined on fractures")
-
-        return self.equation_system.md_variable(
-            self.dilation_damage_history_variable, subdomains
-        )
-
-    def create_variables(self) -> None:
-        """Create variables for the model."""
-        super().create_variables()
-
-        self.equation_system.create_variables(
-            dof_info={"cells": 1},
-            name=self.dilation_damage_history_variable,
-            subdomains=self.mdg.subdomains(dim=self.nd - 1),
-            tags={"si_units": "-"},
-        )
-
-
-class FrictionDamageVariable(FractureDamageVariables):
-    """Friction damage variable for fractures.
-
-    Defines the variable and sets it to the equation system.
-    """
-
-    friction_damage_history_variable = "friction_damage_history"
-
-    def friction_damage_history(self, subdomains: list[pp.Grid]) -> pp.ad.Variable:
-        """Fracture friction damage history [-].
-
-        Parameters:
-            subdomains: List of subdomains where the damage is defined. Should be of co-
-                dimension one, i.e. fractures.
-
-        Returns:
-            Variable for nondimensionalized fracture friction damage.
-        """
-        for sd in subdomains:
-            if sd.dim != self.nd - 1:
-                raise ValueError("Damage only defined on fractures")
-
-        return self.equation_system.md_variable(
-            self.friction_damage_history_variable, subdomains
-        )
-
-    def create_variables(self) -> None:
-        """Create variables for the model."""
-        super().create_variables()
-
-        self.equation_system.create_variables(
-            dof_info={"cells": 1},
-            name=self.friction_damage_history_variable,
-            subdomains=self.mdg.subdomains(dim=self.nd - 1),
-            tags={"si_units": "-"},
-        )
-
-
-class FractureDamageEquations(pp.PorePyModel):
-    """Base class for fracture damage equations.
-
-    Provides shared helpers for damage convolution-based equations. Subclasses should
-    implement specific equations (friction or dilation) and override `set_equations` and
-    `before_nonlinear_loop` to register the equations they provide.
-    """
+    damage_equation_name = "damage_equation"
 
     characteristic_displacement: Callable[[list[pp.Grid]], pp.ad.Operator]
     """Function to compute the characteristic displacement."""
@@ -235,6 +194,10 @@ class FractureDamageEquations(pp.PorePyModel):
     """Method to compute the open/closed state characteristic for contact mechanics."""
     damage_length: Callable[[list[pp.Grid], int], tuple[pp.ad.Operator, pp.ad.Operator]]
     """Method returning the damage length operator."""
+    damage_history: Callable[[list[pp.Grid]], pp.ad.Variable]
+    """Method returning the damage history variable."""
+    damage_evolution_coefficient: Callable[[list[pp.Grid]], pp.ad.Operator]
+    """Method to compute the damage evolution coefficient."""
 
     def damage_convolution_integral(
         self,
@@ -297,105 +260,41 @@ class FractureDamageEquations(pp.PorePyModel):
 
         return eq
 
-
-class DilationDamageEquation(FractureDamageEquations):
-    """Mixin class that provides the dilation damage equation and registration."""
-
-    dilation_damage_equation_name = "dilation_damage_equation"
-    dilation_damage_history: Callable[[list[pp.Grid]], pp.ad.Variable]
-    """Method returning the dilation damage variable."""
-    damage_evolution_coefficient: Callable[[list[pp.Grid]], pp.ad.Operator]
-    """Method to compute the damage evolution coefficient."""
-
     def set_equations(self):
-        """Set the dilation damage equation."""
+        """Set the damage equation."""
         super().set_equations()
         fractures = self.mdg.subdomains(dim=self.nd - 1)
 
-        dilation_eq = self.dilation_damage_equation(fractures)
-        dilation_eq.set_name(self.dilation_damage_equation_name)
-        self.equation_system.set_equation(dilation_eq, fractures, {"cells": 1})
+        eq = self.damage_equation(fractures)
+        eq.set_name(self.damage_equation_name)
+        self.equation_system.set_equation(eq, fractures, {"cells": 1})
 
     def before_nonlinear_loop(self):
-        """Update the dilation damage equation to include new term."""
+        """Update the damage equation to include the new term."""
         super().before_nonlinear_loop()
         fractures = self.mdg.subdomains(dim=self.nd - 1)
         self.equation_system.update_equation(
-            equation_name=self.dilation_damage_equation_name,
-            new_equation=self.dilation_damage_equation(fractures),
-        )
-
-    def dilation_damage_equation(self, subdomains: list[pp.Grid]) -> pp.ad.Operator:
-        """Dilation damage equation.
-
-        Parameters:
-            subdomains: List of fracture subdomains.
-
-        Returns:
-            Dilation damage equation operator.
-        """
-        # If the contact mechanics state is open, use the open state characteristic to
-        # enforce no update of the damage history. Otherwise, the standard version of
-        # the damage equation is used (characteristic=0).
-        characteristic = self.contact_mechanics_open_state_characteristic(subdomains)
-
-        eq = (
-            (pp.ad.Scalar(1.0) - characteristic)
-            * self.damage_convolution_integral(
-                self.damage_length,
-                self.damage_evolution_coefficient,
-                subdomains=subdomains,
-            )
-            - self.dilation_damage_history(subdomains)
-            + characteristic
-            * self.dilation_damage_history(subdomains).previous_timestep(1)
-        )
-        eq.set_name(self.dilation_damage_equation_name)
-        return eq
-
-
-class FrictionDamageEquation(FractureDamageEquations):
-    """Mixin class that provides the friction damage equation and registration."""
-
-    friction_damage_equation_name = "friction_damage_equation"
-    friction_damage_history: Callable[[list[pp.Grid]], pp.ad.Variable]
-    """Method returning the friction damage variable."""
-    damage_evolution_coefficient: Callable[[list[pp.Grid]], pp.ad.Operator]
-    """Method to compute the damage evolution coefficient."""
-
-    def set_equations(self):
-        """Set the friction damage equation."""
-        super().set_equations()
-        fractures = self.mdg.subdomains(dim=self.nd - 1)
-
-        friction_eq = self.friction_damage_equation(fractures)
-        friction_eq.set_name(self.friction_damage_equation_name)
-        self.equation_system.set_equation(friction_eq, fractures, {"cells": 1})
-
-    def before_nonlinear_loop(self):
-        """Update the friction damage equation to include new term."""
-        super().before_nonlinear_loop()
-        fractures = self.mdg.subdomains(dim=self.nd - 1)
-        self.equation_system.update_equation(
-            equation_name=self.friction_damage_equation_name,
-            new_equation=self.friction_damage_equation(fractures),
+            equation_name=self.damage_equation_name,
+            new_equation=self.damage_equation(fractures),
             grids=fractures,
             equations_per_grid_entity={"cells": 1},
         )
 
-    def friction_damage_equation(self, subdomains: list[pp.Grid]) -> pp.ad.Operator:
-        """Friction damage equation.
+    def damage_equation(self, subdomains: list[pp.Grid]) -> pp.ad.Operator:
+        """Damage equation.
 
         Parameters:
             subdomains: List of fracture subdomains.
 
         Returns:
-            Friction damage equation operator.
+            Damage equation operator.
+
         """
         # If the contact mechanics state is open, use the open state characteristic to
         # enforce no update of the damage history. Otherwise, the standard version of
         # the damage equation is used (characteristic=0).
         characteristic = self.contact_mechanics_open_state_characteristic(subdomains)
+
         eq = (
             (pp.ad.Scalar(1.0) - characteristic)
             * self.damage_convolution_integral(
@@ -403,11 +302,10 @@ class FrictionDamageEquation(FractureDamageEquations):
                 self.damage_evolution_coefficient,
                 subdomains=subdomains,
             )
-            - self.friction_damage_history(subdomains)
-            + characteristic
-            * self.friction_damage_history(subdomains).previous_timestep(1)
+            - self.damage_history(subdomains)
+            + characteristic * self.damage_history(subdomains).previous_timestep(1)
         )
-        eq.set_name(self.friction_damage_equation_name)
+        eq.set_name(self.damage_equation_name)
         return eq
 
 

--- a/src/porepy/models/fracture_damage.py
+++ b/src/porepy/models/fracture_damage.py
@@ -1,8 +1,8 @@
 r"""Fracture damage models.
 
-The formulation used here is described in Stefansson et al. in preparation. It includes
-friction for both dilation and friction damage, and the damage can be anisotropic or
-isotropic.
+The formulation used here is described in Stefansson et al. in preparation. It covers
+two damage channels, dilation and friction, either of which may be activated on its own
+or together with the other, and the damage may be isotropic or anisotropic.
 
 The main components are the following:
     1. History variables.
@@ -12,21 +12,34 @@ The main components are the following:
        respectively k and l in the paper.
         .. math::
 
-            \Lambda^{\alpha} = \int_0^t k^{\alpha} l dt,
+            \Lambda^{\alpha}(t) = \int_0^t k(s)\, \ell(t, s)\, \mathrm{d}s,
 
-        where :math:`\alpha` is either friction or dilation damage. The damage evolution
-        coefficient is specified in constitutive_laws.py.
-    3. Constitutive laws that compute the damage from the history variables and modify
-       the friction and dilation according to the damage. k depends on type of damage
-       (friction or dilation) and l depends on the damage being anisotropic or
-       isotropic. The modification of the friction and dilation is done by multiplying
-       the non-damaged quantity by the factor
+        where :math:`\alpha` is either friction or dilation damage, :math:`t` is the
+        current time and :math:`s` the integration variable. The length function
+        depends on both: in the anisotropic case it is projected onto the accumulated
+        slip direction evaluated at the *current* time, which is why the history
+        cannot be accumulated incrementally. The damage evolution coefficient is
+        specified in constitutive_laws.py and is shared by the two channels, so the
+        histories differ only in that they are separate unknowns.
+    3. Constitutive laws that compute the damage states from the history variables and
+       modify the friction and dilation accordingly. k is common to both channels and l
+       depends on the damage being anisotropic or isotropic. The damage states are
 
         .. math::
 
-            d^{\alpha} = d_0^{\alpha} + (1 - d_0^{\alpha}) \exp(-\Lambda^{\alpha}),
+            d^{\alpha} = d_0^{\alpha}
+                + (1 - d_0^{\alpha}) \exp(-\Lambda^{\alpha} / \Lambda_c^{\alpha}),
 
-        where :math:`d_0^{\alpha}` is the initial damage for type :math:`\alpha`.
+        where :math:`d_0^{\alpha}` is the *residual* damage state for type
+        :math:`\alpha`: :math:`d^{\alpha}` starts at one and decays towards
+        :math:`d_0^{\alpha}`, which is the reverse of White's (2014) convention, where
+        the multiplier decays from a value above one towards one. The wear energy scale
+        :math:`\Lambda_c^{\alpha}` is what distinguishes the two channels.
+
+       Each channel applies its damage state multiplicatively: dilation to the intact
+       shear dilation gap, friction to the intact friction coefficient. See
+       :class:`~porepy.constitutive_laws.DilationDamage` and
+       :class:`~porepy.constitutive_laws.FrictionDamage`.
 """
 
 from functools import partial
@@ -232,7 +245,21 @@ class FractureDamageEquations(pp.PorePyModel):
         subdomains: list[pp.Grid],
         tolerance: float = 1e-14,
     ) -> pp.ad.Operator:
-        """Helper method for convolution integral equations.
+        r"""Helper method for convolution integral equations.
+
+        Discrete counterpart of
+
+        .. math::
+
+            \Lambda^{\alpha}(t) = \int_0^t k^{\alpha}(s)\, \ell(t, s)\, \mathrm{d}s,
+
+        with :math:`t` the current time and :math:`s` the integration variable. The
+        contribution of the current time step is implicit; earlier steps are evaluated
+        at their own time index and are therefore constant within the nonlinear
+        iteration. Note that the sum runs over the whole history rather than updating a
+        stored value: the length function is re-evaluated against the current state at
+        every step, which for the anisotropic length means re-projection onto the
+        present slip direction.
 
         Parameters:
             length_function: Function that takes (subdomains, time_step_index) and
@@ -277,8 +304,8 @@ class DilationDamageEquation(FractureDamageEquations):
     dilation_damage_equation_name = "dilation_damage_equation"
     dilation_damage_history: Callable[[list[pp.Grid]], pp.ad.Variable]
     """Method returning the dilation damage variable."""
-    dilation_damage_evolution_coefficient: Callable[[list[pp.Grid]], pp.ad.Operator]
-    """Method to compute the damage coefficient for dilation damage."""
+    damage_evolution_coefficient: Callable[[list[pp.Grid]], pp.ad.Operator]
+    """Method to compute the damage evolution coefficient."""
 
     def set_equations(self):
         """Set the dilation damage equation."""
@@ -316,7 +343,7 @@ class DilationDamageEquation(FractureDamageEquations):
             (pp.ad.Scalar(1.0) - characteristic)
             * self.damage_convolution_integral(
                 self.damage_length,
-                self.dilation_damage_evolution_coefficient,
+                self.damage_evolution_coefficient,
                 subdomains=subdomains,
             )
             - self.dilation_damage_history(subdomains)
@@ -333,8 +360,8 @@ class FrictionDamageEquation(FractureDamageEquations):
     friction_damage_equation_name = "friction_damage_equation"
     friction_damage_history: Callable[[list[pp.Grid]], pp.ad.Variable]
     """Method returning the friction damage variable."""
-    friction_damage_evolution_coefficient: Callable[[list[pp.Grid]], pp.ad.Operator]
-    """Method to compute the damage coefficient for friction damage."""
+    damage_evolution_coefficient: Callable[[list[pp.Grid]], pp.ad.Operator]
+    """Method to compute the damage evolution coefficient."""
 
     def set_equations(self):
         """Set the friction damage equation."""
@@ -373,7 +400,7 @@ class FrictionDamageEquation(FractureDamageEquations):
             (pp.ad.Scalar(1.0) - characteristic)
             * self.damage_convolution_integral(
                 self.damage_length,
-                self.friction_damage_evolution_coefficient,
+                self.damage_evolution_coefficient,
                 subdomains=subdomains,
             )
             - self.friction_damage_history(subdomains)
@@ -451,15 +478,26 @@ class AnisotropicFractureDamageLength(pp.PorePyModel):
     ) -> tuple[pp.ad.Operator, pp.ad.Operator]:
         r"""Integrand for the anisotropic damage equation.
 
-        The damage length is defined as the difference between the positive part of the
-        values of the tangential displacement along the update direction m at time n and
-        the previous time step n-1:
+        The damage length is the *absolute* difference between the positive parts of the
+        tangential plastic jump projected on the slip direction :math:`m` at steps
+        :math:`n` and :math:`n-1`:
 
         .. math::
 
-            L_d = \max(0, m \cdot u_t_{n}) - \max(0, m \cdot u_t_{n-1})
+            \ell_n = \left| \max(0, m \cdot u_{t,n}^p)
+                          - \max(0, m \cdot u_{t,n-1}^p) \right|
 
+        The absolute value is essential and easy to lose: without it, slip that reduces
+        the projection onto :math:`m` would subtract from the accumulated history, i.e.
+        reverse shear would heal the fracture. It is the discrete counterpart of the
+        :math:`\left| m \cdot \dot{u}_t^p \right|` in the continuous length function.
 
+        The :math:`\max(0, \cdot)` pair implements the one-sided nature of asperity
+        contact, the Heaviside factor of the continuous form: slip oblique to :math:`m`
+        contributes with reduced magnitude, and slip beyond 90 degrees not at all.
+
+        Note that :math:`m` is evaluated at the *current* time in both terms, see
+        :meth:`normalized_tangential_plastic_jump`.
 
         Parameters:
             subdomains: List of subdomains where the damage is defined.
@@ -511,7 +549,19 @@ class AnisotropicFractureDamageLength(pp.PorePyModel):
     def normalized_tangential_plastic_jump(
         self, subdomains: list[pp.Grid]
     ) -> pp.ad.Operator:
-        """Normalized tangential plastic jump [-].
+        r"""Normalized tangential plastic jump [-].
+
+        This is the direction of the *accumulated* plastic slip at the current time,
+        :math:`m(t) = u_t^p(t) / \|u_t^p(t)\|` -- not the direction of the current
+        increment. It is evaluated at the current time in both of its occurrences in
+        the anisotropic length function, cf.
+        :meth:`AnisotropicFractureDamageLength.damage_length`.
+
+        The consequence is that the damage history cannot be accumulated incrementally:
+        when :math:`m` rotates, past contributions change, so the slip history must be
+        retained and re-projected. This is why
+        :meth:`FractureDamageVariables.variables_stored_all_time_steps` keeps all time
+        steps rather than a fixed window.
 
         Parameters:
             subdomains: List of subdomains where the jump is defined. Should be of co-

--- a/src/porepy/numerics/solvers/equation_variable_tags.py
+++ b/src/porepy/numerics/solvers/equation_variable_tags.py
@@ -155,8 +155,7 @@ class DefaultEquationTags:
     )
     interface_force_balance = EquationTag(name="interface_force_balance_equation")
     # Fracture damage (?)
-    dilation_damage = EquationTag(name="dilation_damage_equation")
-    friction_damage = EquationTag(name="friction_damage_equation")
+    damage = EquationTag(name="damage_equation")
 
 
 class DefaultVariableTags:
@@ -181,5 +180,4 @@ class DefaultVariableTags:
     interface_displacement = VariableTag(name="u_interface")
     contact_traction = VariableTag(name="contact_traction")
     # Fracture damage (?)
-    dilation_damage_history = VariableTag(name="dilation_damage_history")
-    friction_damage_history = VariableTag(name="friction_damage_history")
+    damage_history = VariableTag(name="damage_history")

--- a/tests/models/test_fracture_damage.py
+++ b/tests/models/test_fracture_damage.py
@@ -123,7 +123,7 @@ def test_isotropic_damage(dim: int):
     # referred to as "first increment" below.
     for damage in damages:
         # Test both damage and damage history variable.
-        names = [damage + "_damage_state", damage + "_damage_history"]
+        names = [damage + "_damage_state", "damage_history"]
         # I) First two displacement jumps are identical, yielding identical damage
         # values after first two steps.
         _assert_damage_values_equal_between_steps(vals, names, 0, 1, 1, 2)
@@ -225,7 +225,7 @@ def test_anisotropic_damage(dim: int):
     # Thus, vals[0] corresponds to t=1 in the time manager, and vals[1]-vals[0] is
     # referred to as "first increment" below.
     for damage in damages:
-        names = [damage + "_damage_state", damage + "_damage_history"]
+        names = [damage + "_damage_state", "damage_history"]
         # I) First two displacement jumps are identical, yielding identical damage
         # values after first two steps.
         _assert_damage_values_equal_between_steps(vals, names, 0, 1, 1, 2)

--- a/tests/models/test_fracture_damage_properties.py
+++ b/tests/models/test_fracture_damage_properties.py
@@ -121,11 +121,9 @@ def build_and_run(
     return model.results, model
 
 
-def _histories(results: list, damage: str) -> list[np.ndarray]:
+def _histories(results: list) -> list[np.ndarray]:
     """Return the list of damage history arrays (one per step)."""
-    return [
-        cast(np.ndarray, getattr(r, f"approx_{damage}_damage_history")) for r in results
-    ]
+    return [cast(np.ndarray, r.approx_damage_history) for r in results]
 
 
 def _damages(results: list, damage: str) -> list[np.ndarray]:
@@ -154,7 +152,7 @@ def test_no_damage_for_zero_tangential_slip():
     results, _ = build_and_run(north, ["dilation", "friction"], isotropic=True)
 
     for damage in ["dilation", "friction"]:
-        for i, h in enumerate(_histories(results, damage)):
+        for i, h in enumerate(_histories(results)):
             np.testing.assert_allclose(
                 h,
                 0.0,
@@ -188,7 +186,7 @@ def test_no_damage_for_open_fracture():
     results, _ = build_and_run(north, ["dilation", "friction"], isotropic=True)
 
     for damage in ["dilation", "friction"]:
-        for i, h in enumerate(_histories(results, damage)):
+        for i, h in enumerate(_histories(results)):
             np.testing.assert_allclose(
                 h,
                 0.0,
@@ -253,7 +251,7 @@ def test_damage_history_non_decreasing_monotonic_slip(monotone_slip_results):
     term, so Lambda(t+1) >= Lambda(t).
     """
     results, _, damage, isotropic = monotone_slip_results
-    histories = _histories(results, damage)
+    histories = _histories(results)
     for i in range(1, len(histories)):
         assert np.all(histories[i] >= histories[i - 1] - 1e-10), (
             f"{damage} (isotropic={isotropic}) history decreased at step {i + 1}: "
@@ -339,8 +337,8 @@ def test_isotropic_more_history_after_reversal():
     results_aniso, _ = build_and_run(north, ["dilation", "friction"], isotropic=False)
 
     for damage in ["dilation", "friction"]:
-        h_iso = _histories(results_iso, damage)[-1]
-        h_aniso = _histories(results_aniso, damage)[-1]
+        h_iso = _histories(results_iso)[-1]
+        h_aniso = _histories(results_aniso)[-1]
 
         assert np.all(h_iso > h_aniso + 1e-12), (
             f"{damage}: isotropic history {h_iso} not strictly greater than "
@@ -372,7 +370,7 @@ def test_isotropic_anisotropic_agree_for_unidirectional_loading():
 
     for damage in ["dilation", "friction"]:
         for i, (h_iso, h_aniso) in enumerate(
-            zip(_histories(results_iso, damage), _histories(results_aniso, damage))
+            zip(_histories(results_iso), _histories(results_aniso))
         ):
             np.testing.assert_allclose(
                 h_iso,

--- a/tests/models/test_fracture_damage_unit.py
+++ b/tests/models/test_fracture_damage_unit.py
@@ -683,3 +683,30 @@ class TestDamageLength:
             d * np.sqrt(2.0) * np.ones(nc),
             rtol=1e-10,
         )
+
+    @pytest.mark.parametrize(
+        "isotropic", [True, False], ids=["isotropic", "anisotropic"]
+    )
+    def test_3d_zero_check_uses_norm_not_component_sum(self, isotropic: bool):
+        """The increment measure must not vanish for a cancelling 3D increment.
+
+        ``damage_convolution_integral`` drops a history term when this second return
+        value falls below tolerance, so it may vanish only when the increment itself
+        does. With ``u_t = (a, -a)`` the tangential components sum to zero while the
+        increment is plainly non-zero. A failure here means the check has reverted to
+        summing components, which silently discards real slip history in 3D.
+        """
+        model = _prepared_model(isotropic=isotropic, damages=["dilation"], dim=3)
+        fractures = self._fractures(model)
+        nc = sum(sd.num_cells for sd in fractures)
+        a = 3.0e-4
+
+        self._set_tangential_jump(model, a, -a, iterate=True)
+        self._set_tangential_jump(model, 0.0, 0.0, time_step_index=0)
+
+        _, increment_norm = model.damage_length(fractures, 0)
+        np.testing.assert_allclose(
+            increment_norm.value(model.equation_system),
+            a * np.sqrt(2.0) * np.ones(nc),
+            rtol=1e-10,
+        )

--- a/tests/models/test_fracture_damage_unit.py
+++ b/tests/models/test_fracture_damage_unit.py
@@ -11,13 +11,11 @@ initialize the equation system and geometry. Values are then injected directly v
 Covered formulas
 ----------------
 - Damage factor:
-    ``d = d0 + (1 - d0) * exp(-clip(Lambda, 0, 10))``
-- Normalized traction:
-    ``(-t_n_nondim) / (0.2 * UCS / char_traction)``
-- Friction damage evolution coefficient:
-    ``3 * normalized_traction / roughness``
-- Dilation damage evolution coefficient:
-    ``log(UCS / (char_traction * pos_normal)) * normalized_traction / roughness``
+    ``d_alpha = d0_alpha + (1 - d0_alpha) * exp(-max(Lambda, 0) / Lambda_c_alpha)``
+- Friction coefficient:
+    ``mu = d_f * mu_intact``
+- Damage evolution coefficient (shared by both channels, Archard):
+    ``k = pos_normal * char_traction / sqrt(Lambda_c_d * Lambda_c_f)``
 - Damage length:
     - Isotropic, k=0: ``L = |u_t_iterate − u_t_ts0|``
     - Anisotropic, k=0: ``L = |max(0, m · u_t_ts0) − |u_t_iterate||``
@@ -85,7 +83,6 @@ def _prepared_model(
         if isotropic
         else damage_example.ExactSolutionAnisotropic
     )
-
     model = model_class(params)
     model.prepare_simulation()
     return model
@@ -96,12 +93,30 @@ def _prepared_model(
 # ---------------------------------------------------------------------------
 
 
-class TestDamageStateFormula:
-    """Algebraic formula ``d = d0 + (1 - d0) * exp(-Lambda)``.
+def _nondimensional_wear_energy_scale(model, damage: str) -> float:
+    """Return ``Lambda_c^alpha`` scaled the same way as the history variable.
 
-    The AD implementation clips Lambda to ``[0, 10]`` before exponentiating. The tests
-    use values strictly inside ``(0, 10)`` so that the clip does not change the input
-    and the formula reduces to the unclipped expression.
+    The history is nondimensionalized by the characteristic wear energy, so the scale it
+    is compared against must be too. Tests prescribe histories as multiples of this
+    quantity, which keeps them independent of the fixture's characteristic scales.
+    """
+    fractures = model.mdg.subdomains(dim=model.nd - 1)
+    scale = getattr(model, f"{damage}_wear_energy_scale")(fractures)
+    return float(
+        np.mean(
+            model.equation_system.evaluate(
+                scale / model.characteristic_wear_energy(fractures)
+            )
+        )
+    )
+
+
+class TestDamageStateFormula:
+    """Algebraic formula ``d = d0 + (1 - d0) * exp(-Lambda / Lambda_c)``.
+
+    The AD implementation clips Lambda below at zero before exponentiating; no upper
+    clip is applied. Histories are prescribed as multiples of the (nondimensionalized)
+    wear energy scale, so the tests read directly as values of the exponent.
     """
 
     @staticmethod
@@ -116,28 +131,36 @@ class TestDamageStateFormula:
         nc = sum(sd.num_cells for sd in fractures)
         return model, fractures, nc
 
-    @pytest.mark.parametrize("damage", ["dilation", "friction"])
-    @pytest.mark.parametrize("lambda_val", [0.0, 0.5, 1.0, 3.0])
-    def test_damage_state_matches_formula(self, damage: str, lambda_val: float):
-        """Damage state evaluates to ``d0 + (1-d0)*exp(-Lambda)`` for both types.
-
-        Parameters:
-            damage: Damage type, either ``"dilation"`` or ``"friction"``.
-            lambda_val: Damage history value prescribed to all fracture cells.
-        """
-        model, fractures, nc = self._prepared_model_with_fractures(damages=[damage])
-        d0 = float(getattr(model.solid, f"residual_{damage}_damage"))
-
+    @staticmethod
+    def _set_history(model, damage: str, exponent: float) -> None:
+        """Prescribe a history of ``exponent * Lambda_c^alpha`` on all cells."""
+        fractures = model.mdg.subdomains(dim=model.nd - 1)
+        nc = sum(sd.num_cells for sd in fractures)
+        scale = _nondimensional_wear_energy_scale(model, damage)
         model.equation_system.set_variable_values(
-            lambda_val * np.ones(nc),
+            exponent * scale * np.ones(nc),
             variables=[getattr(model, f"{damage}_damage_history")(fractures)],
             iterate_index=0,
         )
 
+    @pytest.mark.parametrize("damage", ["dilation", "friction"])
+    @pytest.mark.parametrize("exponent", [0.0, 0.5, 1.0, 3.0])
+    def test_damage_state_matches_formula(self, damage: str, exponent: float):
+        """State evaluates to ``d0 + (1-d0)*exp(-Lambda/Lambda_c)`` for both types.
+
+        Parameters:
+            damage: Damage type, either ``"dilation"`` or ``"friction"``.
+            exponent: History prescribed as this multiple of the wear energy scale.
+        """
+        model, fractures, nc = self._prepared_model_with_fractures(damages=[damage])
+        d0 = float(getattr(model.solid, f"residual_{damage}_damage"))
+
+        self._set_history(model, damage, exponent)
+
         d = getattr(model, f"{damage}_damage_state")(fractures).value(
             model.equation_system
         )
-        expected = d0 + (1.0 - d0) * np.exp(-lambda_val)
+        expected = d0 + (1.0 - d0) * np.exp(-exponent)
         np.testing.assert_allclose(d, expected * np.ones(nc), rtol=1e-12)
 
     @pytest.mark.parametrize("damage", ["dilation", "friction"])
@@ -156,30 +179,24 @@ class TestDamageStateFormula:
         np.testing.assert_allclose(d, np.ones(nc), rtol=1e-12)
 
     def test_dilation_damage_approaches_d0_at_large_history(self):
-        """Lambda = 10 (clip maximum) drives the damage state to d0."""
+        """A history of ten scales drives the damage state to d0."""
         model, fractures, nc = self._prepared_model_with_fractures(damages=["dilation"])
         d0 = float(model.solid.residual_dilation_damage)
 
-        # The clip is at 10, so exp(-10) ≈ 4.5e-5 is the residual offset.
-        model.equation_system.set_variable_values(
-            10.0 * np.ones(nc),
-            variables=[model.dilation_damage_history(fractures)],
-            iterate_index=0,
-        )
-        d = model.residual_dilation_damage(fractures).value(model.equation_system)
+        self._set_history(model, "dilation", 10.0)
+
+        d = model.dilation_damage_state(fractures).value(model.equation_system)
         expected = d0 + (1.0 - d0) * np.exp(-10.0)
-        np.testing.assert_allclose(d, expected * np.ones(nc), rtol=1e-4)
+        np.testing.assert_allclose(d, expected * np.ones(nc), rtol=1e-12)
+        # exp(-10) ~ 4.5e-5, so the state has effectively reached its residual.
+        assert np.all(d - d0 < 1e-4 * (1.0 - d0))
 
     def test_damage_state_is_monotone_in_history(self):
         """A larger history value produces a smaller (more damaged) state."""
         model, fractures, nc = self._prepared_model_with_fractures(damages=["dilation"])
 
-        def _eval(lam: float) -> float:
-            model.equation_system.set_variable_values(
-                lam * np.ones(nc),
-                variables=[model.dilation_damage_history(fractures)],
-                iterate_index=0,
-            )
+        def _eval(exponent: float) -> float:
+            self._set_history(model, "dilation", exponent)
             return float(
                 np.mean(
                     model.dilation_damage_state(fractures).value(model.equation_system)
@@ -195,21 +212,24 @@ class TestDamageStateFormula:
 
 
 class TestDamageEvolutionCoefficients:
-    """Tests for the damage evolution coefficient formulas and normalized traction.
+    r"""Tests for the damage evolution coefficient and normalized traction.
 
     All tests prescribe the contact traction variable to a known nondimensional normal
     value (zero tangential component) and compare the evaluated operator with the
     analytically computed reference.
 
-    The key material parameters (from the default example solid constants) are:
+    The coefficient implements Archard's wear law,
 
-    - ``UCS = 1e8 Pa``
-    - ``roughness = 1e-4 m``
-    - ``char_traction = numerical.characteristic_contact_traction = 1.0 Pa`` (the
-      default in ``NumericalConstants``)
+    .. math::
+        k = |t_n| / u_{char},
 
-    The formulas are written in terms of nondimensional tractions because the contact
-    traction variable is nondimensionalized by ``char_traction``.
+    which is *linear* in the normal traction. A single coefficient serves both channels:
+    what distinguishes them is the wear energy scale in the softening, which is the
+    subject of :meth:`test_channels_differ_only_by_wear_energy_scale`.
+
+    The formula is written in terms of nondimensional tractions because the contact
+    traction variable is nondimensionalized by ``char_traction``, which is multiplied
+    back in before dividing by the characteristic wear energy.
     """
 
     @staticmethod
@@ -239,174 +259,155 @@ class TestDamageEvolutionCoefficients:
         )
 
     def _material_constants(self, model):
-        """Return (char_traction, UCS, roughness) as floats.
+        """Return (char_traction, reference_wear_energy) as floats.
 
         ``char_traction`` is obtained by evaluating the operator, which uses the Young's
         modulus and characteristic displacement (not the scalar stored in
         ``numerical.characteristic_contact_traction``).
         """
         fractures = self._fractures(model)
+        evaluate = model.equation_system.evaluate
         char_t = float(
-            np.mean(
-                model.characteristic_contact_traction(fractures).value(
-                    model.equation_system
-                )
-            )
+            np.mean(evaluate(model.characteristic_contact_traction(fractures)))
         )
-        ucs = float(model.solid.uniaxial_compressive_strength)
-        roughness = float(model.solid.characteristic_fracture_roughness)
-        return char_t, ucs, roughness
+        reference_energy = float(
+            np.mean(evaluate(model.characteristic_wear_energy(fractures)))
+        )
+        return char_t, reference_energy
 
-    def test_normalized_traction_at_transitional_strength(self):
-        """At the transitional normal strength the normalized traction equals 1.
-
-        The transitional strength is ``0.2 * UCS``.  Setting ``t_n_nondim = -0.2 * UCS /
-        char_traction`` places the traction exactly at this level, so the normalized
-        traction should equal 1.
-        """
+    def test_evolution_coefficient_formula(self):
+        """Coefficient equals ``|t_n| * char_traction / sqrt(Lc_d * Lc_f)``."""
         model = _prepared_model(damages=["dilation"])
         fractures = self._fractures(model)
         nc = sum(sd.num_cells for sd in fractures)
-        char_t, ucs, _ = self._material_constants(model)
+        char_t, reference_energy = self._material_constants(model)
 
-        self._set_normal_traction(model, -0.2 * ucs / char_t)
+        self._set_normal_traction(model, -0.4)
+        expected = 0.4 * char_t / reference_energy
 
-        result = model.normalized_traction_for_damage(fractures).value(
-            model.equation_system
-        )
-        np.testing.assert_allclose(result, np.ones(nc), rtol=1e-10)
-
-    def test_normalized_traction_scales_linearly_with_traction(self):
-        """Doubling the compressive traction doubles the normalized traction."""
-        model = _prepared_model(damages=["dilation"])
-        fractures = self._fractures(model)
-        char_t, ucs, _ = self._material_constants(model)
-        base_t = -0.2 * ucs / char_t  # normalized = 1 at this level
-
-        def _eval(factor: float) -> np.ndarray:
-            self._set_normal_traction(model, factor * base_t)
-            return model.normalized_traction_for_damage(fractures).value(
-                model.equation_system
-            )
-
-        np.testing.assert_allclose(_eval(2.0), 2.0 * _eval(1.0), rtol=1e-10)
-
-    def test_friction_damage_evolution_coefficient_formula(self):
-        """Friction coefficient equals ``3 * normalized_traction / roughness``.
-
-        At a traction of ``0.4 * UCS / char_traction`` (twice the transitional strength)
-        the normalized traction is 2, so the coefficient should equal ``3 * 2 /
-        roughness = 6 / roughness``.
-        """
-        model = _prepared_model(damages=["friction"])
-        fractures = self._fractures(model)
-        nc = sum(sd.num_cells for sd in fractures)
-        char_t, ucs, roughness = self._material_constants(model)
-
-        # normalized_traction = 2
-        self._set_normal_traction(model, -0.4 * ucs / char_t)
-        normalized = 2.0
-        expected = 3.0 * normalized / roughness
-
-        result = model.friction_damage_evolution_coefficient(fractures).value(
+        result = model.damage_evolution_coefficient(fractures).value(
             model.equation_system
         )
         np.testing.assert_allclose(result, expected * np.ones(nc), rtol=1e-10)
 
-    def test_friction_coefficient_is_negligible_at_zero_traction(self):
-        """Zero normal traction (open fracture) → negligible friction coefficient.
+    def test_reference_energy_is_geometric_mean_of_the_scales(self):
+        """The nondimensionalisation reference is ``sqrt(Lc_d * Lc_f)``.
+
+        A mechanical reference such as ``char_traction * u_char`` would be an elastic
+        energy, unrelated to the wear energies it is meant to scale, and would leave the
+        nondimensional history far from unity. Pinning the reference to the two scales
+        keeps it at order one whatever they are.
+        """
+        model = _prepared_model(damages=["dilation", "friction"])
+        fractures = self._fractures(model)
+        _, reference_energy = self._material_constants(model)
+
+        expected = np.sqrt(
+            model.solid.dilation_wear_energy_scale
+            * model.solid.friction_wear_energy_scale
+        )
+        np.testing.assert_allclose(reference_energy, expected, rtol=1e-12)
+
+        # The nondimensional scales are reciprocal square roots of the ratio, hence of
+        # order one, and so is the history they are compared against.
+        scale_d = _nondimensional_wear_energy_scale(model, "dilation")
+        scale_f = _nondimensional_wear_energy_scale(model, "friction")
+        np.testing.assert_allclose(scale_d * scale_f, 1.0, rtol=1e-12)
+
+    def test_evolution_coefficient_is_linear_in_traction(self):
+        """The coefficient is linear in the normal traction, with no turning point.
+
+        Sampled across a decade of traction, so a wear rate that saturated, turned over
+        or reversed anywhere in that range would fail. A failure most likely means a
+        nonlinear factor has been introduced into the driver.
+        """
+        model = _prepared_model(damages=["dilation"])
+        fractures = self._fractures(model)
+        char_t, _ = self._material_constants(model)
+        strength_scale = 1e8  # representative rock strength [Pa], sets the range
+
+        def _eval(fraction_of_strength: float) -> np.ndarray:
+            self._set_normal_traction(
+                model, -fraction_of_strength * strength_scale / char_t
+            )
+            return model.damage_evolution_coefficient(fractures).value(
+                model.equation_system
+            )
+
+        base = _eval(0.1)
+        for factor in (2.0, 4.0, 5.0, 9.0):
+            np.testing.assert_allclose(_eval(0.1 * factor), factor * base, rtol=1e-10)
+
+    def test_channels_differ_only_by_wear_energy_scale(self):
+        """Only the softening scale distinguishes the two channels.
+
+        Setting the two histories to the same value must give damage states related by
+        the wear energy scales alone. A failure here means a per-channel factor has
+        crept back into the driver, which is what a single history rules out.
+        """
+        model = _prepared_model(damages=["dilation", "friction"])
+        fractures = self._fractures(model)
+        nc = sum(sd.num_cells for sd in fractures)
+
+        scale_d = _nondimensional_wear_energy_scale(model, "dilation")
+        scale_f = _nondimensional_wear_energy_scale(model, "friction")
+
+        for history in (0.2 * scale_d, scale_d, 2.0 * scale_d):
+            for damage in ("dilation", "friction"):
+                model.equation_system.set_variable_values(
+                    history * np.ones(nc),
+                    variables=[getattr(model, f"{damage}_damage_history")(fractures)],
+                    iterate_index=0,
+                )
+            evaluate = model.equation_system.evaluate
+            d_dil = evaluate(model.dilation_damage_state(fractures))
+            d_fri = evaluate(model.friction_damage_state(fractures))
+
+            d0_d = model.solid.residual_dilation_damage
+            d0_f = model.solid.residual_friction_damage
+            # Strip the residuals; the remaining factors are
+            # exp(-Lambda/Lambda_c^alpha), so their logs are in the ratio
+            # Lambda_c^f / Lambda_c^d.
+            decay_d = (d_dil - d0_d) / (1.0 - d0_d)
+            decay_f = (d_fri - d0_f) / (1.0 - d0_f)
+            np.testing.assert_allclose(
+                np.log(decay_f) / np.log(decay_d), scale_d / scale_f, rtol=1e-10
+            )
+
+    def test_coefficient_is_negligible_at_zero_traction(self):
+        """Zero normal traction (open fracture) gives a negligible coefficient.
 
         The positive-normal-traction helper clips the contact traction to a maximum of
         ``-1e-15`` (nondim) before negating, so a traction of zero produces ``pos_normal
-        = 1e-15`` rather than exactly zero.  The resulting friction coefficient is then:
-
-        .. math::
-
-            k_{f} = \\frac{3 \\cdot 10^{-15}}{0.2 \\, UCS / t_{char} \\cdot
-                \\text{roughness}}
-
-        which is many orders of magnitude smaller than any physically relevant value.
+        = 1e-15`` rather than exactly zero. The resulting coefficient is many orders of
+        magnitude below any physically relevant value.
         """
-        model = _prepared_model(damages=["friction"])
+        model = _prepared_model(damages=["dilation"])
         fractures = self._fractures(model)
         nc = sum(sd.num_cells for sd in fractures)
-        char_t, ucs, roughness = self._material_constants(model)
+        char_t, reference_energy = self._material_constants(model)
 
         self._set_normal_traction(model, 0.0)
 
         clip_floor = 1e-15  # pos_normal_nondim produced by the clip
-        transitional_nondim = 0.2 * ucs / char_t
-        expected_clip_value = 3.0 * (clip_floor / transitional_nondim) / roughness
+        expected = clip_floor * char_t / reference_energy
 
-        result = model.friction_damage_evolution_coefficient(fractures).value(
+        result = model.damage_evolution_coefficient(fractures).value(
             model.equation_system
         )
-        np.testing.assert_allclose(result, expected_clip_value * np.ones(nc), rtol=1e-6)
+        np.testing.assert_allclose(result, expected * np.ones(nc), rtol=1e-6)
 
-    def test_dilation_damage_evolution_coefficient_formula(self):
-        """Dilation coefficient equals ``K_ad * normalized_traction / roughness``.
-
-        At a traction of ``0.4 * UCS / char_traction`` the parameters are::
-
-            pos_normal = 0.4 * UCS / char_traction
-            K_ad = log(UCS / (char_traction * pos_normal)) = log(1 / 0.4)
-            normalized_traction = 2.0
-            expected = K_ad * 2.0 / roughness
-        """
-        model = _prepared_model(damages=["dilation"])
-        fractures = self._fractures(model)
-        nc = sum(sd.num_cells for sd in fractures)
-        char_t, ucs, roughness = self._material_constants(model)
-
-        t_n_nondim = -0.4 * ucs / char_t
-        self._set_normal_traction(model, t_n_nondim)
-
-        pos_normal_nondim = -t_n_nondim  # = 0.4 * ucs / char_t
-        dimensionless_strength = ucs / char_t
-        K_ad = np.log(dimensionless_strength / pos_normal_nondim)
-        normalized = 2.0
-        expected = K_ad * normalized / roughness
-
-        result = model.dilation_damage_evolution_coefficient(fractures).value(
-            model.equation_system
-        )
-        np.testing.assert_allclose(result, expected * np.ones(nc), rtol=1e-10)
-
-    def test_dilation_damage_evolution_coefficient_at_ucs(self):
-        """Dilation coefficient diverges (K_ad → 0) as traction approaches UCS.
-
-        At ``t_n_nondim = -UCS / char_traction`` the positive normal traction equals
-        ``UCS / char_traction``, so ``K_ad = log(1) = 0`` and the coefficient is zero.
-        """
-        model = _prepared_model(damages=["dilation"])
-        fractures = self._fractures(model)
-        nc = sum(sd.num_cells for sd in fractures)
-        char_t, ucs, _ = self._material_constants(model)
-
-        self._set_normal_traction(model, -ucs / char_t)
-
-        result = model.dilation_damage_evolution_coefficient(fractures).value(
-            model.equation_system
-        )
-        np.testing.assert_allclose(result, np.zeros(nc), atol=1e-6)
-
-    def test_dilation_and_friction_coefficients_have_same_sign(self):
-        """Both coefficients are non-negative under compression."""
+    def test_coefficient_is_non_negative(self):
+        """The coefficient is non-negative under compression."""
         model = _prepared_model(damages=["dilation", "friction"])
         fractures = self._fractures(model)
-        char_t, ucs, _ = self._material_constants(model)
 
-        # Traction well inside the valid range (0.1 * UCS, below UCS)
-        self._set_normal_traction(model, -0.1 * ucs / char_t)
+        self._set_normal_traction(model, -0.1)
 
-        c_dil = model.dilation_damage_evolution_coefficient(fractures).value(
+        coefficient = model.damage_evolution_coefficient(fractures).value(
             model.equation_system
         )
-        c_fri = model.friction_damage_evolution_coefficient(fractures).value(
-            model.equation_system
-        )
-        assert np.all(c_dil >= 0), "Dilation coefficient must be non-negative"
-        assert np.all(c_fri >= 0), "Friction coefficient must be non-negative"
+        assert np.all(coefficient >= 0), "Damage coefficient must be non-negative"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/models/test_fracture_damage_unit.py
+++ b/tests/models/test_fracture_damage_unit.py
@@ -139,7 +139,7 @@ class TestDamageStateFormula:
         scale = _nondimensional_wear_energy_scale(model, damage)
         model.equation_system.set_variable_values(
             exponent * scale * np.ones(nc),
-            variables=[getattr(model, f"{damage}_damage_history")(fractures)],
+            variables=[model.damage_history(fractures)],
             iterate_index=0,
         )
 
@@ -170,7 +170,7 @@ class TestDamageStateFormula:
 
         model.equation_system.set_variable_values(
             np.zeros(nc),
-            variables=[getattr(model, f"{damage}_damage_history")(fractures)],
+            variables=[model.damage_history(fractures)],
             iterate_index=0,
         )
         d = getattr(model, f"{damage}_damage_state")(fractures).value(
@@ -353,12 +353,11 @@ class TestDamageEvolutionCoefficients:
         scale_f = _nondimensional_wear_energy_scale(model, "friction")
 
         for history in (0.2 * scale_d, scale_d, 2.0 * scale_d):
-            for damage in ("dilation", "friction"):
-                model.equation_system.set_variable_values(
-                    history * np.ones(nc),
-                    variables=[getattr(model, f"{damage}_damage_history")(fractures)],
-                    iterate_index=0,
-                )
+            model.equation_system.set_variable_values(
+                history * np.ones(nc),
+                variables=[model.damage_history(fractures)],
+                iterate_index=0,
+            )
             evaluate = model.equation_system.evaluate
             d_dil = evaluate(model.dilation_damage_state(fractures))
             d_fri = evaluate(model.friction_damage_state(fractures))


### PR DESCRIPTION
> **Stacked PR.** Base is `damage-zero-skip-norm` (PR 1), not `develop`.
>
> | | PR | Base |
> |---|---|---|
> | 1 | BUG: Use norm, not component sum, in damage history zero-skip test | `develop` |
> | 2 | **API: Linear damage driver with a single wear-energy history** | `damage-zero-skip-norm` |

## Proposed changes

Two commits, each self-contained.

**1. `API: Linear damage driver with per-channel wear energy scales`**

The damage evolution coefficients were

    k^d = log(UCS/t_n) * t_n / (t_trans * u_char)
    k^f = 3 * t_n / (t_trans * u_char)

so the two channels integrated histories differing by a traction-dependent factor. The
logarithm changed sign for `t_n > UCS`, implying healing, and made the damage rate peak
at `t_n = UCS/e` and fall above it. `t_trans = 0.2 * UCS` was exactly degenerate with
`u_char`, adding a parameter without adding a degree of freedom.

Both are replaced by a single driver `k = -t_n`, with the per-channel scale moved into
the softening:

    d^alpha = d_0^alpha + (1 - d_0^alpha) exp(-Lambda / Lambda_c^alpha)

`Lambda` is then the frictional work per unit area dissipated against the asperities, a
wear energy. Removes `characteristic_fracture_roughness`,
`uniaxial_compressive_strength`, `transitional_normal_strength` and the unused
`dilation_damage_decay` / `friction_damage_decay`; adds `dilation_wear_energy_scale` and
`friction_wear_energy_scale` [J m^-2].

History and scales are nondimensionalised by their geometric mean. That reference is
pinned to the two scales rather than to a mechanical energy so that the nondimensional
history stays at order unity whatever the scales are, which matters because the damage
equation's residual is measured in the same global Euclidean norm as the rest of the
system.

**2. `MAINT: Merge the two damage histories into one`**

With the driver common to both channels, the two histories solved identical equations
and carried the same number. They collapse into a single `damage_history` variable and
`damage_equation`, halving the damage degrees of freedom and the per-iteration cost of
the history convolution, which is rebuilt every time step and grows with the time index.

The channels are unaffected — they remain separate constitutive mixins, distinguished by
their wear energy scales in the softening. The variable and equation move out of the
per-channel mixins into `FractureDamageHistoryMixin`, added whenever any channel is
active, so single-channel models keep working.

`DefaultEquationTags.dilation_damage` / `.friction_damage` collapse to `.damage`, and the
variable tags to `.damage_history`.

### Verification

Twelve configurations — {2D, 3D} × {isotropic, anisotropic} × {dilation, friction, both}
— comparing damage states, softening exponents, contact traction, displacement jump,
friction bound and fracture gap:

| comparison | max relative difference |
|---|---|
| commit 2 vs commit 1 | 8.5e-15 — exactly results-neutral, as the merge should be |
| this branch vs the previous Archard formulation, at `Lambda_c^f = UCS*u_char/15` and `Lambda_c^d = UCS*u_char/(5 ln(UCS/t_n))` | 8.3e-12 |

Contact traction, friction bound and fracture gap are bit-identical in both.

## Types of changes

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Maintenance (e.g., improve logic and performance, remove obsolete code).

Breaking: the damage material constants and the damage history variable are renamed, and
the per-channel damage mixins no longer carry the history. The damage model is unreleased
and this is its only consumer, so the old names are removed rather than deprecated.

## Checklist

- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality. — it removes a duplication: two histories that carried the same number.
- [x] The update is covered by the test suite (including tests added in the PR).
- [x] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag. — n/a, no skipped tests added.
