### PR TITLE
Accelerate face recognition in TetrahedralGrid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,12 @@ Format: each entry is one line, `PR: Summary of the change.`
 Keep summaries to 1-2 sentences and written for a PorePy user, not just the
 author.
 
+The lists are sorted on PR numbers.
+
 ## Unreleased
 
 ### Changes
+PR 1772: SPEED: Faster construction of grid topologies on 3d simplex grids.
 PR 1770: Simplify PR template by deferring to CONTRIBUTING.md for details on code style and conventions.
 PR 1767: Bugfix in THM manufactured setup.
 PR 1766: Fix bug in generation of Cartesian grids not anchored in the origin.

--- a/src/porepy/grids/simplex.py
+++ b/src/porepy/grids/simplex.py
@@ -406,15 +406,22 @@ class TetrahedralGrid(Grid):
         # encode them using the multi-index functionality of numpy and apply np.unique
         # on the 1D array, which is much faster. The second returned value gives the
         # index of the cells which the face belongs to.
-        fn_encoded = np.ravel_multi_index(np.sort(face_nodes, axis=0), [num_nodes] * 3)
-        unique_encoded, cell_faces = np.unique(fn_encoded, return_inverse=True)
-        face_nodes = np.vstack(np.unravel_index(unique_encoded, [num_nodes] * 3))
-
-        # The previous three lines are therefore a more efficient version of the
-        # following out-of-the-box call:
-        # face_nodes, cell_faces = np.unique(
-        #     np.sort(face_nodes, axis=0), axis=1, return_inverse=True
-        # )
+        #
+        # The encoding relies on num_nodes**3 being representable as a numpy int, which
+        # fails for large grids (roughly num_nodes above 2 million on a 64-bit system).
+        # Fall back to the direct, slower comparison of sorted columns in that
+        # case.
+        max_encodable_num_nodes = 2_000_000
+        if num_nodes < max_encodable_num_nodes:
+            fn_encoded = np.ravel_multi_index(
+                np.sort(face_nodes, axis=0), [num_nodes] * 3
+            )
+            unique_encoded, cell_faces = np.unique(fn_encoded, return_inverse=True)
+            face_nodes = np.vstack(np.unravel_index(unique_encoded, [num_nodes] * 3))
+        else:
+            face_nodes, cell_faces = np.unique(
+                np.sort(face_nodes, axis=0), axis=1, return_inverse=True
+            )
 
         # Numpy may return cell-faces as a 2d array, so we need to ravel it.
         cell_faces = cell_faces.ravel(order="F")

--- a/src/porepy/grids/simplex.py
+++ b/src/porepy/grids/simplex.py
@@ -399,18 +399,22 @@ class TetrahedralGrid(Grid):
         sort_ind = np.squeeze(np.argsort(face_nodes, axis=0))
 
         # Now find the unique face-nodes, by comparing columns in the sorted array.
-        # Internal faces will be found twice, once  for each cell, while external faces
-        # only occur once. The second returned value gives the index of the cells which
-        # the face belongs to. Do unique on an array with sorted columns, so that faces
-        # with the same nodes but with different ordering are recognized as the same
-        # face.
+        # Internal faces will be found twice, once for each cell, while external faces
+        # only occur once. Do unique on an array with sorted columns, so that faces with
+        # the same nodes but with different ordering are recognized as the same face.
+        # Since each node triplet consists of integers within a known range, we can
+        # encode them using the multi-index functionality of numpy and apply np.unique
+        # on the 1D array, which is much faster. The second returned value gives the
+        # index of the cells which the face belongs to.
+        fn_encoded = np.ravel_multi_index(np.sort(face_nodes, axis=0), [num_nodes] * 3)
+        unique_encoded, cell_faces = np.unique(fn_encoded, return_inverse=True)
+        face_nodes = np.vstack(np.unravel_index(unique_encoded, [num_nodes] * 3))
+
+        # The previous three lines are therefore a more efficient version of the
+        # following out-of-the-box call:
         # face_nodes, cell_faces = np.unique(
         #     np.sort(face_nodes, axis=0), axis=1, return_inverse=True
         # )
-        fn_sorted = np.sort(face_nodes, axis=0)
-        fn_encoded = np.ravel_multi_index(fn_sorted, [num_nodes] * 3)
-        unique_encoded, cell_faces = np.unique(fn_encoded, return_inverse=True)
-        face_nodes = np.vstack(np.unravel_index(unique_encoded, [num_nodes] * 3))
 
         # Numpy may return cell-faces as a 2d array, so we need to ravel it.
         cell_faces = cell_faces.ravel(order="F")

--- a/src/porepy/grids/simplex.py
+++ b/src/porepy/grids/simplex.py
@@ -399,14 +399,19 @@ class TetrahedralGrid(Grid):
         sort_ind = np.squeeze(np.argsort(face_nodes, axis=0))
 
         # Now find the unique face-nodes, by comparing columns in the sorted array.
-        # Internal faces will be found twice, once  for ecah cell, while external faces
+        # Internal faces will be found twice, once  for each cell, while external faces
         # only occur once. The second returned value gives the index of the cells which
         # the face belongs to. Do unique on an array with sorted columns, so that faces
         # with the same nodes but with different ordering are recognized as the same
         # face.
-        face_nodes, cell_faces = np.unique(
-            np.sort(face_nodes, axis=0), axis=1, return_inverse=True
-        )
+        # face_nodes, cell_faces = np.unique(
+        #     np.sort(face_nodes, axis=0), axis=1, return_inverse=True
+        # )
+        fn_sorted = np.sort(face_nodes, axis=0)
+        fn_encoded = np.ravel_multi_index(fn_sorted, [num_nodes] * 3)
+        unique_encoded, cell_faces = np.unique(fn_encoded, return_inverse=True)
+        face_nodes = np.vstack(np.unravel_index(unique_encoded, [num_nodes] * 3))
+
         # Numpy may return cell-faces as a 2d array, so we need to ravel it.
         cell_faces = cell_faces.ravel(order="F")
 


### PR DESCRIPTION
There was a bottleneck in recognizing unique faces of tetrahedral grids. It becomes apparent on grids with `h = 0.01`.

## Proposed changes

Instead of using `np.unique(..., axis=1)` on the sorted face-node array, this PR first encodes the array using the numpy multi-index functionality. This is only possible because we know it consists of triplets of integers, each within the known range `[0, num_nodes)`. After encoding, we apply `unique` on the 1D array (which is much more efficient), and then decode.

On my machine, with mesh size 0.01 on the unit cube, this change accelerated `pp.TetrahedralGrid.__init__()` from 15.3s to 3.5s.
