### PR TITLE
Dissipation driven history

### DIFF
--- a/src/porepy/compositional/materials.py
+++ b/src/porepy/compositional/materials.py
@@ -535,9 +535,9 @@ class FractureDamageSolidConstants(AsperityContactSolidConstants):
 
     The frictional work per unit area that must be dissipated against the asperities for
     the dilation damage state to decay by a factor :math:`e` towards its residual; see
-    :class:`~porepy.constitutive_laws.FractureDamage`. It absorbs Archard's
-    dimensionless wear coefficient and is therefore an effective calibrated quantity
-    rather than a purely geometric one.
+    :class:`~porepy.constitutive_laws.FractureDamage`. It absorbs the efficiency with
+    which that work removes asperity height, and is therefore an effective calibrated
+    quantity rather than a purely geometric one.
 
     Together with :attr:`friction_wear_energy_scale` it sets how fast the two roles of
     one asperity population degrade: this one governs the loss of the surfaces' ability

--- a/src/porepy/examples/fracture_damage.py
+++ b/src/porepy/examples/fracture_damage.py
@@ -69,22 +69,43 @@ DATA_SAVING_METHOD_NAMES = [
     "dilation_damage_state",
     "friction_damage_state",
 ]
+"""Quantities recorded from the model at every time step."""
+
+EXACT_SOLUTION_METHOD_NAMES = ["damage_length"]
+"""Of those, the ones :class:`ExactSolution` supplies a reference value for."""
 
 
-def make_damagesavedata_class(method_names: list[str]) -> type:
-    """Create a dataclass type with fields for exact/approx values and errors."""
+def make_damagesavedata_class(
+    method_names: list[str], exact_names: list[str] | None = None
+) -> type:
+    """Create a dataclass type with fields for approximate and exact values.
+
+    Parameters:
+        method_names: Names recorded from the model, each gaining an ``approx_`` field.
+        exact_names: Subset of those that also gain an ``exact_`` field. Defaults to all
+            of them, for callers that supply a reference for every quantity.
+
+    Returns:
+        The dataclass type.
+
+    """
+    if exact_names is None:
+        exact_names = list(method_names)
     annotations: dict[str, type] = {}
     namespace: dict[str, object] = {"__annotations__": annotations}
 
     for name in method_names:
-        annotations[f"exact_{name}"] = np.ndarray
+        if name in exact_names:
+            annotations[f"exact_{name}"] = np.ndarray
         annotations[f"approx_{name}"] = np.ndarray
 
     cls = type("DamageSaveData", (object,), namespace)
     return dataclass(cls)
 
 
-DamageSaveData = make_damagesavedata_class(DATA_SAVING_METHOD_NAMES)
+DamageSaveData = make_damagesavedata_class(
+    DATA_SAVING_METHOD_NAMES, EXACT_SOLUTION_METHOD_NAMES
+)
 
 
 class DamageDataSaving(pp.PorePyModel):
@@ -121,33 +142,24 @@ class DamageDataSaving(pp.PorePyModel):
         sds = self.mdg.subdomains(dim=self.nd - 1)
         sd = sds[0]
         n: int = self.time_manager.time_index
-        names = DATA_SAVING_METHOD_NAMES
-        vals = {}
-        for name in names:
+        vals: dict[str, np.ndarray] = {}
+        for name in DATA_SAVING_METHOD_NAMES:
             if name == "damage_length":
-                # Treat damage length as a special case because of signature
-                exact_val = cast(np.ndarray, self.exact_sol.damage_length(sd, n, n))
-                # Since we have already updated the solution, time_step_index=1 gives
-                # the most recent increment.
+                # Treated separately because of its signature. Since the solution has
+                # already been updated, time_step_index=1 gives the most recent
+                # increment.
                 length, _ = self.damage_length(sds, 1)
-                approx_val = cast(np.ndarray, length.value(self.equation_system))
+                vals["approx_" + name] = cast(
+                    np.ndarray, length.value(self.equation_system)
+                )
+                vals["exact_" + name] = cast(
+                    np.ndarray, self.exact_sol.damage_length(sd, n, n)
+                )
             else:
-                if hasattr(self, name):
-                    # Collect data.
-                    exact_val = cast(np.ndarray, getattr(self.exact_sol, name)(sd, n))
-                    approx_val = cast(
-                        np.ndarray, getattr(self, name)(sds).value(self.equation_system)
-                    )
-                else:
-                    # By setting different values, we ensure that the error is large if
-                    # the lack of the method masks some other error.
-                    exact_val = np.ones(sd.num_cells)
-                    approx_val = np.zeros_like(exact_val)
-
-            vals["exact_" + name] = exact_val
-            vals["approx_" + name] = approx_val
-        collected_data = DamageSaveData(**vals)
-        return collected_data
+                vals["approx_" + name] = cast(
+                    np.ndarray, getattr(self, name)(sds).value(self.equation_system)
+                )
+        return DamageSaveData(**vals)
 
 
 class FractureDamageMomentumBalance(  # type: ignore[misc]
@@ -192,10 +204,14 @@ class FractureDamageHistoryMixin(
 
 
 class ExactSolution:
-    """Exact solution for the damage model.
+    """Reference values for the damage verification setup.
 
     The driving force of the problem is assumed to be a Dirichlet boundary condition
-    with transient values defined in the class parameters.
+    with transient values defined in the class parameters, and the displacement jump is
+    taken to follow it. That is what makes a closed form available at all, and it is why
+    the reference covers the damage length rather than the damage itself: the length
+    follows from the prescribed displacements, whereas the history and the damage states
+    would additionally require the contact traction and the whole constitutive law.
 
     """
 
@@ -274,113 +290,6 @@ class ExactSolution:
         # Both should be (nd-1, num_cells)
         return disp_n - disp_prev
 
-    def friction_damage_state(self, sd: pp.Grid, n: int):
-        """Return the exact solution at time step n.
-
-        Parameters:
-            sd: Subdomain where the boundary displacement is defined.
-            n: Time step index.
-
-        Returns:
-            Array of friction damage for the given time step.
-
-        """
-        h = self.damage_history(sd, n)
-        d0 = self.model.solid.residual_friction_damage
-        return d0 + (1 - d0) * np.exp(-h / self._wear_energy_scale("friction"))
-
-    def damage_history(self, sd: pp.Grid, n: int) -> np.ndarray:
-        """Return the damage history at time step n.
-
-        Parameters:
-            sd: Subdomain where the boundary displacement is defined.
-            n: Time step index.
-
-        Returns:
-            Array of damage history for the given time step.
-
-        """
-        return self.convolution(sd, n, self.damage_evolution_coefficient)
-
-    def dilation_damage_state(self, sd: pp.Grid, n: int) -> np.ndarray:
-        """Return the exact solution at time step n.
-
-        Parameters:
-            sd: Subdomain where the boundary displacement is defined.
-            n: Time step index.
-
-        Returns:
-            Array of dilation damage for the given time step.
-
-        """
-        h = self.damage_history(sd, n)
-        d0 = self.model.solid.residual_dilation_damage
-        return d0 + (1 - d0) * np.exp(-h / self._wear_energy_scale("dilation"))
-
-    def convolution(self, sd: pp.Grid, n: int, coefficient_function) -> np.ndarray:
-        """Return the convolution of the displacement increment with the damage kernel.
-
-        Parameters:
-            sd: Subdomain where the boundary displacement is defined.
-            n: Time step index.
-            coefficient_function: Function to compute the coefficient for the
-                convolution.
-
-        Returns:
-            Array of convolution values for the given time step.
-
-        """
-        var = np.zeros(sd.num_cells)
-        # This method can be implemented in subclasses if needed.
-        for i in range(1, n + 1):
-            # Compute the contribution to the damage from the current time step.
-            var_i = self.damage_length(sd, n, i) * coefficient_function(sd, i)
-            var += var_i
-        return var
-
-    def _wear_energy_scale(self, damage: str) -> float:
-        """Wear energy scale of a channel, scaled as the history variable is.
-
-        The history is nondimensionalised by the characteristic wear energy, so the
-        scale it is divided by must be too.
-
-        Parameters:
-            damage: Damage type, either ``"dilation"`` or ``"friction"``.
-
-        Returns:
-            The nondimensionalised wear energy scale.
-
-        """
-        scale = getattr(self.model.solid, f"{damage}_wear_energy_scale")
-        reference_energy = np.sqrt(
-            self.model.solid.dilation_wear_energy_scale
-            * self.model.solid.friction_wear_energy_scale
-        )
-        return float(scale / reference_energy)
-
-    def damage_evolution_coefficient(self, sd: pp.Grid, n: int) -> np.ndarray:
-        """Archard damage evolution coefficient, ``k = -t_n / sqrt(Lc_d * Lc_f)``.
-
-        Mirrors the constitutive-law method of the same name in
-        :class:`~porepy.constitutive_laws.FractureDamageEvolutionCoefficients`; the two
-        must be changed together. ``normal_traction`` is dimensional, so the whole of
-        the nondimensionalisation is the division by the characteristic wear energy.
-
-        Parameters:
-            sd: Subdomain where the boundary displacement is defined.
-            n: Time step index.
-
-        Returns:
-            Array of damage evolution coefficients for the given time step.
-
-        """
-        t = self.normal_traction(sd, n)
-        reference_energy = np.sqrt(
-            self.model.solid.dilation_wear_energy_scale
-            * self.model.solid.friction_wear_energy_scale
-        )
-        return -t / reference_energy
-
 
 class ExactSolutionIsotropic(ExactSolution):
     def damage_length(self, sd: pp.Grid, n: int, i: int):
@@ -443,12 +352,15 @@ solid_params = pp.solid_values.extended_granite_values_for_testing.copy()
 solid_params.update(
     {
         "friction_coefficient": 0.01,  # Low friction => slip \approx bc displacement
-        # Wear energy scales, order 1e2-1e3 Pa m so that the boundary displacements
-        # below accumulate softening exponents of order one, i.e. visible but not
-        # saturated damage. The ratio of the two sets which channel degrades faster.
+        # Wear energy scales, chosen so that the boundary displacements below accumulate
+        # softening exponents of order one, i.e. visible but not saturated damage. Since
+        # the history is the frictional work, the scales that achieve this are smaller
+        # than the traction alone would suggest by roughly the friction coefficient,
+        # which this fixture keeps deliberately low. The ratio of the two sets which
+        # channel degrades faster.
         # IS: Could be changed later to more physically motivated values.
-        "friction_wear_energy_scale": 666.6666666666667,
-        "dilation_wear_energy_scale": 408.8726586591035,
+        "friction_wear_energy_scale": 6.666666666666667,
+        "dilation_wear_energy_scale": 4.088726586591035,
         "residual_friction_damage": 0.3,
         "residual_dilation_damage": 0.6,
         "dilation_angle": 0.01,  # [rad] # Low but nonzero dilation angle to get some

--- a/src/porepy/models/constitutive_laws.py
+++ b/src/porepy/models/constitutive_laws.py
@@ -4904,13 +4904,22 @@ class FractureDamage(pp.PorePyModel):
         # non-negative, but it is a solved variable and a Newton iterate may undershoot.
         # A negative value would make exp(-history) blow up rather than decay, so the
         # lower bound is retained. No upper bound is imposed: exp(-history) decays
-        # smoothly and underflows gracefully, whereas clipping introduces a kink in the
-        # Jacobian at the clip value.
-        f_clip = Function(
-            partial(pp.ad.functions.clip, min_val=0.0, max_val=np.inf),
-            "clip_function",
+        # smoothly and underflows gracefully, whereas an upper bound would introduce a
+        # kink in the Jacobian at the bound.
+        #
+        # The history is the first argument, which is what places the undamaged state on
+        # the differentiable side of the floor.
+        # :func:`~porepy.numerics.ad.functions.maximum` takes the Jacobian from its
+        # first argument where the two are equal, so at exactly zero history the
+        # derivative is that of the softening rather than that of the constant floor.
+        # This matters more than a boundary case usually would: zero is the natural
+        # initial value and the standing value of every cell that has not yet slipped,
+        # and the softening's derivative is largest there.
+        zeros = pp.ad.DenseArray(
+            np.zeros(sum(sd.num_cells for sd in subdomains)), "zero_damage_history"
         )
-        history = f_clip(self.damage_history(subdomains))
+        f_max = Function(pp.ad.functions.maximum, "max_function")
+        history = f_max(self.damage_history(subdomains), zeros)
 
         # Nondimensionalize the wear energy scale, since the history variable is
         # nondimensional.

--- a/src/porepy/models/constitutive_laws.py
+++ b/src/porepy/models/constitutive_laws.py
@@ -4641,7 +4641,7 @@ class ElasticTangentialFractureDeformation(pp.PorePyModel):
 
 
 class FractureDamageEvolutionCoefficients(pp.PorePyModel):
-    r"""Damage evolution coefficient following Archard's wear law.
+    r"""Damage evolution coefficient driven by frictional work.
 
     This is used for computing the history variable according to
 
@@ -4653,17 +4653,27 @@ class FractureDamageEvolutionCoefficients(pp.PorePyModel):
     :class:`~porepy.models.fracture_damage.AnisotropicFractureDamageLength` or
     :class:`~porepy.models.fracture_damage.IsotropicFractureDamageLength`.
 
-    Archard's law states that the volume of material removed by sliding wear is
-    proportional to the normal load and the sliding distance (Archard, 1953,
-    https://doi.org/10.1063/1.1721448). Taking the damage increment to be proportional
-    to the volume worn, the driver is the normal traction,
+    The driver is the frictional shear stress the contact sustains,
 
     .. math::
-        k = -\lambda_n,
+        k = \mu^* \sigma_n,
 
-    with the convention of negative compressive stress implying :math:`k \geq 0`. The
-    history :math:`\Lambda` is then the frictional work per unit area dissipated against
-    the asperities, a wear energy with SI units J m^-2.
+    so that :math:`\ell` supplying the slip makes :math:`\Lambda` the frictional work
+    per unit area done against the asperities, a wear energy with SI units J m^-2. The
+    asperities are worn by the work spent sliding against them, which is what the
+    softening functions are calibrated against.
+
+    Taking the product rather than the traction alone distinguishes this from Archard's
+    law (1953, https://doi.org/10.1063/1.1721448), where the volume worn is proportional
+    to the normal load and the sliding distance. The difference is the factor
+    :math:`\mu^*`: a smooth, well-lubricated contact carrying a heavy load wears more
+    slowly than a rough one carrying the same load over the same distance, and only the
+    work-based driver expresses that.
+
+    Because :math:`\mu^*` may itself depend on the damage state, the current step's
+    contribution to :math:`\Lambda` depends on :math:`\Lambda`. This is a well-posed
+    implicit relation rather than a circularity: :math:`\mu^*` is non-increasing in the
+    history, so the residual is strictly decreasing in it and the root is unique.
 
     Both damage channels share this single history. They are distinguished by their wear
     energy scales :math:`\Lambda_c^{\alpha}`, which enter the softening functions rather
@@ -4695,6 +4705,10 @@ class FractureDamageEvolutionCoefficients(pp.PorePyModel):
     _positive_normal_traction: Callable[[list[pp.Grid]], pp.ad.Operator]
     """Method returning the compressive part of the normal traction. Normally
     defined in a mixin instance of :class:`AsperityStressPartition`."""
+
+    friction_coefficient: Callable[[list[pp.Grid]], pp.ad.Operator]
+    """Method returning the friction coefficient. Normally defined in a mixin instance
+    of :class:`CoulombFrictionBound`, as modified by the laws above it."""
 
     solid: FractureDamageSolidConstants
     """SolidConstants with damage parameters."""
@@ -4765,17 +4779,29 @@ class FractureDamageEvolutionCoefficients(pp.PorePyModel):
         )
 
     def damage_evolution_coefficient(self, subdomains: list[pp.Grid]) -> pp.ad.Operator:
-        r"""Damage evolution coefficient [1/m].
+        r"""Damage evolution coefficient [-].
 
-        Implements :math:`k = -\lambda_n`, nondimensionalised by
-        :meth:`characteristic_wear_energy`. The contact traction is itself
+        Implements :math:`k = \mu^* \sigma_n`, the frictional shear stress the contact
+        sustains, so that :math:`\Lambda = \int k\, \ell\, \mathrm{d}s` is the
+        frictional work per unit area done against the asperities. Nondimensionalised by
+        :meth:`characteristic_wear_energy`; the contact traction is itself
         nondimensionalised by the characteristic contact traction, which is therefore
         multiplied back in here.
 
-        Since :meth:`_positive_normal_traction` clips to the compressive branch, the
-        coefficient is non-negative for any state, and it is linear in the normal
-        traction: the wear rate is monotone in the load, with no turning point above
-        which further confinement would slow the wear.
+        The friction coefficient is read through :meth:`friction_coefficient`, so the
+        driver reflects whatever composition the model actually uses for the friction
+        bound, and the two cannot drift apart.
+
+        Both factors are non-negative --- :meth:`_positive_normal_traction` clips to the
+        compressive branch --- so the history is non-decreasing whatever the state. The
+        coefficient is *not* linear in the normal traction when a stress partition is
+        active, since :math:`\mu^*` then depends on it as well.
+
+        Note that this is the total frictional work, not the dissipation: the part
+        recovered as dilation, :math:`\tan\psi\, \sigma_n`, is included. The
+        dissipation :math:`(\mu^* - \tan\psi)\sigma_n` is the quantity whose
+        positivity makes the law admissible, and it is a different quantity from the one
+        that drives the wear.
 
         Parameters:
             subdomains: List of subdomains where the damage coefficient is defined.
@@ -4786,7 +4812,8 @@ class FractureDamageEvolutionCoefficients(pp.PorePyModel):
 
         """
         coefficient = (
-            self._positive_normal_traction(subdomains)
+            self.friction_coefficient(subdomains)
+            * self._positive_normal_traction(subdomains)
             * self.characteristic_contact_traction(subdomains)
             / self.characteristic_wear_energy(subdomains)
         )

--- a/src/porepy/models/fracture_damage.py
+++ b/src/porepy/models/fracture_damage.py
@@ -158,6 +158,13 @@ class FractureDamageVariable(pp.PorePyModel):
         displacement jump, which requires the contact traction in the case of a nonzero
         elastic jump.
 
+        The history variable itself is also included, so that a damage evolution
+        coefficient depending on the damage state can be evaluated at the step it
+        belongs to. :meth:`FractureDamageEquation.damage_convolution_integral` reaches
+        past steps by pushing the whole coefficient back with ``previous_timestep``,
+        which rewrites every variable in it, so what is stored is the history rather
+        than a separately cached coefficient.
+
         Note that if used with a pure contact mechanics model, the contact traction
         variable is the only variable stored at all time steps, since the interface
         displacement is not included in the model. In that case, the method should be
@@ -171,6 +178,7 @@ class FractureDamageVariable(pp.PorePyModel):
             variables=[
                 self.interface_displacement_variable,
                 self.contact_traction_variable,
+                self.damage_history_variable,
             ]
         )
 

--- a/tests/models/test_fracture_damage_unit.py
+++ b/tests/models/test_fracture_damage_unit.py
@@ -17,16 +17,22 @@ Covered formulas
 - Composed friction coefficient:
     ``mu* = (mu_b + tan psi)/(1 - mu_b tan psi) + a_s mu_p0 d_f``,
     with ``tan psi = (1 - a_s) tan psi_0 d_d``
-- Damage evolution coefficient (shared by both channels, Archard):
-    ``k = pos_normal * char_traction / sqrt(Lambda_c_d * Lambda_c_f)``
-- Damage length:
-    - Isotropic, k=0: ``L = |u_t_iterate − u_t_ts0|``
-    - Anisotropic, k=0: ``L = |max(0, m · u_t_ts0) − |u_t_iterate||``
+- Mated fracture gap:
+    ``g = d_d * g_0``
+- Damage evolution coefficient (shared by both channels):
+    ``k = mu* * pos_normal * char_traction / sqrt(Lambda_c_d * Lambda_c_f)``
+- Damage length, at ``time_step_index=0``:
+    - Isotropic: ``L = |u_t_iterate − u_t_ts0|``
+    - Anisotropic: ``L = |max(0, m · u_t_ts0) − |u_t_iterate||``
 
 where ``t_n_nondim`` is the nondimensional normal contact traction (negative when the
 fracture is in compression), ``char_traction`` is
 ``numerical.characteristic_contact_traction``, ``pos_normal = -t_n_nondim``, ``m =
 u_t_iterate / |u_t_iterate|`` and ``u_t_ts0`` is the value at ``time_step_index=0``.
+
+Not every class here checks a formula: the damage history is a sum over all past steps,
+so the variables it reaches back through must be retained at every step rather than in a
+rolling window, and that declaration is checked too.
 
 TODO: Decide on placement. Everything is defined in constitutive_laws bar the length
 operator, which is defined in the momentum models.fracture_damage.
@@ -231,14 +237,19 @@ class TestDamageEvolutionCoefficients:
     value (zero tangential component) and compare the evaluated operator with the
     analytically computed reference.
 
-    The coefficient implements Archard's wear law,
+    The coefficient is the frictional shear stress the contact sustains,
 
     .. math::
-        k = |t_n| / u_{char},
+        k = \mu^* |t_n|,
 
-    which is *linear* in the normal traction. A single coefficient serves both channels:
-    what distinguishes them is the wear energy scale in the softening, which is the
-    subject of :meth:`test_channels_differ_only_by_wear_energy_scale`.
+    so that the history it drives is a frictional work per unit area. A single
+    coefficient serves both channels: what distinguishes them is the wear energy scale
+    in the softening, which is the subject of
+    :meth:`test_channels_differ_only_by_wear_energy_scale`.
+
+    The fixture leaves the transitional normal traction at its infinite default, so the
+    stress partition is inert and :math:`\mu^*` is the sliding composition alone,
+    independent of the traction. Tests that need the partition active set it explicitly.
 
     The formula is written in terms of nondimensional tractions because the contact
     traction variable is nondimensionalized by ``char_traction``, which is multiplied
@@ -288,15 +299,28 @@ class TestDamageEvolutionCoefficients:
         )
         return char_t, reference_energy
 
