### PR TITLE
Bugfix in Cartesian meshing offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,11 @@ author.
 ### Changes
 PR 1770: Simplify PR template by deferring to CONTRIBUTING.md for details on code style and conventions.
 PR 1767: Bugfix in THM manufactured setup.
+PR 1766: Fix bug in generation of Cartesian grids not anchored in the origin.
 PR 1732: Added support for evaluating restricted variable subsystems without evaluating
     the full Jacobian and then slicing columns.
+
+
 
 
 ### Breaking changes

--- a/src/porepy/grids/mdg_generation.py
+++ b/src/porepy/grids/mdg_generation.py
@@ -568,7 +568,7 @@ def _preprocess_cartesian_args(
 
     Returns:
         nx_cells: Number of cells in each direction.
-        phys_dims: Physical dimensions in each direction. It is inferred from domain.
+        phys_dims: Size of the domain in each direction. It is inferred from domain.
         kwargs: It could contain the item offset: ``float``: Defaults to 0.
 
     """
@@ -578,9 +578,16 @@ def _preprocess_cartesian_args(
     ymin: float = domain.bounding_box["ymin"]
     ymax: float = domain.bounding_box["ymax"]
 
-    phys_dims: list[float] = [xmax, ymax]
+    # The physical dimensions are the extension of the domain in each direction. The
+    # lower corner of the domain is accounted for by translating the grids after
+    # meshing, see create_mdg.
+    phys_dims: list[float] = [xmax - xmin, ymax - ymin]
     if domain.dim == 3:
-        phys_dims = [xmax, ymax, domain.bounding_box["zmax"]]
+        phys_dims = [
+            xmax - xmin,
+            ymax - ymin,
+            domain.bounding_box["zmax"] - domain.bounding_box["zmin"],
+        ]
 
     cell_size: Optional[float] = meshing_args.get("cell_size", None)
     cell_size_x: Optional[float] = meshing_args.get("cell_size_x", cell_size)
@@ -715,6 +722,56 @@ def _preprocess_tensor_grid_args(
     [kwargs.pop(item[0]) for item in meshing_args.items() if item[0] in kwargs]
 
     return (x_pts, y_pts, z_pts, kwargs)
+
+
+def _domain_lower_corner(domain: pp.Domain) -> np.ndarray:
+    """Return the lower corner of the bounding box of a domain.
+
+    Parameters:
+        domain: An instance of :class:`~porepy.geometry.domain.Domain` representing
+            the domain.
+
+    Returns:
+        ``shape=(3, 1)``
+
+        The minimum coordinate of the domain in each of the three coordinate
+        directions. The third component is zero for 2d domains.
+
+    """
+    box = domain.bounding_box
+    return np.array([[box["xmin"]], [box["ymin"]], [box.get("zmin", 0.0)]])
+
+
+def _translate_mdg(mdg: pp.MixedDimensionalGrid, shift: np.ndarray) -> None:
+    """Translate all grids of a mixed-dimensional grid in place.
+
+    Parameters:
+        mdg: The mixed-dimensional grid to be translated.
+        shift: ``shape=(3, 1)``
+
+            Translation vector.
+
+    """
+
+    def translate_grid(grid: pp.Grid) -> None:
+        # The coordinates are shifted directly, rather than recomputing the geometry
+        # from the translated nodes. This is both cheaper and simpler, the latter
+        # since 0d grids have no nodes to recompute their cell center from. All other
+        # geometric quantities (areas, volumes and normal vectors) are invariant under
+        # translation.
+        grid.nodes = grid.nodes + shift
+        grid.face_centers = grid.face_centers + shift
+        grid.cell_centers = grid.cell_centers + shift
+
+    for sd in mdg.subdomains():
+        translate_grid(sd)
+
+    for intf in mdg.interfaces():
+        for side_grid in intf.side_grids.values():
+            translate_grid(side_grid)
+        # The mortar grid keeps its own copy of the coordinates of its side grids.
+        intf.nodes = intf.nodes + shift
+        intf.cell_centers = intf.cell_centers + shift
 
 
 def create_mdg(
@@ -903,9 +960,18 @@ def create_mdg(
             (nx_cells, phys_dims, kwargs) = _preprocess_cartesian_args(
                 domain, meshing_args, kwargs
             )
+            # Structured meshing assumes a domain with its lower corner in the origin.
+            # Mesh a domain translated to the origin, and translate the resulting grids
+            # back to the position of the true domain. The fractures are given in the
+            # coordinates of the true domain, thus they must be translated as well.
+            lower_corner = _domain_lower_corner(domain)
             mdg = pp.meshing.cart_grid(
-                fracs=fractures, nx=nx_cells, physdims=phys_dims, **kwargs
+                fracs=[f - lower_corner[:dim] for f in fractures],
+                nx=nx_cells,
+                physdims=phys_dims,
+                **kwargs,
             )
+            _translate_mdg(mdg, lower_corner)
 
         if grid_type == "tensor_grid":
             (xs, ys, zs, kwargs) = _preprocess_tensor_grid_args(

--- a/tests/applications/md_grids/test_model_geometries.py
+++ b/tests/applications/md_grids/test_model_geometries.py
@@ -14,6 +14,7 @@ from porepy.applications.md_grids.model_geometries import (
     TwoEllipticFractures3d,
     TwoWells3d,
 )
+from porepy.applications.test_utils.models import NoPhysics
 
 
 class SubsurfaceDomainModel(SubsurfaceCuboidDomain):
@@ -97,3 +98,71 @@ def test_created_elliptic_fracs():
 
     assert len(fractures) == 2
     assert np.allclose(model.fracture_major_axes, expected_major_axis)
+
+
+class CartesianSubsurfaceModel(SubsurfaceCuboidDomain, NoPhysics):  # type: ignore[misc]
+    """A subsurface model with two crossing, axis-aligned fractures.
+
+    The fractures are compatible with structured meshing, in contrast to the elliptic
+    fractures of :class:`TwoEllipticFractures3d`.
+
+    """
+
+    def set_fractures(self) -> None:
+        self._fractures = [
+            pp.PlaneFracture(
+                np.array(
+                    [
+                        [5.0, 5.0, 5.0, 5.0],
+                        [5.0, 15.0, 15.0, 5.0],
+                        [-20.0, -20.0, -10.0, -10.0],
+                    ]
+                )
+            ),
+            pp.PlaneFracture(
+                np.array(
+                    [
+                        [0.0, 10.0, 10.0, 0.0],
+                        [5.0, 5.0, 15.0, 15.0],
+                        [-15.0, -15.0, -15.0, -15.0],
+                    ]
+                )
+            ),
+        ]
+
+
+def test_cartesian_meshing_of_subsurface_domain():
+    """Check that a cuboid subsurface domain can be meshed with Cartesian grids.
+
+    Such a domain extends downwards from the surface, hence its lower corner is not in
+    the origin. Failure indicates that the structured meshing does not account for the
+    position of the domain, see pp.create_mdg.
+
+    """
+    domain_sizes = np.array([10.0, 20.0, 30.0])
+    model = CartesianSubsurfaceModel(
+        {
+            "domain_sizes": domain_sizes,
+            "grid_type": "cartesian",
+            "meshing_arguments": {"cell_size": 5.0},
+        }
+    )
+    model.set_geometry()
+    mdg = model.mdg
+
+    # Both fractures and their intersection should be represented in the grid.
+    assert mdg.dim_max() == 3
+    assert mdg.dim_min() == 1
+    assert len(mdg.subdomains(dim=2)) == 2
+    assert len(mdg.subdomains(dim=1)) == 1
+
+    # The 3d grid should fill the domain, which extends downwards from the surface.
+    sd = mdg.subdomains(dim=3)[0]
+    assert np.allclose(sd.nodes.min(axis=1), [0.0, 0.0, -domain_sizes[2]])
+    assert np.allclose(sd.nodes.max(axis=1), [domain_sizes[0], domain_sizes[1], 0.0])
+    assert np.isclose(sd.cell_volumes.sum(), np.prod(domain_sizes))
+
+    # The intersection line should be where the two fractures cross.
+    intersection = mdg.subdomains(dim=1)[0]
+    assert np.allclose(intersection.cell_centers[0], 5.0)
+    assert np.allclose(intersection.cell_centers[2], -15.0)

--- a/tests/grids/test_mdg_generation.py
+++ b/tests/grids/test_mdg_generation.py
@@ -647,3 +647,139 @@ class TestMDGridGenerationWithoutDomains:
             assert mdg.dim_min() == 1
             assert mdg.num_subdomains() == 3
             assert mdg.num_interfaces() == 2
+
+
+class TestDomainsAwayFromOrigin:
+    """Tests of structured meshing of domains whose lower corner is not the origin.
+
+    The structured grid generators mesh a domain anchored at the origin, and
+    ``pp.create_mdg`` translates the resulting grids into the position of the true
+    domain. A failure here most likely means that the translation is missing,
+    incomplete (say, for grids of a specific dimension or for the mortar grids) or
+    applied in the wrong direction.
+
+    """
+
+    domain_size = 4.0
+    """Extension of the test domain in each coordinate direction."""
+
+    def offset(self, dim: int) -> np.ndarray:
+        """Translation of the domain relative to the origin, ``shape=(3, 1)``.
+
+        The negative components mimic subsurface domains, which are commonly placed
+        below the origin. The offset is chosen so that the domain straddles the
+        coordinate planes, while no fracture intersection coincides with one of them.
+
+        """
+        return np.array([[1.0], [-2.5], [-4.0 if dim == 3 else 0.0]])
+
+    def domain_and_fractures(
+        self, dim: int, offset: np.ndarray
+    ) -> tuple[pp.Domain, list[pp.LineFracture] | list[pp.PlaneFracture]]:
+        """A cube (square in 2d) of size 4 with fractures crossing in its center.
+
+        The fractures intersect pairwise, and all of them meet in a single point.
+        Meshing therefore produces grids of all dimensions from ``dim`` down to 0.
+
+        Parameters:
+            dim: Dimension of the domain, 2 or 3.
+            offset: ``shape=(3, 1)``
+
+                Translation of the domain and the fractures relative to the origin.
+
+        Returns:
+            The domain and the fractures, both placed relative to ``offset``.
+
+        """
+        size = self.domain_size
+        x_min, y_min, z_min = offset[:, 0]
+        box = {
+            "xmin": x_min,
+            "xmax": x_min + size,
+            "ymin": y_min,
+            "ymax": y_min + size,
+        }
+        fractures: list[pp.LineFracture] | list[pp.PlaneFracture]
+        if dim == 2:
+            fractures = [
+                pp.LineFracture(pts + offset[:2])
+                for pts in [
+                    np.array([[1.0, 3.0], [2.0, 2.0]]),
+                    np.array([[2.0, 2.0], [1.0, 3.0]]),
+                ]
+            ]
+        else:
+            box.update({"zmin": z_min, "zmax": z_min + size})
+            fractures = [
+                pp.PlaneFracture(pts + offset)
+                for pts in [
+                    np.array([[2, 2, 2, 2], [1, 3, 3, 1], [1, 1, 3, 3]], dtype=float),
+                    np.array([[1, 3, 3, 1], [2, 2, 2, 2], [1, 1, 3, 3]], dtype=float),
+                    np.array([[1, 3, 3, 1], [1, 1, 3, 3], [2, 2, 2, 2]], dtype=float),
+                ]
+            ]
+        return pp.Domain(box), fractures
+
+    def generate_mdg(
+        self, grid_type: str, dim: int, offset: np.ndarray
+    ) -> pp.MixedDimensionalGrid:
+        """Mesh the test geometry translated by ``offset``."""
+        domain, fractures = self.domain_and_fractures(dim, offset)
+        fracture_network = pp.create_fracture_network(fractures, domain)
+        return pp.create_mdg(grid_type, {"cell_size": 1.0}, fracture_network)
+
+    @pytest.mark.parametrize("grid_type", ["cartesian", "tensor_grid"])
+    @pytest.mark.parametrize("dim", [2, 3])
+    def test_translation_invariance(self, grid_type: str, dim: int) -> None:
+        """Compare meshing of a domain at the origin with meshing of the same domain
+        and fractures translated away from the origin.
+
+        The two mixed-dimensional grids should be identical up to the translation, for
+        grids of all dimensions as well as for the mortar grids.
+
+        """
+        offset = self.offset(dim)
+        reference_mdg = self.generate_mdg(grid_type, dim, np.zeros((3, 1)))
+        mdg = self.generate_mdg(grid_type, dim, offset)
+
+        # Verify that the geometry is as intended, so that the comparison below indeed
+        # covers grids of all dimensions.
+        assert mdg.dim_max() == dim
+        assert mdg.dim_min() == 0
+
+        for sd, reference_sd in zip(mdg.subdomains(), reference_mdg.subdomains()):
+            assert sd.dim == reference_sd.dim
+            assert np.allclose(sd.nodes, reference_sd.nodes + offset)
+            assert np.allclose(sd.face_centers, reference_sd.face_centers + offset)
+            assert np.allclose(sd.cell_centers, reference_sd.cell_centers + offset)
+            # The translation should not alter the size of the cells.
+            assert np.allclose(sd.cell_volumes, reference_sd.cell_volumes)
+
+        for intf, reference_intf in zip(mdg.interfaces(), reference_mdg.interfaces()):
+            assert np.allclose(intf.nodes, reference_intf.nodes + offset)
+            assert np.allclose(intf.cell_centers, reference_intf.cell_centers + offset)
+            for side, side_grid in intf.side_grids.items():
+                reference_side_grid = reference_intf.side_grids[side]
+                assert np.allclose(
+                    side_grid.cell_centers, reference_side_grid.cell_centers + offset
+                )
+
+    @pytest.mark.parametrize("grid_type", ["cartesian", "tensor_grid"])
+    @pytest.mark.parametrize("dim", [2, 3])
+    def test_grid_covers_domain(self, grid_type: str, dim: int) -> None:
+        """Verify that the highest-dimensional grid fills the domain.
+
+        This guards against the grid having the right shape but the wrong size, which
+        translation alone will not reveal.
+
+        """
+        offset = self.offset(dim)
+        domain, _ = self.domain_and_fractures(dim, offset)
+        mdg = self.generate_mdg(grid_type, dim, offset)
+
+        sd = mdg.subdomains(dim=dim)[0]
+        box = domain.bounding_box
+        upper_corner = [box["xmax"], box["ymax"], box.get("zmax", 0.0)]
+        assert np.allclose(sd.nodes[:dim].min(axis=1), offset[:dim, 0])
+        assert np.allclose(sd.nodes[:dim].max(axis=1), upper_corner[:dim])
+        assert np.isclose(sd.cell_volumes.sum(), self.domain_size**dim)

--- a/tests/grids/test_mdg_generation.py
+++ b/tests/grids/test_mdg_generation.py
@@ -767,12 +767,7 @@ class TestDomainsAwayFromOrigin:
     @pytest.mark.parametrize("grid_type", ["cartesian", "tensor_grid"])
     @pytest.mark.parametrize("dim", [2, 3])
     def test_grid_covers_domain(self, grid_type: str, dim: int) -> None:
-        """Verify that the highest-dimensional grid fills the domain.
-
-        This guards against the grid having the right shape but the wrong size, which
-        translation alone will not reveal.
-
-        """
+        """Verify that the highest-dimensional grid fills the domain."""
         offset = self.offset(dim)
         domain, _ = self.domain_and_fractures(dim, offset)
         mdg = self.generate_mdg(grid_type, dim, offset)


### PR DESCRIPTION
Please make sure you have read [CONTRIBUTING.md](https://github.com/pmgbergen/porepy/blob/develop/CONTRIBUTING.md) before submitting.

## Proposed changes
In `mdg_generation`, translate Cartesian grids so that their minimum coordinates `(x_min, y_min, z_min)` are at the correct location, not at the origin. This corrects the bug described in #1765 

To be clear, there is no need to fix generation of tensor or simplex grids, these treat the offset correctly.

Resolves #1765

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [x] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [x] [CHANGELOG.md](https://github.com/pmgbergen/porepy/blob/develop/CHANGELOG.md) has been updated, including the "Breaking changes" section if applicable.
- [x] The documentation is up-to-date.
- [x] Static typing is included in the update.
- [x] This PR does not duplicate existing functionality.
- [x] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
