### PR TITLE
Fix failing slow test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,17 @@ All changes to PorePy are documented in this file. It is updated by
 every pull request (PR) that changes user-facing behavior, and is used as the
 basis for release notes.
 
-Format: each entry is one line, `#PR: Summary of the change.`
+Format: each entry is one line, `PR: Summary of the change.`
 Keep summaries to 1-2 sentences and written for a PorePy user, not just the
 author.
 
 ## Unreleased
 
 ### Changes
-#1732: Added support for evaluating restricted variable subsystems without evaluating
+PR 1767: Bugfix in THM manufactured setup.
+PR 1732: Added support for evaluating restricted variable subsystems without evaluating
     the full Jacobian and then slicing columns.
+
 
 ### Breaking changes
 

--- a/src/porepy/grids/mdg_generation.py
+++ b/src/porepy/grids/mdg_generation.py
@@ -860,7 +860,7 @@ def create_mdg(
     # Keep a reference to the user-provided constraints before they are consumed
     # (and removed from kwargs) by the simplex preprocessing below. This is needed
     # for the fractures-outside-domain check further down.
-    constraints: np.ndarray = np.asarray(kwargs.get("constraints", np.array([])))
+    constraints: np.ndarray = kwargs.get("constraints", np.array([]))
 
     # Unstructured cases
     dim: int = _infer_dimension_from_network(fracture_network)

--- a/src/porepy/grids/mdg_generation.py
+++ b/src/porepy/grids/mdg_generation.py
@@ -860,7 +860,7 @@ def create_mdg(
     # Keep a reference to the user-provided constraints before they are consumed
     # (and removed from kwargs) by the simplex preprocessing below. This is needed
     # for the fractures-outside-domain check further down.
-    constraints: np.ndarray = kwargs.get("constraints", np.array([]))
+    constraints: np.ndarray = np.asarray(kwargs.get("constraints", np.array([])))
 
     # Unstructured cases
     dim: int = _infer_dimension_from_network(fracture_network)

--- a/tests/functional/setups/manu_thermoporomech_nofrac_2d.py
+++ b/tests/functional/setups/manu_thermoporomech_nofrac_2d.py
@@ -959,7 +959,7 @@ class UnitSquareGrid(pp.PorePyModel):
         if self.params["grid_type"] == "simplex":
             # Mark the fractures added as constraints (not to be represented as
             # lower-dimensional objects).
-            return {"constraints": [0, 1]}
+            return {"constraints": np.array([0, 1])}
         else:
             return {}
 

--- a/tests/functional/setups/manu_thermoporomech_nofrac_3d.py
+++ b/tests/functional/setups/manu_thermoporomech_nofrac_3d.py
@@ -861,7 +861,7 @@ class UnitCubeGrid(pp.PorePyModel):
         if self.params["grid_type"] == "simplex":
             # Mark the fractures added as constraints (not to be represented as
             # lower-dimensional objects).
-            return {"constraints": [0, 1, 2]}
+            return {"constraints": np.array([0, 1, 2])}
         else:
             return {}
 


### PR DESCRIPTION
Please make sure you have read [CONTRIBUTING.md](https://github.com/pmgbergen/porepy/blob/develop/CONTRIBUTING.md) before submitting.

## Proposed changes
The THM convergence test used a setup where meshing constraints were passed in as lists instead of numpy array. This lead to errors in `mdg_generation`. The constraints are now a list, and for safety, grid generation will also silently convert lists to numpy arrays to avoid similar issues in the future.

## Types of changes

What types of changes does this PR introduce to PorePy?
_Put an `x` in the boxes that apply._

- [ ] Minor change (e.g., dependency bumps, broken links).
- [ ] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Testing (contribution related to testing of existing or new functionality).
- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
- [ ] Other:

## Checklist

_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._

- [ ] [CHANGELOG.md](https://github.com/pmgbergen/porepy/blob/develop/CHANGELOG.md) has been updated, including the "Breaking changes" section if applicable.
- [ ] The documentation is up-to-date.
- [ ] Static typing is included in the update.
- [ ] This PR does not duplicate existing functionality.
- [ ] The update is covered by the test suite (including tests added in the PR).
- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
