### PR TITLE
Dissipation positivity check

### DIFF
--- a/src/porepy/examples/fracture_damage.py
+++ b/src/porepy/examples/fracture_damage.py
@@ -167,6 +167,7 @@ class FractureDamageMomentumBalance(  # type: ignore[misc]
     DamageDataSaving,
     pp.constitutive_laws.FractureDamage,
     pp.constitutive_laws.AsperityStressPartition,
+    pp.constitutive_laws.DissipationPositivityCheck,
     pp.constitutive_laws.DilationRotatedFriction,
     pp.constitutive_laws.FractureDamageEvolutionCoefficients,
     TimeDependentDamageBCs,

--- a/src/porepy/models/constitutive_laws.py
+++ b/src/porepy/models/constitutive_laws.py
@@ -4373,6 +4373,57 @@ class AsperityStressPartition(pp.PorePyModel):
         op.set_name("stress_partition")
         return op
 
+    def frictional_dissipation(self, subdomains: list[pp.Grid]) -> pp.ad.Operator:
+        r"""Frictional dissipation per unit slip [Pa].
+
+        .. math::
+            D = (\mu^* - \tan\psi)\,\sigma_n,
+
+        with :math:`\mu^*` the effective friction coefficient, :math:`\tan\psi` the
+        tangent of the dilation angle, and :math:`\sigma_n` the normal stress.
+
+        This represents the portion of the shear stress that is dissipated as heat due
+        to friction, rather than being recovered as dilation. It is the difference
+        between the effective friction coefficient and the tangent of the dilation
+        angle, multiplied by the normal stress.
+
+        Positivity is what makes the composed law thermodynamically admissible, and it
+        is an algebraic identity rather than a numerical property:
+
+        .. math::
+            \mu^* - \tan\psi
+            = \frac{\mu_b (1 + \tan^2\psi)}{1 - \mu_b \tan\psi} + \mu_p,
+
+        positive term by term whenever :math:`\mu_b \tan\psi < 1` and
+        :math:`\mu_p \geq 0` --- the two conditions
+        :meth:`DilationRotatedFriction._validate_sliding_composition` and
+        :meth:`_validate_ploughing_coefficient` check. A non-positive value therefore
+        means the composition was assembled wrongly, not that the parameters are
+        marginal.
+
+        Parameters:
+            subdomains: List of fracture subdomains.
+
+        Returns:
+            Cell-wise frictional dissipation per unit slip [Pa]. Negligible rather than
+            exactly zero where the fracture is not in contact:
+            :meth:`_positive_normal_traction` clips the tensile branch to its floor of
+            ``1e-15`` rather than to zero.
+
+        """
+        excess = self.friction_coefficient(subdomains) - self.tangent_dilation_angle(
+            subdomains
+        )
+        excess.set_name("dissipated_friction_coefficient")
+
+        op = (
+            excess
+            * self._positive_normal_traction(subdomains)
+            * self.characteristic_contact_traction(subdomains)
+        )
+        op.set_name("frictional_dissipation")
+        return op
+
     def _positive_normal_traction(self, subdomains: list[pp.Grid]) -> pp.ad.Operator:
         """Positive normal traction for fractures [-].
 

--- a/src/porepy/models/constitutive_laws.py
+++ b/src/porepy/models/constitutive_laws.py
@@ -4397,9 +4397,9 @@ class AsperityStressPartition(pp.PorePyModel):
         positive term by term whenever :math:`\mu_b \tan\psi < 1` and
         :math:`\mu_p \geq 0` --- the two conditions
         :meth:`DilationRotatedFriction._validate_sliding_composition` and
-        :meth:`_validate_ploughing_coefficient` check. A non-positive value therefore
-        means the composition was assembled wrongly, not that the parameters are
-        marginal.
+        :meth:`_validate_ploughing_coefficient` check. A negative value therefore means
+        the composition was assembled wrongly, not that the parameters are marginal,
+        which is what :class:`DissipationPositivityCheck` asserts on.
 
         Parameters:
             subdomains: List of fracture subdomains.
@@ -4453,6 +4453,105 @@ class AsperityStressPartition(pp.PorePyModel):
         op = Scalar(-1, "sign_inverter") * t
         op.set_name("positive_normal_traction")
         return op
+
+
+class DissipationPositivityCheck(pp.PorePyModel):
+    r"""Standing check that the composed friction law dissipates non-negatively.
+
+    The frictional dissipation :math:`(\mu^* - \tan\psi)\sigma_n` is non-negative by
+    an algebraic identity, not by numerical accident; see
+    :meth:`AsperityStressPartition.frictional_dissipation`. A negative value therefore
+    means the law is composed wrongly, and this raises rather than warning, since a
+    fracture that produces energy by sliding invalidates every number in the run.
+
+    Be clear about what can and cannot trigger it. The identity is
+
+    .. math::
+        \mu^* - \tan\psi
+        = \frac{\mu_b (1 + \tan^2\psi)}{1 - \mu_b \tan\psi} + \mu_p,
+
+    and the first term alone exceeds :math:`\tan\psi` for any realistic basic friction,
+    so it is the term that carries the sign. Losing it, or negating it, is what drives
+    the dissipation negative --- through a :math:`\mu_b` set negative, which no guard
+    currently rejects, or through a change to the composition that drops it.
+
+    A mis-ordering that costs only the *ploughing* term does **not** trigger this: it
+    lowers :math:`\mu^*` while leaving it well above :math:`\tan\psi`, so the state
+    stays admissible and only the unit tests on the closed form will notice. This check
+    is not a substitute for those.
+
+    As the law stands the check cannot fire from an admissible parameter set. The clips
+    hold :math:`\tan\psi \leq \tan\psi_0` --- both :math:`1 - a_s` and :math:`d^d` only
+    reduce it, and the history is floored --- while
+    :meth:`DilationRotatedFriction._validate_sliding_composition` holds
+    :math:`\mu_b \tan\psi_0 < 1`, so the denominator stays positive and every term is
+    non-negative at every iterate. Its worth is in what it would catch, not in what it
+    catches today.
+
+    Beyond a composition assembled wrongly, that is one thing in particular: a law in
+    which :math:`\mu_b` or :math:`\psi_0` becomes state dependent. Validating at
+    construction sees only the initial state, so a pole crossed mid-run would pass it,
+    and past the pole the dissipation is negative rather than merely large. That is the
+    case where checking each converged state is worth more than checking the parameters
+    once.
+
+    It runs once per converged nonlinear solve, costing one evaluation of a
+    fracture-only operator.
+
+    Mix in alongside :class:`AsperityStressPartition`, which supplies the quantity.
+
+    """
+
+    frictional_dissipation: Callable[[list[pp.Grid]], pp.ad.Operator]
+    """Method returning the frictional dissipation. Normally defined in a mixin instance
+    of :class:`AsperityStressPartition`."""
+
+    def after_nonlinear_convergence(self) -> None:
+        """Assert dissipation positivity on the state the solver converged to.
+
+        Raises:
+            ValueError: If any fracture cell dissipates negatively. See
+                :meth:`_check_dissipation_positivity`.
+
+        """
+        super().after_nonlinear_convergence()  # type: ignore[safe-super]
+        self._check_dissipation_positivity()
+
+    def _check_dissipation_positivity(self) -> None:
+        r"""Raise if any fracture cell carries a negative frictional dissipation.
+
+        Zero is admissible and is not reported: it is the frictionless limit, reached
+        when :math:`\mu_b` and :math:`\mu_p` both vanish, and a fracture that offers no
+        resistance dissipates nothing. Only a strictly negative value is a fault, which
+        is why the test is on the sign rather than on a tolerance --- the quantity is a
+        product of factors that are each non-negative by construction when the law is
+        composed correctly, so there is no rounding path to a small negative value.
+
+        Raises:
+            ValueError: If any fracture cell dissipates negatively.
+
+        """
+        fractures = self.mdg.subdomains(dim=self.nd - 1)
+        if not fractures:
+            return
+
+        dissipation = np.asarray(
+            self.equation_system.evaluate(self.frictional_dissipation(fractures))
+        )
+        negative = dissipation < 0.0
+        if not np.any(negative):
+            return
+
+        worst = int(np.argmin(dissipation))
+        raise ValueError(
+            f"The frictional dissipation (mu* - tan psi) sigma_n is negative in "
+            f"{int(np.sum(negative))} of {dissipation.size} fracture cells, reaching "
+            f"{dissipation[worst]} Pa in cell {worst}. It is non-negative for any "
+            "admissible parameter set, so this means the friction law is composed "
+            "wrongly rather than that the parameters are extreme: check that the "
+            "method resolution order reaches every layer of the composition, and that "
+            "friction_coefficient and tangent_dilation_angle are the composed ones."
+        )
 
 
 class BartonBandis(pp.PorePyModel):

--- a/src/porepy/models/constitutive_laws.py
+++ b/src/porepy/models/constitutive_laws.py
@@ -4099,9 +4099,18 @@ class DilationRotatedFriction(pp.PorePyModel):
         return op
 
     def _validate_sliding_composition(self, subdomains: list[pp.Grid]) -> None:
-        r"""Check that the sliding term stays away from its pole.
+        r"""Check that the sliding term is admissible and away from its pole.
 
-        The composition is a tangent addition, so it diverges as
+        Two conditions, both on the parameters rather than on the state, and both
+        preconditions of the dissipation identity in
+        :meth:`AsperityStressPartition.frictional_dissipation`.
+
+        First, :math:`\mu_b \geq 0`. Friction resists sliding; a negative coefficient
+        would make the surfaces drive themselves apart, and since the term it enters is
+        the one that carries the sign of the dissipation, it is also the only parameter
+        that can make a correctly composed law dissipate negatively.
+
+        Second, the pole. The composition is a tangent addition, so it diverges as
         :math:`\mu_b \tan\psi \to 1`, i.e. as :math:`\phi_b + \psi \to \pi/2`. It is
         enough to check the intact angle, since the stress partition and any damage only
         reduce :math:`\tan\psi` below :math:`\tan\psi_0`, so no state reachable during a
@@ -4116,7 +4125,8 @@ class DilationRotatedFriction(pp.PorePyModel):
             subdomains: List of fracture subdomains.
 
         Raises:
-            ValueError: If the intact parameters put any cell at or beyond the pole.
+            ValueError: If the basic friction coefficient is negative anywhere, or if
+                the intact parameters put any cell at or beyond the pole.
 
         """
         # Check that the super class has a tangent dilation angle method. Otherwise,
@@ -4126,9 +4136,18 @@ class DilationRotatedFriction(pp.PorePyModel):
                 "The super class of DilationRotatedFriction must have a "
                 "tangent_dilation_angle method."
             )