+    @staticmethod
+    def _sliding_friction(model) -> float:
+        """The composed friction coefficient at zero history and inert partition.
+
+        Computed from the material constants rather than read off the model, so that the
+        driver is compared against an independent number. With the partition inert
+        ``a_s = 0`` leaves the sliding composition, and at zero history both damage
+        states are one.
+        """
+        mu_b = float(model.solid.friction_coefficient)
+        tan_psi = float(np.tan(model.solid.dilation_angle))
+        return (mu_b + tan_psi) / (1.0 - mu_b * tan_psi)
+
     def test_evolution_coefficient_formula(self):
-        """Coefficient equals ``|t_n| * char_traction / sqrt(Lc_d * Lc_f)``."""
+        """Coefficient equals ``mu* * |t_n| * char_traction / sqrt(Lc_d * Lc_f)``."""
         model = _prepared_model(damages=["dilation"])
         fractures = self._fractures(model)
         nc = sum(sd.num_cells for sd in fractures)
         char_t, reference_energy = self._material_constants(model)
 
         self._set_normal_traction(model, -0.4)
-        expected = 0.4 * char_t / reference_energy
+        expected = self._sliding_friction(model) * 0.4 * char_t / reference_energy
 
         result = model.damage_evolution_coefficient(fractures).value(
             model.equation_system
@@ -327,29 +351,69 @@ class TestDamageEvolutionCoefficients:
         scale_f = _nondimensional_wear_energy_scale(model, "friction")
         np.testing.assert_allclose(scale_d * scale_f, 1.0, rtol=1e-12)
 
-    def test_evolution_coefficient_is_linear_in_traction(self):
-        """The coefficient is linear in the normal traction, with no turning point.
-
-        Sampled across a decade of traction, so a wear rate that saturated, turned over
-        or reversed anywhere in that range would fail. A failure most likely means a
-        nonlinear factor has been introduced into the driver.
-        """
-        model = _prepared_model(damages=["dilation"])
+    def _coefficient_sampler(self, model):
+        """Return a sampler of the coefficient at a fraction of a strength scale."""
         fractures = self._fractures(model)
         char_t, _ = self._material_constants(model)
         strength_scale = 1e8  # representative rock strength [Pa], sets the range
 
-        def _eval(fraction_of_strength: float) -> np.ndarray:
+        def sample(fraction_of_strength: float) -> np.ndarray:
             self._set_normal_traction(
                 model, -fraction_of_strength * strength_scale / char_t
             )
-            return model.damage_evolution_coefficient(fractures).value(
-                model.equation_system
+            return np.asarray(
+                model.damage_evolution_coefficient(fractures).value(
+                    model.equation_system
+                )
             )
 
-        base = _eval(0.1)
+        return sample
+
+    def test_evolution_coefficient_is_linear_without_a_partition(self):
+        """With the partition inert the coefficient is linear in the normal traction.
+
+        The friction coefficient does not then depend on the traction, so the driver
+        inherits the traction's own linearity: the wear rate is monotone in the load,
+        with no turning point above which further confinement would slow the wear.
+
+        Sampled across a decade, so a wear rate that saturated, turned over or reversed
+        anywhere in that range would fail.
+        """
+        model = _prepared_model(damages=["dilation"])
+        sample = self._coefficient_sampler(model)
+
+        base = sample(0.1)
         for factor in (2.0, 4.0, 5.0, 9.0):
-            np.testing.assert_allclose(_eval(0.1 * factor), factor * base, rtol=1e-10)
+            np.testing.assert_allclose(sample(0.1 * factor), factor * base, rtol=1e-10)
+
+    def test_evolution_coefficient_is_nonlinear_with_a_partition(self):
+        """An active stress partition makes the driver nonlinear in the traction.
+
+        ``mu*`` then rises with the normal traction as contact transfers to ploughing,
+        so the driver grows faster than the load. The test places the transitional
+        traction inside the sampled range, so the samples straddle the transition, and
+        checks the coefficient grows strictly faster than linearly while remaining
+        monotone.
+
+        This is the counterpart to the linearity above: the two together say that the
+        nonlinearity comes from the partition and from nothing else.
+        """
+        model = _prepared_model(
+            damages=["dilation"],
+            solid_overrides={
+                "transitional_normal_traction": 5.0e7,
+                "ploughing_friction_coefficient": 0.4,
+            },
+        )
+        sample = self._coefficient_sampler(model)
+
+        base = float(np.mean(sample(0.1)))
+        for factor in (2.0, 4.0, 5.0, 9.0):
+            scaled = float(np.mean(sample(0.1 * factor)))
+            assert scaled > factor * base * (1.0 + 1e-6), (
+                f"Coefficient grew only {scaled / base:.4f}-fold for a {factor}-fold "
+                "traction increase; the partition should make it grow faster"
+            )
 
     def test_channels_differ_only_by_wear_energy_scale(self):
         """Only the softening scale distinguishes the two channels.
@@ -402,7 +466,9 @@ class TestDamageEvolutionCoefficients:
         self._set_normal_traction(model, 0.0)
 
         clip_floor = 1e-15  # pos_normal_nondim produced by the clip
-        expected = clip_floor * char_t / reference_energy
+        expected = (
+            self._sliding_friction(model) * clip_floor * char_t / reference_energy
+        )
 
         result = model.damage_evolution_coefficient(fractures).value(
             model.equation_system

--- a/tests/models/test_fracture_damage_unit.py
+++ b/tests/models/test_fracture_damage_unit.py
@@ -1164,3 +1164,78 @@ class TestDamageLength:
             a * np.sqrt(2.0) * np.ones(nc),
             rtol=1e-10,
         )
+
+
+# ---------------------------------------------------------------------------
+# 7.  History storage
+# ---------------------------------------------------------------------------
+
+
+class TestAllTimeStepStorage:
+    """Variables the convolution reaches back through are kept at every past step.
+
+    The damage history is a sum over the whole history, so the terms of the sum are
+    formed by pushing operators back with ``previous_timestep(i)`` for arbitrary ``i``.
+    That rewrites every variable inside them, so each such variable must have a stored
+    value at every index rather than the default rolling window of one.
+    ``variables_stored_all_time_steps`` is the declaration of which those are.
+
+    Getting it wrong fails with a ``KeyError`` on the third time step of a run: loud,
+    but only after two steps of work. These tests pin it without running a simulation.
+    """
+
+    @staticmethod
+    def _advanced_model(shifts: int = 4):
+        """A prepared model whose stored solutions have been shifted ``shifts`` times.
+
+        No solve is performed; the shift is what decides how far back values survive.
+        """
+        model = _prepared_model(damages=["dilation", "friction"])
+        for _ in range(shifts):
+            model.update_time_step_solution()
+        return model
+
+    def test_declared_variables_survive_every_past_step(self):
+        """Every variable the model declares is retrievable arbitrarily far back.
+
+        Driven off ``variables_stored_all_time_steps`` rather than a hard-coded list, so
+        that a variable added to the declaration is covered without touching this test,
+        and one dropped from it fails here.
+        """
+        model = self._advanced_model()
+        declared = model.variables_stored_all_time_steps()
+        assert declared, "No variables declared for all-time-step storage"
+
+        for variable in declared:
+            for steps in range(1, 5):
+                model.equation_system.evaluate(variable.previous_timestep(steps))
+
+    def test_the_history_and_its_ingredients_are_declared(self):
+        """The declaration covers the history and the jump it is accumulated from.
+
+        The contact traction is needed alongside the displacements because the plastic
+        jump is obtained from the total jump by subtracting the elastic part.
+        """
+        model = _prepared_model(damages=["dilation", "friction"])
+        declared = {v.name for v in model.variables_stored_all_time_steps()}
+
+        assert model.damage_history_variable in declared
+        assert model.contact_traction_variable in declared
+        assert model.interface_displacement_variable in declared
+
+    def test_undeclared_variables_keep_only_the_default_window(self):
+        """A variable outside the declaration is not retained beyond one step.
+
+        Without this the first test would pass on a model that happened to store
+        everything, and would say nothing about the declaration doing the selecting.
+        The matrix displacement is the natural control: the convolution never reaches
+        back through it, so it keeps the default window.
+        """
+        model = self._advanced_model()
+        matrix_displacement = model.displacement(model.mdg.subdomains(dim=model.nd))
+
+        # One step back is within the default window.
+        model.equation_system.evaluate(matrix_displacement.previous_timestep(1))
+
+        with pytest.raises(KeyError):
+            model.equation_system.evaluate(matrix_displacement.previous_timestep(2))

--- a/tests/models/test_fracture_damage_unit.py
+++ b/tests/models/test_fracture_damage_unit.py
@@ -133,9 +133,9 @@ def _nondimensional_wear_energy_scale(model, damage: str) -> float:
 class TestDamageStateFormula:
     """Algebraic formula ``d = d0 + (1 - d0) * exp(-Lambda / Lambda_c)``.
 
-    The AD implementation clips Lambda below at zero before exponentiating; no upper
-    clip is applied. Histories are prescribed as multiples of the (nondimensionalized)
-    wear energy scale, so the tests read directly as values of the exponent.
+    The AD implementation floors Lambda at zero before exponentiating; no upper bound
+    is applied. Histories are prescribed as multiples of the (nondimensionalized) wear
+    energy scale, so the tests read directly as values of the exponent.
     """
 
     @staticmethod
@@ -196,6 +196,71 @@ class TestDamageStateFormula:
             model.equation_system
         )
         np.testing.assert_allclose(d, np.ones(nc), rtol=1e-12)
+
+    @pytest.mark.parametrize("damage", ["dilation", "friction"])
+    def test_damage_state_is_differentiable_at_zero_history(self, damage: str):
+        """At Lambda = 0 exactly the derivative is the softening's, not the floor's.
+
+        Zero is the most common initial value and the standing value of every cell that
+        has not yet slipped, and ``-(1 - d0)/Lambda_c`` is the largest the derivative
+        ever gets. A floor implemented so that the boundary counts as *floored* rather
+        than as *passed through* would zero it there, leaving the whole damage channel
+        absent from the Newton tangent until the first cell slips --- with the value
+        still correct, so nothing else would show it.
+
+        Parameters:
+            damage: Damage type, either ``"dilation"`` or ``"friction"``.
+        """
+        model, fractures, nc = self._prepared_model_with_fractures(damages=[damage])
+        equation_system = model.equation_system
+        history = model.damage_history(fractures)
+
+        equation_system.set_variable_values(
+            np.zeros(nc), variables=[history], iterate_index=0
+        )
+        jacobian = (
+            getattr(model, f"{damage}_damage_state")(fractures)
+            .value_and_jacobian(equation_system)
+            .jac.tocsr()[:, equation_system.dofs_of([history])]
+        )
+        jacobian.eliminate_zeros()
+
+        d0 = float(getattr(model.solid, f"residual_{damage}_damage"))
+        expected = -(1.0 - d0) / _nondimensional_wear_energy_scale(model, damage)
+        assert jacobian.nnz == nc, (
+            "the damage state must depend on every cell's history"
+        )
+        np.testing.assert_allclose(jacobian.data, expected, rtol=1e-12)
+
+    @pytest.mark.parametrize("damage", ["dilation", "friction"])
+    def test_negative_history_is_floored_and_contributes_no_derivative(
+        self, damage: str
+    ):
+        """An undershooting Newton iterate must not make exp(-Lambda) diverge.
+
+        The history is non-decreasing in exact arithmetic, but it is a solved variable,
+        so the floor has to hold. Below zero the state must sit at its undamaged value
+        with no derivative --- the complement of the boundary case above, and the reason
+        the floor is there at all.
+
+        Parameters:
+            damage: Damage type, either ``"dilation"`` or ``"friction"``.
+        """
+        model, fractures, nc = self._prepared_model_with_fractures(damages=[damage])
+        equation_system = model.equation_system
+        history = model.damage_history(fractures)
+
+        equation_system.set_variable_values(
+            np.full(nc, -5.0), variables=[history], iterate_index=0
+        )
+        state = getattr(model, f"{damage}_damage_state")(fractures).value_and_jacobian(
+            equation_system
+        )
+        jacobian = state.jac.tocsr()[:, equation_system.dofs_of([history])]
+        jacobian.eliminate_zeros()
+
+        np.testing.assert_allclose(state.val, np.ones(nc), rtol=1e-12)
+        assert jacobian.nnz == 0
 
     def test_dilation_damage_approaches_d0_at_large_history(self):
         """A history of ten scales drives the damage state to d0."""


### PR DESCRIPTION
Stacked on the composed friction PR — **the base branch is `composed-friction-partition`,
not `develop`.**

Completes the round-2 damage law. The history stops being Archard's load times distance
and becomes the frictional work per unit area, `k = mu* sigma_n`, with `mu*` read through
`friction_coefficient` so the driver cannot drift from the friction bound. A smooth
contact carrying a heavy load then wears more slowly than a rough one under the same load
and slip, which the load-based driver could not express.

`mu*` may depend on the damage state, so the current step's contribution to `Lambda`
depends on `Lambda`. This is implicit, not circular: `mu*` is non-increasing in the
history, so the residual is strictly decreasing in it and the root is unique.

## Commits

**`MAINT: Store the damage history at all time steps`** — a prerequisite. The convolution
reaches step `i` via `previous_timestep(i)`, which rewrites every variable in the
coefficient; once that contains `mu*` it contains the history, which therefore needs a
stored value at every index rather than the default window of one. Omitting it fails with
a `KeyError` on the third time step of a run; `TestAllTimeStepStorage` pins it without a
simulation. Results-neutral on twelve pinned configurations: bit-identical, all 80 arrays.

**`ENH: Dissipation-driven damage history`** — the driver, plus two consequences.

*The example's wear energies are divided by 100, ratio preserved.* `Lambda` shrinks by
exactly `mu*`, and `Lambda_c` is an energy per area, so the scale that produces order-one
softening moves with the driver's definition. Without it the damage state moves by 0.0027
per step against an assertion requiring 0.01.

*The exact solution loses its damage machinery, 179 lines.* It restated the softening,
the convolution and the driver in numpy, and the new driver would have required the stress
partition and composed friction too, plus a memoised forward recursion for the implicit
step. Not worth building: After multi-PR drift, nothing reads any `exact_*` damage field, `normal_traction`
returns zeros so the reference history is identically zero, and every formula it restated
is separately unit-tested against a closed form. `EXACT_SOLUTION_METHOD_NAMES` now
declares the one quantity that keeps a reference — the damage length, which follows from
the prescribed displacements alone. `make_damagesavedata_class` gained an optional
`exact_names` defaulting to all names, so downstream callers supplying their own
references are unaffected. `collect_data` also loses its `hasattr` fallback, the last silent-failure path
from the previous round.

## Verification

The driver's linearity in traction survives,
because the fixture leaves the transitional traction at its infinite default and the
partition is inert — so rather than deleting that test, its precondition is now explicit
and a counterpart asserts the driver grows *faster* than the load when the partition is
active.