### PR TITLE
DOC: Simplify PR template.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,30 +1,8 @@
-Please make sure you have read [CONTRIBUTING.md](https://github.com/pmgbergen/porepy/blob/develop/CONTRIBUTING.md) before submitting.
+Contributions to PorePy are highly appreciated. Please make sure you have read [CONTRIBUTING.md](https://github.com/pmgbergen/porepy/blob/develop/CONTRIBUTING.md) before submitting. In particular, please provide a short description of the changes in [CHANGELOG.md](https://github.com/pmgbergen/porepy/blob/develop/CHANGELOG.md).
+Please be reminded that all PRs must pass the test suite, including the extended tests if relevant (`pytest --run-skipped`), and be well documented.
 
 ## Proposed changes
 
-Contributions to PorePy are highly appreciated. Clearly explain why this pull request (PR) is needed and why it should be accepted. If this PR solves an issue, explain how it is done. Please, also summarise the changes to the code.
-
-## Types of changes
-
-What types of changes does this PR introduce to PorePy?
-_Put an `x` in the boxes that apply._
-
-- [ ] Minor change (e.g., dependency bumps, broken links).
-- [ ] Bugfix (non-breaking change which fixes an issue).
-- [ ] New feature (non-breaking change which adds functionality).
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
-- [ ] Testing (contribution related to testing of existing or new functionality).
-- [ ] Documentation (contribution related to adding, improving, or fixing documentation).
-- [ ] Maintenance (e.g., improve logic and performance, remove obsolete code).
-- [ ] Other:
-
-## Checklist
-
-_Put an `x` in the boxes that apply or explain briefly why the box is not relevant._
-
-- [ ] [CHANGELOG.md](https://github.com/pmgbergen/porepy/blob/develop/CHANGELOG.md) has been updated, including the "Breaking changes" section if applicable.
-- [ ] The documentation is up-to-date.
-- [ ] Static typing is included in the update.
-- [ ] This PR does not duplicate existing functionality.
-- [ ] The update is covered by the test suite (including tests added in the PR).
-- [ ] If new skipped tests have been introduced in this PR, `pytest` was run with the `--run-skipped` flag.
+Clearly explain why this pull request (PR) is needed and why it should be accepted. If it solves an issue, explain how it is done. Please also summarise the changes to the code.
+What types of changes does this PR introduce to PorePy? Refer to [CONTRIBUTING.md](https://github.com/pmgbergen/porepy/blob/develop/CONTRIBUTING.md#commit-messages) for a list of types.
+Does this PR introduce a breaking change? If so, please explain how and why it is necessary.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-Contributions to PorePy are highly appreciated. Please make sure you have read [CONTRIBUTING.md](https://github.com/pmgbergen/porepy/blob/develop/CONTRIBUTING.md) before submitting. In particular, please provide a short description of the changes in [CHANGELOG.md](https://github.com/pmgbergen/porepy/blob/develop/CHANGELOG.md).
+Contributions to PorePy are highly appreciated. Please make sure you have read [CONTRIBUTING.md](https://github.com/pmgbergen/porepy/blob/develop/CONTRIBUTING.md) before submitting and that your adheres to the standards outlined there. In particular, please provide a short description of the changes in [CHANGELOG.md](https://github.com/pmgbergen/porepy/blob/develop/CHANGELOG.md).
 Please be reminded that all PRs must pass the test suite, including the extended tests if relevant (`pytest --run-skipped`), and be well documented.
 
 ## Proposed changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ author.
 ## Unreleased
 
 ### Changes
+1770: Simplify PR template by deferring to CONTRIBUTING.md for details on code style and conventions.
 #1732: Added support for evaluating restricted variable subsystems without evaluating
     the full Jacobian and then slicing columns.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,8 +109,7 @@ the prefix for its main purpose rather than inventing a new one.
 * Aim for reasonably sized PRs: a PR that does one thing is easier and faster to review than one that mixes,
   say, a refactoring with a new feature.
 * All pull requests undergo code review and are run against the full test suite and static checks.
-* Fill in the PR template, in particular the checklist confirming that documentation, typing, and tests are in
-  order.
+* Document your changes in [CHANGELOG.md](https://github.com/pmgbergen/porepy/blob/develop/CHANGELOG.md) and fill in the PR template.
 * Response times may vary depending on maintainers' other commitments, but all contributions will be followed up.
 
 ## Reporting issues


### PR DESCRIPTION
The check lists are often ignored and seem redundant. With the introduction of contributing (and changelog), some information/instruction is now deferred. Downstream of PR template change: removes stale reference to checklist in CONTRIBUTING.md.