-        intact_product = self.basic_friction_coefficient(
+        basic = self.basic_friction_coefficient(subdomains)
+        basic_value = np.asarray(self.equation_system.evaluate(basic))
+        if np.any(basic_value < 0.0):
+            raise ValueError(
+                "The basic friction coefficient must be non-negative, but reaches "
+                f"{np.min(basic_value)}. Friction resists sliding; a negative value "
+                "would also take the frictional dissipation below zero."
+            )
+
+        intact_product = basic * super().tangent_dilation_angle(  # type: ignore[misc]
             subdomains
-        ) * super().tangent_dilation_angle(subdomains)  # type: ignore[misc]
+        )
         value = np.asarray(self.equation_system.evaluate(intact_product))
         if np.any(value >= 1.0):
             raise ValueError(

--- a/src/porepy/models/constitutive_laws.py
+++ b/src/porepy/models/constitutive_laws.py
@@ -4277,13 +4277,48 @@ class AsperityStressPartition(pp.PorePyModel):
         Parameters:
             subdomains: List of subdomains where the coefficient is defined.
 
+        Raises:
+            ValueError: If the coefficient is negative anywhere. See
+                :meth:`_validate_ploughing_coefficient`.
+
         Returns:
             Operator for the limiting ploughing friction coefficient.
 
         """
-        return Scalar(
+        op = Scalar(
             self.solid.ploughing_friction_coefficient, "ploughing_friction_coefficient"
         )
+        self._validate_ploughing_coefficient(op)
+        return op
+
+    def _validate_ploughing_coefficient(self, coefficient: pp.ad.Operator) -> None:
+        r"""Check that the ploughing coefficient is non-negative.
+
+        Asperities resist being sheared through; they do not assist. A negative
+        :math:`\mu_p^0` would make the composed friction fall below the sliding law it
+        adds to, and at large enough magnitude would take the dissipation
+        :math:`(\mu^* - \tan\psi)\sigma_n` negative, since that identity is positive
+        term by term only while :math:`\mu_p \geq 0`.
+
+        Checked where the value is produced rather than where it is used, so that the
+        quantity validated is unambiguously the intact coefficient:
+        :class:`FractureDamage` scales this by the damage state, and reaches it through
+        ``super()``.
+
+        Parameters:
+            coefficient: The intact ploughing friction coefficient operator.
+
+        Raises:
+            ValueError: If any cell carries a negative coefficient.
+
+        """
+        value = np.asarray(self.equation_system.evaluate(coefficient))
+        if np.any(value < 0.0):
+            raise ValueError(
+                "The ploughing friction coefficient must be non-negative, but reaches "
+                f"{np.min(value)}. It is the resistance asperities offer to being "
+                "sheared through, so a negative value has no physical reading."
+            )
 
     def stress_partition(self, subdomains: list[pp.Grid]) -> pp.ad.Operator:
         r"""Fraction of the contact carried by sheared asperities [-].

--- a/tests/models/test_fracture_damage_unit.py
+++ b/tests/models/test_fracture_damage_unit.py
@@ -804,6 +804,11 @@ class TestComposedFriction:
         """Return the mean of an operator evaluated at iterate index 0."""
         return float(np.mean(model.equation_system.evaluate(operator)))
 
+    @staticmethod
+    def _min(model, operator) -> float:
+        """Return the smallest cell value of an operator at iterate index 0."""
+        return float(np.min(model.equation_system.evaluate(operator)))
+
     # -- Patton recovery, brief section 6.2 ---------------------------------------
 
     def test_patton_recovery_at_vanishing_traction(self):
@@ -911,6 +916,11 @@ class TestComposedFriction:
         It is asserted over a grid of traction and history because ``tan psi`` and
         ``mu_p`` move in opposite directions as either is varied, so a sign error in one
         term can be masked at any single point.
+
+        The assertion is on the smallest cell value rather than on the cell mean. The
+        states prescribed here are spatially uniform, so the two agree numerically; the
+        difference is in what the test guarantees, since a mean stays positive while
+        individual cells go negative.
         """
         model = self._model(residual_dilation=0.2, residual_friction=0.0)
         fractures = self._fractures(model)
@@ -918,7 +928,7 @@ class TestComposedFriction:
         for traction_fraction in (0.01, 0.2, 0.6, 1.0, 2.0):
             for exponent in (0.0, 0.5, 2.0, 10.0):
                 self._set_state(model, traction_fraction, exponent)
-                dissipation = self._mean(
+                dissipation = self._min(
                     model,
                     model.friction_coefficient(fractures)
                     - model.tangent_dilation_angle(fractures),

--- a/tests/models/test_fracture_damage_unit.py
+++ b/tests/models/test_fracture_damage_unit.py
@@ -977,6 +977,66 @@ class TestComposedFriction:
                     f"sigma_n/sigma_T={traction_fraction}, Lambda/Lc^f={exponent}"
                 )
 
+    # -- The standing dissipation check ------------------------------------------------
+
+    def test_check_passes_on_a_correctly_composed_model(self):
+        """The standing check is silent on an ordinary damaged, partitioned state."""
+        model = self._model(residual_dilation=0.2, residual_friction=0.0)
+        self._set_state(model, traction_fraction=0.5, exponent=2.0)
+        model.after_nonlinear_convergence()
+
+    def test_check_fires_when_the_basic_friction_term_is_lost(self):
+        """Losing the basic friction term must be caught.
+
+        ``mu* - tan psi = mu_b (1 + tan^2 psi)/(1 - mu_b tan psi) + mu_p``, and the
+        first term alone exceeds ``tan psi`` for any realistic ``mu_b``, so it is the
+        term that carries the sign. Removing it leaves ``mu* = a_s mu_p0 d^f``, which at
+        low normal traction is below ``tan psi``: a fracture that produces energy by
+        sliding, on a state where nothing else complains.
+
+        Note what this does *not* stand in for. A mis-ordering that costs only the
+        ploughing term leaves the dissipation comfortably positive -- measured, not
+        assumed -- so it is caught by the closed-form tests above rather than here.
+
+        The term is removed by shadowing ``friction_coefficient`` on the instance,
+        which reproduces the effect without building a mis-ordered class.
+        """
+        model = self._model()
+        self._set_state(model, traction_fraction=0.05)
+
+        def ploughing_only(subdomains):
+            return model.stress_partition(
+                subdomains
+            ) * model.ploughing_friction_coefficient(subdomains)
+
+        model.friction_coefficient = ploughing_only
+
+        # Guard against a vacuous test: the mutation must really drive the dissipation
+        # negative, not merely change it. Most perturbations of the composition do not.
+        assert (
+            self._min(model, model.frictional_dissipation(self._fractures(model))) < 0.0
+        )
+        with pytest.raises(ValueError, match="dissipation"):
+            model.after_nonlinear_convergence()
+
+    def test_zero_dissipation_is_admissible(self):
+        """A frictionless, non-ploughing fracture dissipates nothing, and that is fine.
+
+        ``mu* - tan psi = mu_b (1 + tan^2 psi)/(1 - mu_b tan psi) + mu_p`` vanishes when
+        both ``mu_b`` and ``mu_p`` do. The check is therefore on the sign rather than on
+        strict positivity, so that this limit is not reported as a fault.
+        """
+        model = self._model(
+            friction_coefficient=0.0, ploughing_friction_coefficient=0.0
+        )
+        self._set_state(model, traction_fraction=0.4)
+
+        fractures = self._fractures(model)
+        np.testing.assert_allclose(
+            self._mean(model, model.frictional_dissipation(fractures)), 0.0, atol=1e-12
+        )
+        model.after_nonlinear_convergence()
+
     # -- The pole ------------------------------------------------------------------
 
     def test_pole_is_rejected_at_setup(self):

--- a/tests/models/test_fracture_damage_unit.py
+++ b/tests/models/test_fracture_damage_unit.py
@@ -756,13 +756,14 @@ class TestComposedFriction:
         residual_friction: float = 1.0,
         dilation_angle: float = PSI_0,
         friction_coefficient: float = MU_B,
+        ploughing_friction_coefficient: float = MU_P0,
     ):
         return _prepared_model(
             damages=["dilation", "friction"],
             solid_overrides={
                 "transitional_normal_traction": SIGMA_T,
                 "stress_partition_exponent": 1.5,
-                "ploughing_friction_coefficient": MU_P0,
+                "ploughing_friction_coefficient": ploughing_friction_coefficient,
                 "friction_coefficient": friction_coefficient,
                 "dilation_angle": dilation_angle,
                 "residual_dilation_damage": residual_dilation,
@@ -959,6 +960,42 @@ class TestComposedFriction:
         self._set_state(model, traction_fraction=0.3)
         assert np.isfinite(
             self._mean(model, model.friction_coefficient(self._fractures(model)))
+        )
+
+    def test_negative_ploughing_coefficient_is_rejected(self):
+        """A ploughing coefficient below zero raises rather than being composed in.
+
+        Asperities resist being sheared through; they do not assist. The sign matters
+        beyond its own term, since it is one of the two preconditions under which
+        ``mu* - tan psi`` is positive term by term, the other being the pole above.
+        """
+        with pytest.raises(ValueError, match="ploughing friction coefficient"):
+            self._model(ploughing_friction_coefficient=-0.1)
+
+    def test_zero_ploughing_coefficient_is_accepted(self):
+        """Zero is admissible, and is the default: it leaves the ploughing term absent.
+
+        The boundary is worth pinning separately from the negative case, since a guard
+        written with the wrong comparison would reject the library default.
+
+        Asserted against the sliding law alone rather than merely against the guard not
+        firing, so that the test also states what zero *means*: the partition still
+        reduces the dilation through ``1 - a_s``, and only the ploughing term goes.
+        """
+        traction_fraction = 0.3
+        model = self._model(ploughing_friction_coefficient=0.0)
+        self._set_state(model, traction_fraction)
+
+        # Both damage states are intact here -- the residuals default to one and the
+        # history to zero -- so tan psi carries the partition and nothing else.
+        a_s = 1.0 - (1.0 - traction_fraction) ** 1.5
+        tan_psi = (1.0 - a_s) * np.tan(PSI_0)
+        expected = (MU_B + tan_psi) / (1.0 - MU_B * tan_psi)
+
+        np.testing.assert_allclose(
+            self._mean(model, model.friction_coefficient(self._fractures(model))),
+            expected,
+            rtol=1e-10,
         )
 
 

--- a/tests/models/test_fracture_damage_unit.py
+++ b/tests/models/test_fracture_damage_unit.py
@@ -899,6 +899,44 @@ class TestComposedFriction:
                 rtol=1e-12,
             )
 
+    @pytest.mark.parametrize("traction_fraction", [0.15, 0.5, 0.9])
+    @pytest.mark.parametrize("exponent", [0.0, 1.2])
+    def test_frictional_dissipation_matches_formula(
+        self, traction_fraction: float, exponent: float
+    ):
+        """``D = (mu* - tan psi) sigma_n`` against a closed form in Pa.
+
+        Stated from the traction and the history rather than by subtracting the two
+        operators the method itself composes, so the test constrains the quantity rather
+        than restating its implementation. In particular it pins the dimensional factor:
+        the traction variable is nondimensional, and the characteristic traction has to
+        be multiplied back in exactly once.
+
+        Parameters:
+            traction_fraction: Normal traction as a fraction of ``sigma_T``.
+            exponent: History as this multiple of the friction wear energy scale.
+        """
+        residual_d, residual_f = 0.6, 0.3
+        model = self._model(residual_dilation=residual_d, residual_friction=residual_f)
+        self._set_state(model, traction_fraction, exponent)
+
+        scale_ratio = _nondimensional_wear_energy_scale(
+            model, "friction"
+        ) / _nondimensional_wear_energy_scale(model, "dilation")
+
+        a_s = 1.0 - (1.0 - traction_fraction) ** 1.5
+        d_f = residual_f + (1.0 - residual_f) * np.exp(-exponent)
+        d_d = residual_d + (1.0 - residual_d) * np.exp(-exponent * scale_ratio)
+        tan_psi = (1.0 - a_s) * np.tan(PSI_0) * d_d
+        mu_star = (MU_B + tan_psi) / (1.0 - MU_B * tan_psi) + a_s * MU_P0 * d_f
+        expected = (mu_star - tan_psi) * traction_fraction * SIGMA_T
+
+        np.testing.assert_allclose(
+            self._mean(model, model.frictional_dissipation(self._fractures(model))),
+            expected,
+            rtol=1e-10,
+        )
+
     def test_dissipation_is_positive(self):
         r"""``mu* - tan psi > 0`` everywhere in the admissible parameter set.
 

--- a/tests/models/test_fracture_damage_unit.py
+++ b/tests/models/test_fracture_damage_unit.py
@@ -1060,6 +1060,14 @@ class TestComposedFriction:
             self._mean(model, model.friction_coefficient(self._fractures(model)))
         )
 
+    def test_negative_basic_friction_is_rejected(self):
+        """A basic friction coefficient below zero raises at setup.
+
+        Friction resists sliding rather than promoting it.
+        """
+        with pytest.raises(ValueError, match="basic friction coefficient"):
+            self._model(friction_coefficient=-0.5)
+
     def test_negative_ploughing_coefficient_is_rejected(self):
         """A ploughing coefficient below zero raises rather than being composed in.
 


### PR DESCRIPTION
# Assert dissipation positivity

Stacked on #1768 — the base branch is `dissipation-driven-history`, not `develop`.

Adds two parameter guards and a runtime check that the frictional dissipation
`D = (μ* − tanψ)σ_n` is non-negative at every converged solve.

**What it is for.** `μ* − tanψ = μ_b(1 + tan²ψ)/(1 − μ_b tanψ) + μ_p` is an algebraic identity, so with admissible parameters the dissipation is non-negative at every reachable state: the clips hold `tanψ ≤ tanψ_0`, and the guards hold `μ_b tanψ_0 < 1`, `μ_b ≥ 0` and `μ_p⁰ ≥ 0`. The new runtime check therefore cannot fire on parameters. It catches an implementation error, and specifically one that loses or negates the `μ_b` term, that being the only term large enough to carry the sign. It also guards a future law in which `μ_b` or `ψ_0` becomes state dependent, where a pole crossed mid-run would pass a check made once at construction.

**The check is opt-in, via its own mixin.** `constitutive_laws.py` today contains zero lifecycle-hook overrides — constitutive laws are pure operator providers, and the file's only validation idiom is "evaluate a sub-operator inside the operator-returning method and raise" (`_validate_sliding_composition`, `BartonBandis`, `SecondOrderTensorUtils`). Putting `after_nonlinear_convergence` on `AsperityStressPartition` would make a law class join the solve lifecycle and would charge every user of the partition for the check. A separate mixin keeps the laws clean and puts "this model asserts its own admissibility" in the base list where a reader sees it.

## Changes

1. **`AsperityStressPartition.frictional_dissipation`** — `(μ* − tanψ)σ_n`. Both factors are read through `self`, so it is the composed coefficient and the damaged, partitioned dilation angle the model actually uses. Distinct from the total frictional work `μ*σ_n` that drives the wear, which includes the dilational part deliberately.
2. **`μ_p⁰ ≥ 0`**, validated in `ploughing_friction_coefficient` where the value is produced, so that what is checked is unambiguously the intact coefficient rather than the damage-scaled one.
3. **`μ_b ≥ 0`**, alongside the existing pole check in `_validate_sliding_composition`. Both are parameter-level preconditions of the same identity.
4. **`DissipationPositivityCheck`** — overrides `after_nonlinear_convergence` and raises, naming the offending cell count, the minimum and its index. Mixed into `FractureDamageMomentumBalance`. Zero is admissible and not reported: it is the frictionless limit.

## Tests

`test_dissipation_is_positive` tightened from the cell mean to the smallest cell value — identical on the uniform states it prescribes, but a positive mean can hide negative cells. New tests cover the dissipation against a closed form in Pa, the check firing when the basic friction term is removed, the check silent on a correct composition, the frictionless limit accepted, and both parameter guards.

Mutation-tested, since a check nobody has made fire is untested scaffolding: dropping the `characteristic_contact_traction` factor fails the closed-form cases, and the firing test asserts `D < 0` before expecting the raise so it cannot pass vacuously.

The check adds no operator to any equation, so results are unchanged.
